### PR TITLE
Add command to run the fontbakery tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.ninja_log
 *.zip
 .vscode/
-misc
+_misc
 py
 sources/__pycache__
 sources/instance_ufos/
@@ -14,5 +14,6 @@ sources/.fuse_hidden*
 sources/py/
 sources/ufo/*/lib.plist
 temp
+tests_results
 ufo_built.stamp
 venv

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ help:
 	@echo "  * make clean_fonts  : Empties the current fonts/ folder."
 	@echo "  * make export_fonts : Export fonts/ directory into a zip file."
 	@echo "  * make fonts        : Generate font binaries from UFO sources."
+	@echo "  * make tests -i     : Runs automated tests (output at the $(tests_output_dir)/ folder ). -i option is mandatory."
 	@echo "UFO sources scripts"
 	@echo "  * make ufo_anchors_on_accented_glyphs : Place anchors points on accented glyphs (the UFO files must be opened and exported throught Fontforge after)."
 	@echo "  * make ufo_digits_glyphs              : Build digits based glyphs."

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
+.PHONY: export_fonts tests clean clean_fonts 
+
+# Name of the font
+font_name := Giphurs
+
 # If the version is below 1, a 0 is added
 #font_version := $(shell echo "0"$(shell echo "scale=3;("$(shell echo $(shell fc-query -f '%{fontversion}\n' fonts/otf/Giphurs-Regular.otf)"+16" | bc)"/65536)" | bc))
 # If the version is 1.000 or above
 font_version := $(shell echo $(shell echo "scale=3;("$(shell echo $(shell fc-query -f '%{fontversion}\n' fonts/otf/Giphurs-Regular.otf)"+16" | bc)"/65536)" | bc))
+
+# Output directory of make tests (Don't put the '/' at the end!)
+tests_output_dir := tests_results
+
 
 # documentaton
 help:
@@ -17,11 +26,25 @@ help:
 
 # make a zip archive of the font folder
 export_fonts:
-	zip -r Giphurs_fonts_v$(font_version).zip fonts/ OFL.txt
+	zip -r $(font_name)_fonts_v$(font_version).zip fonts/ OFL.txt
 
 # build the fonts (otf, ttf, woof2, static + variables)
 fonts: sources/ufo
 	./sources/build_fonts.sh
+
+# run fontbakery tests
+tests:
+	rm -rf $(tests_output_dir)
+	mkdir $(tests_output_dir)
+	fontbakery check-googlefonts -F fonts/otf/$(font_name)-Thin.otf > $(tests_output_dir)/fontbakery_otf_100.log & \
+	fontbakery check-googlefonts -F fonts/otf/$(font_name)-Regular.otf > $(tests_output_dir)/fontbakery_otf_400.log & \
+	fontbakery check-googlefonts -F fonts/otf/$(font_name)ExtraBlack-Regular.otf > $(tests_output_dir)/fontbakery_otf_1000.log & \
+	fontbakery check-googlefonts -F fonts/ttf/$(font_name)-Thin.ttf > $(tests_output_dir)/fontbakery_ttf_100.log & \
+	fontbakery check-googlefonts -F fonts/ttf/$(font_name)-Regular.ttf > $(tests_output_dir)/fontbakery_ttf_400.log & \
+	fontbakery check-googlefonts -F fonts/ttf/$(font_name)ExtraBlack-Regular.ttf > $(tests_output_dir)/fontbakery_ttf_1000.log & \
+	fontbakery check-googlefonts -F fonts/variable/$(font_name)\[wght\].ttf > $(tests_output_dir)/fontbakery_ttf_var.log & \
+	wait
+	@echo "Done"
 
 # place anchors points on accented glyphs
 ufo_anchors_on_accented_glyphs: sources/ufo
@@ -44,12 +67,15 @@ ufo_use_typo_metrics: sources/ufo
 	python3 ufo_use_typo_metrics.py sources/ufo/Giphurs-ExtraBlack.ufo
 
 # clean all generated files from the scripts
+
+# Cleaning process
 clean:
 	rm -rf sources/instance_ufos
 	rm -rf sources/__pycache__
 	rm -f sources/*.ninja
 	rm -f sources/.fuse_hidden*
 	rm -f sources/.ninja_log
+	rm -rf test_results
 	rm -f *.zip
 
 clean_fonts:


### PR DESCRIPTION
Adds `make tests` command which allows to run the Fontbakery tests we're using to check the font. This command needs the `-i` option to avoid stopping alll of the test if there's at least 1 fail. It actually check the weights 100, 400 and 1000 for both `otf` and `ttf` format (not the SC variant), and the variable `ttf`.

Also added some documentation about testing in the wiki: [Testing the font](https://github.com/Corne2Plum3/Giphurs/wiki/Testing-the-font). Also this closes issue #1 which was outdated for a while.

Small bonus but also added in the `.gitignore` a folder `_misc`, if like me you want to have files in the project's repo you don't want to push.