### PR TITLE
Some small kerning fixes

### DIFF
--- a/output/fontbakery/fontbakery-report.html
+++ b/output/fontbakery/fontbakery-report.html
@@ -1228,15 +1228,15 @@ subset declarations to METADATA.pb, or by editing the glyphset
 definitions.</p>
 <ul>
 <li>U+02CD MODIFIER LETTER LOW MACRON: try adding lisu</li>
-<li>U+02D8 BREVE: try adding one of: canadian-aboriginal, yi</li>
-<li>U+02D9 DOT ABOVE: try adding one of: canadian-aboriginal, yi</li>
-<li>U+02DB OGONEK: try adding one of: canadian-aboriginal, yi</li>
-<li>U+0302 COMBINING CIRCUMFLEX ACCENT: try adding one of: tifinagh, coptic, math, cherokee</li>
+<li>U+02D8 BREVE: try adding one of: yi, canadian-aboriginal</li>
+<li>U+02D9 DOT ABOVE: try adding one of: yi, canadian-aboriginal</li>
+<li>U+02DB OGONEK: try adding one of: yi, canadian-aboriginal</li>
+<li>U+0302 COMBINING CIRCUMFLEX ACCENT: try adding one of: math, coptic, tifinagh, cherokee</li>
 <li>U+0306 COMBINING BREVE: try adding one of: old-permic, tifinagh</li>
-<li>U+0307 COMBINING DOT ABOVE: try adding one of: old-permic, syriac, tifinagh, coptic, malayalam, math, tai-le, todhri, canadian-aboriginal, hebrew, duployan</li>
+<li>U+0307 COMBINING DOT ABOVE: try adding one of: old-permic, syriac, hebrew, todhri, coptic, tifinagh, tai-le, canadian-aboriginal, math, malayalam, duployan</li>
 <li>U+030A COMBINING RING ABOVE: try adding one of: syriac, duployan</li>
-<li>U+030B COMBINING DOUBLE ACUTE ACCENT: try adding one of: cherokee, osage</li>
-<li>U+030C COMBINING CARON: try adding one of: tai-le, cherokee</li>
+<li>U+030B COMBINING DOUBLE ACUTE ACCENT: try adding one of: osage, cherokee</li>
+<li>U+030C COMBINING CARON: try adding one of: cherokee, tai-le</li>
 <li>U+030D COMBINING VERTICAL LINE ABOVE: try adding sunuwar</li>
 <li>U+030F COMBINING DOUBLE GRAVE ACCENT: not included in any glyphset definition</li>
 <li>U+0311 COMBINING INVERTED BREVE: try adding one of: coptic, todhri</li>
@@ -1253,8 +1253,8 @@ definitions.</p>
 <li>U+032D COMBINING CIRCUMFLEX ACCENT BELOW: try adding one of: syriac, sunuwar</li>
 <li>U+032E COMBINING BREVE BELOW: try adding syriac</li>
 <li>U+032F COMBINING INVERTED BREVE BELOW: try adding math</li>
-<li>U+0330 COMBINING TILDE BELOW: try adding one of: syriac, math, cherokee</li>
-<li>U+0331 COMBINING MACRON BELOW: try adding one of: thai, syriac, gothic, sunuwar, tifinagh, cherokee, caucasian-albanian</li>
+<li>U+0330 COMBINING TILDE BELOW: try adding one of: math, syriac, cherokee</li>
+<li>U+0331 COMBINING MACRON BELOW: try adding one of: syriac, sunuwar, thai, caucasian-albanian, tifinagh, cherokee, gothic</li>
 <li>U+0337 COMBINING SHORT SOLIDUS OVERLAY: not included in any glyphset definition</li>
 <li>U+0338 COMBINING LONG SOLIDUS OVERLAY: try adding math</li>
 <li>U+0340 COMBINING GRAVE TONE MARK: not included in any glyphset definition</li>
@@ -1268,8 +1268,8 @@ definitions.</p>
 <li>U+1DC5 COMBINING GRAVE-MACRON: not included in any glyphset definition</li>
 <li>U+1DC6 COMBINING MACRON-GRAVE: not included in any glyphset definition</li>
 <li>U+1DC7 COMBINING ACUTE-MACRON: not included in any glyphset definition</li>
-<li>U+2010 HYPHEN: try adding one of: kharoshthi, syloti-nagri, lisu, kaithi, armenian, coptic, sundanese, cham, sora-sompeng, arabic, hebrew, yi, kayah-li</li>
-<li>U+2011 NON-BREAKING HYPHEN: try adding one of: arabic, syloti-nagri, yi</li>
+<li>U+2010 HYPHEN: try adding one of: sundanese, kayah-li, armenian, sora-sompeng, yi, hebrew, arabic, syloti-nagri, kaithi, lisu, coptic, kharoshthi, cham</li>
+<li>U+2011 NON-BREAKING HYPHEN: try adding one of: yi, arabic, syloti-nagri</li>
 <li>U+2012 FIGURE DASH: not included in any glyphset definition</li>
 <li>U+2015 HORIZONTAL BAR: try adding adlam</li>
 <li>U+2016 DOUBLE VERTICAL LINE: try adding math</li>
@@ -1307,7 +1307,7 @@ definitions.</p>
 <li>U+204C BLACK LEFTWARDS BULLET: not included in any glyphset definition</li>
 <li>U+204D BLACK RIGHTWARDS BULLET: not included in any glyphset definition</li>
 <li>U+204E LOW ASTERISK: not included in any glyphset definition</li>
-<li>U+204F REVERSED SEMICOLON: try adding one of: arabic, adlam</li>
+<li>U+204F REVERSED SEMICOLON: try adding one of: adlam, arabic</li>
 <li>U+2050 CLOSE UP: try adding math</li>
 <li>U+2051 TWO ASTERISKS ALIGNED VERTICALLY: not included in any glyphset definition</li>
 <li>U+2052 COMMERCIAL MINUS SIGN: not included in any glyphset definition</li>
@@ -1318,7 +1318,7 @@ definitions.</p>
 <li>U+2057 QUADRUPLE PRIME: try adding math</li>
 <li>U+2058 FOUR DOT PUNCTUATION: try adding coptic</li>
 <li>U+2059 FIVE DOT PUNCTUATION: try adding coptic</li>
-<li>U+205A TWO DOT PUNCTUATION: try adding one of: old-turkic, carian, georgian, glagolitic, lycian, old-hungarian</li>
+<li>U+205A TWO DOT PUNCTUATION: try adding one of: carian, old-turkic, georgian, old-hungarian, glagolitic, lycian</li>
 <li>U+205B FOUR DOT MARK: not included in any glyphset definition</li>
 <li>U+205C DOTTED CROSS: not included in any glyphset definition</li>
 <li>U+205D TRICOLON: try adding one of: carian, meroitic-hieroglyphs, old-hungarian, meroitic</li>
@@ -1502,14 +1502,14 @@ definitions.</p>
 <li>U+2189 VULGAR FRACTION ZERO THIRDS: try adding symbols</li>
 <li>U+218A TURNED DIGIT TWO: try adding symbols</li>
 <li>U+218B TURNED DIGIT THREE: try adding symbols</li>
-<li>U+2190 LEFTWARDS ARROW: try adding one of: symbols, math</li>
-<li>U+2192 RIGHTWARDS ARROW: try adding one of: symbols, math</li>
-<li>U+2194 LEFT RIGHT ARROW: try adding one of: symbols, math</li>
-<li>U+2195 UP DOWN ARROW: try adding one of: symbols, math</li>
-<li>U+2196 NORTH WEST ARROW: try adding one of: symbols, math</li>
-<li>U+2197 NORTH EAST ARROW: try adding one of: symbols, math</li>
-<li>U+2198 SOUTH EAST ARROW: try adding one of: symbols, math</li>
-<li>U+2199 SOUTH WEST ARROW: try adding one of: symbols, math</li>
+<li>U+2190 LEFTWARDS ARROW: try adding one of: math, symbols</li>
+<li>U+2192 RIGHTWARDS ARROW: try adding one of: math, symbols</li>
+<li>U+2194 LEFT RIGHT ARROW: try adding one of: math, symbols</li>
+<li>U+2195 UP DOWN ARROW: try adding one of: math, symbols</li>
+<li>U+2196 NORTH WEST ARROW: try adding one of: math, symbols</li>
+<li>U+2197 NORTH EAST ARROW: try adding one of: math, symbols</li>
+<li>U+2198 SOUTH EAST ARROW: try adding one of: math, symbols</li>
+<li>U+2199 SOUTH WEST ARROW: try adding one of: math, symbols</li>
 <li>U+219A LEFTWARDS ARROW WITH STROKE: try adding math</li>
 <li>U+219B RIGHTWARDS ARROW WITH STROKE: try adding math</li>
 <li>U+219C LEFTWARDS WAVE ARROW: try adding math</li>
@@ -1634,8 +1634,8 @@ definitions.</p>
 <li>U+2214 DOT PLUS: try adding math</li>
 <li>U+2216 SET MINUS: try adding math</li>
 <li>U+2217 ASTERISK OPERATOR: try adding math</li>
-<li>U+2218 RING OPERATOR: try adding one of: symbols, math</li>
-<li>U+2219 BULLET OPERATOR: try adding one of: tai-tham, symbols, math, yi</li>
+<li>U+2218 RING OPERATOR: try adding one of: math, symbols</li>
+<li>U+2219 BULLET OPERATOR: try adding one of: math, symbols, yi, tai-tham</li>
 <li>U+221A SQUARE ROOT: try adding math</li>
 <li>U+221B CUBE ROOT: try adding math</li>
 <li>U+221C FOURTH ROOT: try adding math</li>
@@ -1763,7 +1763,7 @@ definitions.</p>
 <li>U+2296 CIRCLED MINUS: try adding math</li>
 <li>U+2297 CIRCLED TIMES: try adding math</li>
 <li>U+2298 CIRCLED DIVISION SLASH: try adding math</li>
-<li>U+2299 CIRCLED DOT OPERATOR: try adding one of: symbols, math</li>
+<li>U+2299 CIRCLED DOT OPERATOR: try adding one of: math, symbols</li>
 <li>U+229A CIRCLED RING OPERATOR: try adding math</li>
 <li>U+229B CIRCLED ASTERISK OPERATOR: try adding math</li>
 <li>U+229C CIRCLED EQUALS: try adding math</li>
@@ -1806,9 +1806,9 @@ definitions.</p>
 <li>U+22C1 N-ARY LOGICAL OR: try adding math</li>
 <li>U+22C2 N-ARY INTERSECTION: try adding math</li>
 <li>U+22C3 N-ARY UNION: try adding math</li>
-<li>U+22C4 DIAMOND OPERATOR: try adding one of: symbols, math</li>
-<li>U+22C5 DOT OPERATOR: try adding one of: symbols, math</li>
-<li>U+22C6 STAR OPERATOR: try adding one of: symbols, math</li>
+<li>U+22C4 DIAMOND OPERATOR: try adding one of: math, symbols</li>
+<li>U+22C5 DOT OPERATOR: try adding one of: math, symbols</li>
+<li>U+22C6 STAR OPERATOR: try adding one of: math, symbols</li>
 <li>U+22C7 DIVISION TIMES: try adding math</li>
 <li>U+22C8 BOWTIE: try adding math</li>
 <li>U+22C9 LEFT NORMAL FACTOR SEMIDIRECT PRODUCT: try adding math</li>
@@ -1866,28 +1866,28 @@ definitions.</p>
 <li>U+22FD CONTAINS WITH OVERBAR: try adding math</li>
 <li>U+22FE SMALL CONTAINS WITH OVERBAR: try adding math</li>
 <li>U+22FF Z NOTATION BAG MEMBERSHIP: try adding math</li>
-<li>U+2460 CIRCLED DIGIT ONE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2461 CIRCLED DIGIT TWO: try adding one of: yi, symbols, mongolian</li>
-<li>U+2462 CIRCLED DIGIT THREE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2463 CIRCLED DIGIT FOUR: try adding one of: yi, symbols, mongolian</li>
-<li>U+2464 CIRCLED DIGIT FIVE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2465 CIRCLED DIGIT SIX: try adding one of: yi, symbols, mongolian</li>
-<li>U+2466 CIRCLED DIGIT SEVEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2467 CIRCLED DIGIT EIGHT: try adding one of: yi, symbols, mongolian</li>
-<li>U+2468 CIRCLED DIGIT NINE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2469 CIRCLED NUMBER TEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246A CIRCLED NUMBER ELEVEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246B CIRCLED NUMBER TWELVE: try adding one of: yi, symbols, mongolian</li>
-<li>U+246C CIRCLED NUMBER THIRTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246D CIRCLED NUMBER FOURTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246E CIRCLED NUMBER FIFTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246F CIRCLED NUMBER SIXTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2470 CIRCLED NUMBER SEVENTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2471 CIRCLED NUMBER EIGHTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2472 CIRCLED NUMBER NINETEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2473 CIRCLED NUMBER TWENTY: try adding one of: yi, symbols, mongolian</li>
-<li>U+2474 PARENTHESIZED DIGIT ONE: try adding one of: symbols, math</li>
-<li>U+2475 PARENTHESIZED DIGIT TWO: try adding one of: symbols, math</li>
+<li>U+2460 CIRCLED DIGIT ONE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2461 CIRCLED DIGIT TWO: try adding one of: symbols, yi, mongolian</li>
+<li>U+2462 CIRCLED DIGIT THREE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2463 CIRCLED DIGIT FOUR: try adding one of: symbols, yi, mongolian</li>
+<li>U+2464 CIRCLED DIGIT FIVE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2465 CIRCLED DIGIT SIX: try adding one of: symbols, yi, mongolian</li>
+<li>U+2466 CIRCLED DIGIT SEVEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2467 CIRCLED DIGIT EIGHT: try adding one of: symbols, yi, mongolian</li>
+<li>U+2468 CIRCLED DIGIT NINE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2469 CIRCLED NUMBER TEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246A CIRCLED NUMBER ELEVEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246B CIRCLED NUMBER TWELVE: try adding one of: symbols, yi, mongolian</li>
+<li>U+246C CIRCLED NUMBER THIRTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246D CIRCLED NUMBER FOURTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246E CIRCLED NUMBER FIFTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246F CIRCLED NUMBER SIXTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2470 CIRCLED NUMBER SEVENTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2471 CIRCLED NUMBER EIGHTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2472 CIRCLED NUMBER NINETEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2473 CIRCLED NUMBER TWENTY: try adding one of: symbols, yi, mongolian</li>
+<li>U+2474 PARENTHESIZED DIGIT ONE: try adding one of: math, symbols</li>
+<li>U+2475 PARENTHESIZED DIGIT TWO: try adding one of: math, symbols</li>
 <li>U+2476 PARENTHESIZED DIGIT THREE: try adding symbols</li>
 <li>U+2477 PARENTHESIZED DIGIT FOUR: try adding symbols</li>
 <li>U+2478 PARENTHESIZED DIGIT FIVE: try adding symbols</li>
@@ -2026,7 +2026,7 @@ definitions.</p>
 <li>U+24FD DOUBLE CIRCLED DIGIT NINE: try adding symbols</li>
 <li>U+24FE DOUBLE CIRCLED NUMBER TEN: try adding symbols</li>
 <li>U+24FF NEGATIVE CIRCLED DIGIT ZERO: try adding symbols</li>
-<li>U+25CC DOTTED CIRCLE: try adding one of: syriac, armenian, tai-le, tamil, zanabazar-square, coptic, mende-kikakui, khudawadi, gujarati, kayah-li, music, mandaic, elbasan, manichaean, soyombo, tagbanwa, thaana, hanunoo, khojki, devanagari, tifinagh, meetei-mayek, pahawh-hmong, sharada, oriya, newa, kharoshthi, buhid, phags-pa, bassa-vah, balinese, canadian-aboriginal, kannada, symbols, psalter-pahlavi, bhaiksuki, rejang, old-permic, syloti-nagri, warang-citi, kaithi, siddham, sogdian, khmer, saurashtra, ahom, batak, new-tai-lue, dogra, math, sundanese, mongolian, lepcha, nko, tibetan, buginese, sinhala, caucasian-albanian, myanmar, malayalam, osage, tirhuta, lao, javanese, thai, chakma, mahajani, modi, masaram-gondi, brahmi, hanifi-rohingya, duployan, takri, miao, limbu, tagalog, tai-viet, telugu, yi, gurmukhi, wancho, marchen, hebrew, grantha, gunjala-gondi, bengali, adlam, cham, tai-tham</li>
+<li>U+25CC DOTTED CIRCLE: try adding one of: mahajani, manichaean, syriac, gunjala-gondi, khojki, siddham, math, symbols, tagalog, cham, marchen, newa, takri, buginese, mandaic, balinese, malayalam, oriya, thaana, khudawadi, wancho, limbu, tamil, javanese, psalter-pahlavi, yi, gurmukhi, sundanese, gujarati, lepcha, brahmi, tai-tham, sogdian, duployan, warang-citi, kayah-li, sinhala, batak, tagbanwa, bengali, tai-viet, devanagari, modi, bhaiksuki, telugu, saurashtra, kannada, hebrew, kharoshthi, soyombo, adlam, hanifi-rohingya, osage, phags-pa, tifinagh, tirhuta, myanmar, syloti-nagri, coptic, hanunoo, meetei-mayek, buhid, mende-kikakui, elbasan, mongolian, miao, thai, ahom, pahawh-hmong, tai-le, tibetan, canadian-aboriginal, bassa-vah, armenian, nko, khmer, chakma, lao, new-tai-lue, rejang, music, zanabazar-square, old-permic, grantha, sharada, caucasian-albanian, masaram-gondi, dogra, kaithi</li>
 <li>U+25CF BLACK CIRCLE: try adding symbols</li>
 <li>U+25EF LARGE CIRCLE: try adding symbols</li>
 <li>U+2776 DINGBAT NEGATIVE CIRCLED DIGIT ONE: try adding symbols</li>
@@ -2095,15 +2095,15 @@ subset declarations to METADATA.pb, or by editing the glyphset
 definitions.</p>
 <ul>
 <li>U+02CD MODIFIER LETTER LOW MACRON: try adding lisu</li>
-<li>U+02D8 BREVE: try adding one of: canadian-aboriginal, yi</li>
-<li>U+02D9 DOT ABOVE: try adding one of: canadian-aboriginal, yi</li>
-<li>U+02DB OGONEK: try adding one of: canadian-aboriginal, yi</li>
-<li>U+0302 COMBINING CIRCUMFLEX ACCENT: try adding one of: tifinagh, coptic, math, cherokee</li>
+<li>U+02D8 BREVE: try adding one of: yi, canadian-aboriginal</li>
+<li>U+02D9 DOT ABOVE: try adding one of: yi, canadian-aboriginal</li>
+<li>U+02DB OGONEK: try adding one of: yi, canadian-aboriginal</li>
+<li>U+0302 COMBINING CIRCUMFLEX ACCENT: try adding one of: math, coptic, tifinagh, cherokee</li>
 <li>U+0306 COMBINING BREVE: try adding one of: old-permic, tifinagh</li>
-<li>U+0307 COMBINING DOT ABOVE: try adding one of: old-permic, syriac, tifinagh, coptic, malayalam, math, tai-le, todhri, canadian-aboriginal, hebrew, duployan</li>
+<li>U+0307 COMBINING DOT ABOVE: try adding one of: old-permic, syriac, hebrew, todhri, coptic, tifinagh, tai-le, canadian-aboriginal, math, malayalam, duployan</li>
 <li>U+030A COMBINING RING ABOVE: try adding one of: syriac, duployan</li>
-<li>U+030B COMBINING DOUBLE ACUTE ACCENT: try adding one of: cherokee, osage</li>
-<li>U+030C COMBINING CARON: try adding one of: tai-le, cherokee</li>
+<li>U+030B COMBINING DOUBLE ACUTE ACCENT: try adding one of: osage, cherokee</li>
+<li>U+030C COMBINING CARON: try adding one of: cherokee, tai-le</li>
 <li>U+030D COMBINING VERTICAL LINE ABOVE: try adding sunuwar</li>
 <li>U+030F COMBINING DOUBLE GRAVE ACCENT: not included in any glyphset definition</li>
 <li>U+0311 COMBINING INVERTED BREVE: try adding one of: coptic, todhri</li>
@@ -2120,8 +2120,8 @@ definitions.</p>
 <li>U+032D COMBINING CIRCUMFLEX ACCENT BELOW: try adding one of: syriac, sunuwar</li>
 <li>U+032E COMBINING BREVE BELOW: try adding syriac</li>
 <li>U+032F COMBINING INVERTED BREVE BELOW: try adding math</li>
-<li>U+0330 COMBINING TILDE BELOW: try adding one of: syriac, math, cherokee</li>
-<li>U+0331 COMBINING MACRON BELOW: try adding one of: thai, syriac, gothic, sunuwar, tifinagh, cherokee, caucasian-albanian</li>
+<li>U+0330 COMBINING TILDE BELOW: try adding one of: math, syriac, cherokee</li>
+<li>U+0331 COMBINING MACRON BELOW: try adding one of: syriac, sunuwar, thai, caucasian-albanian, tifinagh, cherokee, gothic</li>
 <li>U+0337 COMBINING SHORT SOLIDUS OVERLAY: not included in any glyphset definition</li>
 <li>U+0338 COMBINING LONG SOLIDUS OVERLAY: try adding math</li>
 <li>U+0340 COMBINING GRAVE TONE MARK: not included in any glyphset definition</li>
@@ -2135,8 +2135,8 @@ definitions.</p>
 <li>U+1DC5 COMBINING GRAVE-MACRON: not included in any glyphset definition</li>
 <li>U+1DC6 COMBINING MACRON-GRAVE: not included in any glyphset definition</li>
 <li>U+1DC7 COMBINING ACUTE-MACRON: not included in any glyphset definition</li>
-<li>U+2010 HYPHEN: try adding one of: kharoshthi, syloti-nagri, lisu, kaithi, armenian, coptic, sundanese, cham, sora-sompeng, arabic, hebrew, yi, kayah-li</li>
-<li>U+2011 NON-BREAKING HYPHEN: try adding one of: arabic, syloti-nagri, yi</li>
+<li>U+2010 HYPHEN: try adding one of: sundanese, kayah-li, armenian, sora-sompeng, yi, hebrew, arabic, syloti-nagri, kaithi, lisu, coptic, kharoshthi, cham</li>
+<li>U+2011 NON-BREAKING HYPHEN: try adding one of: yi, arabic, syloti-nagri</li>
 <li>U+2012 FIGURE DASH: not included in any glyphset definition</li>
 <li>U+2015 HORIZONTAL BAR: try adding adlam</li>
 <li>U+2016 DOUBLE VERTICAL LINE: try adding math</li>
@@ -2174,7 +2174,7 @@ definitions.</p>
 <li>U+204C BLACK LEFTWARDS BULLET: not included in any glyphset definition</li>
 <li>U+204D BLACK RIGHTWARDS BULLET: not included in any glyphset definition</li>
 <li>U+204E LOW ASTERISK: not included in any glyphset definition</li>
-<li>U+204F REVERSED SEMICOLON: try adding one of: arabic, adlam</li>
+<li>U+204F REVERSED SEMICOLON: try adding one of: adlam, arabic</li>
 <li>U+2050 CLOSE UP: try adding math</li>
 <li>U+2051 TWO ASTERISKS ALIGNED VERTICALLY: not included in any glyphset definition</li>
 <li>U+2052 COMMERCIAL MINUS SIGN: not included in any glyphset definition</li>
@@ -2185,7 +2185,7 @@ definitions.</p>
 <li>U+2057 QUADRUPLE PRIME: try adding math</li>
 <li>U+2058 FOUR DOT PUNCTUATION: try adding coptic</li>
 <li>U+2059 FIVE DOT PUNCTUATION: try adding coptic</li>
-<li>U+205A TWO DOT PUNCTUATION: try adding one of: old-turkic, carian, georgian, glagolitic, lycian, old-hungarian</li>
+<li>U+205A TWO DOT PUNCTUATION: try adding one of: carian, old-turkic, georgian, old-hungarian, glagolitic, lycian</li>
 <li>U+205B FOUR DOT MARK: not included in any glyphset definition</li>
 <li>U+205C DOTTED CROSS: not included in any glyphset definition</li>
 <li>U+205D TRICOLON: try adding one of: carian, meroitic-hieroglyphs, old-hungarian, meroitic</li>
@@ -2369,14 +2369,14 @@ definitions.</p>
 <li>U+2189 VULGAR FRACTION ZERO THIRDS: try adding symbols</li>
 <li>U+218A TURNED DIGIT TWO: try adding symbols</li>
 <li>U+218B TURNED DIGIT THREE: try adding symbols</li>
-<li>U+2190 LEFTWARDS ARROW: try adding one of: symbols, math</li>
-<li>U+2192 RIGHTWARDS ARROW: try adding one of: symbols, math</li>
-<li>U+2194 LEFT RIGHT ARROW: try adding one of: symbols, math</li>
-<li>U+2195 UP DOWN ARROW: try adding one of: symbols, math</li>
-<li>U+2196 NORTH WEST ARROW: try adding one of: symbols, math</li>
-<li>U+2197 NORTH EAST ARROW: try adding one of: symbols, math</li>
-<li>U+2198 SOUTH EAST ARROW: try adding one of: symbols, math</li>
-<li>U+2199 SOUTH WEST ARROW: try adding one of: symbols, math</li>
+<li>U+2190 LEFTWARDS ARROW: try adding one of: math, symbols</li>
+<li>U+2192 RIGHTWARDS ARROW: try adding one of: math, symbols</li>
+<li>U+2194 LEFT RIGHT ARROW: try adding one of: math, symbols</li>
+<li>U+2195 UP DOWN ARROW: try adding one of: math, symbols</li>
+<li>U+2196 NORTH WEST ARROW: try adding one of: math, symbols</li>
+<li>U+2197 NORTH EAST ARROW: try adding one of: math, symbols</li>
+<li>U+2198 SOUTH EAST ARROW: try adding one of: math, symbols</li>
+<li>U+2199 SOUTH WEST ARROW: try adding one of: math, symbols</li>
 <li>U+219A LEFTWARDS ARROW WITH STROKE: try adding math</li>
 <li>U+219B RIGHTWARDS ARROW WITH STROKE: try adding math</li>
 <li>U+219C LEFTWARDS WAVE ARROW: try adding math</li>
@@ -2501,8 +2501,8 @@ definitions.</p>
 <li>U+2214 DOT PLUS: try adding math</li>
 <li>U+2216 SET MINUS: try adding math</li>
 <li>U+2217 ASTERISK OPERATOR: try adding math</li>
-<li>U+2218 RING OPERATOR: try adding one of: symbols, math</li>
-<li>U+2219 BULLET OPERATOR: try adding one of: tai-tham, symbols, math, yi</li>
+<li>U+2218 RING OPERATOR: try adding one of: math, symbols</li>
+<li>U+2219 BULLET OPERATOR: try adding one of: math, symbols, yi, tai-tham</li>
 <li>U+221A SQUARE ROOT: try adding math</li>
 <li>U+221B CUBE ROOT: try adding math</li>
 <li>U+221C FOURTH ROOT: try adding math</li>
@@ -2630,7 +2630,7 @@ definitions.</p>
 <li>U+2296 CIRCLED MINUS: try adding math</li>
 <li>U+2297 CIRCLED TIMES: try adding math</li>
 <li>U+2298 CIRCLED DIVISION SLASH: try adding math</li>
-<li>U+2299 CIRCLED DOT OPERATOR: try adding one of: symbols, math</li>
+<li>U+2299 CIRCLED DOT OPERATOR: try adding one of: math, symbols</li>
 <li>U+229A CIRCLED RING OPERATOR: try adding math</li>
 <li>U+229B CIRCLED ASTERISK OPERATOR: try adding math</li>
 <li>U+229C CIRCLED EQUALS: try adding math</li>
@@ -2673,9 +2673,9 @@ definitions.</p>
 <li>U+22C1 N-ARY LOGICAL OR: try adding math</li>
 <li>U+22C2 N-ARY INTERSECTION: try adding math</li>
 <li>U+22C3 N-ARY UNION: try adding math</li>
-<li>U+22C4 DIAMOND OPERATOR: try adding one of: symbols, math</li>
-<li>U+22C5 DOT OPERATOR: try adding one of: symbols, math</li>
-<li>U+22C6 STAR OPERATOR: try adding one of: symbols, math</li>
+<li>U+22C4 DIAMOND OPERATOR: try adding one of: math, symbols</li>
+<li>U+22C5 DOT OPERATOR: try adding one of: math, symbols</li>
+<li>U+22C6 STAR OPERATOR: try adding one of: math, symbols</li>
 <li>U+22C7 DIVISION TIMES: try adding math</li>
 <li>U+22C8 BOWTIE: try adding math</li>
 <li>U+22C9 LEFT NORMAL FACTOR SEMIDIRECT PRODUCT: try adding math</li>
@@ -2733,28 +2733,28 @@ definitions.</p>
 <li>U+22FD CONTAINS WITH OVERBAR: try adding math</li>
 <li>U+22FE SMALL CONTAINS WITH OVERBAR: try adding math</li>
 <li>U+22FF Z NOTATION BAG MEMBERSHIP: try adding math</li>
-<li>U+2460 CIRCLED DIGIT ONE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2461 CIRCLED DIGIT TWO: try adding one of: yi, symbols, mongolian</li>
-<li>U+2462 CIRCLED DIGIT THREE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2463 CIRCLED DIGIT FOUR: try adding one of: yi, symbols, mongolian</li>
-<li>U+2464 CIRCLED DIGIT FIVE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2465 CIRCLED DIGIT SIX: try adding one of: yi, symbols, mongolian</li>
-<li>U+2466 CIRCLED DIGIT SEVEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2467 CIRCLED DIGIT EIGHT: try adding one of: yi, symbols, mongolian</li>
-<li>U+2468 CIRCLED DIGIT NINE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2469 CIRCLED NUMBER TEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246A CIRCLED NUMBER ELEVEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246B CIRCLED NUMBER TWELVE: try adding one of: yi, symbols, mongolian</li>
-<li>U+246C CIRCLED NUMBER THIRTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246D CIRCLED NUMBER FOURTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246E CIRCLED NUMBER FIFTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246F CIRCLED NUMBER SIXTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2470 CIRCLED NUMBER SEVENTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2471 CIRCLED NUMBER EIGHTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2472 CIRCLED NUMBER NINETEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2473 CIRCLED NUMBER TWENTY: try adding one of: yi, symbols, mongolian</li>
-<li>U+2474 PARENTHESIZED DIGIT ONE: try adding one of: symbols, math</li>
-<li>U+2475 PARENTHESIZED DIGIT TWO: try adding one of: symbols, math</li>
+<li>U+2460 CIRCLED DIGIT ONE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2461 CIRCLED DIGIT TWO: try adding one of: symbols, yi, mongolian</li>
+<li>U+2462 CIRCLED DIGIT THREE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2463 CIRCLED DIGIT FOUR: try adding one of: symbols, yi, mongolian</li>
+<li>U+2464 CIRCLED DIGIT FIVE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2465 CIRCLED DIGIT SIX: try adding one of: symbols, yi, mongolian</li>
+<li>U+2466 CIRCLED DIGIT SEVEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2467 CIRCLED DIGIT EIGHT: try adding one of: symbols, yi, mongolian</li>
+<li>U+2468 CIRCLED DIGIT NINE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2469 CIRCLED NUMBER TEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246A CIRCLED NUMBER ELEVEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246B CIRCLED NUMBER TWELVE: try adding one of: symbols, yi, mongolian</li>
+<li>U+246C CIRCLED NUMBER THIRTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246D CIRCLED NUMBER FOURTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246E CIRCLED NUMBER FIFTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246F CIRCLED NUMBER SIXTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2470 CIRCLED NUMBER SEVENTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2471 CIRCLED NUMBER EIGHTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2472 CIRCLED NUMBER NINETEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2473 CIRCLED NUMBER TWENTY: try adding one of: symbols, yi, mongolian</li>
+<li>U+2474 PARENTHESIZED DIGIT ONE: try adding one of: math, symbols</li>
+<li>U+2475 PARENTHESIZED DIGIT TWO: try adding one of: math, symbols</li>
 <li>U+2476 PARENTHESIZED DIGIT THREE: try adding symbols</li>
 <li>U+2477 PARENTHESIZED DIGIT FOUR: try adding symbols</li>
 <li>U+2478 PARENTHESIZED DIGIT FIVE: try adding symbols</li>
@@ -2893,7 +2893,7 @@ definitions.</p>
 <li>U+24FD DOUBLE CIRCLED DIGIT NINE: try adding symbols</li>
 <li>U+24FE DOUBLE CIRCLED NUMBER TEN: try adding symbols</li>
 <li>U+24FF NEGATIVE CIRCLED DIGIT ZERO: try adding symbols</li>
-<li>U+25CC DOTTED CIRCLE: try adding one of: syriac, armenian, tai-le, tamil, zanabazar-square, coptic, mende-kikakui, khudawadi, gujarati, kayah-li, music, mandaic, elbasan, manichaean, soyombo, tagbanwa, thaana, hanunoo, khojki, devanagari, tifinagh, meetei-mayek, pahawh-hmong, sharada, oriya, newa, kharoshthi, buhid, phags-pa, bassa-vah, balinese, canadian-aboriginal, kannada, symbols, psalter-pahlavi, bhaiksuki, rejang, old-permic, syloti-nagri, warang-citi, kaithi, siddham, sogdian, khmer, saurashtra, ahom, batak, new-tai-lue, dogra, math, sundanese, mongolian, lepcha, nko, tibetan, buginese, sinhala, caucasian-albanian, myanmar, malayalam, osage, tirhuta, lao, javanese, thai, chakma, mahajani, modi, masaram-gondi, brahmi, hanifi-rohingya, duployan, takri, miao, limbu, tagalog, tai-viet, telugu, yi, gurmukhi, wancho, marchen, hebrew, grantha, gunjala-gondi, bengali, adlam, cham, tai-tham</li>
+<li>U+25CC DOTTED CIRCLE: try adding one of: mahajani, manichaean, syriac, gunjala-gondi, khojki, siddham, math, symbols, tagalog, cham, marchen, newa, takri, buginese, mandaic, balinese, malayalam, oriya, thaana, khudawadi, wancho, limbu, tamil, javanese, psalter-pahlavi, yi, gurmukhi, sundanese, gujarati, lepcha, brahmi, tai-tham, sogdian, duployan, warang-citi, kayah-li, sinhala, batak, tagbanwa, bengali, tai-viet, devanagari, modi, bhaiksuki, telugu, saurashtra, kannada, hebrew, kharoshthi, soyombo, adlam, hanifi-rohingya, osage, phags-pa, tifinagh, tirhuta, myanmar, syloti-nagri, coptic, hanunoo, meetei-mayek, buhid, mende-kikakui, elbasan, mongolian, miao, thai, ahom, pahawh-hmong, tai-le, tibetan, canadian-aboriginal, bassa-vah, armenian, nko, khmer, chakma, lao, new-tai-lue, rejang, music, zanabazar-square, old-permic, grantha, sharada, caucasian-albanian, masaram-gondi, dogra, kaithi</li>
 <li>U+25CF BLACK CIRCLE: try adding symbols</li>
 <li>U+25EF LARGE CIRCLE: try adding symbols</li>
 <li>U+2776 DINGBAT NEGATIVE CIRCLED DIGIT ONE: try adding symbols</li>

--- a/output/fontbakery/fontbakery-report.md
+++ b/output/fontbakery/fontbakery-report.md
@@ -261,15 +261,15 @@ subset declarations to METADATA.pb, or by editing the glyphset
 definitions.</p>
 <ul>
 <li>U+02CD MODIFIER LETTER LOW MACRON: try adding lisu</li>
-<li>U+02D8 BREVE: try adding one of: canadian-aboriginal, yi</li>
-<li>U+02D9 DOT ABOVE: try adding one of: canadian-aboriginal, yi</li>
-<li>U+02DB OGONEK: try adding one of: canadian-aboriginal, yi</li>
-<li>U+0302 COMBINING CIRCUMFLEX ACCENT: try adding one of: tifinagh, coptic, math, cherokee</li>
+<li>U+02D8 BREVE: try adding one of: yi, canadian-aboriginal</li>
+<li>U+02D9 DOT ABOVE: try adding one of: yi, canadian-aboriginal</li>
+<li>U+02DB OGONEK: try adding one of: yi, canadian-aboriginal</li>
+<li>U+0302 COMBINING CIRCUMFLEX ACCENT: try adding one of: math, coptic, tifinagh, cherokee</li>
 <li>U+0306 COMBINING BREVE: try adding one of: old-permic, tifinagh</li>
-<li>U+0307 COMBINING DOT ABOVE: try adding one of: old-permic, syriac, tifinagh, coptic, malayalam, math, tai-le, todhri, canadian-aboriginal, hebrew, duployan</li>
+<li>U+0307 COMBINING DOT ABOVE: try adding one of: old-permic, syriac, hebrew, todhri, coptic, tifinagh, tai-le, canadian-aboriginal, math, malayalam, duployan</li>
 <li>U+030A COMBINING RING ABOVE: try adding one of: syriac, duployan</li>
-<li>U+030B COMBINING DOUBLE ACUTE ACCENT: try adding one of: cherokee, osage</li>
-<li>U+030C COMBINING CARON: try adding one of: tai-le, cherokee</li>
+<li>U+030B COMBINING DOUBLE ACUTE ACCENT: try adding one of: osage, cherokee</li>
+<li>U+030C COMBINING CARON: try adding one of: cherokee, tai-le</li>
 <li>U+030D COMBINING VERTICAL LINE ABOVE: try adding sunuwar</li>
 <li>U+030F COMBINING DOUBLE GRAVE ACCENT: not included in any glyphset definition</li>
 <li>U+0311 COMBINING INVERTED BREVE: try adding one of: coptic, todhri</li>
@@ -286,8 +286,8 @@ definitions.</p>
 <li>U+032D COMBINING CIRCUMFLEX ACCENT BELOW: try adding one of: syriac, sunuwar</li>
 <li>U+032E COMBINING BREVE BELOW: try adding syriac</li>
 <li>U+032F COMBINING INVERTED BREVE BELOW: try adding math</li>
-<li>U+0330 COMBINING TILDE BELOW: try adding one of: syriac, math, cherokee</li>
-<li>U+0331 COMBINING MACRON BELOW: try adding one of: thai, syriac, gothic, sunuwar, tifinagh, cherokee, caucasian-albanian</li>
+<li>U+0330 COMBINING TILDE BELOW: try adding one of: math, syriac, cherokee</li>
+<li>U+0331 COMBINING MACRON BELOW: try adding one of: syriac, sunuwar, thai, caucasian-albanian, tifinagh, cherokee, gothic</li>
 <li>U+0337 COMBINING SHORT SOLIDUS OVERLAY: not included in any glyphset definition</li>
 <li>U+0338 COMBINING LONG SOLIDUS OVERLAY: try adding math</li>
 <li>U+0340 COMBINING GRAVE TONE MARK: not included in any glyphset definition</li>
@@ -301,8 +301,8 @@ definitions.</p>
 <li>U+1DC5 COMBINING GRAVE-MACRON: not included in any glyphset definition</li>
 <li>U+1DC6 COMBINING MACRON-GRAVE: not included in any glyphset definition</li>
 <li>U+1DC7 COMBINING ACUTE-MACRON: not included in any glyphset definition</li>
-<li>U+2010 HYPHEN: try adding one of: kharoshthi, syloti-nagri, lisu, kaithi, armenian, coptic, sundanese, cham, sora-sompeng, arabic, hebrew, yi, kayah-li</li>
-<li>U+2011 NON-BREAKING HYPHEN: try adding one of: arabic, syloti-nagri, yi</li>
+<li>U+2010 HYPHEN: try adding one of: sundanese, kayah-li, armenian, sora-sompeng, yi, hebrew, arabic, syloti-nagri, kaithi, lisu, coptic, kharoshthi, cham</li>
+<li>U+2011 NON-BREAKING HYPHEN: try adding one of: yi, arabic, syloti-nagri</li>
 <li>U+2012 FIGURE DASH: not included in any glyphset definition</li>
 <li>U+2015 HORIZONTAL BAR: try adding adlam</li>
 <li>U+2016 DOUBLE VERTICAL LINE: try adding math</li>
@@ -340,7 +340,7 @@ definitions.</p>
 <li>U+204C BLACK LEFTWARDS BULLET: not included in any glyphset definition</li>
 <li>U+204D BLACK RIGHTWARDS BULLET: not included in any glyphset definition</li>
 <li>U+204E LOW ASTERISK: not included in any glyphset definition</li>
-<li>U+204F REVERSED SEMICOLON: try adding one of: arabic, adlam</li>
+<li>U+204F REVERSED SEMICOLON: try adding one of: adlam, arabic</li>
 <li>U+2050 CLOSE UP: try adding math</li>
 <li>U+2051 TWO ASTERISKS ALIGNED VERTICALLY: not included in any glyphset definition</li>
 <li>U+2052 COMMERCIAL MINUS SIGN: not included in any glyphset definition</li>
@@ -351,7 +351,7 @@ definitions.</p>
 <li>U+2057 QUADRUPLE PRIME: try adding math</li>
 <li>U+2058 FOUR DOT PUNCTUATION: try adding coptic</li>
 <li>U+2059 FIVE DOT PUNCTUATION: try adding coptic</li>
-<li>U+205A TWO DOT PUNCTUATION: try adding one of: old-turkic, carian, georgian, glagolitic, lycian, old-hungarian</li>
+<li>U+205A TWO DOT PUNCTUATION: try adding one of: carian, old-turkic, georgian, old-hungarian, glagolitic, lycian</li>
 <li>U+205B FOUR DOT MARK: not included in any glyphset definition</li>
 <li>U+205C DOTTED CROSS: not included in any glyphset definition</li>
 <li>U+205D TRICOLON: try adding one of: carian, meroitic-hieroglyphs, old-hungarian, meroitic</li>
@@ -535,14 +535,14 @@ definitions.</p>
 <li>U+2189 VULGAR FRACTION ZERO THIRDS: try adding symbols</li>
 <li>U+218A TURNED DIGIT TWO: try adding symbols</li>
 <li>U+218B TURNED DIGIT THREE: try adding symbols</li>
-<li>U+2190 LEFTWARDS ARROW: try adding one of: symbols, math</li>
-<li>U+2192 RIGHTWARDS ARROW: try adding one of: symbols, math</li>
-<li>U+2194 LEFT RIGHT ARROW: try adding one of: symbols, math</li>
-<li>U+2195 UP DOWN ARROW: try adding one of: symbols, math</li>
-<li>U+2196 NORTH WEST ARROW: try adding one of: symbols, math</li>
-<li>U+2197 NORTH EAST ARROW: try adding one of: symbols, math</li>
-<li>U+2198 SOUTH EAST ARROW: try adding one of: symbols, math</li>
-<li>U+2199 SOUTH WEST ARROW: try adding one of: symbols, math</li>
+<li>U+2190 LEFTWARDS ARROW: try adding one of: math, symbols</li>
+<li>U+2192 RIGHTWARDS ARROW: try adding one of: math, symbols</li>
+<li>U+2194 LEFT RIGHT ARROW: try adding one of: math, symbols</li>
+<li>U+2195 UP DOWN ARROW: try adding one of: math, symbols</li>
+<li>U+2196 NORTH WEST ARROW: try adding one of: math, symbols</li>
+<li>U+2197 NORTH EAST ARROW: try adding one of: math, symbols</li>
+<li>U+2198 SOUTH EAST ARROW: try adding one of: math, symbols</li>
+<li>U+2199 SOUTH WEST ARROW: try adding one of: math, symbols</li>
 <li>U+219A LEFTWARDS ARROW WITH STROKE: try adding math</li>
 <li>U+219B RIGHTWARDS ARROW WITH STROKE: try adding math</li>
 <li>U+219C LEFTWARDS WAVE ARROW: try adding math</li>
@@ -667,8 +667,8 @@ definitions.</p>
 <li>U+2214 DOT PLUS: try adding math</li>
 <li>U+2216 SET MINUS: try adding math</li>
 <li>U+2217 ASTERISK OPERATOR: try adding math</li>
-<li>U+2218 RING OPERATOR: try adding one of: symbols, math</li>
-<li>U+2219 BULLET OPERATOR: try adding one of: tai-tham, symbols, math, yi</li>
+<li>U+2218 RING OPERATOR: try adding one of: math, symbols</li>
+<li>U+2219 BULLET OPERATOR: try adding one of: math, symbols, yi, tai-tham</li>
 <li>U+221A SQUARE ROOT: try adding math</li>
 <li>U+221B CUBE ROOT: try adding math</li>
 <li>U+221C FOURTH ROOT: try adding math</li>
@@ -796,7 +796,7 @@ definitions.</p>
 <li>U+2296 CIRCLED MINUS: try adding math</li>
 <li>U+2297 CIRCLED TIMES: try adding math</li>
 <li>U+2298 CIRCLED DIVISION SLASH: try adding math</li>
-<li>U+2299 CIRCLED DOT OPERATOR: try adding one of: symbols, math</li>
+<li>U+2299 CIRCLED DOT OPERATOR: try adding one of: math, symbols</li>
 <li>U+229A CIRCLED RING OPERATOR: try adding math</li>
 <li>U+229B CIRCLED ASTERISK OPERATOR: try adding math</li>
 <li>U+229C CIRCLED EQUALS: try adding math</li>
@@ -839,9 +839,9 @@ definitions.</p>
 <li>U+22C1 N-ARY LOGICAL OR: try adding math</li>
 <li>U+22C2 N-ARY INTERSECTION: try adding math</li>
 <li>U+22C3 N-ARY UNION: try adding math</li>
-<li>U+22C4 DIAMOND OPERATOR: try adding one of: symbols, math</li>
-<li>U+22C5 DOT OPERATOR: try adding one of: symbols, math</li>
-<li>U+22C6 STAR OPERATOR: try adding one of: symbols, math</li>
+<li>U+22C4 DIAMOND OPERATOR: try adding one of: math, symbols</li>
+<li>U+22C5 DOT OPERATOR: try adding one of: math, symbols</li>
+<li>U+22C6 STAR OPERATOR: try adding one of: math, symbols</li>
 <li>U+22C7 DIVISION TIMES: try adding math</li>
 <li>U+22C8 BOWTIE: try adding math</li>
 <li>U+22C9 LEFT NORMAL FACTOR SEMIDIRECT PRODUCT: try adding math</li>
@@ -899,28 +899,28 @@ definitions.</p>
 <li>U+22FD CONTAINS WITH OVERBAR: try adding math</li>
 <li>U+22FE SMALL CONTAINS WITH OVERBAR: try adding math</li>
 <li>U+22FF Z NOTATION BAG MEMBERSHIP: try adding math</li>
-<li>U+2460 CIRCLED DIGIT ONE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2461 CIRCLED DIGIT TWO: try adding one of: yi, symbols, mongolian</li>
-<li>U+2462 CIRCLED DIGIT THREE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2463 CIRCLED DIGIT FOUR: try adding one of: yi, symbols, mongolian</li>
-<li>U+2464 CIRCLED DIGIT FIVE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2465 CIRCLED DIGIT SIX: try adding one of: yi, symbols, mongolian</li>
-<li>U+2466 CIRCLED DIGIT SEVEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2467 CIRCLED DIGIT EIGHT: try adding one of: yi, symbols, mongolian</li>
-<li>U+2468 CIRCLED DIGIT NINE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2469 CIRCLED NUMBER TEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246A CIRCLED NUMBER ELEVEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246B CIRCLED NUMBER TWELVE: try adding one of: yi, symbols, mongolian</li>
-<li>U+246C CIRCLED NUMBER THIRTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246D CIRCLED NUMBER FOURTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246E CIRCLED NUMBER FIFTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246F CIRCLED NUMBER SIXTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2470 CIRCLED NUMBER SEVENTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2471 CIRCLED NUMBER EIGHTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2472 CIRCLED NUMBER NINETEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2473 CIRCLED NUMBER TWENTY: try adding one of: yi, symbols, mongolian</li>
-<li>U+2474 PARENTHESIZED DIGIT ONE: try adding one of: symbols, math</li>
-<li>U+2475 PARENTHESIZED DIGIT TWO: try adding one of: symbols, math</li>
+<li>U+2460 CIRCLED DIGIT ONE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2461 CIRCLED DIGIT TWO: try adding one of: symbols, yi, mongolian</li>
+<li>U+2462 CIRCLED DIGIT THREE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2463 CIRCLED DIGIT FOUR: try adding one of: symbols, yi, mongolian</li>
+<li>U+2464 CIRCLED DIGIT FIVE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2465 CIRCLED DIGIT SIX: try adding one of: symbols, yi, mongolian</li>
+<li>U+2466 CIRCLED DIGIT SEVEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2467 CIRCLED DIGIT EIGHT: try adding one of: symbols, yi, mongolian</li>
+<li>U+2468 CIRCLED DIGIT NINE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2469 CIRCLED NUMBER TEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246A CIRCLED NUMBER ELEVEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246B CIRCLED NUMBER TWELVE: try adding one of: symbols, yi, mongolian</li>
+<li>U+246C CIRCLED NUMBER THIRTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246D CIRCLED NUMBER FOURTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246E CIRCLED NUMBER FIFTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246F CIRCLED NUMBER SIXTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2470 CIRCLED NUMBER SEVENTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2471 CIRCLED NUMBER EIGHTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2472 CIRCLED NUMBER NINETEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2473 CIRCLED NUMBER TWENTY: try adding one of: symbols, yi, mongolian</li>
+<li>U+2474 PARENTHESIZED DIGIT ONE: try adding one of: math, symbols</li>
+<li>U+2475 PARENTHESIZED DIGIT TWO: try adding one of: math, symbols</li>
 <li>U+2476 PARENTHESIZED DIGIT THREE: try adding symbols</li>
 <li>U+2477 PARENTHESIZED DIGIT FOUR: try adding symbols</li>
 <li>U+2478 PARENTHESIZED DIGIT FIVE: try adding symbols</li>
@@ -1059,7 +1059,7 @@ definitions.</p>
 <li>U+24FD DOUBLE CIRCLED DIGIT NINE: try adding symbols</li>
 <li>U+24FE DOUBLE CIRCLED NUMBER TEN: try adding symbols</li>
 <li>U+24FF NEGATIVE CIRCLED DIGIT ZERO: try adding symbols</li>
-<li>U+25CC DOTTED CIRCLE: try adding one of: syriac, armenian, tai-le, tamil, zanabazar-square, coptic, mende-kikakui, khudawadi, gujarati, kayah-li, music, mandaic, elbasan, manichaean, soyombo, tagbanwa, thaana, hanunoo, khojki, devanagari, tifinagh, meetei-mayek, pahawh-hmong, sharada, oriya, newa, kharoshthi, buhid, phags-pa, bassa-vah, balinese, canadian-aboriginal, kannada, symbols, psalter-pahlavi, bhaiksuki, rejang, old-permic, syloti-nagri, warang-citi, kaithi, siddham, sogdian, khmer, saurashtra, ahom, batak, new-tai-lue, dogra, math, sundanese, mongolian, lepcha, nko, tibetan, buginese, sinhala, caucasian-albanian, myanmar, malayalam, osage, tirhuta, lao, javanese, thai, chakma, mahajani, modi, masaram-gondi, brahmi, hanifi-rohingya, duployan, takri, miao, limbu, tagalog, tai-viet, telugu, yi, gurmukhi, wancho, marchen, hebrew, grantha, gunjala-gondi, bengali, adlam, cham, tai-tham</li>
+<li>U+25CC DOTTED CIRCLE: try adding one of: mahajani, manichaean, syriac, gunjala-gondi, khojki, siddham, math, symbols, tagalog, cham, marchen, newa, takri, buginese, mandaic, balinese, malayalam, oriya, thaana, khudawadi, wancho, limbu, tamil, javanese, psalter-pahlavi, yi, gurmukhi, sundanese, gujarati, lepcha, brahmi, tai-tham, sogdian, duployan, warang-citi, kayah-li, sinhala, batak, tagbanwa, bengali, tai-viet, devanagari, modi, bhaiksuki, telugu, saurashtra, kannada, hebrew, kharoshthi, soyombo, adlam, hanifi-rohingya, osage, phags-pa, tifinagh, tirhuta, myanmar, syloti-nagri, coptic, hanunoo, meetei-mayek, buhid, mende-kikakui, elbasan, mongolian, miao, thai, ahom, pahawh-hmong, tai-le, tibetan, canadian-aboriginal, bassa-vah, armenian, nko, khmer, chakma, lao, new-tai-lue, rejang, music, zanabazar-square, old-permic, grantha, sharada, caucasian-albanian, masaram-gondi, dogra, kaithi</li>
 <li>U+25CF BLACK CIRCLE: try adding symbols</li>
 <li>U+25EF LARGE CIRCLE: try adding symbols</li>
 <li>U+2776 DINGBAT NEGATIVE CIRCLED DIGIT ONE: try adding symbols</li>
@@ -1343,15 +1343,15 @@ subset declarations to METADATA.pb, or by editing the glyphset
 definitions.</p>
 <ul>
 <li>U+02CD MODIFIER LETTER LOW MACRON: try adding lisu</li>
-<li>U+02D8 BREVE: try adding one of: canadian-aboriginal, yi</li>
-<li>U+02D9 DOT ABOVE: try adding one of: canadian-aboriginal, yi</li>
-<li>U+02DB OGONEK: try adding one of: canadian-aboriginal, yi</li>
-<li>U+0302 COMBINING CIRCUMFLEX ACCENT: try adding one of: tifinagh, coptic, math, cherokee</li>
+<li>U+02D8 BREVE: try adding one of: yi, canadian-aboriginal</li>
+<li>U+02D9 DOT ABOVE: try adding one of: yi, canadian-aboriginal</li>
+<li>U+02DB OGONEK: try adding one of: yi, canadian-aboriginal</li>
+<li>U+0302 COMBINING CIRCUMFLEX ACCENT: try adding one of: math, coptic, tifinagh, cherokee</li>
 <li>U+0306 COMBINING BREVE: try adding one of: old-permic, tifinagh</li>
-<li>U+0307 COMBINING DOT ABOVE: try adding one of: old-permic, syriac, tifinagh, coptic, malayalam, math, tai-le, todhri, canadian-aboriginal, hebrew, duployan</li>
+<li>U+0307 COMBINING DOT ABOVE: try adding one of: old-permic, syriac, hebrew, todhri, coptic, tifinagh, tai-le, canadian-aboriginal, math, malayalam, duployan</li>
 <li>U+030A COMBINING RING ABOVE: try adding one of: syriac, duployan</li>
-<li>U+030B COMBINING DOUBLE ACUTE ACCENT: try adding one of: cherokee, osage</li>
-<li>U+030C COMBINING CARON: try adding one of: tai-le, cherokee</li>
+<li>U+030B COMBINING DOUBLE ACUTE ACCENT: try adding one of: osage, cherokee</li>
+<li>U+030C COMBINING CARON: try adding one of: cherokee, tai-le</li>
 <li>U+030D COMBINING VERTICAL LINE ABOVE: try adding sunuwar</li>
 <li>U+030F COMBINING DOUBLE GRAVE ACCENT: not included in any glyphset definition</li>
 <li>U+0311 COMBINING INVERTED BREVE: try adding one of: coptic, todhri</li>
@@ -1368,8 +1368,8 @@ definitions.</p>
 <li>U+032D COMBINING CIRCUMFLEX ACCENT BELOW: try adding one of: syriac, sunuwar</li>
 <li>U+032E COMBINING BREVE BELOW: try adding syriac</li>
 <li>U+032F COMBINING INVERTED BREVE BELOW: try adding math</li>
-<li>U+0330 COMBINING TILDE BELOW: try adding one of: syriac, math, cherokee</li>
-<li>U+0331 COMBINING MACRON BELOW: try adding one of: thai, syriac, gothic, sunuwar, tifinagh, cherokee, caucasian-albanian</li>
+<li>U+0330 COMBINING TILDE BELOW: try adding one of: math, syriac, cherokee</li>
+<li>U+0331 COMBINING MACRON BELOW: try adding one of: syriac, sunuwar, thai, caucasian-albanian, tifinagh, cherokee, gothic</li>
 <li>U+0337 COMBINING SHORT SOLIDUS OVERLAY: not included in any glyphset definition</li>
 <li>U+0338 COMBINING LONG SOLIDUS OVERLAY: try adding math</li>
 <li>U+0340 COMBINING GRAVE TONE MARK: not included in any glyphset definition</li>
@@ -1383,8 +1383,8 @@ definitions.</p>
 <li>U+1DC5 COMBINING GRAVE-MACRON: not included in any glyphset definition</li>
 <li>U+1DC6 COMBINING MACRON-GRAVE: not included in any glyphset definition</li>
 <li>U+1DC7 COMBINING ACUTE-MACRON: not included in any glyphset definition</li>
-<li>U+2010 HYPHEN: try adding one of: kharoshthi, syloti-nagri, lisu, kaithi, armenian, coptic, sundanese, cham, sora-sompeng, arabic, hebrew, yi, kayah-li</li>
-<li>U+2011 NON-BREAKING HYPHEN: try adding one of: arabic, syloti-nagri, yi</li>
+<li>U+2010 HYPHEN: try adding one of: sundanese, kayah-li, armenian, sora-sompeng, yi, hebrew, arabic, syloti-nagri, kaithi, lisu, coptic, kharoshthi, cham</li>
+<li>U+2011 NON-BREAKING HYPHEN: try adding one of: yi, arabic, syloti-nagri</li>
 <li>U+2012 FIGURE DASH: not included in any glyphset definition</li>
 <li>U+2015 HORIZONTAL BAR: try adding adlam</li>
 <li>U+2016 DOUBLE VERTICAL LINE: try adding math</li>
@@ -1422,7 +1422,7 @@ definitions.</p>
 <li>U+204C BLACK LEFTWARDS BULLET: not included in any glyphset definition</li>
 <li>U+204D BLACK RIGHTWARDS BULLET: not included in any glyphset definition</li>
 <li>U+204E LOW ASTERISK: not included in any glyphset definition</li>
-<li>U+204F REVERSED SEMICOLON: try adding one of: arabic, adlam</li>
+<li>U+204F REVERSED SEMICOLON: try adding one of: adlam, arabic</li>
 <li>U+2050 CLOSE UP: try adding math</li>
 <li>U+2051 TWO ASTERISKS ALIGNED VERTICALLY: not included in any glyphset definition</li>
 <li>U+2052 COMMERCIAL MINUS SIGN: not included in any glyphset definition</li>
@@ -1433,7 +1433,7 @@ definitions.</p>
 <li>U+2057 QUADRUPLE PRIME: try adding math</li>
 <li>U+2058 FOUR DOT PUNCTUATION: try adding coptic</li>
 <li>U+2059 FIVE DOT PUNCTUATION: try adding coptic</li>
-<li>U+205A TWO DOT PUNCTUATION: try adding one of: old-turkic, carian, georgian, glagolitic, lycian, old-hungarian</li>
+<li>U+205A TWO DOT PUNCTUATION: try adding one of: carian, old-turkic, georgian, old-hungarian, glagolitic, lycian</li>
 <li>U+205B FOUR DOT MARK: not included in any glyphset definition</li>
 <li>U+205C DOTTED CROSS: not included in any glyphset definition</li>
 <li>U+205D TRICOLON: try adding one of: carian, meroitic-hieroglyphs, old-hungarian, meroitic</li>
@@ -1617,14 +1617,14 @@ definitions.</p>
 <li>U+2189 VULGAR FRACTION ZERO THIRDS: try adding symbols</li>
 <li>U+218A TURNED DIGIT TWO: try adding symbols</li>
 <li>U+218B TURNED DIGIT THREE: try adding symbols</li>
-<li>U+2190 LEFTWARDS ARROW: try adding one of: symbols, math</li>
-<li>U+2192 RIGHTWARDS ARROW: try adding one of: symbols, math</li>
-<li>U+2194 LEFT RIGHT ARROW: try adding one of: symbols, math</li>
-<li>U+2195 UP DOWN ARROW: try adding one of: symbols, math</li>
-<li>U+2196 NORTH WEST ARROW: try adding one of: symbols, math</li>
-<li>U+2197 NORTH EAST ARROW: try adding one of: symbols, math</li>
-<li>U+2198 SOUTH EAST ARROW: try adding one of: symbols, math</li>
-<li>U+2199 SOUTH WEST ARROW: try adding one of: symbols, math</li>
+<li>U+2190 LEFTWARDS ARROW: try adding one of: math, symbols</li>
+<li>U+2192 RIGHTWARDS ARROW: try adding one of: math, symbols</li>
+<li>U+2194 LEFT RIGHT ARROW: try adding one of: math, symbols</li>
+<li>U+2195 UP DOWN ARROW: try adding one of: math, symbols</li>
+<li>U+2196 NORTH WEST ARROW: try adding one of: math, symbols</li>
+<li>U+2197 NORTH EAST ARROW: try adding one of: math, symbols</li>
+<li>U+2198 SOUTH EAST ARROW: try adding one of: math, symbols</li>
+<li>U+2199 SOUTH WEST ARROW: try adding one of: math, symbols</li>
 <li>U+219A LEFTWARDS ARROW WITH STROKE: try adding math</li>
 <li>U+219B RIGHTWARDS ARROW WITH STROKE: try adding math</li>
 <li>U+219C LEFTWARDS WAVE ARROW: try adding math</li>
@@ -1749,8 +1749,8 @@ definitions.</p>
 <li>U+2214 DOT PLUS: try adding math</li>
 <li>U+2216 SET MINUS: try adding math</li>
 <li>U+2217 ASTERISK OPERATOR: try adding math</li>
-<li>U+2218 RING OPERATOR: try adding one of: symbols, math</li>
-<li>U+2219 BULLET OPERATOR: try adding one of: tai-tham, symbols, math, yi</li>
+<li>U+2218 RING OPERATOR: try adding one of: math, symbols</li>
+<li>U+2219 BULLET OPERATOR: try adding one of: math, symbols, yi, tai-tham</li>
 <li>U+221A SQUARE ROOT: try adding math</li>
 <li>U+221B CUBE ROOT: try adding math</li>
 <li>U+221C FOURTH ROOT: try adding math</li>
@@ -1878,7 +1878,7 @@ definitions.</p>
 <li>U+2296 CIRCLED MINUS: try adding math</li>
 <li>U+2297 CIRCLED TIMES: try adding math</li>
 <li>U+2298 CIRCLED DIVISION SLASH: try adding math</li>
-<li>U+2299 CIRCLED DOT OPERATOR: try adding one of: symbols, math</li>
+<li>U+2299 CIRCLED DOT OPERATOR: try adding one of: math, symbols</li>
 <li>U+229A CIRCLED RING OPERATOR: try adding math</li>
 <li>U+229B CIRCLED ASTERISK OPERATOR: try adding math</li>
 <li>U+229C CIRCLED EQUALS: try adding math</li>
@@ -1921,9 +1921,9 @@ definitions.</p>
 <li>U+22C1 N-ARY LOGICAL OR: try adding math</li>
 <li>U+22C2 N-ARY INTERSECTION: try adding math</li>
 <li>U+22C3 N-ARY UNION: try adding math</li>
-<li>U+22C4 DIAMOND OPERATOR: try adding one of: symbols, math</li>
-<li>U+22C5 DOT OPERATOR: try adding one of: symbols, math</li>
-<li>U+22C6 STAR OPERATOR: try adding one of: symbols, math</li>
+<li>U+22C4 DIAMOND OPERATOR: try adding one of: math, symbols</li>
+<li>U+22C5 DOT OPERATOR: try adding one of: math, symbols</li>
+<li>U+22C6 STAR OPERATOR: try adding one of: math, symbols</li>
 <li>U+22C7 DIVISION TIMES: try adding math</li>
 <li>U+22C8 BOWTIE: try adding math</li>
 <li>U+22C9 LEFT NORMAL FACTOR SEMIDIRECT PRODUCT: try adding math</li>
@@ -1981,28 +1981,28 @@ definitions.</p>
 <li>U+22FD CONTAINS WITH OVERBAR: try adding math</li>
 <li>U+22FE SMALL CONTAINS WITH OVERBAR: try adding math</li>
 <li>U+22FF Z NOTATION BAG MEMBERSHIP: try adding math</li>
-<li>U+2460 CIRCLED DIGIT ONE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2461 CIRCLED DIGIT TWO: try adding one of: yi, symbols, mongolian</li>
-<li>U+2462 CIRCLED DIGIT THREE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2463 CIRCLED DIGIT FOUR: try adding one of: yi, symbols, mongolian</li>
-<li>U+2464 CIRCLED DIGIT FIVE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2465 CIRCLED DIGIT SIX: try adding one of: yi, symbols, mongolian</li>
-<li>U+2466 CIRCLED DIGIT SEVEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2467 CIRCLED DIGIT EIGHT: try adding one of: yi, symbols, mongolian</li>
-<li>U+2468 CIRCLED DIGIT NINE: try adding one of: yi, symbols, mongolian</li>
-<li>U+2469 CIRCLED NUMBER TEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246A CIRCLED NUMBER ELEVEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246B CIRCLED NUMBER TWELVE: try adding one of: yi, symbols, mongolian</li>
-<li>U+246C CIRCLED NUMBER THIRTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246D CIRCLED NUMBER FOURTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246E CIRCLED NUMBER FIFTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+246F CIRCLED NUMBER SIXTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2470 CIRCLED NUMBER SEVENTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2471 CIRCLED NUMBER EIGHTEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2472 CIRCLED NUMBER NINETEEN: try adding one of: yi, symbols, mongolian</li>
-<li>U+2473 CIRCLED NUMBER TWENTY: try adding one of: yi, symbols, mongolian</li>
-<li>U+2474 PARENTHESIZED DIGIT ONE: try adding one of: symbols, math</li>
-<li>U+2475 PARENTHESIZED DIGIT TWO: try adding one of: symbols, math</li>
+<li>U+2460 CIRCLED DIGIT ONE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2461 CIRCLED DIGIT TWO: try adding one of: symbols, yi, mongolian</li>
+<li>U+2462 CIRCLED DIGIT THREE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2463 CIRCLED DIGIT FOUR: try adding one of: symbols, yi, mongolian</li>
+<li>U+2464 CIRCLED DIGIT FIVE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2465 CIRCLED DIGIT SIX: try adding one of: symbols, yi, mongolian</li>
+<li>U+2466 CIRCLED DIGIT SEVEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2467 CIRCLED DIGIT EIGHT: try adding one of: symbols, yi, mongolian</li>
+<li>U+2468 CIRCLED DIGIT NINE: try adding one of: symbols, yi, mongolian</li>
+<li>U+2469 CIRCLED NUMBER TEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246A CIRCLED NUMBER ELEVEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246B CIRCLED NUMBER TWELVE: try adding one of: symbols, yi, mongolian</li>
+<li>U+246C CIRCLED NUMBER THIRTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246D CIRCLED NUMBER FOURTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246E CIRCLED NUMBER FIFTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+246F CIRCLED NUMBER SIXTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2470 CIRCLED NUMBER SEVENTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2471 CIRCLED NUMBER EIGHTEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2472 CIRCLED NUMBER NINETEEN: try adding one of: symbols, yi, mongolian</li>
+<li>U+2473 CIRCLED NUMBER TWENTY: try adding one of: symbols, yi, mongolian</li>
+<li>U+2474 PARENTHESIZED DIGIT ONE: try adding one of: math, symbols</li>
+<li>U+2475 PARENTHESIZED DIGIT TWO: try adding one of: math, symbols</li>
 <li>U+2476 PARENTHESIZED DIGIT THREE: try adding symbols</li>
 <li>U+2477 PARENTHESIZED DIGIT FOUR: try adding symbols</li>
 <li>U+2478 PARENTHESIZED DIGIT FIVE: try adding symbols</li>
@@ -2141,7 +2141,7 @@ definitions.</p>
 <li>U+24FD DOUBLE CIRCLED DIGIT NINE: try adding symbols</li>
 <li>U+24FE DOUBLE CIRCLED NUMBER TEN: try adding symbols</li>
 <li>U+24FF NEGATIVE CIRCLED DIGIT ZERO: try adding symbols</li>
-<li>U+25CC DOTTED CIRCLE: try adding one of: syriac, armenian, tai-le, tamil, zanabazar-square, coptic, mende-kikakui, khudawadi, gujarati, kayah-li, music, mandaic, elbasan, manichaean, soyombo, tagbanwa, thaana, hanunoo, khojki, devanagari, tifinagh, meetei-mayek, pahawh-hmong, sharada, oriya, newa, kharoshthi, buhid, phags-pa, bassa-vah, balinese, canadian-aboriginal, kannada, symbols, psalter-pahlavi, bhaiksuki, rejang, old-permic, syloti-nagri, warang-citi, kaithi, siddham, sogdian, khmer, saurashtra, ahom, batak, new-tai-lue, dogra, math, sundanese, mongolian, lepcha, nko, tibetan, buginese, sinhala, caucasian-albanian, myanmar, malayalam, osage, tirhuta, lao, javanese, thai, chakma, mahajani, modi, masaram-gondi, brahmi, hanifi-rohingya, duployan, takri, miao, limbu, tagalog, tai-viet, telugu, yi, gurmukhi, wancho, marchen, hebrew, grantha, gunjala-gondi, bengali, adlam, cham, tai-tham</li>
+<li>U+25CC DOTTED CIRCLE: try adding one of: mahajani, manichaean, syriac, gunjala-gondi, khojki, siddham, math, symbols, tagalog, cham, marchen, newa, takri, buginese, mandaic, balinese, malayalam, oriya, thaana, khudawadi, wancho, limbu, tamil, javanese, psalter-pahlavi, yi, gurmukhi, sundanese, gujarati, lepcha, brahmi, tai-tham, sogdian, duployan, warang-citi, kayah-li, sinhala, batak, tagbanwa, bengali, tai-viet, devanagari, modi, bhaiksuki, telugu, saurashtra, kannada, hebrew, kharoshthi, soyombo, adlam, hanifi-rohingya, osage, phags-pa, tifinagh, tirhuta, myanmar, syloti-nagri, coptic, hanunoo, meetei-mayek, buhid, mende-kikakui, elbasan, mongolian, miao, thai, ahom, pahawh-hmong, tai-le, tibetan, canadian-aboriginal, bassa-vah, armenian, nko, khmer, chakma, lao, new-tai-lue, rejang, music, zanabazar-square, old-permic, grantha, sharada, caucasian-albanian, masaram-gondi, dogra, kaithi</li>
 <li>U+25CF BLACK CIRCLE: try adding symbols</li>
 <li>U+25EF LARGE CIRCLE: try adding symbols</li>
 <li>U+2776 DINGBAT NEGATIVE CIRCLED DIGIT ONE: try adding symbols</li>

--- a/sources/ufo/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/ufo/Giphurs-ExtraBlack.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -8084,7 +8084,6 @@ lookup kern_Horizontal_kerning {
     pos @kc82_first_31 @kc82_second_12 -175;
     pos @kc82_first_31 @kc82_second_13 -270;
     pos @kc82_first_31 @kc82_second_17 -35;
-    pos @kc82_first_31 @kc82_second_21 -70;
     pos @kc82_first_31 @kc82_second_22 35;
     pos @kc82_first_31 @kc82_second_23 -140;
     pos @kc82_first_31 @kc82_second_24 -140;
@@ -8094,6 +8093,7 @@ lookup kern_Horizontal_kerning {
     pos @kc82_first_31 @kc82_second_39 -140;
     pos @kc82_first_31 @kc82_second_40 -175;
     pos @kc82_first_32 @kc82_second_1 -35;
+    pos @kc82_first_32 @kc82_second_2 -70;
     pos @kc82_first_32 @kc82_second_4 -70;
     pos @kc82_first_32 @kc82_second_6 -140;
     pos @kc82_first_32 @kc82_second_7 -140;
@@ -8101,6 +8101,7 @@ lookup kern_Horizontal_kerning {
     pos @kc82_first_32 @kc82_second_9 -70;
     pos @kc82_first_32 @kc82_second_10 -35;
     pos @kc82_first_32 @kc82_second_12 -35;
+    pos @kc82_first_32 @kc82_second_13 -70;
     pos @kc82_first_32 @kc82_second_15 -70;
     pos @kc82_first_32 @kc82_second_16 -140;
     pos @kc82_first_32 @kc82_second_20 -70;
@@ -11448,6 +11449,7 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
+#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 

--- a/sources/ufo/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/ufo/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/12/20 10:05:39</string>
+    <string>2025/02/24 17:55:02</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/ufo/Giphurs-Regular.ufo/features.fea
+++ b/sources/ufo/Giphurs-Regular.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -8071,8 +8071,6 @@ lookup kern_Horizontal_kerning {
     pos @kc82_first_31 @kc82_second_12 -140;
     pos @kc82_first_31 @kc82_second_13 -210;
     pos @kc82_first_31 @kc82_second_17 -70;
-    pos @kc82_first_31 @kc82_second_21 -210;
-    pos @kc82_first_31 @kc82_second_22 35;
     pos @kc82_first_31 @kc82_second_24 -210;
     pos @kc82_first_31 @kc82_second_29 -210;
     pos @kc82_first_31 @kc82_second_36 -140;
@@ -8087,12 +8085,14 @@ lookup kern_Horizontal_kerning {
     pos @kc82_first_32 @kc82_second_9 -70;
     pos @kc82_first_32 @kc82_second_10 -35;
     pos @kc82_first_32 @kc82_second_12 -35;
+    pos @kc82_first_32 @kc82_second_13 -70;
     pos @kc82_first_32 @kc82_second_15 -70;
     pos @kc82_first_32 @kc82_second_16 -140;
     pos @kc82_first_32 @kc82_second_20 -70;
     pos @kc82_first_32 @kc82_second_28 -140;
     pos @kc82_first_32 @kc82_second_31 -70;
     pos @kc82_first_32 @kc82_second_33 -70;
+    pos @kc82_first_32 @kc82_second_36 -70;
     pos @kc82_first_32 @kc82_second_42 -35;
     pos @kc82_first_32 @kc82_second_44 -35;
     pos @kc82_first_32 @kc82_second_45 -35;
@@ -11036,6 +11036,7 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
+#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 

--- a/sources/ufo/Giphurs-Regular.ufo/fontinfo.plist
+++ b/sources/ufo/Giphurs-Regular.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/12/20 10:05:30</string>
+    <string>2025/02/24 17:47:13</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/ufo/Giphurs-Thin.ufo/features.fea
+++ b/sources/ufo/Giphurs-Thin.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -8089,7 +8089,6 @@ lookup kern_Horizontal_kerning {
     pos @kc82_first_31 @kc82_second_13 -280;
     pos @kc82_first_31 @kc82_second_17 -70;
     pos @kc82_first_31 @kc82_second_18 -35;
-    pos @kc82_first_31 @kc82_second_21 -140;
     pos @kc82_first_31 @kc82_second_22 35;
     pos @kc82_first_31 @kc82_second_23 -70;
     pos @kc82_first_31 @kc82_second_24 -140;
@@ -8106,6 +8105,7 @@ lookup kern_Horizontal_kerning {
     pos @kc82_first_32 @kc82_second_9 -70;
     pos @kc82_first_32 @kc82_second_10 -35;
     pos @kc82_first_32 @kc82_second_12 -35;
+    pos @kc82_first_32 @kc82_second_13 -140;
     pos @kc82_first_32 @kc82_second_15 -70;
     pos @kc82_first_32 @kc82_second_16 -140;
     pos @kc82_first_32 @kc82_second_20 -70;
@@ -10924,6 +10924,7 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
+#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 

--- a/sources/ufo/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/ufo/Giphurs-Thin.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2024/12/20 10:05:17</string>
+    <string>2025/02/24 17:54:05</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>


### PR DESCRIPTION
Fixes the kerning with the letter f on the left being too high with some glyphs (for example with `fu`), and thus on all weights

There are also some fixes with round glyphs such as `O` or `G.cv21` as small caps with `Æ`.