### PR TITLE
Add meta table

### DIFF
--- a/sources/lib.plist
+++ b/sources/lib.plist
@@ -17,5 +17,20 @@
                 <integer>1</integer>
             </dict>
         </array>
+        <key>public.openTypeMeta</key>
+        <dict>
+            <key>dlng</key>
+            <array>
+                <string>Latn</string>
+                <string>Cyrl</string>
+                <string>Grek</string>
+            </array>
+            <key>slng</key>
+            <array>
+                <string>Latn</string>
+                <string>Cyrl</string>
+                <string>Grek</string>
+            </array>
+        </dict>
     </dict>
 </plist>


### PR DESCRIPTION
I don't know what I'm doing but this works I guess? At least the WARN on font bakery is gone.

Also this appears with font bakery tests:
```
WARNING: meta NOT subset; don't know how to subset; dropped
WARNING: meta NOT subset; don't know how to subset; dropped
WARNING: meta NOT subset; don't know how to subset; dropped
```