### PR TITLE
Add font proofing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 _misc
 py
 fonts-backup/
+output/proof/
 sources/__pycache__
 sources/instance_ufos/
 sources/sfd_cleaned/

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,6 @@ font_name := Giphurs
 # If the version is 1.000 or above
 font_version := $(shell echo $(shell echo "scale=3;("$(shell echo $(shell fc-query -f '%{fontversion}\n' fonts/otf/Giphurs-Regular.otf)"+16" | bc)"/65536)" | bc))
 
-# Output directory of make tests (Don't put the '/' at the end!)
-tests_output_dir := output
-
-
 # documentaton
 help:
 	@echo "Available make commands:"
@@ -19,7 +15,8 @@ help:
 	@echo "  * make clean_fonts  : Empties the current fonts/ folder."
 	@echo "  * make export_fonts : Export fonts/ directory into a zip file."
 	@echo "  * make fonts        : Generate font binaries from UFO sources."
-	@echo "  * make tests -i     : Runs automated tests (output at the $(tests_output_dir)/ folder ). -i option is mandatory."
+	@echo "  * make proof        : Creates HTML proof (in output/proof/) directory"
+	@echo "  * make tests -i     : Runs automated tests (in output/ folder ). -i option is mandatory."
 	@echo "UFO sources scripts"
 	@echo "  * make ufo_accented_glyphs            : Build accented glyphs (the UFO files must be opened and exported throught Fontforge after)."
 	@echo "  * make ufo_composite_glyphs           : Build composite glyphs (the UFO files must be opened and exported throught Fontforge after, and accented glyphs has to be already built)."

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ export_fonts:
 fonts: sources/ufo
 	./sources/build_fonts.sh
 
+# create HTML specimens of the (variable) fonts
+proof: fonts/
+	./sources/proof.sh
+
 # run fontbakery tests
 tests:
 	./sources/tests.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+diffenator2>=0.3.8
 fontbakery>=0.12.7
 fontmake>=3.9
 gftools[qa]>=0.9

--- a/sources/proof.sh
+++ b/sources/proof.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# without '/' !!!
+FONT_FILES=$(find fonts/variable -type f)
+OUTPUT_DIR="output/proof"
+
+PROOF_START_TIME=$(date +%s)
+
+mkdir -p $OUTPUT_DIR
+
+if [ -z FONT_FILES ]
+then
+    echo -e "\x1b[0;33mWARNING: No font files found to make proof.\x1b[0;0m"
+else
+    diffenator2 proof $FONT_FILES -o $OUTPUT_DIR
+fi
+
+PROOF_END_TIME=$(date +%s)
+PROOF_DURATION=$(($PROOF_END_TIME-$PROOF_START_TIME))
+echo -e "\x1b[1;32mProofs done succesfully in "$PROOF_DURATION" second(s) UwU\x1b[0;0m"


### PR DESCRIPTION
*Idea copied https://github.com/googlefonts/googlefonts-project-template*

This allows to have HTML specimens of the font, giving another way to see if the font looks ass or not. The result is at `output/proof`, which I don't include in the repo. It checks only variable ttf files which generates instances for each weight.

![image](https://github.com/user-attachments/assets/4e286ddc-9f94-43b8-b1d1-87cfac4c6a25)

You can test the fonts with `make proof` :)