### PR TITLE
Add uni20C0, uni27F0 and uni27F1

### DIFF
--- a/sources/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlack.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -11577,42 +11577,42 @@ feature mkmk {
 	\uni20A0 \colonmonetary \uni20A2 \franc \lira \uni20A5 \uni20A6 \peseta \uni20A8 
 	\uni20A9 \uni20AA \dong \Euro \uni20AD \uni20AE \uni20AF \uni20B0 \uni20B1 
 	\uni20B2 \uni20B3 \uni20B4 \uni20B5 \uni20B6 \uni20B7 \uni20B8 \uni20B9 \uni20BA 
-	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni2100 \uni2101 \uni2102 \uni2105 
-	\uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 \uni2141 
-	\uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 \uni2124 
-	\uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 \uni211B 
-	\Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 \uni2133 
-	\uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 \uni2116 
-	\uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 \trademark 
-	\uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 \uni212A 
-	\uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 \uni2138 
-	\uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D \uni217E 
-	\uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 \uni2174 
-	\uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 \uni2188 
-	\uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 \uni2197 
-	\uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 \uni21A2 
-	\uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 \uni21AB 
-	\uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 \uni21B1 
-	\uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 \uni21E4 
-	\uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF \uni21C0 
-	\uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 \uni21C8 
-	\uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 \uni21D6 
-	\uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC \uni21DD 
-	\uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 \uni21E7 
-	\uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 \uni21F1 
-	\uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 \uni21FA 
-	\uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 \partialdiff 
-	\existential \uni2204 \emptyset \Delta \gradient \element \uni220A \notelement 
-	\suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation \minus 
-	\uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 \radical 
-	\uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 \uni2222 
-	\uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor \integral 
-	\logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 \uni2232 
-	\uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 \uni223A 
-	\uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 \uni2242 
-	\uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D \uni224F 
-	\uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
-	\uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
+	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni20C0 \uni2100 \uni2101 \uni2102 
+	\uni2105 \uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 
+	\uni2141 \uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 
+	\uni2124 \uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 
+	\uni211B \Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 
+	\uni2133 \uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 
+	\uni2116 \uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 
+	\trademark \uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 
+	\uni212A \uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 
+	\uni2138 \uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D 
+	\uni217E \uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 
+	\uni2174 \uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 
+	\uni2188 \uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 
+	\uni2197 \uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 
+	\uni21A2 \uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 
+	\uni21AB \uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 
+	\uni21B1 \uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 
+	\uni21E4 \uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF 
+	\uni21C0 \uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 
+	\uni21C8 \uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 
+	\uni21D6 \uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC 
+	\uni21DD \uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 
+	\uni21E7 \uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 
+	\uni21F1 \uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 
+	\uni21FA \uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 
+	\partialdiff \existential \uni2204 \emptyset \Delta \gradient \element \uni220A 
+	\notelement \suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation 
+	\minus \uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 
+	\radical \uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 
+	\uni2222 \uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor 
+	\integral \logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 
+	\uni2232 \uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 
+	\uni223A \uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 
+	\uni2242 \uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D 
+	\uni224F \uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 
+	\uni2257 \uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
 	\equivalence \uni2262 \uni2263 \lessequal \greaterequal \uni2266 \uni2267 
 	\uni2268 \uni2269 \uni226A \uni226B \uni226C \uni2272 \uni2273 \uni2276 \uni2277 
 	\uni226E \uni226F \uni227A \uni227B \uni227C \uni227D \uni227E \uni227F 
@@ -11656,175 +11656,175 @@ feature mkmk {
 	\uni24A5 \uni24A6 \uni24A7 \uni24A8 \uni24A9 \uni24AA \uni24AB \uni24AC \uni24AD 
 	\uni24AE \uni24AF \uni24B0 \uni24B1 \uni24B2 \uni24B3 \uni24B4 \uni24B5 \uni24F5 
 	\uni24F6 \uni24F7 \uni24F8 \uni24F9 \uni24FA \uni24FB \uni24FC \uni24FD \uni24FE 
-	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni1F00 \uni1F01 
-	\uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 \uni1F09 \uni1F0A 
-	\uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 \uni1F12 \uni1F13 
-	\uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C \uni1F1D \uni1F20 
-	\uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 \uni1F28 \uni1F29 
-	\uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 \uni1F31 \uni1F32 
-	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 \uni1F3A \uni1F3B 
-	\uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 
-	\uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D \uni1F50 \uni1F51 
-	\uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 \uni1F5B \uni1F5D 
-	\uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 
-	\uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1F70 
-	\uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 \uni1F78 \uni1F79 
-	\uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
-	\uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C \uni1F8D \uni1F8E 
-	\uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 \uni1F96 \uni1F97 
-	\uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E \uni1F9F \uni1FA0 
-	\uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 \uni1FA8 \uni1FA9 
-	\uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 \uni1FB0 \uni1FB1 
-	\uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 \uni1FBA \uni1FBC 
-	\uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 \uni1FCA \uni1FCC 
-	\uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 \uni1FDA \uni1FCB 
-	\uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 \uni1FE7 \uni1FE3 
-	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 
-	\uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB \uni1FC9 \uni2E17 
-	\uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 \uni214C \omicron 
-	\uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 \uni2C65 \uni2C66 
-	\uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE \uni1D49 \uni1D43 
-	\uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 \uni2C6D \uni2C72 
-	\uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 \uni1D7D \uniA7B4 
-	\uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc \j.sc \k.sc \l.sc 
-	\m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc \x.sc \y.sc \z.sc 
-	\agrave.sc \aacute.sc \acircumflex.sc \atilde.sc \adieresis.sc \aring.sc 
-	\ae.sc \ccedilla.sc \egrave.sc \eacute.sc \ecircumflex.sc \edieresis.sc 
-	\igrave.sc \iacute.sc \icircumflex.sc \idieresis.sc \ntilde.sc \ograve.sc 
-	\oacute.sc \ocircumflex.sc \otilde.sc \odieresis.sc \oslash.sc \ugrave.sc 
-	\uacute.sc \ucircumflex.sc \udieresis.sc \yacute.sc \thorn.sc \ydieresis.sc 
-	\amacron.sc \abreve.sc \aogonek.sc \cacute.sc \ccircumflex.sc \cdotaccent.sc 
-	\ccaron.sc \dcaron.sc \dcroat.sc \emacron.sc \ebreve.sc \edotaccent.sc 
-	\eogonek.sc \ecaron.sc \gcircumflex.sc \gbreve.sc \gdotaccent.sc 
-	\gcommaaccent.sc \hcircumflex.sc \hbar.sc \itilde.sc \imacron.sc \ibreve.sc 
-	\iogonek.sc \ij.sc \jcircumflex.sc \kcommaaccent.sc \kgreenlandic.sc 
-	\lacute.sc \lcommaaccent.sc \lcaron.sc \ldot.sc \lslash.sc \nacute.sc 
-	\ncommaaccent.sc \ncaron.sc \napostrophe.sc \eng.sc \omacron.sc \obreve.sc 
-	\ohungarumlaut.sc \oe.sc \racute.sc \rcommaaccent.sc \rcaron.sc \sacute.sc 
-	\scircumflex.sc \scedilla.sc \scaron.sc \uni0163.sc \tcaron.sc \tbar.sc 
-	\utilde.sc \umacron.sc \ubreve.sc \uring.sc \uhungarumlaut.sc \uogonek.sc 
-	\wcircumflex.sc \ycircumflex.sc \zacute.sc \zdotaccent.sc \zcaron.sc 
-	\uni0180.sc \uni0183.sc \uni0185.sc \uni0188.sc \uni018C.sc \florin.sc 
-	\uni0195.sc \uni0199.sc \uni019A.sc \uni019B.sc \uni019E.sc \ohorn.sc 
-	\uni01A3.sc \uni01A5.sc \uni01A8.sc \uni01AB.sc \uni01AD.sc \uhorn.sc 
-	\uni01B4.sc \uni01B6.sc \uni01B9.sc \uni01BD.sc \uni01BF.sc \uni01C5.sc 
-	\uni01C6.sc \uni01C8.sc \uni01C9.sc \uni01CB.sc \uni01CC.sc \uni01CE.sc 
-	\uni01D0.sc \uni01D2.sc \uni01D4.sc \uni01D6.sc \uni01D8.sc \uni01DA.sc 
-	\uni01DC.sc \uni01DD.sc \uni01DF.sc \uni01E1.sc \uni01E3.sc \uni01E5.sc 
-	\gcaron.sc \uni01E9.sc \uni01EB.sc \uni01ED.sc \uni01F0.sc \uni01F2.sc 
-	\uni01F3.sc \uni01F5.sc \uni01F9.sc \aringacute.sc \aeacute.sc 
-	\oslashacute.sc \uni0201.sc \uni0203.sc \uni0205.sc \uni0207.sc \uni0209.sc 
-	\uni020B.sc \uni020D.sc \uni020F.sc \uni0211.sc \uni0213.sc \uni0215.sc 
-	\uni0217.sc \scommaaccent.sc \uni021B.sc \uni021D.sc \uni021F.sc \uni0221.sc 
-	\uni0223.sc \uni0225.sc \uni0227.sc \uni0229.sc \uni022B.sc \uni022D.sc 
-	\uni022F.sc \uni0231.sc \uni0233.sc \uni0234.sc \uni0235.sc \uni0236.sc 
-	\uni0237.sc \uni023C.sc \uni0242.sc \uni0247.sc \uni0249.sc \uni024B.sc 
-	\uni024D.sc \uni024F.sc \uni0250.sc \uni0251.sc \uni0253.sc \uni0254.sc 
-	\uni0256.sc \uni0257.sc \uni0259.sc \uni025B.sc \uni0260.sc \uni0263.sc 
-	\uni0264.sc \uni0266.sc \uni0268.sc \uni0269.sc \uni026A.sc \uni026F.sc 
-	\uni0272.sc \uni0275.sc \uni027D.sc \uni0283.sc \uni0288.sc \uni0289.sc 
-	\uni028A.sc \uni028B.sc \uni028C.sc \uni0292.sc \uni0298.sc \uni029D.sc 
-	\uni02A3.sc \uni02A4.sc \uni02A5.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni02A9.sc \uni02AA.sc \uni02AB.sc \uni0377.sc \uni037B.sc \uni037C.sc 
-	\uni037D.sc \iotadieresistonos.sc \alphatonos.sc \epsilontonos.sc 
-	\etatonos.sc \iotatonos.sc \upsilondieresistonos.sc \alpha.sc \beta.sc 
-	\gamma.sc \delta.sc \epsilon.sc \zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc 
-	\lambda.sc \uni03BC.sc \nu.sc \xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc 
-	\tau.sc \upsilon.sc \phi.sc \chi.sc \psi.sc \omega.sc \iotadieresis.sc 
-	\upsilondieresis.sc \omicrontonos.sc \upsilontonos.sc \omegatonos.sc 
-	\uni03D9.sc \uni03DB.sc \uni03DD.sc \uni03F2.sc \uni03F3.sc \uni03F8.sc 
-	\uni03FC.sc \uni0430.sc \uni0431.sc \uni0432.sc \uni0433.sc \uni0434.sc 
-	\uni0435.sc \uni0436.sc \uni0437.sc \uni0438.sc \uni0439.sc \uni043A.sc 
-	\uni043B.sc \uni043C.sc \uni043D.sc \uni043E.sc \uni043F.sc \uni0440.sc 
-	\uni0441.sc \uni0442.sc \uni0443.sc \uni0444.sc \uni0445.sc \uni0446.sc 
-	\uni0447.sc \uni0448.sc \uni0449.sc \uni044A.sc \uni044B.sc \uni044C.sc 
-	\uni044D.sc \uni044E.sc \uni044F.sc \uni0450.sc \uni0451.sc \uni0452.sc 
-	\uni0453.sc \uni0454.sc \uni0455.sc \uni0456.sc \uni0457.sc \uni0458.sc 
-	\uni0459.sc \uni045A.sc \uni045B.sc \uni045C.sc \uni045D.sc \uni045E.sc 
-	\uni045F.sc \uni0461.sc \uni0463.sc \uni0465.sc \uni0467.sc \uni0469.sc 
-	\uni046B.sc \uni046D.sc \uni046F.sc \uni0471.sc \uni0473.sc \uni0475.sc 
-	\uni0477.sc \uni047B.sc \uni047D.sc \uni047F.sc \uni0481.sc \uni048B.sc 
-	\uni048D.sc \uni048F.sc \uni0491.sc \uni0493.sc \uni0495.sc \uni0497.sc 
-	\uni0499.sc \uni049B.sc \uni049D.sc \uni049F.sc \uni04A1.sc \uni04A3.sc 
-	\uni04A5.sc \uni04A7.sc \uni04A9.sc \uni04AB.sc \uni04AD.sc \uni04AF.sc 
-	\uni04B1.sc \uni04B3.sc \uni04B5.sc \uni04B7.sc \uni04B9.sc \uni04BB.sc 
-	\uni04BD.sc \uni04BF.sc \uni04C2.sc \uni04C4.sc \uni04C6.sc \uni04C8.sc 
-	\uni04CA.sc \uni04CC.sc \uni04CE.sc \uni04D1.sc \uni04D3.sc \uni04D5.sc 
-	\uni04D7.sc \uni04D9.sc \uni04DB.sc \uni04DD.sc \uni04DF.sc \uni04E3.sc 
-	\uni04E5.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni04ED.sc \uni04EF.sc 
-	\uni04F1.sc \uni04F3.sc \uni04F5.sc \uni04F7.sc \uni04F9.sc \uni04FB.sc 
-	\uni04FD.sc \uni04FF.sc \uni0501.sc \uni0503.sc \uni0505.sc \uni0507.sc 
-	\uni0509.sc \uni050B.sc \uni050D.sc \uni050F.sc \uni0511.sc \uni0513.sc 
-	\uni0515.sc \uni0517.sc \uni0519.sc \uni051B.sc \uni051D.sc \uni051F.sc 
-	\uni0521.sc \uni0523.sc \uni0525.sc \uni0527.sc \uni0529.sc \uni052B.sc 
-	\uni052D.sc \uni052F.sc \uni1D7D.sc \uni1E01.sc \uni1E03.sc \uni1E05.sc 
-	\uni1E07.sc \uni1E09.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc \uni1E11.sc 
-	\uni1E13.sc \uni1E15.sc \uni1E17.sc \uni1E19.sc \uni1E1B.sc \uni1E1D.sc 
-	\uni1E1F.sc \uni1E21.sc \uni1E23.sc \uni1E25.sc \uni1E27.sc \uni1E29.sc 
-	\uni1E2B.sc \uni1E2D.sc \uni1E2F.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc 
-	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc \uni1E3F.sc \uni1E41.sc 
-	\uni1E43.sc \uni1E45.sc \uni1E47.sc \uni1E49.sc \uni1E4B.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1E55.sc \uni1E57.sc \uni1E59.sc 
-	\uni1E5B.sc \uni1E5D.sc \uni1E5F.sc \uni1E61.sc \uni1E63.sc \uni1E65.sc 
-	\uni1E67.sc \uni1E69.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc 
-	\uni1E73.sc \uni1E75.sc \uni1E77.sc \uni1E79.sc \uni1E7B.sc \uni1E7D.sc 
-	\uni1E7F.sc \wgrave.sc \wacute.sc \wdieresis.sc \uni1E87.sc \uni1E89.sc 
-	\uni1E8B.sc \uni1E8D.sc \uni1E8F.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc 
-	\uni1E96.sc \uni1E97.sc \uni1E98.sc \uni1E99.sc \uni1E9A.sc \germandbls.sc 
-	\uni1E9F.sc \uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc \uni1EA9.sc 
-	\uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc \uni1EB3.sc \uni1EB5.sc 
-	\uni1EB7.sc \uni1EB9.sc \uni1EBB.sc \uni1EBD.sc \uni1EBF.sc \uni1EC1.sc 
-	\uni1EC3.sc \uni1EC5.sc \uni1EC7.sc \uni1EC9.sc \uni1ECB.sc \uni1ECD.sc 
-	\uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc \uni1EE5.sc 
-	\uni1EE7.sc \uni1EE9.sc \uni1EEB.sc \uni1EED.sc \uni1EEF.sc \uni1EF1.sc 
-	\ygrave.sc \uni1EF5.sc \uni1EF7.sc \uni1EF9.sc \uni1EFB.sc \uni1EFD.sc 
-	\uni1EFF.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc \uni1F03.sc \uni1F04.sc 
-	\uni1F05.sc \uni1F06.sc \uni1F07.sc \uni1F10.sc \uni1F11.sc \uni1F12.sc 
-	\uni1F13.sc \uni1F14.sc \uni1F15.sc \uni1F20.sc \uni1F21.sc \uni1F22.sc 
-	\uni1F23.sc \uni1F24.sc \uni1F25.sc \uni1F26.sc \uni1F27.sc \uni1F30.sc 
-	\uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
-	\uni1F37.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc \uni1F54.sc 
-	\uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc 
-	\uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F70.sc 
-	\uni1F71.sc \uni1F72.sc \uni1F73.sc \uni1F74.sc \uni1F75.sc \uni1F76.sc 
-	\uni1F77.sc \uni1F78.sc \uni1F79.sc \uni1F7A.sc \uni1F7B.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1F80.sc \uni1F81.sc \uni1F82.sc \uni1F83.sc \uni1F84.sc 
-	\uni1F85.sc \uni1F86.sc \uni1F87.sc \uni1F90.sc \uni1F91.sc \uni1F92.sc 
-	\uni1F93.sc \uni1F94.sc \uni1F95.sc \uni1F96.sc \uni1F97.sc \uni1FA0.sc 
-	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc \uni1FB4.sc 
-	\uni1FB6.sc \uni1FB7.sc \uni1FC2.sc \uni1FC3.sc \uni1FC4.sc \uni1FC6.sc 
-	\uni1FC7.sc \uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni1FE0.sc \uni1FE1.sc \uni1FE2.sc \uni1FE3.sc \uni1FE4.sc 
-	\uni1FE5.sc \uni1FE6.sc \uni1FE7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
-	\uni1FF6.sc \uni1FF7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \uni2178.sc \uni2179.sc 
-	\uni217A.sc \uni217B.sc \uni217C.sc \uni217D.sc \uni217E.sc \uni217F.sc 
-	\uni2C73.sc \uniA78C.sc \uniA7B5.sc \uniA7B7.sc \uniA7C8.sc \zero.pnum 
-	\one.pnum \two.pnum \three.pnum \four.pnum \five.pnum \six.pnum \seven.pnum 
-	\eight.pnum \nine.pnum \zero.tnum \one.tnum \two.tnum \three.tnum \four.tnum 
-	\five.tnum \six.tnum \seven.tnum \eight.tnum \nine.tnum \zero.onum \one.onum 
-	\two.onum \three.onum \four.onum \five.onum \six.onum \seven.onum \eight.onum 
-	\nine.onum \zero.onum.tnum \one.onum.tnum \two.onum.tnum \three.onum.tnum 
-	\four.onum.tnum \five.onum.tnum \six.onum.tnum \seven.onum.tnum 
-	\eight.onum.tnum \nine.onum.tnum \zero.numr \one.numr \two.numr \three.numr 
-	\four.numr \five.numr \six.numr \seven.numr \eight.numr \nine.numr \zero.dnom 
-	\one.dnom \two.dnom \three.dnom \four.dnom \five.dnom \six.dnom \seven.dnom 
-	\eight.dnom \nine.dnom \zero.superior.pnum \one.superior.pnum 
-	\two.superior.pnum \three.superior.pnum \four.superior.pnum 
-	\five.superior.pnum \six.superior.pnum \seven.superior.pnum 
-	\eight.superior.pnum \nine.superior.pnum \zero.subscript.pnum 
-	\one.subscript.pnum \two.subscript.pnum \three.subscript.pnum 
-	\four.subscript.pnum \five.subscript.pnum \six.subscript.pnum 
-	\seven.subscript.pnum \eight.subscript.pnum \nine.subscript.pnum 
-	\zero.numr.pnum \one.numr.pnum \two.numr.pnum \three.numr.pnum 
-	\four.numr.pnum \five.numr.pnum \six.numr.pnum \seven.numr.pnum 
-	\eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum \one.dnom.pnum 
-	\two.dnom.pnum \three.dnom.pnum \four.dnom.pnum \five.dnom.pnum 
-	\six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum \nine.dnom.pnum 
-	\zero.superior.tnum \one.superior.tnum \two.superior.tnum 
+	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni27F0 \uni27F1 
+	\uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 
+	\uni1F09 \uni1F0A \uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 
+	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C 
+	\uni1F1D \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 
+	\uni1F28 \uni1F29 \uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 
+	\uni1F31 \uni1F32 \uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 
+	\uni1F3A \uni1F3B \uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 
+	\uni1F43 \uni1F44 \uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
+	\uni1F50 \uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 
+	\uni1F5B \uni1F5D \uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 
+	\uni1F66 \uni1F67 \uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E 
+	\uni1F6F \uni1F70 \uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 
+	\uni1F78 \uni1F79 \uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 
+	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C 
+	\uni1F8D \uni1F8E \uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 
+	\uni1F96 \uni1F97 \uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E 
+	\uni1F9F \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 
+	\uni1FA8 \uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 
+	\uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 
+	\uni1FBA \uni1FBC \uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 
+	\uni1FCA \uni1FCC \uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 
+	\uni1FDA \uni1FCB \uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 
+	\uni1FE7 \uni1FE3 \uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 
+	\uni1FF4 \uni1FF6 \uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB 
+	\uni1FC9 \uni2E17 \uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 
+	\uni214C \omicron \uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 
+	\uni2C65 \uni2C66 \uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE 
+	\uni1D49 \uni1D43 \uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 
+	\uni2C6D \uni2C72 \uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 
+	\uni1D7D \uniA7B4 \uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc 
+	\j.sc \k.sc \l.sc \m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc 
+	\x.sc \y.sc \z.sc \agrave.sc \aacute.sc \acircumflex.sc \atilde.sc 
+	\adieresis.sc \aring.sc \ae.sc \ccedilla.sc \egrave.sc \eacute.sc 
+	\ecircumflex.sc \edieresis.sc \igrave.sc \iacute.sc \icircumflex.sc 
+	\idieresis.sc \ntilde.sc \ograve.sc \oacute.sc \ocircumflex.sc \otilde.sc 
+	\odieresis.sc \oslash.sc \ugrave.sc \uacute.sc \ucircumflex.sc \udieresis.sc 
+	\yacute.sc \thorn.sc \ydieresis.sc \amacron.sc \abreve.sc \aogonek.sc 
+	\cacute.sc \ccircumflex.sc \cdotaccent.sc \ccaron.sc \dcaron.sc \dcroat.sc 
+	\emacron.sc \ebreve.sc \edotaccent.sc \eogonek.sc \ecaron.sc \gcircumflex.sc 
+	\gbreve.sc \gdotaccent.sc \gcommaaccent.sc \hcircumflex.sc \hbar.sc 
+	\itilde.sc \imacron.sc \ibreve.sc \iogonek.sc \ij.sc \jcircumflex.sc 
+	\kcommaaccent.sc \kgreenlandic.sc \lacute.sc \lcommaaccent.sc \lcaron.sc 
+	\ldot.sc \lslash.sc \nacute.sc \ncommaaccent.sc \ncaron.sc \napostrophe.sc 
+	\eng.sc \omacron.sc \obreve.sc \ohungarumlaut.sc \oe.sc \racute.sc 
+	\rcommaaccent.sc \rcaron.sc \sacute.sc \scircumflex.sc \scedilla.sc 
+	\scaron.sc \uni0163.sc \tcaron.sc \tbar.sc \utilde.sc \umacron.sc \ubreve.sc 
+	\uring.sc \uhungarumlaut.sc \uogonek.sc \wcircumflex.sc \ycircumflex.sc 
+	\zacute.sc \zdotaccent.sc \zcaron.sc \uni0180.sc \uni0183.sc \uni0185.sc 
+	\uni0188.sc \uni018C.sc \florin.sc \uni0195.sc \uni0199.sc \uni019A.sc 
+	\uni019B.sc \uni019E.sc \ohorn.sc \uni01A3.sc \uni01A5.sc \uni01A8.sc 
+	\uni01AB.sc \uni01AD.sc \uhorn.sc \uni01B4.sc \uni01B6.sc \uni01B9.sc 
+	\uni01BD.sc \uni01BF.sc \uni01C5.sc \uni01C6.sc \uni01C8.sc \uni01C9.sc 
+	\uni01CB.sc \uni01CC.sc \uni01CE.sc \uni01D0.sc \uni01D2.sc \uni01D4.sc 
+	\uni01D6.sc \uni01D8.sc \uni01DA.sc \uni01DC.sc \uni01DD.sc \uni01DF.sc 
+	\uni01E1.sc \uni01E3.sc \uni01E5.sc \gcaron.sc \uni01E9.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F0.sc \uni01F2.sc \uni01F3.sc \uni01F5.sc \uni01F9.sc 
+	\aringacute.sc \aeacute.sc \oslashacute.sc \uni0201.sc \uni0203.sc 
+	\uni0205.sc \uni0207.sc \uni0209.sc \uni020B.sc \uni020D.sc \uni020F.sc 
+	\uni0211.sc \uni0213.sc \uni0215.sc \uni0217.sc \scommaaccent.sc \uni021B.sc 
+	\uni021D.sc \uni021F.sc \uni0221.sc \uni0223.sc \uni0225.sc \uni0227.sc 
+	\uni0229.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni0233.sc 
+	\uni0234.sc \uni0235.sc \uni0236.sc \uni0237.sc \uni023C.sc \uni0242.sc 
+	\uni0247.sc \uni0249.sc \uni024B.sc \uni024D.sc \uni024F.sc \uni0250.sc 
+	\uni0251.sc \uni0253.sc \uni0254.sc \uni0256.sc \uni0257.sc \uni0259.sc 
+	\uni025B.sc \uni0260.sc \uni0263.sc \uni0264.sc \uni0266.sc \uni0268.sc 
+	\uni0269.sc \uni026A.sc \uni026F.sc \uni0272.sc \uni0275.sc \uni027D.sc 
+	\uni0283.sc \uni0288.sc \uni0289.sc \uni028A.sc \uni028B.sc \uni028C.sc 
+	\uni0292.sc \uni0298.sc \uni029D.sc \uni02A3.sc \uni02A4.sc \uni02A5.sc 
+	\uni02A6.sc \uni02A7.sc \uni02A8.sc \uni02A9.sc \uni02AA.sc \uni02AB.sc 
+	\uni0377.sc \uni037B.sc \uni037C.sc \uni037D.sc \iotadieresistonos.sc 
+	\alphatonos.sc \epsilontonos.sc \etatonos.sc \iotatonos.sc 
+	\upsilondieresistonos.sc \alpha.sc \beta.sc \gamma.sc \delta.sc \epsilon.sc 
+	\zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc \lambda.sc \uni03BC.sc \nu.sc 
+	\xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc \tau.sc \upsilon.sc \phi.sc \chi.sc 
+	\psi.sc \omega.sc \iotadieresis.sc \upsilondieresis.sc \omicrontonos.sc 
+	\upsilontonos.sc \omegatonos.sc \uni03D9.sc \uni03DB.sc \uni03DD.sc 
+	\uni03F2.sc \uni03F3.sc \uni03F8.sc \uni03FC.sc \uni0430.sc \uni0431.sc 
+	\uni0432.sc \uni0433.sc \uni0434.sc \uni0435.sc \uni0436.sc \uni0437.sc 
+	\uni0438.sc \uni0439.sc \uni043A.sc \uni043B.sc \uni043C.sc \uni043D.sc 
+	\uni043E.sc \uni043F.sc \uni0440.sc \uni0441.sc \uni0442.sc \uni0443.sc 
+	\uni0444.sc \uni0445.sc \uni0446.sc \uni0447.sc \uni0448.sc \uni0449.sc 
+	\uni044A.sc \uni044B.sc \uni044C.sc \uni044D.sc \uni044E.sc \uni044F.sc 
+	\uni0450.sc \uni0451.sc \uni0452.sc \uni0453.sc \uni0454.sc \uni0455.sc 
+	\uni0456.sc \uni0457.sc \uni0458.sc \uni0459.sc \uni045A.sc \uni045B.sc 
+	\uni045C.sc \uni045D.sc \uni045E.sc \uni045F.sc \uni0461.sc \uni0463.sc 
+	\uni0465.sc \uni0467.sc \uni0469.sc \uni046B.sc \uni046D.sc \uni046F.sc 
+	\uni0471.sc \uni0473.sc \uni0475.sc \uni0477.sc \uni047B.sc \uni047D.sc 
+	\uni047F.sc \uni0481.sc \uni048B.sc \uni048D.sc \uni048F.sc \uni0491.sc 
+	\uni0493.sc \uni0495.sc \uni0497.sc \uni0499.sc \uni049B.sc \uni049D.sc 
+	\uni049F.sc \uni04A1.sc \uni04A3.sc \uni04A5.sc \uni04A7.sc \uni04A9.sc 
+	\uni04AB.sc \uni04AD.sc \uni04AF.sc \uni04B1.sc \uni04B3.sc \uni04B5.sc 
+	\uni04B7.sc \uni04B9.sc \uni04BB.sc \uni04BD.sc \uni04BF.sc \uni04C2.sc 
+	\uni04C4.sc \uni04C6.sc \uni04C8.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
+	\uni04D1.sc \uni04D3.sc \uni04D5.sc \uni04D7.sc \uni04D9.sc \uni04DB.sc 
+	\uni04DD.sc \uni04DF.sc \uni04E3.sc \uni04E5.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni04EF.sc \uni04F1.sc \uni04F3.sc \uni04F5.sc 
+	\uni04F7.sc \uni04F9.sc \uni04FB.sc \uni04FD.sc \uni04FF.sc \uni0501.sc 
+	\uni0503.sc \uni0505.sc \uni0507.sc \uni0509.sc \uni050B.sc \uni050D.sc 
+	\uni050F.sc \uni0511.sc \uni0513.sc \uni0515.sc \uni0517.sc \uni0519.sc 
+	\uni051B.sc \uni051D.sc \uni051F.sc \uni0521.sc \uni0523.sc \uni0525.sc 
+	\uni0527.sc \uni0529.sc \uni052B.sc \uni052D.sc \uni052F.sc \uni1D7D.sc 
+	\uni1E01.sc \uni1E03.sc \uni1E05.sc \uni1E07.sc \uni1E09.sc \uni1E0B.sc 
+	\uni1E0D.sc \uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E15.sc \uni1E17.sc 
+	\uni1E19.sc \uni1E1B.sc \uni1E1D.sc \uni1E1F.sc \uni1E21.sc \uni1E23.sc 
+	\uni1E25.sc \uni1E27.sc \uni1E29.sc \uni1E2B.sc \uni1E2D.sc \uni1E2F.sc 
+	\uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc 
+	\uni1E3D.sc \uni1E3F.sc \uni1E41.sc \uni1E43.sc \uni1E45.sc \uni1E47.sc 
+	\uni1E49.sc \uni1E4B.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1E55.sc \uni1E57.sc \uni1E59.sc \uni1E5B.sc \uni1E5D.sc \uni1E5F.sc 
+	\uni1E61.sc \uni1E63.sc \uni1E65.sc \uni1E67.sc \uni1E69.sc \uni1E6B.sc 
+	\uni1E6D.sc \uni1E6F.sc \uni1E71.sc \uni1E73.sc \uni1E75.sc \uni1E77.sc 
+	\uni1E79.sc \uni1E7B.sc \uni1E7D.sc \uni1E7F.sc \wgrave.sc \wacute.sc 
+	\wdieresis.sc \uni1E87.sc \uni1E89.sc \uni1E8B.sc \uni1E8D.sc \uni1E8F.sc 
+	\uni1E91.sc \uni1E93.sc \uni1E95.sc \uni1E96.sc \uni1E97.sc \uni1E98.sc 
+	\uni1E99.sc \uni1E9A.sc \germandbls.sc \uni1E9F.sc \uni1EA1.sc \uni1EA3.sc 
+	\uni1EA5.sc \uni1EA7.sc \uni1EA9.sc \uni1EAB.sc \uni1EAD.sc \uni1EAF.sc 
+	\uni1EB1.sc \uni1EB3.sc \uni1EB5.sc \uni1EB7.sc \uni1EB9.sc \uni1EBB.sc 
+	\uni1EBD.sc \uni1EBF.sc \uni1EC1.sc \uni1EC3.sc \uni1EC5.sc \uni1EC7.sc 
+	\uni1EC9.sc \uni1ECB.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1EE5.sc \uni1EE7.sc \uni1EE9.sc \uni1EEB.sc 
+	\uni1EED.sc \uni1EEF.sc \uni1EF1.sc \ygrave.sc \uni1EF5.sc \uni1EF7.sc 
+	\uni1EF9.sc \uni1EFB.sc \uni1EFD.sc \uni1EFF.sc \uni1F00.sc \uni1F01.sc 
+	\uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc 
+	\uni1F10.sc \uni1F11.sc \uni1F12.sc \uni1F13.sc \uni1F14.sc \uni1F15.sc 
+	\uni1F20.sc \uni1F21.sc \uni1F22.sc \uni1F23.sc \uni1F24.sc \uni1F25.sc 
+	\uni1F26.sc \uni1F27.sc \uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc 
+	\uni1F34.sc \uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F40.sc \uni1F41.sc 
+	\uni1F42.sc \uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F50.sc \uni1F51.sc 
+	\uni1F52.sc \uni1F53.sc \uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc 
+	\uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F70.sc \uni1F71.sc \uni1F72.sc \uni1F73.sc 
+	\uni1F74.sc \uni1F75.sc \uni1F76.sc \uni1F77.sc \uni1F78.sc \uni1F79.sc 
+	\uni1F7A.sc \uni1F7B.sc \uni1F7C.sc \uni1F7D.sc \uni1F80.sc \uni1F81.sc 
+	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc \uni1F87.sc 
+	\uni1F90.sc \uni1F91.sc \uni1F92.sc \uni1F93.sc \uni1F94.sc \uni1F95.sc 
+	\uni1F96.sc \uni1F97.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FB0.sc \uni1FB1.sc 
+	\uni1FB2.sc \uni1FB3.sc \uni1FB4.sc \uni1FB6.sc \uni1FB7.sc \uni1FC2.sc 
+	\uni1FC3.sc \uni1FC4.sc \uni1FC6.sc \uni1FC7.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni1FE0.sc \uni1FE1.sc 
+	\uni1FE2.sc \uni1FE3.sc \uni1FE4.sc \uni1FE5.sc \uni1FE6.sc \uni1FE7.sc 
+	\uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2174.sc \uni2175.sc \uni2176.sc 
+	\uni2177.sc \uni2178.sc \uni2179.sc \uni217A.sc \uni217B.sc \uni217C.sc 
+	\uni217D.sc \uni217E.sc \uni217F.sc \uni2C73.sc \uniA78C.sc \uniA7B5.sc 
+	\uniA7B7.sc \uniA7C8.sc \zero.pnum \one.pnum \two.pnum \three.pnum \four.pnum 
+	\five.pnum \six.pnum \seven.pnum \eight.pnum \nine.pnum \zero.tnum \one.tnum 
+	\two.tnum \three.tnum \four.tnum \five.tnum \six.tnum \seven.tnum \eight.tnum 
+	\nine.tnum \zero.onum \one.onum \two.onum \three.onum \four.onum \five.onum 
+	\six.onum \seven.onum \eight.onum \nine.onum \zero.onum.tnum \one.onum.tnum 
+	\two.onum.tnum \three.onum.tnum \four.onum.tnum \five.onum.tnum 
+	\six.onum.tnum \seven.onum.tnum \eight.onum.tnum \nine.onum.tnum \zero.numr 
+	\one.numr \two.numr \three.numr \four.numr \five.numr \six.numr \seven.numr 
+	\eight.numr \nine.numr \zero.dnom \one.dnom \two.dnom \three.dnom \four.dnom 
+	\five.dnom \six.dnom \seven.dnom \eight.dnom \nine.dnom \zero.superior.pnum 
+	\one.superior.pnum \two.superior.pnum \three.superior.pnum 
+	\four.superior.pnum \five.superior.pnum \six.superior.pnum 
+	\seven.superior.pnum \eight.superior.pnum \nine.superior.pnum 
+	\zero.subscript.pnum \one.subscript.pnum \two.subscript.pnum 
+	\three.subscript.pnum \four.subscript.pnum \five.subscript.pnum 
+	\six.subscript.pnum \seven.subscript.pnum \eight.subscript.pnum 
+	\nine.subscript.pnum \zero.numr.pnum \one.numr.pnum \two.numr.pnum 
+	\three.numr.pnum \four.numr.pnum \five.numr.pnum \six.numr.pnum 
+	\seven.numr.pnum \eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum 
+	\one.dnom.pnum \two.dnom.pnum \three.dnom.pnum \four.dnom.pnum 
+	\five.dnom.pnum \six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum 
+	\nine.dnom.pnum \zero.superior.tnum \one.superior.tnum \two.superior.tnum 
 	\three.superior.tnum \four.superior.tnum \five.superior.tnum 
 	\six.superior.tnum \seven.superior.tnum \eight.superior.tnum 
 	\nine.superior.tnum \zero.subscript.tnum \one.subscript.tnum 

--- a/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/11 21:17:20</string>
+    <string>2025/03/12 18:14:32</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/contents.plist
@@ -3036,6 +3036,8 @@
     <string>uni20B_E_.glif</string>
     <key>uni20BF</key>
     <string>uni20B_F_.glif</string>
+    <key>uni20C0</key>
+    <string>uni20C_0.glif</string>
     <key>uni2100</key>
     <string>uni2100.glif</string>
     <key>uni2101</key>
@@ -4428,6 +4430,10 @@
     <string>uni27F_2.glif</string>
     <key>uni27F3</key>
     <string>uni27F_3.glif</string>
+    <key>uni27F0</key>
+    <string>uni27F_0.glif</string>
+    <key>uni27F1</key>
+    <string>uni27F_1.glif</string>
     <key>uni1F00</key>
     <string>uni1F_00.glif</string>
     <key>uni1F01</key>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni20C_0.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni20C_0.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni20C0" format="2">
+  <advance width="1139"/>
+  <unicode hex="20C0"/>
+  <outline>
+    <contour>
+      <point x="70" y="-160" type="line"/>
+      <point x="1069" y="-160" type="line"/>
+      <point x="1069" y="-480" type="line"/>
+      <point x="70" y="-480" type="line"/>
+    </contour>
+    <contour>
+      <point x="410" y="520" type="curve" smooth="yes"/>
+      <point x="410" y="383"/>
+      <point x="465" y="290"/>
+      <point x="602" y="290" type="curve" smooth="yes"/>
+      <point x="706" y="290"/>
+      <point x="761" y="344"/>
+      <point x="782" y="430" type="curve"/>
+      <point x="1089" y="252" type="line"/>
+      <point x="1001" y="79"/>
+      <point x="823" y="-30"/>
+      <point x="602" y="-30" type="curve" smooth="yes"/>
+      <point x="282" y="-30"/>
+      <point x="50" y="200"/>
+      <point x="50" y="520" type="curve" smooth="yes"/>
+      <point x="50" y="840"/>
+      <point x="280" y="1070"/>
+      <point x="600" y="1070" type="curve" smooth="yes"/>
+      <point x="821" y="1070"/>
+      <point x="999" y="961"/>
+      <point x="1087" y="788" type="curve"/>
+      <point x="780" y="610" type="line"/>
+      <point x="759" y="696"/>
+      <point x="704" y="750"/>
+      <point x="600" y="750" type="curve" smooth="yes"/>
+      <point x="463" y="750"/>
+      <point x="410" y="657"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni27F_0.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni27F_0.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F0" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F0"/>
+  <outline>
+    <contour>
+      <point x="1378" y="852" type="line"/>
+      <point x="1378" y="0" type="line"/>
+      <point x="1154" y="0" type="line"/>
+      <point x="1154" y="852" type="line"/>
+    </contour>
+    <contour>
+      <point x="466" y="852" type="line"/>
+      <point x="466" y="0" type="line"/>
+      <point x="242" y="0" type="line"/>
+      <point x="242" y="852" type="line"/>
+    </contour>
+    <contour>
+      <point x="1074" y="1202" type="line"/>
+      <point x="1074" y="0" type="line"/>
+      <point x="850" y="0" type="line"/>
+      <point x="850" y="1202" type="line"/>
+    </contour>
+    <contour>
+      <point x="854" y="1480" type="line"/>
+      <point x="1598" y="736" type="line"/>
+      <point x="1368" y="506" type="line"/>
+      <point x="810" y="1084" type="line"/>
+      <point x="252" y="506" type="line"/>
+      <point x="22" y="736" type="line"/>
+      <point x="766" y="1480" type="line"/>
+    </contour>
+    <contour>
+      <point x="770" y="1202" type="line"/>
+      <point x="770" y="0" type="line"/>
+      <point x="546" y="0" type="line"/>
+      <point x="546" y="1202" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni27F_1.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni27F_1.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F1" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F1"/>
+  <outline>
+    <contour>
+      <point x="242" y="628" type="line"/>
+      <point x="242" y="1480" type="line"/>
+      <point x="466" y="1480" type="line"/>
+      <point x="466" y="628" type="line"/>
+    </contour>
+    <contour>
+      <point x="1154" y="628" type="line"/>
+      <point x="1154" y="1480" type="line"/>
+      <point x="1378" y="1480" type="line"/>
+      <point x="1378" y="628" type="line"/>
+    </contour>
+    <contour>
+      <point x="546" y="278" type="line"/>
+      <point x="546" y="1480" type="line"/>
+      <point x="770" y="1480" type="line"/>
+      <point x="770" y="278" type="line"/>
+    </contour>
+    <contour>
+      <point x="766" y="0" type="line"/>
+      <point x="22" y="744" type="line"/>
+      <point x="252" y="974" type="line"/>
+      <point x="810" y="396" type="line"/>
+      <point x="1368" y="974" type="line"/>
+      <point x="1598" y="744" type="line"/>
+      <point x="854" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="850" y="278" type="line"/>
+      <point x="850" y="1480" type="line"/>
+      <point x="1074" y="1480" type="line"/>
+      <point x="1074" y="278" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -11523,42 +11523,42 @@ feature mkmk {
 	\uni20A0 \colonmonetary \uni20A2 \franc \lira \uni20A5 \uni20A6 \peseta \uni20A8 
 	\uni20A9 \uni20AA \dong \Euro \uni20AD \uni20AE \uni20AF \uni20B0 \uni20B1 
 	\uni20B2 \uni20B3 \uni20B4 \uni20B5 \uni20B6 \uni20B7 \uni20B8 \uni20B9 \uni20BA 
-	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni2100 \uni2101 \uni2102 \uni2105 
-	\uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 \uni2141 
-	\uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 \uni2124 
-	\uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 \uni211B 
-	\Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 \uni2133 
-	\uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 \uni2116 
-	\uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 \trademark 
-	\uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 \uni212A 
-	\uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 \uni2138 
-	\uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D \uni217E 
-	\uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 \uni2174 
-	\uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 \uni2188 
-	\uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 \uni2197 
-	\uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 \uni21A2 
-	\uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 \uni21AB 
-	\uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 \uni21B1 
-	\uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 \uni21E4 
-	\uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF \uni21C0 
-	\uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 \uni21C8 
-	\uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 \uni21D6 
-	\uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC \uni21DD 
-	\uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 \uni21E7 
-	\uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 \uni21F1 
-	\uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 \uni21FA 
-	\uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 \partialdiff 
-	\existential \uni2204 \emptyset \Delta \gradient \element \uni220A \notelement 
-	\suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation \minus 
-	\uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 \radical 
-	\uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 \uni2222 
-	\uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor \integral 
-	\logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 \uni2232 
-	\uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 \uni223A 
-	\uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 \uni2242 
-	\uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D \uni224F 
-	\uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
-	\uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
+	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni20C0 \uni2100 \uni2101 \uni2102 
+	\uni2105 \uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 
+	\uni2141 \uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 
+	\uni2124 \uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 
+	\uni211B \Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 
+	\uni2133 \uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 
+	\uni2116 \uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 
+	\trademark \uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 
+	\uni212A \uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 
+	\uni2138 \uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D 
+	\uni217E \uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 
+	\uni2174 \uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 
+	\uni2188 \uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 
+	\uni2197 \uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 
+	\uni21A2 \uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 
+	\uni21AB \uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 
+	\uni21B1 \uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 
+	\uni21E4 \uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF 
+	\uni21C0 \uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 
+	\uni21C8 \uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 
+	\uni21D6 \uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC 
+	\uni21DD \uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 
+	\uni21E7 \uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 
+	\uni21F1 \uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 
+	\uni21FA \uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 
+	\partialdiff \existential \uni2204 \emptyset \Delta \gradient \element \uni220A 
+	\notelement \suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation 
+	\minus \uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 
+	\radical \uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 
+	\uni2222 \uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor 
+	\integral \logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 
+	\uni2232 \uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 
+	\uni223A \uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 
+	\uni2242 \uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D 
+	\uni224F \uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 
+	\uni2257 \uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
 	\equivalence \uni2262 \uni2263 \lessequal \greaterequal \uni2266 \uni2267 
 	\uni2268 \uni2269 \uni226A \uni226B \uni226C \uni2272 \uni2273 \uni2276 \uni2277 
 	\uni226E \uni226F \uni227A \uni227B \uni227C \uni227D \uni227E \uni227F 
@@ -11602,175 +11602,175 @@ feature mkmk {
 	\uni24A5 \uni24A6 \uni24A7 \uni24A8 \uni24A9 \uni24AA \uni24AB \uni24AC \uni24AD 
 	\uni24AE \uni24AF \uni24B0 \uni24B1 \uni24B2 \uni24B3 \uni24B4 \uni24B5 \uni24F5 
 	\uni24F6 \uni24F7 \uni24F8 \uni24F9 \uni24FA \uni24FB \uni24FC \uni24FD \uni24FE 
-	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni1F00 \uni1F01 
-	\uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 \uni1F09 \uni1F0A 
-	\uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 \uni1F12 \uni1F13 
-	\uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C \uni1F1D \uni1F20 
-	\uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 \uni1F28 \uni1F29 
-	\uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 \uni1F31 \uni1F32 
-	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 \uni1F3A \uni1F3B 
-	\uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 
-	\uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D \uni1F50 \uni1F51 
-	\uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 \uni1F5B \uni1F5D 
-	\uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 
-	\uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1F70 
-	\uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 \uni1F78 \uni1F79 
-	\uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
-	\uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C \uni1F8D \uni1F8E 
-	\uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 \uni1F96 \uni1F97 
-	\uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E \uni1F9F \uni1FA0 
-	\uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 \uni1FA8 \uni1FA9 
-	\uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 \uni1FB0 \uni1FB1 
-	\uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 \uni1FBA \uni1FBC 
-	\uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 \uni1FCA \uni1FCC 
-	\uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 \uni1FDA \uni1FCB 
-	\uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 \uni1FE7 \uni1FE3 
-	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 
-	\uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB \uni1FC9 \uni2E17 
-	\uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 \uni214C \omicron 
-	\uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 \uni2C65 \uni2C66 
-	\uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE \uni1D49 \uni1D43 
-	\uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 \uni2C6D \uni2C72 
-	\uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 \uni1D7D \uniA7B4 
-	\uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc \j.sc \k.sc \l.sc 
-	\m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc \x.sc \y.sc \z.sc 
-	\agrave.sc \aacute.sc \acircumflex.sc \atilde.sc \adieresis.sc \aring.sc 
-	\ae.sc \ccedilla.sc \egrave.sc \eacute.sc \ecircumflex.sc \edieresis.sc 
-	\igrave.sc \iacute.sc \icircumflex.sc \idieresis.sc \ntilde.sc \ograve.sc 
-	\oacute.sc \ocircumflex.sc \otilde.sc \odieresis.sc \oslash.sc \ugrave.sc 
-	\uacute.sc \ucircumflex.sc \udieresis.sc \yacute.sc \thorn.sc \ydieresis.sc 
-	\amacron.sc \abreve.sc \aogonek.sc \cacute.sc \ccircumflex.sc \cdotaccent.sc 
-	\ccaron.sc \dcaron.sc \dcroat.sc \emacron.sc \ebreve.sc \edotaccent.sc 
-	\eogonek.sc \ecaron.sc \gcircumflex.sc \gbreve.sc \gdotaccent.sc 
-	\gcommaaccent.sc \hcircumflex.sc \hbar.sc \itilde.sc \imacron.sc \ibreve.sc 
-	\iogonek.sc \ij.sc \jcircumflex.sc \kcommaaccent.sc \kgreenlandic.sc 
-	\lacute.sc \lcommaaccent.sc \lcaron.sc \ldot.sc \lslash.sc \nacute.sc 
-	\ncommaaccent.sc \ncaron.sc \napostrophe.sc \eng.sc \omacron.sc \obreve.sc 
-	\ohungarumlaut.sc \oe.sc \racute.sc \rcommaaccent.sc \rcaron.sc \sacute.sc 
-	\scircumflex.sc \scedilla.sc \scaron.sc \uni0163.sc \tcaron.sc \tbar.sc 
-	\utilde.sc \umacron.sc \ubreve.sc \uring.sc \uhungarumlaut.sc \uogonek.sc 
-	\wcircumflex.sc \ycircumflex.sc \zacute.sc \zdotaccent.sc \zcaron.sc 
-	\uni0180.sc \uni0183.sc \uni0185.sc \uni0188.sc \uni018C.sc \florin.sc 
-	\uni0195.sc \uni0199.sc \uni019A.sc \uni019B.sc \uni019E.sc \ohorn.sc 
-	\uni01A3.sc \uni01A5.sc \uni01A8.sc \uni01AB.sc \uni01AD.sc \uhorn.sc 
-	\uni01B4.sc \uni01B6.sc \uni01B9.sc \uni01BD.sc \uni01BF.sc \uni01C5.sc 
-	\uni01C6.sc \uni01C8.sc \uni01C9.sc \uni01CB.sc \uni01CC.sc \uni01CE.sc 
-	\uni01D0.sc \uni01D2.sc \uni01D4.sc \uni01D6.sc \uni01D8.sc \uni01DA.sc 
-	\uni01DC.sc \uni01DD.sc \uni01DF.sc \uni01E1.sc \uni01E3.sc \uni01E5.sc 
-	\gcaron.sc \uni01E9.sc \uni01EB.sc \uni01ED.sc \uni01F0.sc \uni01F2.sc 
-	\uni01F3.sc \uni01F5.sc \uni01F9.sc \aringacute.sc \aeacute.sc 
-	\oslashacute.sc \uni0201.sc \uni0203.sc \uni0205.sc \uni0207.sc \uni0209.sc 
-	\uni020B.sc \uni020D.sc \uni020F.sc \uni0211.sc \uni0213.sc \uni0215.sc 
-	\uni0217.sc \scommaaccent.sc \uni021B.sc \uni021D.sc \uni021F.sc \uni0221.sc 
-	\uni0223.sc \uni0225.sc \uni0227.sc \uni0229.sc \uni022B.sc \uni022D.sc 
-	\uni022F.sc \uni0231.sc \uni0233.sc \uni0234.sc \uni0235.sc \uni0236.sc 
-	\uni0237.sc \uni023C.sc \uni0242.sc \uni0247.sc \uni0249.sc \uni024B.sc 
-	\uni024D.sc \uni024F.sc \uni0250.sc \uni0251.sc \uni0253.sc \uni0254.sc 
-	\uni0256.sc \uni0257.sc \uni0259.sc \uni025B.sc \uni0260.sc \uni0263.sc 
-	\uni0264.sc \uni0266.sc \uni0268.sc \uni0269.sc \uni026A.sc \uni026F.sc 
-	\uni0272.sc \uni0275.sc \uni027D.sc \uni0283.sc \uni0288.sc \uni0289.sc 
-	\uni028A.sc \uni028B.sc \uni028C.sc \uni0292.sc \uni0298.sc \uni029D.sc 
-	\uni02A3.sc \uni02A4.sc \uni02A5.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni02A9.sc \uni02AA.sc \uni02AB.sc \uni0377.sc \uni037B.sc \uni037C.sc 
-	\uni037D.sc \iotadieresistonos.sc \alphatonos.sc \epsilontonos.sc 
-	\etatonos.sc \iotatonos.sc \upsilondieresistonos.sc \alpha.sc \beta.sc 
-	\gamma.sc \delta.sc \epsilon.sc \zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc 
-	\lambda.sc \uni03BC.sc \nu.sc \xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc 
-	\tau.sc \upsilon.sc \phi.sc \chi.sc \psi.sc \omega.sc \iotadieresis.sc 
-	\upsilondieresis.sc \omicrontonos.sc \upsilontonos.sc \omegatonos.sc 
-	\uni03D9.sc \uni03DB.sc \uni03DD.sc \uni03F2.sc \uni03F3.sc \uni03F8.sc 
-	\uni03FC.sc \uni0430.sc \uni0431.sc \uni0432.sc \uni0433.sc \uni0434.sc 
-	\uni0435.sc \uni0436.sc \uni0437.sc \uni0438.sc \uni0439.sc \uni043A.sc 
-	\uni043B.sc \uni043C.sc \uni043D.sc \uni043E.sc \uni043F.sc \uni0440.sc 
-	\uni0441.sc \uni0442.sc \uni0443.sc \uni0444.sc \uni0445.sc \uni0446.sc 
-	\uni0447.sc \uni0448.sc \uni0449.sc \uni044A.sc \uni044B.sc \uni044C.sc 
-	\uni044D.sc \uni044E.sc \uni044F.sc \uni0450.sc \uni0451.sc \uni0452.sc 
-	\uni0453.sc \uni0454.sc \uni0455.sc \uni0456.sc \uni0457.sc \uni0458.sc 
-	\uni0459.sc \uni045A.sc \uni045B.sc \uni045C.sc \uni045D.sc \uni045E.sc 
-	\uni045F.sc \uni0461.sc \uni0463.sc \uni0465.sc \uni0467.sc \uni0469.sc 
-	\uni046B.sc \uni046D.sc \uni046F.sc \uni0471.sc \uni0473.sc \uni0475.sc 
-	\uni0477.sc \uni047B.sc \uni047D.sc \uni047F.sc \uni0481.sc \uni048B.sc 
-	\uni048D.sc \uni048F.sc \uni0491.sc \uni0493.sc \uni0495.sc \uni0497.sc 
-	\uni0499.sc \uni049B.sc \uni049D.sc \uni049F.sc \uni04A1.sc \uni04A3.sc 
-	\uni04A5.sc \uni04A7.sc \uni04A9.sc \uni04AB.sc \uni04AD.sc \uni04AF.sc 
-	\uni04B1.sc \uni04B3.sc \uni04B5.sc \uni04B7.sc \uni04B9.sc \uni04BB.sc 
-	\uni04BD.sc \uni04BF.sc \uni04C2.sc \uni04C4.sc \uni04C6.sc \uni04C8.sc 
-	\uni04CA.sc \uni04CC.sc \uni04CE.sc \uni04D1.sc \uni04D3.sc \uni04D5.sc 
-	\uni04D7.sc \uni04D9.sc \uni04DB.sc \uni04DD.sc \uni04DF.sc \uni04E3.sc 
-	\uni04E5.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni04ED.sc \uni04EF.sc 
-	\uni04F1.sc \uni04F3.sc \uni04F5.sc \uni04F7.sc \uni04F9.sc \uni04FB.sc 
-	\uni04FD.sc \uni04FF.sc \uni0501.sc \uni0503.sc \uni0505.sc \uni0507.sc 
-	\uni0509.sc \uni050B.sc \uni050D.sc \uni050F.sc \uni0511.sc \uni0513.sc 
-	\uni0515.sc \uni0517.sc \uni0519.sc \uni051B.sc \uni051D.sc \uni051F.sc 
-	\uni0521.sc \uni0523.sc \uni0525.sc \uni0527.sc \uni0529.sc \uni052B.sc 
-	\uni052D.sc \uni052F.sc \uni1D7D.sc \uni1E01.sc \uni1E03.sc \uni1E05.sc 
-	\uni1E07.sc \uni1E09.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc \uni1E11.sc 
-	\uni1E13.sc \uni1E15.sc \uni1E17.sc \uni1E19.sc \uni1E1B.sc \uni1E1D.sc 
-	\uni1E1F.sc \uni1E21.sc \uni1E23.sc \uni1E25.sc \uni1E27.sc \uni1E29.sc 
-	\uni1E2B.sc \uni1E2D.sc \uni1E2F.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc 
-	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc \uni1E3F.sc \uni1E41.sc 
-	\uni1E43.sc \uni1E45.sc \uni1E47.sc \uni1E49.sc \uni1E4B.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1E55.sc \uni1E57.sc \uni1E59.sc 
-	\uni1E5B.sc \uni1E5D.sc \uni1E5F.sc \uni1E61.sc \uni1E63.sc \uni1E65.sc 
-	\uni1E67.sc \uni1E69.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc 
-	\uni1E73.sc \uni1E75.sc \uni1E77.sc \uni1E79.sc \uni1E7B.sc \uni1E7D.sc 
-	\uni1E7F.sc \wgrave.sc \wacute.sc \wdieresis.sc \uni1E87.sc \uni1E89.sc 
-	\uni1E8B.sc \uni1E8D.sc \uni1E8F.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc 
-	\uni1E96.sc \uni1E97.sc \uni1E98.sc \uni1E99.sc \uni1E9A.sc \germandbls.sc 
-	\uni1E9F.sc \uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc \uni1EA9.sc 
-	\uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc \uni1EB3.sc \uni1EB5.sc 
-	\uni1EB7.sc \uni1EB9.sc \uni1EBB.sc \uni1EBD.sc \uni1EBF.sc \uni1EC1.sc 
-	\uni1EC3.sc \uni1EC5.sc \uni1EC7.sc \uni1EC9.sc \uni1ECB.sc \uni1ECD.sc 
-	\uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc \uni1EE5.sc 
-	\uni1EE7.sc \uni1EE9.sc \uni1EEB.sc \uni1EED.sc \uni1EEF.sc \uni1EF1.sc 
-	\ygrave.sc \uni1EF5.sc \uni1EF7.sc \uni1EF9.sc \uni1EFB.sc \uni1EFD.sc 
-	\uni1EFF.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc \uni1F03.sc \uni1F04.sc 
-	\uni1F05.sc \uni1F06.sc \uni1F07.sc \uni1F10.sc \uni1F11.sc \uni1F12.sc 
-	\uni1F13.sc \uni1F14.sc \uni1F15.sc \uni1F20.sc \uni1F21.sc \uni1F22.sc 
-	\uni1F23.sc \uni1F24.sc \uni1F25.sc \uni1F26.sc \uni1F27.sc \uni1F30.sc 
-	\uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
-	\uni1F37.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc \uni1F54.sc 
-	\uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc 
-	\uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F70.sc 
-	\uni1F71.sc \uni1F72.sc \uni1F73.sc \uni1F74.sc \uni1F75.sc \uni1F76.sc 
-	\uni1F77.sc \uni1F78.sc \uni1F79.sc \uni1F7A.sc \uni1F7B.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1F80.sc \uni1F81.sc \uni1F82.sc \uni1F83.sc \uni1F84.sc 
-	\uni1F85.sc \uni1F86.sc \uni1F87.sc \uni1F90.sc \uni1F91.sc \uni1F92.sc 
-	\uni1F93.sc \uni1F94.sc \uni1F95.sc \uni1F96.sc \uni1F97.sc \uni1FA0.sc 
-	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc \uni1FB4.sc 
-	\uni1FB6.sc \uni1FB7.sc \uni1FC2.sc \uni1FC3.sc \uni1FC4.sc \uni1FC6.sc 
-	\uni1FC7.sc \uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni1FE0.sc \uni1FE1.sc \uni1FE2.sc \uni1FE3.sc \uni1FE4.sc 
-	\uni1FE5.sc \uni1FE6.sc \uni1FE7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
-	\uni1FF6.sc \uni1FF7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \uni2178.sc \uni2179.sc 
-	\uni217A.sc \uni217B.sc \uni217C.sc \uni217D.sc \uni217E.sc \uni217F.sc 
-	\uni2C73.sc \uniA78C.sc \uniA7B5.sc \uniA7B7.sc \uniA7C8.sc \zero.pnum 
-	\one.pnum \two.pnum \three.pnum \four.pnum \five.pnum \six.pnum \seven.pnum 
-	\eight.pnum \nine.pnum \zero.tnum \one.tnum \two.tnum \three.tnum \four.tnum 
-	\five.tnum \six.tnum \seven.tnum \eight.tnum \nine.tnum \zero.onum \one.onum 
-	\two.onum \three.onum \four.onum \five.onum \six.onum \seven.onum \eight.onum 
-	\nine.onum \zero.onum.tnum \one.onum.tnum \two.onum.tnum \three.onum.tnum 
-	\four.onum.tnum \five.onum.tnum \six.onum.tnum \seven.onum.tnum 
-	\eight.onum.tnum \nine.onum.tnum \zero.numr \one.numr \two.numr \three.numr 
-	\four.numr \five.numr \six.numr \seven.numr \eight.numr \nine.numr \zero.dnom 
-	\one.dnom \two.dnom \three.dnom \four.dnom \five.dnom \six.dnom \seven.dnom 
-	\eight.dnom \nine.dnom \zero.superior.pnum \one.superior.pnum 
-	\two.superior.pnum \three.superior.pnum \four.superior.pnum 
-	\five.superior.pnum \six.superior.pnum \seven.superior.pnum 
-	\eight.superior.pnum \nine.superior.pnum \zero.subscript.pnum 
-	\one.subscript.pnum \two.subscript.pnum \three.subscript.pnum 
-	\four.subscript.pnum \five.subscript.pnum \six.subscript.pnum 
-	\seven.subscript.pnum \eight.subscript.pnum \nine.subscript.pnum 
-	\zero.numr.pnum \one.numr.pnum \two.numr.pnum \three.numr.pnum 
-	\four.numr.pnum \five.numr.pnum \six.numr.pnum \seven.numr.pnum 
-	\eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum \one.dnom.pnum 
-	\two.dnom.pnum \three.dnom.pnum \four.dnom.pnum \five.dnom.pnum 
-	\six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum \nine.dnom.pnum 
-	\zero.superior.tnum \one.superior.tnum \two.superior.tnum 
+	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni27F0 \uni27F1 
+	\uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 
+	\uni1F09 \uni1F0A \uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 
+	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C 
+	\uni1F1D \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 
+	\uni1F28 \uni1F29 \uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 
+	\uni1F31 \uni1F32 \uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 
+	\uni1F3A \uni1F3B \uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 
+	\uni1F43 \uni1F44 \uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
+	\uni1F50 \uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 
+	\uni1F5B \uni1F5D \uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 
+	\uni1F66 \uni1F67 \uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E 
+	\uni1F6F \uni1F70 \uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 
+	\uni1F78 \uni1F79 \uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 
+	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C 
+	\uni1F8D \uni1F8E \uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 
+	\uni1F96 \uni1F97 \uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E 
+	\uni1F9F \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 
+	\uni1FA8 \uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 
+	\uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 
+	\uni1FBA \uni1FBC \uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 
+	\uni1FCA \uni1FCC \uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 
+	\uni1FDA \uni1FCB \uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 
+	\uni1FE7 \uni1FE3 \uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 
+	\uni1FF4 \uni1FF6 \uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB 
+	\uni1FC9 \uni2E17 \uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 
+	\uni214C \omicron \uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 
+	\uni2C65 \uni2C66 \uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE 
+	\uni1D49 \uni1D43 \uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 
+	\uni2C6D \uni2C72 \uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 
+	\uni1D7D \uniA7B4 \uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc 
+	\j.sc \k.sc \l.sc \m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc 
+	\x.sc \y.sc \z.sc \agrave.sc \aacute.sc \acircumflex.sc \atilde.sc 
+	\adieresis.sc \aring.sc \ae.sc \ccedilla.sc \egrave.sc \eacute.sc 
+	\ecircumflex.sc \edieresis.sc \igrave.sc \iacute.sc \icircumflex.sc 
+	\idieresis.sc \ntilde.sc \ograve.sc \oacute.sc \ocircumflex.sc \otilde.sc 
+	\odieresis.sc \oslash.sc \ugrave.sc \uacute.sc \ucircumflex.sc \udieresis.sc 
+	\yacute.sc \thorn.sc \ydieresis.sc \amacron.sc \abreve.sc \aogonek.sc 
+	\cacute.sc \ccircumflex.sc \cdotaccent.sc \ccaron.sc \dcaron.sc \dcroat.sc 
+	\emacron.sc \ebreve.sc \edotaccent.sc \eogonek.sc \ecaron.sc \gcircumflex.sc 
+	\gbreve.sc \gdotaccent.sc \gcommaaccent.sc \hcircumflex.sc \hbar.sc 
+	\itilde.sc \imacron.sc \ibreve.sc \iogonek.sc \ij.sc \jcircumflex.sc 
+	\kcommaaccent.sc \kgreenlandic.sc \lacute.sc \lcommaaccent.sc \lcaron.sc 
+	\ldot.sc \lslash.sc \nacute.sc \ncommaaccent.sc \ncaron.sc \napostrophe.sc 
+	\eng.sc \omacron.sc \obreve.sc \ohungarumlaut.sc \oe.sc \racute.sc 
+	\rcommaaccent.sc \rcaron.sc \sacute.sc \scircumflex.sc \scedilla.sc 
+	\scaron.sc \uni0163.sc \tcaron.sc \tbar.sc \utilde.sc \umacron.sc \ubreve.sc 
+	\uring.sc \uhungarumlaut.sc \uogonek.sc \wcircumflex.sc \ycircumflex.sc 
+	\zacute.sc \zdotaccent.sc \zcaron.sc \uni0180.sc \uni0183.sc \uni0185.sc 
+	\uni0188.sc \uni018C.sc \florin.sc \uni0195.sc \uni0199.sc \uni019A.sc 
+	\uni019B.sc \uni019E.sc \ohorn.sc \uni01A3.sc \uni01A5.sc \uni01A8.sc 
+	\uni01AB.sc \uni01AD.sc \uhorn.sc \uni01B4.sc \uni01B6.sc \uni01B9.sc 
+	\uni01BD.sc \uni01BF.sc \uni01C5.sc \uni01C6.sc \uni01C8.sc \uni01C9.sc 
+	\uni01CB.sc \uni01CC.sc \uni01CE.sc \uni01D0.sc \uni01D2.sc \uni01D4.sc 
+	\uni01D6.sc \uni01D8.sc \uni01DA.sc \uni01DC.sc \uni01DD.sc \uni01DF.sc 
+	\uni01E1.sc \uni01E3.sc \uni01E5.sc \gcaron.sc \uni01E9.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F0.sc \uni01F2.sc \uni01F3.sc \uni01F5.sc \uni01F9.sc 
+	\aringacute.sc \aeacute.sc \oslashacute.sc \uni0201.sc \uni0203.sc 
+	\uni0205.sc \uni0207.sc \uni0209.sc \uni020B.sc \uni020D.sc \uni020F.sc 
+	\uni0211.sc \uni0213.sc \uni0215.sc \uni0217.sc \scommaaccent.sc \uni021B.sc 
+	\uni021D.sc \uni021F.sc \uni0221.sc \uni0223.sc \uni0225.sc \uni0227.sc 
+	\uni0229.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni0233.sc 
+	\uni0234.sc \uni0235.sc \uni0236.sc \uni0237.sc \uni023C.sc \uni0242.sc 
+	\uni0247.sc \uni0249.sc \uni024B.sc \uni024D.sc \uni024F.sc \uni0250.sc 
+	\uni0251.sc \uni0253.sc \uni0254.sc \uni0256.sc \uni0257.sc \uni0259.sc 
+	\uni025B.sc \uni0260.sc \uni0263.sc \uni0264.sc \uni0266.sc \uni0268.sc 
+	\uni0269.sc \uni026A.sc \uni026F.sc \uni0272.sc \uni0275.sc \uni027D.sc 
+	\uni0283.sc \uni0288.sc \uni0289.sc \uni028A.sc \uni028B.sc \uni028C.sc 
+	\uni0292.sc \uni0298.sc \uni029D.sc \uni02A3.sc \uni02A4.sc \uni02A5.sc 
+	\uni02A6.sc \uni02A7.sc \uni02A8.sc \uni02A9.sc \uni02AA.sc \uni02AB.sc 
+	\uni0377.sc \uni037B.sc \uni037C.sc \uni037D.sc \iotadieresistonos.sc 
+	\alphatonos.sc \epsilontonos.sc \etatonos.sc \iotatonos.sc 
+	\upsilondieresistonos.sc \alpha.sc \beta.sc \gamma.sc \delta.sc \epsilon.sc 
+	\zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc \lambda.sc \uni03BC.sc \nu.sc 
+	\xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc \tau.sc \upsilon.sc \phi.sc \chi.sc 
+	\psi.sc \omega.sc \iotadieresis.sc \upsilondieresis.sc \omicrontonos.sc 
+	\upsilontonos.sc \omegatonos.sc \uni03D9.sc \uni03DB.sc \uni03DD.sc 
+	\uni03F2.sc \uni03F3.sc \uni03F8.sc \uni03FC.sc \uni0430.sc \uni0431.sc 
+	\uni0432.sc \uni0433.sc \uni0434.sc \uni0435.sc \uni0436.sc \uni0437.sc 
+	\uni0438.sc \uni0439.sc \uni043A.sc \uni043B.sc \uni043C.sc \uni043D.sc 
+	\uni043E.sc \uni043F.sc \uni0440.sc \uni0441.sc \uni0442.sc \uni0443.sc 
+	\uni0444.sc \uni0445.sc \uni0446.sc \uni0447.sc \uni0448.sc \uni0449.sc 
+	\uni044A.sc \uni044B.sc \uni044C.sc \uni044D.sc \uni044E.sc \uni044F.sc 
+	\uni0450.sc \uni0451.sc \uni0452.sc \uni0453.sc \uni0454.sc \uni0455.sc 
+	\uni0456.sc \uni0457.sc \uni0458.sc \uni0459.sc \uni045A.sc \uni045B.sc 
+	\uni045C.sc \uni045D.sc \uni045E.sc \uni045F.sc \uni0461.sc \uni0463.sc 
+	\uni0465.sc \uni0467.sc \uni0469.sc \uni046B.sc \uni046D.sc \uni046F.sc 
+	\uni0471.sc \uni0473.sc \uni0475.sc \uni0477.sc \uni047B.sc \uni047D.sc 
+	\uni047F.sc \uni0481.sc \uni048B.sc \uni048D.sc \uni048F.sc \uni0491.sc 
+	\uni0493.sc \uni0495.sc \uni0497.sc \uni0499.sc \uni049B.sc \uni049D.sc 
+	\uni049F.sc \uni04A1.sc \uni04A3.sc \uni04A5.sc \uni04A7.sc \uni04A9.sc 
+	\uni04AB.sc \uni04AD.sc \uni04AF.sc \uni04B1.sc \uni04B3.sc \uni04B5.sc 
+	\uni04B7.sc \uni04B9.sc \uni04BB.sc \uni04BD.sc \uni04BF.sc \uni04C2.sc 
+	\uni04C4.sc \uni04C6.sc \uni04C8.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
+	\uni04D1.sc \uni04D3.sc \uni04D5.sc \uni04D7.sc \uni04D9.sc \uni04DB.sc 
+	\uni04DD.sc \uni04DF.sc \uni04E3.sc \uni04E5.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni04EF.sc \uni04F1.sc \uni04F3.sc \uni04F5.sc 
+	\uni04F7.sc \uni04F9.sc \uni04FB.sc \uni04FD.sc \uni04FF.sc \uni0501.sc 
+	\uni0503.sc \uni0505.sc \uni0507.sc \uni0509.sc \uni050B.sc \uni050D.sc 
+	\uni050F.sc \uni0511.sc \uni0513.sc \uni0515.sc \uni0517.sc \uni0519.sc 
+	\uni051B.sc \uni051D.sc \uni051F.sc \uni0521.sc \uni0523.sc \uni0525.sc 
+	\uni0527.sc \uni0529.sc \uni052B.sc \uni052D.sc \uni052F.sc \uni1D7D.sc 
+	\uni1E01.sc \uni1E03.sc \uni1E05.sc \uni1E07.sc \uni1E09.sc \uni1E0B.sc 
+	\uni1E0D.sc \uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E15.sc \uni1E17.sc 
+	\uni1E19.sc \uni1E1B.sc \uni1E1D.sc \uni1E1F.sc \uni1E21.sc \uni1E23.sc 
+	\uni1E25.sc \uni1E27.sc \uni1E29.sc \uni1E2B.sc \uni1E2D.sc \uni1E2F.sc 
+	\uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc 
+	\uni1E3D.sc \uni1E3F.sc \uni1E41.sc \uni1E43.sc \uni1E45.sc \uni1E47.sc 
+	\uni1E49.sc \uni1E4B.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1E55.sc \uni1E57.sc \uni1E59.sc \uni1E5B.sc \uni1E5D.sc \uni1E5F.sc 
+	\uni1E61.sc \uni1E63.sc \uni1E65.sc \uni1E67.sc \uni1E69.sc \uni1E6B.sc 
+	\uni1E6D.sc \uni1E6F.sc \uni1E71.sc \uni1E73.sc \uni1E75.sc \uni1E77.sc 
+	\uni1E79.sc \uni1E7B.sc \uni1E7D.sc \uni1E7F.sc \wgrave.sc \wacute.sc 
+	\wdieresis.sc \uni1E87.sc \uni1E89.sc \uni1E8B.sc \uni1E8D.sc \uni1E8F.sc 
+	\uni1E91.sc \uni1E93.sc \uni1E95.sc \uni1E96.sc \uni1E97.sc \uni1E98.sc 
+	\uni1E99.sc \uni1E9A.sc \germandbls.sc \uni1E9F.sc \uni1EA1.sc \uni1EA3.sc 
+	\uni1EA5.sc \uni1EA7.sc \uni1EA9.sc \uni1EAB.sc \uni1EAD.sc \uni1EAF.sc 
+	\uni1EB1.sc \uni1EB3.sc \uni1EB5.sc \uni1EB7.sc \uni1EB9.sc \uni1EBB.sc 
+	\uni1EBD.sc \uni1EBF.sc \uni1EC1.sc \uni1EC3.sc \uni1EC5.sc \uni1EC7.sc 
+	\uni1EC9.sc \uni1ECB.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1EE5.sc \uni1EE7.sc \uni1EE9.sc \uni1EEB.sc 
+	\uni1EED.sc \uni1EEF.sc \uni1EF1.sc \ygrave.sc \uni1EF5.sc \uni1EF7.sc 
+	\uni1EF9.sc \uni1EFB.sc \uni1EFD.sc \uni1EFF.sc \uni1F00.sc \uni1F01.sc 
+	\uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc 
+	\uni1F10.sc \uni1F11.sc \uni1F12.sc \uni1F13.sc \uni1F14.sc \uni1F15.sc 
+	\uni1F20.sc \uni1F21.sc \uni1F22.sc \uni1F23.sc \uni1F24.sc \uni1F25.sc 
+	\uni1F26.sc \uni1F27.sc \uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc 
+	\uni1F34.sc \uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F40.sc \uni1F41.sc 
+	\uni1F42.sc \uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F50.sc \uni1F51.sc 
+	\uni1F52.sc \uni1F53.sc \uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc 
+	\uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F70.sc \uni1F71.sc \uni1F72.sc \uni1F73.sc 
+	\uni1F74.sc \uni1F75.sc \uni1F76.sc \uni1F77.sc \uni1F78.sc \uni1F79.sc 
+	\uni1F7A.sc \uni1F7B.sc \uni1F7C.sc \uni1F7D.sc \uni1F80.sc \uni1F81.sc 
+	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc \uni1F87.sc 
+	\uni1F90.sc \uni1F91.sc \uni1F92.sc \uni1F93.sc \uni1F94.sc \uni1F95.sc 
+	\uni1F96.sc \uni1F97.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FB0.sc \uni1FB1.sc 
+	\uni1FB2.sc \uni1FB3.sc \uni1FB4.sc \uni1FB6.sc \uni1FB7.sc \uni1FC2.sc 
+	\uni1FC3.sc \uni1FC4.sc \uni1FC6.sc \uni1FC7.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni1FE0.sc \uni1FE1.sc 
+	\uni1FE2.sc \uni1FE3.sc \uni1FE4.sc \uni1FE5.sc \uni1FE6.sc \uni1FE7.sc 
+	\uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2174.sc \uni2175.sc \uni2176.sc 
+	\uni2177.sc \uni2178.sc \uni2179.sc \uni217A.sc \uni217B.sc \uni217C.sc 
+	\uni217D.sc \uni217E.sc \uni217F.sc \uni2C73.sc \uniA78C.sc \uniA7B5.sc 
+	\uniA7B7.sc \uniA7C8.sc \zero.pnum \one.pnum \two.pnum \three.pnum \four.pnum 
+	\five.pnum \six.pnum \seven.pnum \eight.pnum \nine.pnum \zero.tnum \one.tnum 
+	\two.tnum \three.tnum \four.tnum \five.tnum \six.tnum \seven.tnum \eight.tnum 
+	\nine.tnum \zero.onum \one.onum \two.onum \three.onum \four.onum \five.onum 
+	\six.onum \seven.onum \eight.onum \nine.onum \zero.onum.tnum \one.onum.tnum 
+	\two.onum.tnum \three.onum.tnum \four.onum.tnum \five.onum.tnum 
+	\six.onum.tnum \seven.onum.tnum \eight.onum.tnum \nine.onum.tnum \zero.numr 
+	\one.numr \two.numr \three.numr \four.numr \five.numr \six.numr \seven.numr 
+	\eight.numr \nine.numr \zero.dnom \one.dnom \two.dnom \three.dnom \four.dnom 
+	\five.dnom \six.dnom \seven.dnom \eight.dnom \nine.dnom \zero.superior.pnum 
+	\one.superior.pnum \two.superior.pnum \three.superior.pnum 
+	\four.superior.pnum \five.superior.pnum \six.superior.pnum 
+	\seven.superior.pnum \eight.superior.pnum \nine.superior.pnum 
+	\zero.subscript.pnum \one.subscript.pnum \two.subscript.pnum 
+	\three.subscript.pnum \four.subscript.pnum \five.subscript.pnum 
+	\six.subscript.pnum \seven.subscript.pnum \eight.subscript.pnum 
+	\nine.subscript.pnum \zero.numr.pnum \one.numr.pnum \two.numr.pnum 
+	\three.numr.pnum \four.numr.pnum \five.numr.pnum \six.numr.pnum 
+	\seven.numr.pnum \eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum 
+	\one.dnom.pnum \two.dnom.pnum \three.dnom.pnum \four.dnom.pnum 
+	\five.dnom.pnum \six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum 
+	\nine.dnom.pnum \zero.superior.tnum \one.superior.tnum \two.superior.tnum 
 	\three.superior.tnum \four.superior.tnum \five.superior.tnum 
 	\six.superior.tnum \seven.superior.tnum \eight.superior.tnum 
 	\nine.superior.tnum \zero.subscript.tnum \one.subscript.tnum 

--- a/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/11 21:28:52</string>
+    <string>2025/03/12 18:14:57</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/contents.plist
@@ -3036,6 +3036,8 @@
     <string>uni20B_E_.glif</string>
     <key>uni20BF</key>
     <string>uni20B_F_.glif</string>
+    <key>uni20C0</key>
+    <string>uni20C_0.glif</string>
     <key>uni2100</key>
     <string>uni2100.glif</string>
     <key>uni2101</key>
@@ -4428,6 +4430,10 @@
     <string>uni27F_2.glif</string>
     <key>uni27F3</key>
     <string>uni27F_3.glif</string>
+    <key>uni27F0</key>
+    <string>uni27F_0.glif</string>
+    <key>uni27F1</key>
+    <string>uni27F_1.glif</string>
     <key>uni1F00</key>
     <string>uni1F_00.glif</string>
     <key>uni1F01</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni20C_0.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni20C_0.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni20C0" format="2">
+  <advance width="1139"/>
+  <unicode hex="20C0"/>
+  <outline>
+    <contour>
+      <point x="-88" y="-160" type="line"/>
+      <point x="911" y="-160" type="line"/>
+      <point x="854" y="-480" type="line"/>
+      <point x="-145" y="-480" type="line"/>
+    </contour>
+    <contour>
+      <point x="602" y="750" type="curve" smooth="yes"/>
+      <point x="372" y="750"/>
+      <point x="365" y="478"/>
+      <point x="365" y="449" type="curve" smooth="yes"/>
+      <point x="365" y="352"/>
+      <point x="411" y="290"/>
+      <point x="523" y="290" type="curve" smooth="yes"/>
+      <point x="627" y="290"/>
+      <point x="692" y="344"/>
+      <point x="728" y="430" type="curve"/>
+      <point x="1003" y="252" type="line"/>
+      <point x="884" y="79"/>
+      <point x="688" y="-30"/>
+      <point x="467" y="-30" type="curve" smooth="yes"/>
+      <point x="184" y="-30"/>
+      <point x="2" y="150"/>
+      <point x="2" y="412" type="curve" smooth="yes"/>
+      <point x="2" y="751"/>
+      <point x="277" y="1070"/>
+      <point x="659" y="1070" type="curve" smooth="yes"/>
+      <point x="880" y="1070"/>
+      <point x="1039" y="961"/>
+      <point x="1096" y="788" type="curve"/>
+      <point x="758" y="610" type="line"/>
+      <point x="752" y="696"/>
+      <point x="706" y="750"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni27F_0.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni27F_0.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F0" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F0"/>
+  <outline>
+    <contour>
+      <point x="1398" y="852" type="line"/>
+      <point x="1248" y="0" type="line"/>
+      <point x="1024" y="0" type="line"/>
+      <point x="1174" y="852" type="line"/>
+    </contour>
+    <contour>
+      <point x="486" y="852" type="line"/>
+      <point x="336" y="0" type="line"/>
+      <point x="112" y="0" type="line"/>
+      <point x="262" y="852" type="line"/>
+    </contour>
+    <contour>
+      <point x="1156" y="1202" type="line"/>
+      <point x="944" y="0" type="line"/>
+      <point x="720" y="0" type="line"/>
+      <point x="932" y="1202" type="line"/>
+    </contour>
+    <contour>
+      <point x="985" y="1480" type="line"/>
+      <point x="1598" y="736" type="line"/>
+      <point x="1327" y="506" type="line"/>
+      <point x="871" y="1084" type="line"/>
+      <point x="211" y="506" type="line"/>
+      <point x="22" y="736" type="line"/>
+      <point x="897" y="1480" type="line"/>
+    </contour>
+    <contour>
+      <point x="852" y="1202" type="line"/>
+      <point x="640" y="0" type="line"/>
+      <point x="416" y="0" type="line"/>
+      <point x="628" y="1202" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni27F_1.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni27F_1.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F1" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F1"/>
+  <outline>
+    <contour>
+      <point x="223" y="628" type="line"/>
+      <point x="373" y="1480" type="line"/>
+      <point x="597" y="1480" type="line"/>
+      <point x="447" y="628" type="line"/>
+    </contour>
+    <contour>
+      <point x="1135" y="628" type="line"/>
+      <point x="1285" y="1480" type="line"/>
+      <point x="1509" y="1480" type="line"/>
+      <point x="1359" y="628" type="line"/>
+    </contour>
+    <contour>
+      <point x="465" y="278" type="line"/>
+      <point x="677" y="1480" type="line"/>
+      <point x="901" y="1480" type="line"/>
+      <point x="689" y="278" type="line"/>
+    </contour>
+    <contour>
+      <point x="636" y="0" type="line"/>
+      <point x="23" y="744" type="line"/>
+      <point x="294" y="974" type="line"/>
+      <point x="750" y="396" type="line"/>
+      <point x="1410" y="974" type="line"/>
+      <point x="1599" y="744" type="line"/>
+      <point x="724" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="769" y="278" type="line"/>
+      <point x="981" y="1480" type="line"/>
+      <point x="1205" y="1480" type="line"/>
+      <point x="993" y="278" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Italic.ufo/features.fea
+++ b/sources/Giphurs-Italic.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -11260,42 +11260,42 @@ feature mkmk {
 	\uni20A0 \colonmonetary \uni20A2 \franc \lira \uni20A5 \uni20A6 \peseta \uni20A8 
 	\uni20A9 \uni20AA \dong \Euro \uni20AD \uni20AE \uni20AF \uni20B0 \uni20B1 
 	\uni20B2 \uni20B3 \uni20B4 \uni20B5 \uni20B6 \uni20B7 \uni20B8 \uni20B9 \uni20BA 
-	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni2100 \uni2101 \uni2102 \uni2105 
-	\uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 \uni2141 
-	\uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 \uni2124 
-	\uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 \uni211B 
-	\Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 \uni2133 
-	\uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 \uni2116 
-	\uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 \trademark 
-	\uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 \uni212A 
-	\uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 \uni2138 
-	\uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D \uni217E 
-	\uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 \uni2174 
-	\uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 \uni2188 
-	\uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 \uni2197 
-	\uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 \uni21A2 
-	\uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 \uni21AB 
-	\uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 \uni21B1 
-	\uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 \uni21E4 
-	\uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF \uni21C0 
-	\uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 \uni21C8 
-	\uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 \uni21D6 
-	\uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC \uni21DD 
-	\uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 \uni21E7 
-	\uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 \uni21F1 
-	\uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 \uni21FA 
-	\uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 \partialdiff 
-	\existential \uni2204 \emptyset \Delta \gradient \element \uni220A \notelement 
-	\suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation \minus 
-	\uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 \radical 
-	\uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 \uni2222 
-	\uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor \integral 
-	\logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 \uni2232 
-	\uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 \uni223A 
-	\uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 \uni2242 
-	\uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D \uni224F 
-	\uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
-	\uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
+	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni20C0 \uni2100 \uni2101 \uni2102 
+	\uni2105 \uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 
+	\uni2141 \uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 
+	\uni2124 \uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 
+	\uni211B \Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 
+	\uni2133 \uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 
+	\uni2116 \uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 
+	\trademark \uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 
+	\uni212A \uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 
+	\uni2138 \uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D 
+	\uni217E \uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 
+	\uni2174 \uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 
+	\uni2188 \uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 
+	\uni2197 \uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 
+	\uni21A2 \uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 
+	\uni21AB \uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 
+	\uni21B1 \uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 
+	\uni21E4 \uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF 
+	\uni21C0 \uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 
+	\uni21C8 \uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 
+	\uni21D6 \uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC 
+	\uni21DD \uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 
+	\uni21E7 \uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 
+	\uni21F1 \uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 
+	\uni21FA \uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 
+	\partialdiff \existential \uni2204 \emptyset \Delta \gradient \element \uni220A 
+	\notelement \suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation 
+	\minus \uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 
+	\radical \uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 
+	\uni2222 \uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor 
+	\integral \logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 
+	\uni2232 \uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 
+	\uni223A \uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 
+	\uni2242 \uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D 
+	\uni224F \uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 
+	\uni2257 \uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
 	\equivalence \uni2262 \uni2263 \lessequal \greaterequal \uni2266 \uni2267 
 	\uni2268 \uni2269 \uni226A \uni226B \uni226C \uni2272 \uni2273 \uni2276 \uni2277 
 	\uni226E \uni226F \uni227A \uni227B \uni227C \uni227D \uni227E \uni227F 
@@ -11339,175 +11339,175 @@ feature mkmk {
 	\uni24A5 \uni24A6 \uni24A7 \uni24A8 \uni24A9 \uni24AA \uni24AB \uni24AC \uni24AD 
 	\uni24AE \uni24AF \uni24B0 \uni24B1 \uni24B2 \uni24B3 \uni24B4 \uni24B5 \uni24F5 
 	\uni24F6 \uni24F7 \uni24F8 \uni24F9 \uni24FA \uni24FB \uni24FC \uni24FD \uni24FE 
-	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni1F00 \uni1F01 
-	\uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 \uni1F09 \uni1F0A 
-	\uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 \uni1F12 \uni1F13 
-	\uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C \uni1F1D \uni1F20 
-	\uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 \uni1F28 \uni1F29 
-	\uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 \uni1F31 \uni1F32 
-	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 \uni1F3A \uni1F3B 
-	\uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 
-	\uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D \uni1F50 \uni1F51 
-	\uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 \uni1F5B \uni1F5D 
-	\uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 
-	\uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1F70 
-	\uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 \uni1F78 \uni1F79 
-	\uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
-	\uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C \uni1F8D \uni1F8E 
-	\uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 \uni1F96 \uni1F97 
-	\uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E \uni1F9F \uni1FA0 
-	\uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 \uni1FA8 \uni1FA9 
-	\uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 \uni1FB0 \uni1FB1 
-	\uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 \uni1FBA \uni1FBC 
-	\uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 \uni1FCA \uni1FCC 
-	\uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 \uni1FDA \uni1FCB 
-	\uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 \uni1FE7 \uni1FE3 
-	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 
-	\uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB \uni1FC9 \uni2E17 
-	\uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 \uni214C \omicron 
-	\uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 \uni2C65 \uni2C66 
-	\uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE \uni1D49 \uni1D43 
-	\uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 \uni2C6D \uni2C72 
-	\uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 \uni1D7D \uniA7B4 
-	\uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc \j.sc \k.sc \l.sc 
-	\m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc \x.sc \y.sc \z.sc 
-	\agrave.sc \aacute.sc \acircumflex.sc \atilde.sc \adieresis.sc \aring.sc 
-	\ae.sc \ccedilla.sc \egrave.sc \eacute.sc \ecircumflex.sc \edieresis.sc 
-	\igrave.sc \iacute.sc \icircumflex.sc \idieresis.sc \ntilde.sc \ograve.sc 
-	\oacute.sc \ocircumflex.sc \otilde.sc \odieresis.sc \oslash.sc \ugrave.sc 
-	\uacute.sc \ucircumflex.sc \udieresis.sc \yacute.sc \thorn.sc \ydieresis.sc 
-	\amacron.sc \abreve.sc \aogonek.sc \cacute.sc \ccircumflex.sc \cdotaccent.sc 
-	\ccaron.sc \dcaron.sc \dcroat.sc \emacron.sc \ebreve.sc \edotaccent.sc 
-	\eogonek.sc \ecaron.sc \gcircumflex.sc \gbreve.sc \gdotaccent.sc 
-	\gcommaaccent.sc \hcircumflex.sc \hbar.sc \itilde.sc \imacron.sc \ibreve.sc 
-	\iogonek.sc \ij.sc \jcircumflex.sc \kcommaaccent.sc \kgreenlandic.sc 
-	\lacute.sc \lcommaaccent.sc \lcaron.sc \ldot.sc \lslash.sc \nacute.sc 
-	\ncommaaccent.sc \ncaron.sc \napostrophe.sc \eng.sc \omacron.sc \obreve.sc 
-	\ohungarumlaut.sc \oe.sc \racute.sc \rcommaaccent.sc \rcaron.sc \sacute.sc 
-	\scircumflex.sc \scedilla.sc \scaron.sc \uni0163.sc \tcaron.sc \tbar.sc 
-	\utilde.sc \umacron.sc \ubreve.sc \uring.sc \uhungarumlaut.sc \uogonek.sc 
-	\wcircumflex.sc \ycircumflex.sc \zacute.sc \zdotaccent.sc \zcaron.sc 
-	\uni0180.sc \uni0183.sc \uni0185.sc \uni0188.sc \uni018C.sc \florin.sc 
-	\uni0195.sc \uni0199.sc \uni019A.sc \uni019B.sc \uni019E.sc \ohorn.sc 
-	\uni01A3.sc \uni01A5.sc \uni01A8.sc \uni01AB.sc \uni01AD.sc \uhorn.sc 
-	\uni01B4.sc \uni01B6.sc \uni01B9.sc \uni01BD.sc \uni01BF.sc \uni01C5.sc 
-	\uni01C6.sc \uni01C8.sc \uni01C9.sc \uni01CB.sc \uni01CC.sc \uni01CE.sc 
-	\uni01D0.sc \uni01D2.sc \uni01D4.sc \uni01D6.sc \uni01D8.sc \uni01DA.sc 
-	\uni01DC.sc \uni01DD.sc \uni01DF.sc \uni01E1.sc \uni01E3.sc \uni01E5.sc 
-	\gcaron.sc \uni01E9.sc \uni01EB.sc \uni01ED.sc \uni01F0.sc \uni01F2.sc 
-	\uni01F3.sc \uni01F5.sc \uni01F9.sc \aringacute.sc \aeacute.sc 
-	\oslashacute.sc \uni0201.sc \uni0203.sc \uni0205.sc \uni0207.sc \uni0209.sc 
-	\uni020B.sc \uni020D.sc \uni020F.sc \uni0211.sc \uni0213.sc \uni0215.sc 
-	\uni0217.sc \scommaaccent.sc \uni021B.sc \uni021D.sc \uni021F.sc \uni0221.sc 
-	\uni0223.sc \uni0225.sc \uni0227.sc \uni0229.sc \uni022B.sc \uni022D.sc 
-	\uni022F.sc \uni0231.sc \uni0233.sc \uni0234.sc \uni0235.sc \uni0236.sc 
-	\uni0237.sc \uni023C.sc \uni0242.sc \uni0247.sc \uni0249.sc \uni024B.sc 
-	\uni024D.sc \uni024F.sc \uni0250.sc \uni0251.sc \uni0253.sc \uni0254.sc 
-	\uni0256.sc \uni0257.sc \uni0259.sc \uni025B.sc \uni0260.sc \uni0263.sc 
-	\uni0264.sc \uni0266.sc \uni0268.sc \uni0269.sc \uni026A.sc \uni026F.sc 
-	\uni0272.sc \uni0275.sc \uni027D.sc \uni0283.sc \uni0288.sc \uni0289.sc 
-	\uni028A.sc \uni028B.sc \uni028C.sc \uni0292.sc \uni0298.sc \uni029D.sc 
-	\uni02A3.sc \uni02A4.sc \uni02A5.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni02A9.sc \uni02AA.sc \uni02AB.sc \uni0377.sc \uni037B.sc \uni037C.sc 
-	\uni037D.sc \iotadieresistonos.sc \alphatonos.sc \epsilontonos.sc 
-	\etatonos.sc \iotatonos.sc \upsilondieresistonos.sc \alpha.sc \beta.sc 
-	\gamma.sc \delta.sc \epsilon.sc \zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc 
-	\lambda.sc \uni03BC.sc \nu.sc \xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc 
-	\tau.sc \upsilon.sc \phi.sc \chi.sc \psi.sc \omega.sc \iotadieresis.sc 
-	\upsilondieresis.sc \omicrontonos.sc \upsilontonos.sc \omegatonos.sc 
-	\uni03D9.sc \uni03DB.sc \uni03DD.sc \uni03F2.sc \uni03F3.sc \uni03F8.sc 
-	\uni03FC.sc \uni0430.sc \uni0431.sc \uni0432.sc \uni0433.sc \uni0434.sc 
-	\uni0435.sc \uni0436.sc \uni0437.sc \uni0438.sc \uni0439.sc \uni043A.sc 
-	\uni043B.sc \uni043C.sc \uni043D.sc \uni043E.sc \uni043F.sc \uni0440.sc 
-	\uni0441.sc \uni0442.sc \uni0443.sc \uni0444.sc \uni0445.sc \uni0446.sc 
-	\uni0447.sc \uni0448.sc \uni0449.sc \uni044A.sc \uni044B.sc \uni044C.sc 
-	\uni044D.sc \uni044E.sc \uni044F.sc \uni0450.sc \uni0451.sc \uni0452.sc 
-	\uni0453.sc \uni0454.sc \uni0455.sc \uni0456.sc \uni0457.sc \uni0458.sc 
-	\uni0459.sc \uni045A.sc \uni045B.sc \uni045C.sc \uni045D.sc \uni045E.sc 
-	\uni045F.sc \uni0461.sc \uni0463.sc \uni0465.sc \uni0467.sc \uni0469.sc 
-	\uni046B.sc \uni046D.sc \uni046F.sc \uni0471.sc \uni0473.sc \uni0475.sc 
-	\uni0477.sc \uni047B.sc \uni047D.sc \uni047F.sc \uni0481.sc \uni048B.sc 
-	\uni048D.sc \uni048F.sc \uni0491.sc \uni0493.sc \uni0495.sc \uni0497.sc 
-	\uni0499.sc \uni049B.sc \uni049D.sc \uni049F.sc \uni04A1.sc \uni04A3.sc 
-	\uni04A5.sc \uni04A7.sc \uni04A9.sc \uni04AB.sc \uni04AD.sc \uni04AF.sc 
-	\uni04B1.sc \uni04B3.sc \uni04B5.sc \uni04B7.sc \uni04B9.sc \uni04BB.sc 
-	\uni04BD.sc \uni04BF.sc \uni04C2.sc \uni04C4.sc \uni04C6.sc \uni04C8.sc 
-	\uni04CA.sc \uni04CC.sc \uni04CE.sc \uni04D1.sc \uni04D3.sc \uni04D5.sc 
-	\uni04D7.sc \uni04D9.sc \uni04DB.sc \uni04DD.sc \uni04DF.sc \uni04E3.sc 
-	\uni04E5.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni04ED.sc \uni04EF.sc 
-	\uni04F1.sc \uni04F3.sc \uni04F5.sc \uni04F7.sc \uni04F9.sc \uni04FB.sc 
-	\uni04FD.sc \uni04FF.sc \uni0501.sc \uni0503.sc \uni0505.sc \uni0507.sc 
-	\uni0509.sc \uni050B.sc \uni050D.sc \uni050F.sc \uni0511.sc \uni0513.sc 
-	\uni0515.sc \uni0517.sc \uni0519.sc \uni051B.sc \uni051D.sc \uni051F.sc 
-	\uni0521.sc \uni0523.sc \uni0525.sc \uni0527.sc \uni0529.sc \uni052B.sc 
-	\uni052D.sc \uni052F.sc \uni1D7D.sc \uni1E01.sc \uni1E03.sc \uni1E05.sc 
-	\uni1E07.sc \uni1E09.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc \uni1E11.sc 
-	\uni1E13.sc \uni1E15.sc \uni1E17.sc \uni1E19.sc \uni1E1B.sc \uni1E1D.sc 
-	\uni1E1F.sc \uni1E21.sc \uni1E23.sc \uni1E25.sc \uni1E27.sc \uni1E29.sc 
-	\uni1E2B.sc \uni1E2D.sc \uni1E2F.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc 
-	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc \uni1E3F.sc \uni1E41.sc 
-	\uni1E43.sc \uni1E45.sc \uni1E47.sc \uni1E49.sc \uni1E4B.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1E55.sc \uni1E57.sc \uni1E59.sc 
-	\uni1E5B.sc \uni1E5D.sc \uni1E5F.sc \uni1E61.sc \uni1E63.sc \uni1E65.sc 
-	\uni1E67.sc \uni1E69.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc 
-	\uni1E73.sc \uni1E75.sc \uni1E77.sc \uni1E79.sc \uni1E7B.sc \uni1E7D.sc 
-	\uni1E7F.sc \wgrave.sc \wacute.sc \wdieresis.sc \uni1E87.sc \uni1E89.sc 
-	\uni1E8B.sc \uni1E8D.sc \uni1E8F.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc 
-	\uni1E96.sc \uni1E97.sc \uni1E98.sc \uni1E99.sc \uni1E9A.sc \germandbls.sc 
-	\uni1E9F.sc \uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc \uni1EA9.sc 
-	\uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc \uni1EB3.sc \uni1EB5.sc 
-	\uni1EB7.sc \uni1EB9.sc \uni1EBB.sc \uni1EBD.sc \uni1EBF.sc \uni1EC1.sc 
-	\uni1EC3.sc \uni1EC5.sc \uni1EC7.sc \uni1EC9.sc \uni1ECB.sc \uni1ECD.sc 
-	\uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc \uni1EE5.sc 
-	\uni1EE7.sc \uni1EE9.sc \uni1EEB.sc \uni1EED.sc \uni1EEF.sc \uni1EF1.sc 
-	\ygrave.sc \uni1EF5.sc \uni1EF7.sc \uni1EF9.sc \uni1EFB.sc \uni1EFD.sc 
-	\uni1EFF.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc \uni1F03.sc \uni1F04.sc 
-	\uni1F05.sc \uni1F06.sc \uni1F07.sc \uni1F10.sc \uni1F11.sc \uni1F12.sc 
-	\uni1F13.sc \uni1F14.sc \uni1F15.sc \uni1F20.sc \uni1F21.sc \uni1F22.sc 
-	\uni1F23.sc \uni1F24.sc \uni1F25.sc \uni1F26.sc \uni1F27.sc \uni1F30.sc 
-	\uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
-	\uni1F37.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc \uni1F54.sc 
-	\uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc 
-	\uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F70.sc 
-	\uni1F71.sc \uni1F72.sc \uni1F73.sc \uni1F74.sc \uni1F75.sc \uni1F76.sc 
-	\uni1F77.sc \uni1F78.sc \uni1F79.sc \uni1F7A.sc \uni1F7B.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1F80.sc \uni1F81.sc \uni1F82.sc \uni1F83.sc \uni1F84.sc 
-	\uni1F85.sc \uni1F86.sc \uni1F87.sc \uni1F90.sc \uni1F91.sc \uni1F92.sc 
-	\uni1F93.sc \uni1F94.sc \uni1F95.sc \uni1F96.sc \uni1F97.sc \uni1FA0.sc 
-	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc \uni1FB4.sc 
-	\uni1FB6.sc \uni1FB7.sc \uni1FC2.sc \uni1FC3.sc \uni1FC4.sc \uni1FC6.sc 
-	\uni1FC7.sc \uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni1FE0.sc \uni1FE1.sc \uni1FE2.sc \uni1FE3.sc \uni1FE4.sc 
-	\uni1FE5.sc \uni1FE6.sc \uni1FE7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
-	\uni1FF6.sc \uni1FF7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \uni2178.sc \uni2179.sc 
-	\uni217A.sc \uni217B.sc \uni217C.sc \uni217D.sc \uni217E.sc \uni217F.sc 
-	\uni2C73.sc \uniA78C.sc \uniA7B5.sc \uniA7B7.sc \uniA7C8.sc \zero.pnum 
-	\one.pnum \two.pnum \three.pnum \four.pnum \five.pnum \six.pnum \seven.pnum 
-	\eight.pnum \nine.pnum \zero.tnum \one.tnum \two.tnum \three.tnum \four.tnum 
-	\five.tnum \six.tnum \seven.tnum \eight.tnum \nine.tnum \zero.onum \one.onum 
-	\two.onum \three.onum \four.onum \five.onum \six.onum \seven.onum \eight.onum 
-	\nine.onum \zero.onum.tnum \one.onum.tnum \two.onum.tnum \three.onum.tnum 
-	\four.onum.tnum \five.onum.tnum \six.onum.tnum \seven.onum.tnum 
-	\eight.onum.tnum \nine.onum.tnum \zero.numr \one.numr \two.numr \three.numr 
-	\four.numr \five.numr \six.numr \seven.numr \eight.numr \nine.numr \zero.dnom 
-	\one.dnom \two.dnom \three.dnom \four.dnom \five.dnom \six.dnom \seven.dnom 
-	\eight.dnom \nine.dnom \zero.superior.pnum \one.superior.pnum 
-	\two.superior.pnum \three.superior.pnum \four.superior.pnum 
-	\five.superior.pnum \six.superior.pnum \seven.superior.pnum 
-	\eight.superior.pnum \nine.superior.pnum \zero.subscript.pnum 
-	\one.subscript.pnum \two.subscript.pnum \three.subscript.pnum 
-	\four.subscript.pnum \five.subscript.pnum \six.subscript.pnum 
-	\seven.subscript.pnum \eight.subscript.pnum \nine.subscript.pnum 
-	\zero.numr.pnum \one.numr.pnum \two.numr.pnum \three.numr.pnum 
-	\four.numr.pnum \five.numr.pnum \six.numr.pnum \seven.numr.pnum 
-	\eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum \one.dnom.pnum 
-	\two.dnom.pnum \three.dnom.pnum \four.dnom.pnum \five.dnom.pnum 
-	\six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum \nine.dnom.pnum 
-	\zero.superior.tnum \one.superior.tnum \two.superior.tnum 
+	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni27F0 \uni27F1 
+	\uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 
+	\uni1F09 \uni1F0A \uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 
+	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C 
+	\uni1F1D \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 
+	\uni1F28 \uni1F29 \uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 
+	\uni1F31 \uni1F32 \uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 
+	\uni1F3A \uni1F3B \uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 
+	\uni1F43 \uni1F44 \uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
+	\uni1F50 \uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 
+	\uni1F5B \uni1F5D \uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 
+	\uni1F66 \uni1F67 \uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E 
+	\uni1F6F \uni1F70 \uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 
+	\uni1F78 \uni1F79 \uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 
+	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C 
+	\uni1F8D \uni1F8E \uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 
+	\uni1F96 \uni1F97 \uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E 
+	\uni1F9F \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 
+	\uni1FA8 \uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 
+	\uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 
+	\uni1FBA \uni1FBC \uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 
+	\uni1FCA \uni1FCC \uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 
+	\uni1FDA \uni1FCB \uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 
+	\uni1FE7 \uni1FE3 \uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 
+	\uni1FF4 \uni1FF6 \uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB 
+	\uni1FC9 \uni2E17 \uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 
+	\uni214C \omicron \uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 
+	\uni2C65 \uni2C66 \uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE 
+	\uni1D49 \uni1D43 \uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 
+	\uni2C6D \uni2C72 \uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 
+	\uni1D7D \uniA7B4 \uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc 
+	\j.sc \k.sc \l.sc \m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc 
+	\x.sc \y.sc \z.sc \agrave.sc \aacute.sc \acircumflex.sc \atilde.sc 
+	\adieresis.sc \aring.sc \ae.sc \ccedilla.sc \egrave.sc \eacute.sc 
+	\ecircumflex.sc \edieresis.sc \igrave.sc \iacute.sc \icircumflex.sc 
+	\idieresis.sc \ntilde.sc \ograve.sc \oacute.sc \ocircumflex.sc \otilde.sc 
+	\odieresis.sc \oslash.sc \ugrave.sc \uacute.sc \ucircumflex.sc \udieresis.sc 
+	\yacute.sc \thorn.sc \ydieresis.sc \amacron.sc \abreve.sc \aogonek.sc 
+	\cacute.sc \ccircumflex.sc \cdotaccent.sc \ccaron.sc \dcaron.sc \dcroat.sc 
+	\emacron.sc \ebreve.sc \edotaccent.sc \eogonek.sc \ecaron.sc \gcircumflex.sc 
+	\gbreve.sc \gdotaccent.sc \gcommaaccent.sc \hcircumflex.sc \hbar.sc 
+	\itilde.sc \imacron.sc \ibreve.sc \iogonek.sc \ij.sc \jcircumflex.sc 
+	\kcommaaccent.sc \kgreenlandic.sc \lacute.sc \lcommaaccent.sc \lcaron.sc 
+	\ldot.sc \lslash.sc \nacute.sc \ncommaaccent.sc \ncaron.sc \napostrophe.sc 
+	\eng.sc \omacron.sc \obreve.sc \ohungarumlaut.sc \oe.sc \racute.sc 
+	\rcommaaccent.sc \rcaron.sc \sacute.sc \scircumflex.sc \scedilla.sc 
+	\scaron.sc \uni0163.sc \tcaron.sc \tbar.sc \utilde.sc \umacron.sc \ubreve.sc 
+	\uring.sc \uhungarumlaut.sc \uogonek.sc \wcircumflex.sc \ycircumflex.sc 
+	\zacute.sc \zdotaccent.sc \zcaron.sc \uni0180.sc \uni0183.sc \uni0185.sc 
+	\uni0188.sc \uni018C.sc \florin.sc \uni0195.sc \uni0199.sc \uni019A.sc 
+	\uni019B.sc \uni019E.sc \ohorn.sc \uni01A3.sc \uni01A5.sc \uni01A8.sc 
+	\uni01AB.sc \uni01AD.sc \uhorn.sc \uni01B4.sc \uni01B6.sc \uni01B9.sc 
+	\uni01BD.sc \uni01BF.sc \uni01C5.sc \uni01C6.sc \uni01C8.sc \uni01C9.sc 
+	\uni01CB.sc \uni01CC.sc \uni01CE.sc \uni01D0.sc \uni01D2.sc \uni01D4.sc 
+	\uni01D6.sc \uni01D8.sc \uni01DA.sc \uni01DC.sc \uni01DD.sc \uni01DF.sc 
+	\uni01E1.sc \uni01E3.sc \uni01E5.sc \gcaron.sc \uni01E9.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F0.sc \uni01F2.sc \uni01F3.sc \uni01F5.sc \uni01F9.sc 
+	\aringacute.sc \aeacute.sc \oslashacute.sc \uni0201.sc \uni0203.sc 
+	\uni0205.sc \uni0207.sc \uni0209.sc \uni020B.sc \uni020D.sc \uni020F.sc 
+	\uni0211.sc \uni0213.sc \uni0215.sc \uni0217.sc \scommaaccent.sc \uni021B.sc 
+	\uni021D.sc \uni021F.sc \uni0221.sc \uni0223.sc \uni0225.sc \uni0227.sc 
+	\uni0229.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni0233.sc 
+	\uni0234.sc \uni0235.sc \uni0236.sc \uni0237.sc \uni023C.sc \uni0242.sc 
+	\uni0247.sc \uni0249.sc \uni024B.sc \uni024D.sc \uni024F.sc \uni0250.sc 
+	\uni0251.sc \uni0253.sc \uni0254.sc \uni0256.sc \uni0257.sc \uni0259.sc 
+	\uni025B.sc \uni0260.sc \uni0263.sc \uni0264.sc \uni0266.sc \uni0268.sc 
+	\uni0269.sc \uni026A.sc \uni026F.sc \uni0272.sc \uni0275.sc \uni027D.sc 
+	\uni0283.sc \uni0288.sc \uni0289.sc \uni028A.sc \uni028B.sc \uni028C.sc 
+	\uni0292.sc \uni0298.sc \uni029D.sc \uni02A3.sc \uni02A4.sc \uni02A5.sc 
+	\uni02A6.sc \uni02A7.sc \uni02A8.sc \uni02A9.sc \uni02AA.sc \uni02AB.sc 
+	\uni0377.sc \uni037B.sc \uni037C.sc \uni037D.sc \iotadieresistonos.sc 
+	\alphatonos.sc \epsilontonos.sc \etatonos.sc \iotatonos.sc 
+	\upsilondieresistonos.sc \alpha.sc \beta.sc \gamma.sc \delta.sc \epsilon.sc 
+	\zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc \lambda.sc \uni03BC.sc \nu.sc 
+	\xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc \tau.sc \upsilon.sc \phi.sc \chi.sc 
+	\psi.sc \omega.sc \iotadieresis.sc \upsilondieresis.sc \omicrontonos.sc 
+	\upsilontonos.sc \omegatonos.sc \uni03D9.sc \uni03DB.sc \uni03DD.sc 
+	\uni03F2.sc \uni03F3.sc \uni03F8.sc \uni03FC.sc \uni0430.sc \uni0431.sc 
+	\uni0432.sc \uni0433.sc \uni0434.sc \uni0435.sc \uni0436.sc \uni0437.sc 
+	\uni0438.sc \uni0439.sc \uni043A.sc \uni043B.sc \uni043C.sc \uni043D.sc 
+	\uni043E.sc \uni043F.sc \uni0440.sc \uni0441.sc \uni0442.sc \uni0443.sc 
+	\uni0444.sc \uni0445.sc \uni0446.sc \uni0447.sc \uni0448.sc \uni0449.sc 
+	\uni044A.sc \uni044B.sc \uni044C.sc \uni044D.sc \uni044E.sc \uni044F.sc 
+	\uni0450.sc \uni0451.sc \uni0452.sc \uni0453.sc \uni0454.sc \uni0455.sc 
+	\uni0456.sc \uni0457.sc \uni0458.sc \uni0459.sc \uni045A.sc \uni045B.sc 
+	\uni045C.sc \uni045D.sc \uni045E.sc \uni045F.sc \uni0461.sc \uni0463.sc 
+	\uni0465.sc \uni0467.sc \uni0469.sc \uni046B.sc \uni046D.sc \uni046F.sc 
+	\uni0471.sc \uni0473.sc \uni0475.sc \uni0477.sc \uni047B.sc \uni047D.sc 
+	\uni047F.sc \uni0481.sc \uni048B.sc \uni048D.sc \uni048F.sc \uni0491.sc 
+	\uni0493.sc \uni0495.sc \uni0497.sc \uni0499.sc \uni049B.sc \uni049D.sc 
+	\uni049F.sc \uni04A1.sc \uni04A3.sc \uni04A5.sc \uni04A7.sc \uni04A9.sc 
+	\uni04AB.sc \uni04AD.sc \uni04AF.sc \uni04B1.sc \uni04B3.sc \uni04B5.sc 
+	\uni04B7.sc \uni04B9.sc \uni04BB.sc \uni04BD.sc \uni04BF.sc \uni04C2.sc 
+	\uni04C4.sc \uni04C6.sc \uni04C8.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
+	\uni04D1.sc \uni04D3.sc \uni04D5.sc \uni04D7.sc \uni04D9.sc \uni04DB.sc 
+	\uni04DD.sc \uni04DF.sc \uni04E3.sc \uni04E5.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni04EF.sc \uni04F1.sc \uni04F3.sc \uni04F5.sc 
+	\uni04F7.sc \uni04F9.sc \uni04FB.sc \uni04FD.sc \uni04FF.sc \uni0501.sc 
+	\uni0503.sc \uni0505.sc \uni0507.sc \uni0509.sc \uni050B.sc \uni050D.sc 
+	\uni050F.sc \uni0511.sc \uni0513.sc \uni0515.sc \uni0517.sc \uni0519.sc 
+	\uni051B.sc \uni051D.sc \uni051F.sc \uni0521.sc \uni0523.sc \uni0525.sc 
+	\uni0527.sc \uni0529.sc \uni052B.sc \uni052D.sc \uni052F.sc \uni1D7D.sc 
+	\uni1E01.sc \uni1E03.sc \uni1E05.sc \uni1E07.sc \uni1E09.sc \uni1E0B.sc 
+	\uni1E0D.sc \uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E15.sc \uni1E17.sc 
+	\uni1E19.sc \uni1E1B.sc \uni1E1D.sc \uni1E1F.sc \uni1E21.sc \uni1E23.sc 
+	\uni1E25.sc \uni1E27.sc \uni1E29.sc \uni1E2B.sc \uni1E2D.sc \uni1E2F.sc 
+	\uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc 
+	\uni1E3D.sc \uni1E3F.sc \uni1E41.sc \uni1E43.sc \uni1E45.sc \uni1E47.sc 
+	\uni1E49.sc \uni1E4B.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1E55.sc \uni1E57.sc \uni1E59.sc \uni1E5B.sc \uni1E5D.sc \uni1E5F.sc 
+	\uni1E61.sc \uni1E63.sc \uni1E65.sc \uni1E67.sc \uni1E69.sc \uni1E6B.sc 
+	\uni1E6D.sc \uni1E6F.sc \uni1E71.sc \uni1E73.sc \uni1E75.sc \uni1E77.sc 
+	\uni1E79.sc \uni1E7B.sc \uni1E7D.sc \uni1E7F.sc \wgrave.sc \wacute.sc 
+	\wdieresis.sc \uni1E87.sc \uni1E89.sc \uni1E8B.sc \uni1E8D.sc \uni1E8F.sc 
+	\uni1E91.sc \uni1E93.sc \uni1E95.sc \uni1E96.sc \uni1E97.sc \uni1E98.sc 
+	\uni1E99.sc \uni1E9A.sc \germandbls.sc \uni1E9F.sc \uni1EA1.sc \uni1EA3.sc 
+	\uni1EA5.sc \uni1EA7.sc \uni1EA9.sc \uni1EAB.sc \uni1EAD.sc \uni1EAF.sc 
+	\uni1EB1.sc \uni1EB3.sc \uni1EB5.sc \uni1EB7.sc \uni1EB9.sc \uni1EBB.sc 
+	\uni1EBD.sc \uni1EBF.sc \uni1EC1.sc \uni1EC3.sc \uni1EC5.sc \uni1EC7.sc 
+	\uni1EC9.sc \uni1ECB.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1EE5.sc \uni1EE7.sc \uni1EE9.sc \uni1EEB.sc 
+	\uni1EED.sc \uni1EEF.sc \uni1EF1.sc \ygrave.sc \uni1EF5.sc \uni1EF7.sc 
+	\uni1EF9.sc \uni1EFB.sc \uni1EFD.sc \uni1EFF.sc \uni1F00.sc \uni1F01.sc 
+	\uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc 
+	\uni1F10.sc \uni1F11.sc \uni1F12.sc \uni1F13.sc \uni1F14.sc \uni1F15.sc 
+	\uni1F20.sc \uni1F21.sc \uni1F22.sc \uni1F23.sc \uni1F24.sc \uni1F25.sc 
+	\uni1F26.sc \uni1F27.sc \uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc 
+	\uni1F34.sc \uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F40.sc \uni1F41.sc 
+	\uni1F42.sc \uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F50.sc \uni1F51.sc 
+	\uni1F52.sc \uni1F53.sc \uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc 
+	\uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F70.sc \uni1F71.sc \uni1F72.sc \uni1F73.sc 
+	\uni1F74.sc \uni1F75.sc \uni1F76.sc \uni1F77.sc \uni1F78.sc \uni1F79.sc 
+	\uni1F7A.sc \uni1F7B.sc \uni1F7C.sc \uni1F7D.sc \uni1F80.sc \uni1F81.sc 
+	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc \uni1F87.sc 
+	\uni1F90.sc \uni1F91.sc \uni1F92.sc \uni1F93.sc \uni1F94.sc \uni1F95.sc 
+	\uni1F96.sc \uni1F97.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FB0.sc \uni1FB1.sc 
+	\uni1FB2.sc \uni1FB3.sc \uni1FB4.sc \uni1FB6.sc \uni1FB7.sc \uni1FC2.sc 
+	\uni1FC3.sc \uni1FC4.sc \uni1FC6.sc \uni1FC7.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni1FE0.sc \uni1FE1.sc 
+	\uni1FE2.sc \uni1FE3.sc \uni1FE4.sc \uni1FE5.sc \uni1FE6.sc \uni1FE7.sc 
+	\uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2174.sc \uni2175.sc \uni2176.sc 
+	\uni2177.sc \uni2178.sc \uni2179.sc \uni217A.sc \uni217B.sc \uni217C.sc 
+	\uni217D.sc \uni217E.sc \uni217F.sc \uni2C73.sc \uniA78C.sc \uniA7B5.sc 
+	\uniA7B7.sc \uniA7C8.sc \zero.pnum \one.pnum \two.pnum \three.pnum \four.pnum 
+	\five.pnum \six.pnum \seven.pnum \eight.pnum \nine.pnum \zero.tnum \one.tnum 
+	\two.tnum \three.tnum \four.tnum \five.tnum \six.tnum \seven.tnum \eight.tnum 
+	\nine.tnum \zero.onum \one.onum \two.onum \three.onum \four.onum \five.onum 
+	\six.onum \seven.onum \eight.onum \nine.onum \zero.onum.tnum \one.onum.tnum 
+	\two.onum.tnum \three.onum.tnum \four.onum.tnum \five.onum.tnum 
+	\six.onum.tnum \seven.onum.tnum \eight.onum.tnum \nine.onum.tnum \zero.numr 
+	\one.numr \two.numr \three.numr \four.numr \five.numr \six.numr \seven.numr 
+	\eight.numr \nine.numr \zero.dnom \one.dnom \two.dnom \three.dnom \four.dnom 
+	\five.dnom \six.dnom \seven.dnom \eight.dnom \nine.dnom \zero.superior.pnum 
+	\one.superior.pnum \two.superior.pnum \three.superior.pnum 
+	\four.superior.pnum \five.superior.pnum \six.superior.pnum 
+	\seven.superior.pnum \eight.superior.pnum \nine.superior.pnum 
+	\zero.subscript.pnum \one.subscript.pnum \two.subscript.pnum 
+	\three.subscript.pnum \four.subscript.pnum \five.subscript.pnum 
+	\six.subscript.pnum \seven.subscript.pnum \eight.subscript.pnum 
+	\nine.subscript.pnum \zero.numr.pnum \one.numr.pnum \two.numr.pnum 
+	\three.numr.pnum \four.numr.pnum \five.numr.pnum \six.numr.pnum 
+	\seven.numr.pnum \eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum 
+	\one.dnom.pnum \two.dnom.pnum \three.dnom.pnum \four.dnom.pnum 
+	\five.dnom.pnum \six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum 
+	\nine.dnom.pnum \zero.superior.tnum \one.superior.tnum \two.superior.tnum 
 	\three.superior.tnum \four.superior.tnum \five.superior.tnum 
 	\six.superior.tnum \seven.superior.tnum \eight.superior.tnum 
 	\nine.superior.tnum \zero.subscript.tnum \one.subscript.tnum 

--- a/sources/Giphurs-Italic.ufo/fontinfo.plist
+++ b/sources/Giphurs-Italic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/11 21:27:01</string>
+    <string>2025/03/12 18:14:06</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Italic.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-Italic.ufo/glyphs/contents.plist
@@ -3036,6 +3036,8 @@
     <string>uni20B_E_.glif</string>
     <key>uni20BF</key>
     <string>uni20B_F_.glif</string>
+    <key>uni20C0</key>
+    <string>uni20C_0.glif</string>
     <key>uni2100</key>
     <string>uni2100.glif</string>
     <key>uni2101</key>
@@ -4428,6 +4430,10 @@
     <string>uni27F_2.glif</string>
     <key>uni27F3</key>
     <string>uni27F_3.glif</string>
+    <key>uni27F0</key>
+    <string>uni27F_0.glif</string>
+    <key>uni27F1</key>
+    <string>uni27F_1.glif</string>
     <key>uni1F00</key>
     <string>uni1F_00.glif</string>
     <key>uni1F01</key>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni20C_0.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni20C_0.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni20C0" format="2">
+  <advance width="1142"/>
+  <unicode hex="20C0"/>
+  <outline>
+    <contour>
+      <point x="-18" y="-160" type="line"/>
+      <point x="844" y="-160" type="line"/>
+      <point x="816" y="-320" type="line"/>
+      <point x="-46" y="-320" type="line"/>
+    </contour>
+    <contour>
+      <point x="627" y="900" type="curve" smooth="yes"/>
+      <point x="387" y="900"/>
+      <point x="234" y="656"/>
+      <point x="234" y="429" type="curve" smooth="yes"/>
+      <point x="234" y="258"/>
+      <point x="330" y="140"/>
+      <point x="493" y="140" type="curve" smooth="yes"/>
+      <point x="634" y="140"/>
+      <point x="747" y="207"/>
+      <point x="819" y="340" type="curve"/>
+      <point x="956" y="252" type="line"/>
+      <point x="842" y="74"/>
+      <point x="663" y="-20"/>
+      <point x="464" y="-20" type="curve" smooth="yes"/>
+      <point x="218" y="-20"/>
+      <point x="52" y="155"/>
+      <point x="52" y="409" type="curve" smooth="yes"/>
+      <point x="52" y="746"/>
+      <point x="321" y="1060"/>
+      <point x="655" y="1060" type="curve" smooth="yes"/>
+      <point x="854" y="1060"/>
+      <point x="999" y="966"/>
+      <point x="1051" y="788" type="curve"/>
+      <point x="882" y="700" type="line"/>
+      <point x="856" y="833"/>
+      <point x="768" y="900"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni27F_0.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni27F_0.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F0" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F0"/>
+  <outline>
+    <contour>
+      <point x="1372" y="932" type="line"/>
+      <point x="1208" y="0" type="line"/>
+      <point x="1064" y="0" type="line"/>
+      <point x="1228" y="932" type="line"/>
+    </contour>
+    <contour>
+      <point x="460" y="932" type="line"/>
+      <point x="296" y="0" type="line"/>
+      <point x="152" y="0" type="line"/>
+      <point x="316" y="932" type="line"/>
+    </contour>
+    <contour>
+      <point x="1132" y="1292" type="line"/>
+      <point x="904" y="0" type="line"/>
+      <point x="760" y="0" type="line"/>
+      <point x="988" y="1292" type="line"/>
+    </contour>
+    <contour>
+      <point x="985" y="1480" type="line"/>
+      <point x="1571" y="768" type="line"/>
+      <point x="1436" y="651" type="line"/>
+      <point x="910" y="1304" type="line"/>
+      <point x="154" y="651" type="line"/>
+      <point x="59" y="768" type="line"/>
+      <point x="897" y="1480" type="line"/>
+    </contour>
+    <contour>
+      <point x="828" y="1292" type="line"/>
+      <point x="600" y="0" type="line"/>
+      <point x="456" y="0" type="line"/>
+      <point x="684" y="1292" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni27F_1.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni27F_1.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F1" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F1"/>
+  <outline>
+    <contour>
+      <point x="249" y="548" type="line"/>
+      <point x="413" y="1480" type="line"/>
+      <point x="557" y="1480" type="line"/>
+      <point x="393" y="548" type="line"/>
+    </contour>
+    <contour>
+      <point x="1161" y="548" type="line"/>
+      <point x="1325" y="1480" type="line"/>
+      <point x="1469" y="1480" type="line"/>
+      <point x="1305" y="548" type="line"/>
+    </contour>
+    <contour>
+      <point x="489" y="188" type="line"/>
+      <point x="717" y="1480" type="line"/>
+      <point x="861" y="1480" type="line"/>
+      <point x="633" y="188" type="line"/>
+    </contour>
+    <contour>
+      <point x="636" y="0" type="line"/>
+      <point x="50" y="712" type="line"/>
+      <point x="185" y="829" type="line"/>
+      <point x="711" y="176" type="line"/>
+      <point x="1467" y="829" type="line"/>
+      <point x="1562" y="712" type="line"/>
+      <point x="724" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="793" y="188" type="line"/>
+      <point x="1021" y="1480" type="line"/>
+      <point x="1165" y="1480" type="line"/>
+      <point x="937" y="188" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Regular.ufo/features.fea
+++ b/sources/Giphurs-Regular.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -11173,42 +11173,42 @@ feature mkmk {
 	\uni20A0 \colonmonetary \uni20A2 \franc \lira \uni20A5 \uni20A6 \peseta \uni20A8 
 	\uni20A9 \uni20AA \dong \Euro \uni20AD \uni20AE \uni20AF \uni20B0 \uni20B1 
 	\uni20B2 \uni20B3 \uni20B4 \uni20B5 \uni20B6 \uni20B7 \uni20B8 \uni20B9 \uni20BA 
-	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni2100 \uni2101 \uni2102 \uni2105 
-	\uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 \uni2141 
-	\uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 \uni2124 
-	\uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 \uni211B 
-	\Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 \uni2133 
-	\uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 \uni2116 
-	\uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 \trademark 
-	\uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 \uni212A 
-	\uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 \uni2138 
-	\uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D \uni217E 
-	\uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 \uni2174 
-	\uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 \uni2188 
-	\uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 \uni2197 
-	\uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 \uni21A2 
-	\uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 \uni21AB 
-	\uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 \uni21B1 
-	\uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 \uni21E4 
-	\uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF \uni21C0 
-	\uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 \uni21C8 
-	\uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 \uni21D6 
-	\uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC \uni21DD 
-	\uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 \uni21E7 
-	\uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 \uni21F1 
-	\uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 \uni21FA 
-	\uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 \partialdiff 
-	\existential \uni2204 \emptyset \Delta \gradient \element \uni220A \notelement 
-	\suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation \minus 
-	\uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 \radical 
-	\uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 \uni2222 
-	\uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor \integral 
-	\logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 \uni2232 
-	\uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 \uni223A 
-	\uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 \uni2242 
-	\uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D \uni224F 
-	\uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
-	\uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
+	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni20C0 \uni2100 \uni2101 \uni2102 
+	\uni2105 \uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 
+	\uni2141 \uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 
+	\uni2124 \uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 
+	\uni211B \Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 
+	\uni2133 \uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 
+	\uni2116 \uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 
+	\trademark \uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 
+	\uni212A \uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 
+	\uni2138 \uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D 
+	\uni217E \uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 
+	\uni2174 \uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 
+	\uni2188 \uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 
+	\uni2197 \uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 
+	\uni21A2 \uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 
+	\uni21AB \uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 
+	\uni21B1 \uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 
+	\uni21E4 \uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF 
+	\uni21C0 \uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 
+	\uni21C8 \uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 
+	\uni21D6 \uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC 
+	\uni21DD \uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 
+	\uni21E7 \uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 
+	\uni21F1 \uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 
+	\uni21FA \uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 
+	\partialdiff \existential \uni2204 \emptyset \Delta \gradient \element \uni220A 
+	\notelement \suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation 
+	\minus \uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 
+	\radical \uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 
+	\uni2222 \uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor 
+	\integral \logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 
+	\uni2232 \uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 
+	\uni223A \uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 
+	\uni2242 \uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D 
+	\uni224F \uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 
+	\uni2257 \uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
 	\equivalence \uni2262 \uni2263 \lessequal \greaterequal \uni2266 \uni2267 
 	\uni2268 \uni2269 \uni226A \uni226B \uni226C \uni2272 \uni2273 \uni2276 \uni2277 
 	\uni226E \uni226F \uni227A \uni227B \uni227C \uni227D \uni227E \uni227F 
@@ -11252,175 +11252,175 @@ feature mkmk {
 	\uni24A5 \uni24A6 \uni24A7 \uni24A8 \uni24A9 \uni24AA \uni24AB \uni24AC \uni24AD 
 	\uni24AE \uni24AF \uni24B0 \uni24B1 \uni24B2 \uni24B3 \uni24B4 \uni24B5 \uni24F5 
 	\uni24F6 \uni24F7 \uni24F8 \uni24F9 \uni24FA \uni24FB \uni24FC \uni24FD \uni24FE 
-	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni1F00 \uni1F01 
-	\uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 \uni1F09 \uni1F0A 
-	\uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 \uni1F12 \uni1F13 
-	\uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C \uni1F1D \uni1F20 
-	\uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 \uni1F28 \uni1F29 
-	\uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 \uni1F31 \uni1F32 
-	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 \uni1F3A \uni1F3B 
-	\uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 
-	\uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D \uni1F50 \uni1F51 
-	\uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 \uni1F5B \uni1F5D 
-	\uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 
-	\uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1F70 
-	\uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 \uni1F78 \uni1F79 
-	\uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
-	\uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C \uni1F8D \uni1F8E 
-	\uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 \uni1F96 \uni1F97 
-	\uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E \uni1F9F \uni1FA0 
-	\uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 \uni1FA8 \uni1FA9 
-	\uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 \uni1FB0 \uni1FB1 
-	\uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 \uni1FBA \uni1FBC 
-	\uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 \uni1FCA \uni1FCC 
-	\uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 \uni1FDA \uni1FCB 
-	\uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 \uni1FE7 \uni1FE3 
-	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 
-	\uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB \uni1FC9 \uni2E17 
-	\uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 \uni214C \omicron 
-	\uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 \uni2C65 \uni2C66 
-	\uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE \uni1D49 \uni1D43 
-	\uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 \uni2C6D \uni2C72 
-	\uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 \uni1D7D \uniA7B4 
-	\uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc \j.sc \k.sc \l.sc 
-	\m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc \x.sc \y.sc \z.sc 
-	\agrave.sc \aacute.sc \acircumflex.sc \atilde.sc \adieresis.sc \aring.sc 
-	\ae.sc \ccedilla.sc \egrave.sc \eacute.sc \ecircumflex.sc \edieresis.sc 
-	\igrave.sc \iacute.sc \icircumflex.sc \idieresis.sc \ntilde.sc \ograve.sc 
-	\oacute.sc \ocircumflex.sc \otilde.sc \odieresis.sc \oslash.sc \ugrave.sc 
-	\uacute.sc \ucircumflex.sc \udieresis.sc \yacute.sc \thorn.sc \ydieresis.sc 
-	\amacron.sc \abreve.sc \aogonek.sc \cacute.sc \ccircumflex.sc \cdotaccent.sc 
-	\ccaron.sc \dcaron.sc \dcroat.sc \emacron.sc \ebreve.sc \edotaccent.sc 
-	\eogonek.sc \ecaron.sc \gcircumflex.sc \gbreve.sc \gdotaccent.sc 
-	\gcommaaccent.sc \hcircumflex.sc \hbar.sc \itilde.sc \imacron.sc \ibreve.sc 
-	\iogonek.sc \ij.sc \jcircumflex.sc \kcommaaccent.sc \kgreenlandic.sc 
-	\lacute.sc \lcommaaccent.sc \lcaron.sc \ldot.sc \lslash.sc \nacute.sc 
-	\ncommaaccent.sc \ncaron.sc \napostrophe.sc \eng.sc \omacron.sc \obreve.sc 
-	\ohungarumlaut.sc \oe.sc \racute.sc \rcommaaccent.sc \rcaron.sc \sacute.sc 
-	\scircumflex.sc \scedilla.sc \scaron.sc \uni0163.sc \tcaron.sc \tbar.sc 
-	\utilde.sc \umacron.sc \ubreve.sc \uring.sc \uhungarumlaut.sc \uogonek.sc 
-	\wcircumflex.sc \ycircumflex.sc \zacute.sc \zdotaccent.sc \zcaron.sc 
-	\uni0180.sc \uni0183.sc \uni0185.sc \uni0188.sc \uni018C.sc \florin.sc 
-	\uni0195.sc \uni0199.sc \uni019A.sc \uni019B.sc \uni019E.sc \ohorn.sc 
-	\uni01A3.sc \uni01A5.sc \uni01A8.sc \uni01AB.sc \uni01AD.sc \uhorn.sc 
-	\uni01B4.sc \uni01B6.sc \uni01B9.sc \uni01BD.sc \uni01BF.sc \uni01C5.sc 
-	\uni01C6.sc \uni01C8.sc \uni01C9.sc \uni01CB.sc \uni01CC.sc \uni01CE.sc 
-	\uni01D0.sc \uni01D2.sc \uni01D4.sc \uni01D6.sc \uni01D8.sc \uni01DA.sc 
-	\uni01DC.sc \uni01DD.sc \uni01DF.sc \uni01E1.sc \uni01E3.sc \uni01E5.sc 
-	\gcaron.sc \uni01E9.sc \uni01EB.sc \uni01ED.sc \uni01F0.sc \uni01F2.sc 
-	\uni01F3.sc \uni01F5.sc \uni01F9.sc \aringacute.sc \aeacute.sc 
-	\oslashacute.sc \uni0201.sc \uni0203.sc \uni0205.sc \uni0207.sc \uni0209.sc 
-	\uni020B.sc \uni020D.sc \uni020F.sc \uni0211.sc \uni0213.sc \uni0215.sc 
-	\uni0217.sc \scommaaccent.sc \uni021B.sc \uni021D.sc \uni021F.sc \uni0221.sc 
-	\uni0223.sc \uni0225.sc \uni0227.sc \uni0229.sc \uni022B.sc \uni022D.sc 
-	\uni022F.sc \uni0231.sc \uni0233.sc \uni0234.sc \uni0235.sc \uni0236.sc 
-	\uni0237.sc \uni023C.sc \uni0242.sc \uni0247.sc \uni0249.sc \uni024B.sc 
-	\uni024D.sc \uni024F.sc \uni0250.sc \uni0251.sc \uni0253.sc \uni0254.sc 
-	\uni0256.sc \uni0257.sc \uni0259.sc \uni025B.sc \uni0260.sc \uni0263.sc 
-	\uni0264.sc \uni0266.sc \uni0268.sc \uni0269.sc \uni026A.sc \uni026F.sc 
-	\uni0272.sc \uni0275.sc \uni027D.sc \uni0283.sc \uni0288.sc \uni0289.sc 
-	\uni028A.sc \uni028B.sc \uni028C.sc \uni0292.sc \uni0298.sc \uni029D.sc 
-	\uni02A3.sc \uni02A4.sc \uni02A5.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni02A9.sc \uni02AA.sc \uni02AB.sc \uni0377.sc \uni037B.sc \uni037C.sc 
-	\uni037D.sc \iotadieresistonos.sc \alphatonos.sc \epsilontonos.sc 
-	\etatonos.sc \iotatonos.sc \upsilondieresistonos.sc \alpha.sc \beta.sc 
-	\gamma.sc \delta.sc \epsilon.sc \zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc 
-	\lambda.sc \uni03BC.sc \nu.sc \xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc 
-	\tau.sc \upsilon.sc \phi.sc \chi.sc \psi.sc \omega.sc \iotadieresis.sc 
-	\upsilondieresis.sc \omicrontonos.sc \upsilontonos.sc \omegatonos.sc 
-	\uni03D9.sc \uni03DB.sc \uni03DD.sc \uni03F2.sc \uni03F3.sc \uni03F8.sc 
-	\uni03FC.sc \uni0430.sc \uni0431.sc \uni0432.sc \uni0433.sc \uni0434.sc 
-	\uni0435.sc \uni0436.sc \uni0437.sc \uni0438.sc \uni0439.sc \uni043A.sc 
-	\uni043B.sc \uni043C.sc \uni043D.sc \uni043E.sc \uni043F.sc \uni0440.sc 
-	\uni0441.sc \uni0442.sc \uni0443.sc \uni0444.sc \uni0445.sc \uni0446.sc 
-	\uni0447.sc \uni0448.sc \uni0449.sc \uni044A.sc \uni044B.sc \uni044C.sc 
-	\uni044D.sc \uni044E.sc \uni044F.sc \uni0450.sc \uni0451.sc \uni0452.sc 
-	\uni0453.sc \uni0454.sc \uni0455.sc \uni0456.sc \uni0457.sc \uni0458.sc 
-	\uni0459.sc \uni045A.sc \uni045B.sc \uni045C.sc \uni045D.sc \uni045E.sc 
-	\uni045F.sc \uni0461.sc \uni0463.sc \uni0465.sc \uni0467.sc \uni0469.sc 
-	\uni046B.sc \uni046D.sc \uni046F.sc \uni0471.sc \uni0473.sc \uni0475.sc 
-	\uni0477.sc \uni047B.sc \uni047D.sc \uni047F.sc \uni0481.sc \uni048B.sc 
-	\uni048D.sc \uni048F.sc \uni0491.sc \uni0493.sc \uni0495.sc \uni0497.sc 
-	\uni0499.sc \uni049B.sc \uni049D.sc \uni049F.sc \uni04A1.sc \uni04A3.sc 
-	\uni04A5.sc \uni04A7.sc \uni04A9.sc \uni04AB.sc \uni04AD.sc \uni04AF.sc 
-	\uni04B1.sc \uni04B3.sc \uni04B5.sc \uni04B7.sc \uni04B9.sc \uni04BB.sc 
-	\uni04BD.sc \uni04BF.sc \uni04C2.sc \uni04C4.sc \uni04C6.sc \uni04C8.sc 
-	\uni04CA.sc \uni04CC.sc \uni04CE.sc \uni04D1.sc \uni04D3.sc \uni04D5.sc 
-	\uni04D7.sc \uni04D9.sc \uni04DB.sc \uni04DD.sc \uni04DF.sc \uni04E3.sc 
-	\uni04E5.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni04ED.sc \uni04EF.sc 
-	\uni04F1.sc \uni04F3.sc \uni04F5.sc \uni04F7.sc \uni04F9.sc \uni04FB.sc 
-	\uni04FD.sc \uni04FF.sc \uni0501.sc \uni0503.sc \uni0505.sc \uni0507.sc 
-	\uni0509.sc \uni050B.sc \uni050D.sc \uni050F.sc \uni0511.sc \uni0513.sc 
-	\uni0515.sc \uni0517.sc \uni0519.sc \uni051B.sc \uni051D.sc \uni051F.sc 
-	\uni0521.sc \uni0523.sc \uni0525.sc \uni0527.sc \uni0529.sc \uni052B.sc 
-	\uni052D.sc \uni052F.sc \uni1D7D.sc \uni1E01.sc \uni1E03.sc \uni1E05.sc 
-	\uni1E07.sc \uni1E09.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc \uni1E11.sc 
-	\uni1E13.sc \uni1E15.sc \uni1E17.sc \uni1E19.sc \uni1E1B.sc \uni1E1D.sc 
-	\uni1E1F.sc \uni1E21.sc \uni1E23.sc \uni1E25.sc \uni1E27.sc \uni1E29.sc 
-	\uni1E2B.sc \uni1E2D.sc \uni1E2F.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc 
-	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc \uni1E3F.sc \uni1E41.sc 
-	\uni1E43.sc \uni1E45.sc \uni1E47.sc \uni1E49.sc \uni1E4B.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1E55.sc \uni1E57.sc \uni1E59.sc 
-	\uni1E5B.sc \uni1E5D.sc \uni1E5F.sc \uni1E61.sc \uni1E63.sc \uni1E65.sc 
-	\uni1E67.sc \uni1E69.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc 
-	\uni1E73.sc \uni1E75.sc \uni1E77.sc \uni1E79.sc \uni1E7B.sc \uni1E7D.sc 
-	\uni1E7F.sc \wgrave.sc \wacute.sc \wdieresis.sc \uni1E87.sc \uni1E89.sc 
-	\uni1E8B.sc \uni1E8D.sc \uni1E8F.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc 
-	\uni1E96.sc \uni1E97.sc \uni1E98.sc \uni1E99.sc \uni1E9A.sc \germandbls.sc 
-	\uni1E9F.sc \uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc \uni1EA9.sc 
-	\uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc \uni1EB3.sc \uni1EB5.sc 
-	\uni1EB7.sc \uni1EB9.sc \uni1EBB.sc \uni1EBD.sc \uni1EBF.sc \uni1EC1.sc 
-	\uni1EC3.sc \uni1EC5.sc \uni1EC7.sc \uni1EC9.sc \uni1ECB.sc \uni1ECD.sc 
-	\uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc \uni1EE5.sc 
-	\uni1EE7.sc \uni1EE9.sc \uni1EEB.sc \uni1EED.sc \uni1EEF.sc \uni1EF1.sc 
-	\ygrave.sc \uni1EF5.sc \uni1EF7.sc \uni1EF9.sc \uni1EFB.sc \uni1EFD.sc 
-	\uni1EFF.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc \uni1F03.sc \uni1F04.sc 
-	\uni1F05.sc \uni1F06.sc \uni1F07.sc \uni1F10.sc \uni1F11.sc \uni1F12.sc 
-	\uni1F13.sc \uni1F14.sc \uni1F15.sc \uni1F20.sc \uni1F21.sc \uni1F22.sc 
-	\uni1F23.sc \uni1F24.sc \uni1F25.sc \uni1F26.sc \uni1F27.sc \uni1F30.sc 
-	\uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
-	\uni1F37.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc \uni1F54.sc 
-	\uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc 
-	\uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F70.sc 
-	\uni1F71.sc \uni1F72.sc \uni1F73.sc \uni1F74.sc \uni1F75.sc \uni1F76.sc 
-	\uni1F77.sc \uni1F78.sc \uni1F79.sc \uni1F7A.sc \uni1F7B.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1F80.sc \uni1F81.sc \uni1F82.sc \uni1F83.sc \uni1F84.sc 
-	\uni1F85.sc \uni1F86.sc \uni1F87.sc \uni1F90.sc \uni1F91.sc \uni1F92.sc 
-	\uni1F93.sc \uni1F94.sc \uni1F95.sc \uni1F96.sc \uni1F97.sc \uni1FA0.sc 
-	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc \uni1FB4.sc 
-	\uni1FB6.sc \uni1FB7.sc \uni1FC2.sc \uni1FC3.sc \uni1FC4.sc \uni1FC6.sc 
-	\uni1FC7.sc \uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni1FE0.sc \uni1FE1.sc \uni1FE2.sc \uni1FE3.sc \uni1FE4.sc 
-	\uni1FE5.sc \uni1FE6.sc \uni1FE7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
-	\uni1FF6.sc \uni1FF7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \uni2178.sc \uni2179.sc 
-	\uni217A.sc \uni217B.sc \uni217C.sc \uni217D.sc \uni217E.sc \uni217F.sc 
-	\uni2C73.sc \uniA78C.sc \uniA7B5.sc \uniA7B7.sc \uniA7C8.sc \zero.pnum 
-	\one.pnum \two.pnum \three.pnum \four.pnum \five.pnum \six.pnum \seven.pnum 
-	\eight.pnum \nine.pnum \zero.tnum \one.tnum \two.tnum \three.tnum \four.tnum 
-	\five.tnum \six.tnum \seven.tnum \eight.tnum \nine.tnum \zero.onum \one.onum 
-	\two.onum \three.onum \four.onum \five.onum \six.onum \seven.onum \eight.onum 
-	\nine.onum \zero.onum.tnum \one.onum.tnum \two.onum.tnum \three.onum.tnum 
-	\four.onum.tnum \five.onum.tnum \six.onum.tnum \seven.onum.tnum 
-	\eight.onum.tnum \nine.onum.tnum \zero.numr \one.numr \two.numr \three.numr 
-	\four.numr \five.numr \six.numr \seven.numr \eight.numr \nine.numr \zero.dnom 
-	\one.dnom \two.dnom \three.dnom \four.dnom \five.dnom \six.dnom \seven.dnom 
-	\eight.dnom \nine.dnom \zero.superior.pnum \one.superior.pnum 
-	\two.superior.pnum \three.superior.pnum \four.superior.pnum 
-	\five.superior.pnum \six.superior.pnum \seven.superior.pnum 
-	\eight.superior.pnum \nine.superior.pnum \zero.subscript.pnum 
-	\one.subscript.pnum \two.subscript.pnum \three.subscript.pnum 
-	\four.subscript.pnum \five.subscript.pnum \six.subscript.pnum 
-	\seven.subscript.pnum \eight.subscript.pnum \nine.subscript.pnum 
-	\zero.numr.pnum \one.numr.pnum \two.numr.pnum \three.numr.pnum 
-	\four.numr.pnum \five.numr.pnum \six.numr.pnum \seven.numr.pnum 
-	\eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum \one.dnom.pnum 
-	\two.dnom.pnum \three.dnom.pnum \four.dnom.pnum \five.dnom.pnum 
-	\six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum \nine.dnom.pnum 
-	\zero.superior.tnum \one.superior.tnum \two.superior.tnum 
+	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni27F0 \uni27F1 
+	\uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 
+	\uni1F09 \uni1F0A \uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 
+	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C 
+	\uni1F1D \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 
+	\uni1F28 \uni1F29 \uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 
+	\uni1F31 \uni1F32 \uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 
+	\uni1F3A \uni1F3B \uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 
+	\uni1F43 \uni1F44 \uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
+	\uni1F50 \uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 
+	\uni1F5B \uni1F5D \uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 
+	\uni1F66 \uni1F67 \uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E 
+	\uni1F6F \uni1F70 \uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 
+	\uni1F78 \uni1F79 \uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 
+	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C 
+	\uni1F8D \uni1F8E \uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 
+	\uni1F96 \uni1F97 \uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E 
+	\uni1F9F \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 
+	\uni1FA8 \uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 
+	\uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 
+	\uni1FBA \uni1FBC \uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 
+	\uni1FCA \uni1FCC \uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 
+	\uni1FDA \uni1FCB \uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 
+	\uni1FE7 \uni1FE3 \uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 
+	\uni1FF4 \uni1FF6 \uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB 
+	\uni1FC9 \uni2E17 \uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 
+	\uni214C \omicron \uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 
+	\uni2C65 \uni2C66 \uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE 
+	\uni1D49 \uni1D43 \uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 
+	\uni2C6D \uni2C72 \uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 
+	\uni1D7D \uniA7B4 \uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc 
+	\j.sc \k.sc \l.sc \m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc 
+	\x.sc \y.sc \z.sc \agrave.sc \aacute.sc \acircumflex.sc \atilde.sc 
+	\adieresis.sc \aring.sc \ae.sc \ccedilla.sc \egrave.sc \eacute.sc 
+	\ecircumflex.sc \edieresis.sc \igrave.sc \iacute.sc \icircumflex.sc 
+	\idieresis.sc \ntilde.sc \ograve.sc \oacute.sc \ocircumflex.sc \otilde.sc 
+	\odieresis.sc \oslash.sc \ugrave.sc \uacute.sc \ucircumflex.sc \udieresis.sc 
+	\yacute.sc \thorn.sc \ydieresis.sc \amacron.sc \abreve.sc \aogonek.sc 
+	\cacute.sc \ccircumflex.sc \cdotaccent.sc \ccaron.sc \dcaron.sc \dcroat.sc 
+	\emacron.sc \ebreve.sc \edotaccent.sc \eogonek.sc \ecaron.sc \gcircumflex.sc 
+	\gbreve.sc \gdotaccent.sc \gcommaaccent.sc \hcircumflex.sc \hbar.sc 
+	\itilde.sc \imacron.sc \ibreve.sc \iogonek.sc \ij.sc \jcircumflex.sc 
+	\kcommaaccent.sc \kgreenlandic.sc \lacute.sc \lcommaaccent.sc \lcaron.sc 
+	\ldot.sc \lslash.sc \nacute.sc \ncommaaccent.sc \ncaron.sc \napostrophe.sc 
+	\eng.sc \omacron.sc \obreve.sc \ohungarumlaut.sc \oe.sc \racute.sc 
+	\rcommaaccent.sc \rcaron.sc \sacute.sc \scircumflex.sc \scedilla.sc 
+	\scaron.sc \uni0163.sc \tcaron.sc \tbar.sc \utilde.sc \umacron.sc \ubreve.sc 
+	\uring.sc \uhungarumlaut.sc \uogonek.sc \wcircumflex.sc \ycircumflex.sc 
+	\zacute.sc \zdotaccent.sc \zcaron.sc \uni0180.sc \uni0183.sc \uni0185.sc 
+	\uni0188.sc \uni018C.sc \florin.sc \uni0195.sc \uni0199.sc \uni019A.sc 
+	\uni019B.sc \uni019E.sc \ohorn.sc \uni01A3.sc \uni01A5.sc \uni01A8.sc 
+	\uni01AB.sc \uni01AD.sc \uhorn.sc \uni01B4.sc \uni01B6.sc \uni01B9.sc 
+	\uni01BD.sc \uni01BF.sc \uni01C5.sc \uni01C6.sc \uni01C8.sc \uni01C9.sc 
+	\uni01CB.sc \uni01CC.sc \uni01CE.sc \uni01D0.sc \uni01D2.sc \uni01D4.sc 
+	\uni01D6.sc \uni01D8.sc \uni01DA.sc \uni01DC.sc \uni01DD.sc \uni01DF.sc 
+	\uni01E1.sc \uni01E3.sc \uni01E5.sc \gcaron.sc \uni01E9.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F0.sc \uni01F2.sc \uni01F3.sc \uni01F5.sc \uni01F9.sc 
+	\aringacute.sc \aeacute.sc \oslashacute.sc \uni0201.sc \uni0203.sc 
+	\uni0205.sc \uni0207.sc \uni0209.sc \uni020B.sc \uni020D.sc \uni020F.sc 
+	\uni0211.sc \uni0213.sc \uni0215.sc \uni0217.sc \scommaaccent.sc \uni021B.sc 
+	\uni021D.sc \uni021F.sc \uni0221.sc \uni0223.sc \uni0225.sc \uni0227.sc 
+	\uni0229.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni0233.sc 
+	\uni0234.sc \uni0235.sc \uni0236.sc \uni0237.sc \uni023C.sc \uni0242.sc 
+	\uni0247.sc \uni0249.sc \uni024B.sc \uni024D.sc \uni024F.sc \uni0250.sc 
+	\uni0251.sc \uni0253.sc \uni0254.sc \uni0256.sc \uni0257.sc \uni0259.sc 
+	\uni025B.sc \uni0260.sc \uni0263.sc \uni0264.sc \uni0266.sc \uni0268.sc 
+	\uni0269.sc \uni026A.sc \uni026F.sc \uni0272.sc \uni0275.sc \uni027D.sc 
+	\uni0283.sc \uni0288.sc \uni0289.sc \uni028A.sc \uni028B.sc \uni028C.sc 
+	\uni0292.sc \uni0298.sc \uni029D.sc \uni02A3.sc \uni02A4.sc \uni02A5.sc 
+	\uni02A6.sc \uni02A7.sc \uni02A8.sc \uni02A9.sc \uni02AA.sc \uni02AB.sc 
+	\uni0377.sc \uni037B.sc \uni037C.sc \uni037D.sc \iotadieresistonos.sc 
+	\alphatonos.sc \epsilontonos.sc \etatonos.sc \iotatonos.sc 
+	\upsilondieresistonos.sc \alpha.sc \beta.sc \gamma.sc \delta.sc \epsilon.sc 
+	\zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc \lambda.sc \uni03BC.sc \nu.sc 
+	\xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc \tau.sc \upsilon.sc \phi.sc \chi.sc 
+	\psi.sc \omega.sc \iotadieresis.sc \upsilondieresis.sc \omicrontonos.sc 
+	\upsilontonos.sc \omegatonos.sc \uni03D9.sc \uni03DB.sc \uni03DD.sc 
+	\uni03F2.sc \uni03F3.sc \uni03F8.sc \uni03FC.sc \uni0430.sc \uni0431.sc 
+	\uni0432.sc \uni0433.sc \uni0434.sc \uni0435.sc \uni0436.sc \uni0437.sc 
+	\uni0438.sc \uni0439.sc \uni043A.sc \uni043B.sc \uni043C.sc \uni043D.sc 
+	\uni043E.sc \uni043F.sc \uni0440.sc \uni0441.sc \uni0442.sc \uni0443.sc 
+	\uni0444.sc \uni0445.sc \uni0446.sc \uni0447.sc \uni0448.sc \uni0449.sc 
+	\uni044A.sc \uni044B.sc \uni044C.sc \uni044D.sc \uni044E.sc \uni044F.sc 
+	\uni0450.sc \uni0451.sc \uni0452.sc \uni0453.sc \uni0454.sc \uni0455.sc 
+	\uni0456.sc \uni0457.sc \uni0458.sc \uni0459.sc \uni045A.sc \uni045B.sc 
+	\uni045C.sc \uni045D.sc \uni045E.sc \uni045F.sc \uni0461.sc \uni0463.sc 
+	\uni0465.sc \uni0467.sc \uni0469.sc \uni046B.sc \uni046D.sc \uni046F.sc 
+	\uni0471.sc \uni0473.sc \uni0475.sc \uni0477.sc \uni047B.sc \uni047D.sc 
+	\uni047F.sc \uni0481.sc \uni048B.sc \uni048D.sc \uni048F.sc \uni0491.sc 
+	\uni0493.sc \uni0495.sc \uni0497.sc \uni0499.sc \uni049B.sc \uni049D.sc 
+	\uni049F.sc \uni04A1.sc \uni04A3.sc \uni04A5.sc \uni04A7.sc \uni04A9.sc 
+	\uni04AB.sc \uni04AD.sc \uni04AF.sc \uni04B1.sc \uni04B3.sc \uni04B5.sc 
+	\uni04B7.sc \uni04B9.sc \uni04BB.sc \uni04BD.sc \uni04BF.sc \uni04C2.sc 
+	\uni04C4.sc \uni04C6.sc \uni04C8.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
+	\uni04D1.sc \uni04D3.sc \uni04D5.sc \uni04D7.sc \uni04D9.sc \uni04DB.sc 
+	\uni04DD.sc \uni04DF.sc \uni04E3.sc \uni04E5.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni04EF.sc \uni04F1.sc \uni04F3.sc \uni04F5.sc 
+	\uni04F7.sc \uni04F9.sc \uni04FB.sc \uni04FD.sc \uni04FF.sc \uni0501.sc 
+	\uni0503.sc \uni0505.sc \uni0507.sc \uni0509.sc \uni050B.sc \uni050D.sc 
+	\uni050F.sc \uni0511.sc \uni0513.sc \uni0515.sc \uni0517.sc \uni0519.sc 
+	\uni051B.sc \uni051D.sc \uni051F.sc \uni0521.sc \uni0523.sc \uni0525.sc 
+	\uni0527.sc \uni0529.sc \uni052B.sc \uni052D.sc \uni052F.sc \uni1D7D.sc 
+	\uni1E01.sc \uni1E03.sc \uni1E05.sc \uni1E07.sc \uni1E09.sc \uni1E0B.sc 
+	\uni1E0D.sc \uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E15.sc \uni1E17.sc 
+	\uni1E19.sc \uni1E1B.sc \uni1E1D.sc \uni1E1F.sc \uni1E21.sc \uni1E23.sc 
+	\uni1E25.sc \uni1E27.sc \uni1E29.sc \uni1E2B.sc \uni1E2D.sc \uni1E2F.sc 
+	\uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc 
+	\uni1E3D.sc \uni1E3F.sc \uni1E41.sc \uni1E43.sc \uni1E45.sc \uni1E47.sc 
+	\uni1E49.sc \uni1E4B.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1E55.sc \uni1E57.sc \uni1E59.sc \uni1E5B.sc \uni1E5D.sc \uni1E5F.sc 
+	\uni1E61.sc \uni1E63.sc \uni1E65.sc \uni1E67.sc \uni1E69.sc \uni1E6B.sc 
+	\uni1E6D.sc \uni1E6F.sc \uni1E71.sc \uni1E73.sc \uni1E75.sc \uni1E77.sc 
+	\uni1E79.sc \uni1E7B.sc \uni1E7D.sc \uni1E7F.sc \wgrave.sc \wacute.sc 
+	\wdieresis.sc \uni1E87.sc \uni1E89.sc \uni1E8B.sc \uni1E8D.sc \uni1E8F.sc 
+	\uni1E91.sc \uni1E93.sc \uni1E95.sc \uni1E96.sc \uni1E97.sc \uni1E98.sc 
+	\uni1E99.sc \uni1E9A.sc \germandbls.sc \uni1E9F.sc \uni1EA1.sc \uni1EA3.sc 
+	\uni1EA5.sc \uni1EA7.sc \uni1EA9.sc \uni1EAB.sc \uni1EAD.sc \uni1EAF.sc 
+	\uni1EB1.sc \uni1EB3.sc \uni1EB5.sc \uni1EB7.sc \uni1EB9.sc \uni1EBB.sc 
+	\uni1EBD.sc \uni1EBF.sc \uni1EC1.sc \uni1EC3.sc \uni1EC5.sc \uni1EC7.sc 
+	\uni1EC9.sc \uni1ECB.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1EE5.sc \uni1EE7.sc \uni1EE9.sc \uni1EEB.sc 
+	\uni1EED.sc \uni1EEF.sc \uni1EF1.sc \ygrave.sc \uni1EF5.sc \uni1EF7.sc 
+	\uni1EF9.sc \uni1EFB.sc \uni1EFD.sc \uni1EFF.sc \uni1F00.sc \uni1F01.sc 
+	\uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc 
+	\uni1F10.sc \uni1F11.sc \uni1F12.sc \uni1F13.sc \uni1F14.sc \uni1F15.sc 
+	\uni1F20.sc \uni1F21.sc \uni1F22.sc \uni1F23.sc \uni1F24.sc \uni1F25.sc 
+	\uni1F26.sc \uni1F27.sc \uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc 
+	\uni1F34.sc \uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F40.sc \uni1F41.sc 
+	\uni1F42.sc \uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F50.sc \uni1F51.sc 
+	\uni1F52.sc \uni1F53.sc \uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc 
+	\uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F70.sc \uni1F71.sc \uni1F72.sc \uni1F73.sc 
+	\uni1F74.sc \uni1F75.sc \uni1F76.sc \uni1F77.sc \uni1F78.sc \uni1F79.sc 
+	\uni1F7A.sc \uni1F7B.sc \uni1F7C.sc \uni1F7D.sc \uni1F80.sc \uni1F81.sc 
+	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc \uni1F87.sc 
+	\uni1F90.sc \uni1F91.sc \uni1F92.sc \uni1F93.sc \uni1F94.sc \uni1F95.sc 
+	\uni1F96.sc \uni1F97.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FB0.sc \uni1FB1.sc 
+	\uni1FB2.sc \uni1FB3.sc \uni1FB4.sc \uni1FB6.sc \uni1FB7.sc \uni1FC2.sc 
+	\uni1FC3.sc \uni1FC4.sc \uni1FC6.sc \uni1FC7.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni1FE0.sc \uni1FE1.sc 
+	\uni1FE2.sc \uni1FE3.sc \uni1FE4.sc \uni1FE5.sc \uni1FE6.sc \uni1FE7.sc 
+	\uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2174.sc \uni2175.sc \uni2176.sc 
+	\uni2177.sc \uni2178.sc \uni2179.sc \uni217A.sc \uni217B.sc \uni217C.sc 
+	\uni217D.sc \uni217E.sc \uni217F.sc \uni2C73.sc \uniA78C.sc \uniA7B5.sc 
+	\uniA7B7.sc \uniA7C8.sc \zero.pnum \one.pnum \two.pnum \three.pnum \four.pnum 
+	\five.pnum \six.pnum \seven.pnum \eight.pnum \nine.pnum \zero.tnum \one.tnum 
+	\two.tnum \three.tnum \four.tnum \five.tnum \six.tnum \seven.tnum \eight.tnum 
+	\nine.tnum \zero.onum \one.onum \two.onum \three.onum \four.onum \five.onum 
+	\six.onum \seven.onum \eight.onum \nine.onum \zero.onum.tnum \one.onum.tnum 
+	\two.onum.tnum \three.onum.tnum \four.onum.tnum \five.onum.tnum 
+	\six.onum.tnum \seven.onum.tnum \eight.onum.tnum \nine.onum.tnum \zero.numr 
+	\one.numr \two.numr \three.numr \four.numr \five.numr \six.numr \seven.numr 
+	\eight.numr \nine.numr \zero.dnom \one.dnom \two.dnom \three.dnom \four.dnom 
+	\five.dnom \six.dnom \seven.dnom \eight.dnom \nine.dnom \zero.superior.pnum 
+	\one.superior.pnum \two.superior.pnum \three.superior.pnum 
+	\four.superior.pnum \five.superior.pnum \six.superior.pnum 
+	\seven.superior.pnum \eight.superior.pnum \nine.superior.pnum 
+	\zero.subscript.pnum \one.subscript.pnum \two.subscript.pnum 
+	\three.subscript.pnum \four.subscript.pnum \five.subscript.pnum 
+	\six.subscript.pnum \seven.subscript.pnum \eight.subscript.pnum 
+	\nine.subscript.pnum \zero.numr.pnum \one.numr.pnum \two.numr.pnum 
+	\three.numr.pnum \four.numr.pnum \five.numr.pnum \six.numr.pnum 
+	\seven.numr.pnum \eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum 
+	\one.dnom.pnum \two.dnom.pnum \three.dnom.pnum \four.dnom.pnum 
+	\five.dnom.pnum \six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum 
+	\nine.dnom.pnum \zero.superior.tnum \one.superior.tnum \two.superior.tnum 
 	\three.superior.tnum \four.superior.tnum \five.superior.tnum 
 	\six.superior.tnum \seven.superior.tnum \eight.superior.tnum 
 	\nine.superior.tnum \zero.subscript.tnum \one.subscript.tnum 

--- a/sources/Giphurs-Regular.ufo/fontinfo.plist
+++ b/sources/Giphurs-Regular.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/11 21:16:59</string>
+    <string>2025/03/12 18:13:33</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Regular.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-Regular.ufo/glyphs/contents.plist
@@ -3036,6 +3036,8 @@
     <string>uni20B_E_.glif</string>
     <key>uni20BF</key>
     <string>uni20B_F_.glif</string>
+    <key>uni20C0</key>
+    <string>uni20C_0.glif</string>
     <key>uni2100</key>
     <string>uni2100.glif</string>
     <key>uni2101</key>
@@ -4428,6 +4430,10 @@
     <string>uni27F_2.glif</string>
     <key>uni27F3</key>
     <string>uni27F_3.glif</string>
+    <key>uni27F0</key>
+    <string>uni27F_0.glif</string>
+    <key>uni27F1</key>
+    <string>uni27F_1.glif</string>
     <key>uni1F00</key>
     <string>uni1F_00.glif</string>
     <key>uni1F01</key>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni20C_0.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni20C_0.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni20C0" format="2">
+  <advance width="1142"/>
+  <unicode hex="20C0"/>
+  <outline>
+    <contour>
+      <point x="140" y="-160" type="line"/>
+      <point x="1002" y="-160" type="line"/>
+      <point x="1002" y="-320" type="line"/>
+      <point x="140" y="-320" type="line"/>
+    </contour>
+    <contour>
+      <point x="280" y="520" type="curve" smooth="yes"/>
+      <point x="280" y="300"/>
+      <point x="407" y="140"/>
+      <point x="598" y="140" type="curve" smooth="yes"/>
+      <point x="739" y="140"/>
+      <point x="840" y="207"/>
+      <point x="889" y="340" type="curve"/>
+      <point x="1042" y="252" type="line"/>
+      <point x="959" y="74"/>
+      <point x="797" y="-20"/>
+      <point x="598" y="-20" type="curve" smooth="yes"/>
+      <point x="317" y="-20"/>
+      <point x="100" y="208"/>
+      <point x="100" y="520" type="curve" smooth="yes"/>
+      <point x="100" y="832"/>
+      <point x="317" y="1060"/>
+      <point x="598" y="1060" type="curve" smooth="yes"/>
+      <point x="797" y="1060"/>
+      <point x="959" y="966"/>
+      <point x="1042" y="788" type="curve"/>
+      <point x="889" y="700" type="line"/>
+      <point x="840" y="833"/>
+      <point x="739" y="900"/>
+      <point x="598" y="900" type="curve" smooth="yes"/>
+      <point x="407" y="900"/>
+      <point x="280" y="740"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni27F_0.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni27F_0.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F0" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F0"/>
+  <outline>
+    <contour>
+      <point x="1338" y="932" type="line"/>
+      <point x="1338" y="0" type="line"/>
+      <point x="1194" y="0" type="line"/>
+      <point x="1194" y="932" type="line"/>
+    </contour>
+    <contour>
+      <point x="426" y="932" type="line"/>
+      <point x="426" y="0" type="line"/>
+      <point x="282" y="0" type="line"/>
+      <point x="282" y="932" type="line"/>
+    </contour>
+    <contour>
+      <point x="1034" y="1292" type="line"/>
+      <point x="1034" y="0" type="line"/>
+      <point x="890" y="0" type="line"/>
+      <point x="890" y="1292" type="line"/>
+    </contour>
+    <contour>
+      <point x="854" y="1480" type="line"/>
+      <point x="1566" y="768" type="line"/>
+      <point x="1451" y="651" type="line"/>
+      <point x="810" y="1304" type="line"/>
+      <point x="169" y="651" type="line"/>
+      <point x="54" y="768" type="line"/>
+      <point x="766" y="1480" type="line"/>
+    </contour>
+    <contour>
+      <point x="730" y="1292" type="line"/>
+      <point x="730" y="0" type="line"/>
+      <point x="586" y="0" type="line"/>
+      <point x="586" y="1292" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni27F_1.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni27F_1.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F1" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F1"/>
+  <outline>
+    <contour>
+      <point x="282" y="548" type="line"/>
+      <point x="282" y="1480" type="line"/>
+      <point x="426" y="1480" type="line"/>
+      <point x="426" y="548" type="line"/>
+    </contour>
+    <contour>
+      <point x="1194" y="548" type="line"/>
+      <point x="1194" y="1480" type="line"/>
+      <point x="1338" y="1480" type="line"/>
+      <point x="1338" y="548" type="line"/>
+    </contour>
+    <contour>
+      <point x="586" y="188" type="line"/>
+      <point x="586" y="1480" type="line"/>
+      <point x="730" y="1480" type="line"/>
+      <point x="730" y="188" type="line"/>
+    </contour>
+    <contour>
+      <point x="766" y="0" type="line"/>
+      <point x="54" y="712" type="line"/>
+      <point x="169" y="829" type="line"/>
+      <point x="810" y="176" type="line"/>
+      <point x="1451" y="829" type="line"/>
+      <point x="1566" y="712" type="line"/>
+      <point x="854" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="890" y="188" type="line"/>
+      <point x="890" y="1480" type="line"/>
+      <point x="1034" y="1480" type="line"/>
+      <point x="1034" y="188" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Thin.ufo/features.fea
+++ b/sources/Giphurs-Thin.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -11060,42 +11060,42 @@ feature mkmk {
 	\uni20A0 \colonmonetary \uni20A2 \franc \lira \uni20A5 \uni20A6 \peseta \uni20A8 
 	\uni20A9 \uni20AA \dong \Euro \uni20AD \uni20AE \uni20AF \uni20B0 \uni20B1 
 	\uni20B2 \uni20B3 \uni20B4 \uni20B5 \uni20B6 \uni20B7 \uni20B8 \uni20B9 \uni20BA 
-	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni2100 \uni2101 \uni2102 \uni2105 
-	\uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 \uni2141 
-	\uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 \uni2124 
-	\uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 \uni211B 
-	\Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 \uni2133 
-	\uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 \uni2116 
-	\uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 \trademark 
-	\uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 \uni212A 
-	\uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 \uni2138 
-	\uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D \uni217E 
-	\uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 \uni2174 
-	\uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 \uni2188 
-	\uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 \uni2197 
-	\uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 \uni21A2 
-	\uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 \uni21AB 
-	\uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 \uni21B1 
-	\uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 \uni21E4 
-	\uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF \uni21C0 
-	\uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 \uni21C8 
-	\uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 \uni21D6 
-	\uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC \uni21DD 
-	\uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 \uni21E7 
-	\uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 \uni21F1 
-	\uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 \uni21FA 
-	\uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 \partialdiff 
-	\existential \uni2204 \emptyset \Delta \gradient \element \uni220A \notelement 
-	\suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation \minus 
-	\uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 \radical 
-	\uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 \uni2222 
-	\uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor \integral 
-	\logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 \uni2232 
-	\uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 \uni223A 
-	\uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 \uni2242 
-	\uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D \uni224F 
-	\uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
-	\uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
+	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni20C0 \uni2100 \uni2101 \uni2102 
+	\uni2105 \uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 
+	\uni2141 \uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 
+	\uni2124 \uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 
+	\uni211B \Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 
+	\uni2133 \uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 
+	\uni2116 \uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 
+	\trademark \uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 
+	\uni212A \uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 
+	\uni2138 \uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D 
+	\uni217E \uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 
+	\uni2174 \uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 
+	\uni2188 \uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 
+	\uni2197 \uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 
+	\uni21A2 \uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 
+	\uni21AB \uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 
+	\uni21B1 \uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 
+	\uni21E4 \uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF 
+	\uni21C0 \uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 
+	\uni21C8 \uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 
+	\uni21D6 \uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC 
+	\uni21DD \uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 
+	\uni21E7 \uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 
+	\uni21F1 \uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 
+	\uni21FA \uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 
+	\partialdiff \existential \uni2204 \emptyset \Delta \gradient \element \uni220A 
+	\notelement \suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation 
+	\minus \uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 
+	\radical \uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 
+	\uni2222 \uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor 
+	\integral \logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 
+	\uni2232 \uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 
+	\uni223A \uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 
+	\uni2242 \uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D 
+	\uni224F \uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 
+	\uni2257 \uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
 	\equivalence \uni2262 \uni2263 \lessequal \greaterequal \uni2266 \uni2267 
 	\uni2268 \uni2269 \uni226A \uni226B \uni226C \uni2272 \uni2273 \uni2276 \uni2277 
 	\uni226E \uni226F \uni227A \uni227B \uni227C \uni227D \uni227E \uni227F 
@@ -11139,175 +11139,175 @@ feature mkmk {
 	\uni24A5 \uni24A6 \uni24A7 \uni24A8 \uni24A9 \uni24AA \uni24AB \uni24AC \uni24AD 
 	\uni24AE \uni24AF \uni24B0 \uni24B1 \uni24B2 \uni24B3 \uni24B4 \uni24B5 \uni24F5 
 	\uni24F6 \uni24F7 \uni24F8 \uni24F9 \uni24FA \uni24FB \uni24FC \uni24FD \uni24FE 
-	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni1F00 \uni1F01 
-	\uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 \uni1F09 \uni1F0A 
-	\uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 \uni1F12 \uni1F13 
-	\uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C \uni1F1D \uni1F20 
-	\uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 \uni1F28 \uni1F29 
-	\uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 \uni1F31 \uni1F32 
-	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 \uni1F3A \uni1F3B 
-	\uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 
-	\uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D \uni1F50 \uni1F51 
-	\uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 \uni1F5B \uni1F5D 
-	\uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 
-	\uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1F70 
-	\uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 \uni1F78 \uni1F79 
-	\uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
-	\uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C \uni1F8D \uni1F8E 
-	\uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 \uni1F96 \uni1F97 
-	\uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E \uni1F9F \uni1FA0 
-	\uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 \uni1FA8 \uni1FA9 
-	\uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 \uni1FB0 \uni1FB1 
-	\uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 \uni1FBA \uni1FBC 
-	\uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 \uni1FCA \uni1FCC 
-	\uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 \uni1FDA \uni1FCB 
-	\uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 \uni1FE7 \uni1FE3 
-	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 
-	\uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB \uni1FC9 \uni2E17 
-	\uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 \uni214C \omicron 
-	\uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 \uni2C65 \uni2C66 
-	\uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE \uni1D49 \uni1D43 
-	\uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 \uni2C6D \uni2C72 
-	\uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 \uni1D7D \uniA7B4 
-	\uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc \j.sc \k.sc \l.sc 
-	\m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc \x.sc \y.sc \z.sc 
-	\agrave.sc \aacute.sc \acircumflex.sc \atilde.sc \adieresis.sc \aring.sc 
-	\ae.sc \ccedilla.sc \egrave.sc \eacute.sc \ecircumflex.sc \edieresis.sc 
-	\igrave.sc \iacute.sc \icircumflex.sc \idieresis.sc \ntilde.sc \ograve.sc 
-	\oacute.sc \ocircumflex.sc \otilde.sc \odieresis.sc \oslash.sc \ugrave.sc 
-	\uacute.sc \ucircumflex.sc \udieresis.sc \yacute.sc \thorn.sc \ydieresis.sc 
-	\amacron.sc \abreve.sc \aogonek.sc \cacute.sc \ccircumflex.sc \cdotaccent.sc 
-	\ccaron.sc \dcaron.sc \dcroat.sc \emacron.sc \ebreve.sc \edotaccent.sc 
-	\eogonek.sc \ecaron.sc \gcircumflex.sc \gbreve.sc \gdotaccent.sc 
-	\gcommaaccent.sc \hcircumflex.sc \hbar.sc \itilde.sc \imacron.sc \ibreve.sc 
-	\iogonek.sc \ij.sc \jcircumflex.sc \kcommaaccent.sc \kgreenlandic.sc 
-	\lacute.sc \lcommaaccent.sc \lcaron.sc \ldot.sc \lslash.sc \nacute.sc 
-	\ncommaaccent.sc \ncaron.sc \napostrophe.sc \eng.sc \omacron.sc \obreve.sc 
-	\ohungarumlaut.sc \oe.sc \racute.sc \rcommaaccent.sc \rcaron.sc \sacute.sc 
-	\scircumflex.sc \scedilla.sc \scaron.sc \uni0163.sc \tcaron.sc \tbar.sc 
-	\utilde.sc \umacron.sc \ubreve.sc \uring.sc \uhungarumlaut.sc \uogonek.sc 
-	\wcircumflex.sc \ycircumflex.sc \zacute.sc \zdotaccent.sc \zcaron.sc 
-	\uni0180.sc \uni0183.sc \uni0185.sc \uni0188.sc \uni018C.sc \florin.sc 
-	\uni0195.sc \uni0199.sc \uni019A.sc \uni019B.sc \uni019E.sc \ohorn.sc 
-	\uni01A3.sc \uni01A5.sc \uni01A8.sc \uni01AB.sc \uni01AD.sc \uhorn.sc 
-	\uni01B4.sc \uni01B6.sc \uni01B9.sc \uni01BD.sc \uni01BF.sc \uni01C5.sc 
-	\uni01C6.sc \uni01C8.sc \uni01C9.sc \uni01CB.sc \uni01CC.sc \uni01CE.sc 
-	\uni01D0.sc \uni01D2.sc \uni01D4.sc \uni01D6.sc \uni01D8.sc \uni01DA.sc 
-	\uni01DC.sc \uni01DD.sc \uni01DF.sc \uni01E1.sc \uni01E3.sc \uni01E5.sc 
-	\gcaron.sc \uni01E9.sc \uni01EB.sc \uni01ED.sc \uni01F0.sc \uni01F2.sc 
-	\uni01F3.sc \uni01F5.sc \uni01F9.sc \aringacute.sc \aeacute.sc 
-	\oslashacute.sc \uni0201.sc \uni0203.sc \uni0205.sc \uni0207.sc \uni0209.sc 
-	\uni020B.sc \uni020D.sc \uni020F.sc \uni0211.sc \uni0213.sc \uni0215.sc 
-	\uni0217.sc \scommaaccent.sc \uni021B.sc \uni021D.sc \uni021F.sc \uni0221.sc 
-	\uni0223.sc \uni0225.sc \uni0227.sc \uni0229.sc \uni022B.sc \uni022D.sc 
-	\uni022F.sc \uni0231.sc \uni0233.sc \uni0234.sc \uni0235.sc \uni0236.sc 
-	\uni0237.sc \uni023C.sc \uni0242.sc \uni0247.sc \uni0249.sc \uni024B.sc 
-	\uni024D.sc \uni024F.sc \uni0250.sc \uni0251.sc \uni0253.sc \uni0254.sc 
-	\uni0256.sc \uni0257.sc \uni0259.sc \uni025B.sc \uni0260.sc \uni0263.sc 
-	\uni0264.sc \uni0266.sc \uni0268.sc \uni0269.sc \uni026A.sc \uni026F.sc 
-	\uni0272.sc \uni0275.sc \uni027D.sc \uni0283.sc \uni0288.sc \uni0289.sc 
-	\uni028A.sc \uni028B.sc \uni028C.sc \uni0292.sc \uni0298.sc \uni029D.sc 
-	\uni02A3.sc \uni02A4.sc \uni02A5.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni02A9.sc \uni02AA.sc \uni02AB.sc \uni0377.sc \uni037B.sc \uni037C.sc 
-	\uni037D.sc \iotadieresistonos.sc \alphatonos.sc \epsilontonos.sc 
-	\etatonos.sc \iotatonos.sc \upsilondieresistonos.sc \alpha.sc \beta.sc 
-	\gamma.sc \delta.sc \epsilon.sc \zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc 
-	\lambda.sc \uni03BC.sc \nu.sc \xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc 
-	\tau.sc \upsilon.sc \phi.sc \chi.sc \psi.sc \omega.sc \iotadieresis.sc 
-	\upsilondieresis.sc \omicrontonos.sc \upsilontonos.sc \omegatonos.sc 
-	\uni03D9.sc \uni03DB.sc \uni03DD.sc \uni03F2.sc \uni03F3.sc \uni03F8.sc 
-	\uni03FC.sc \uni0430.sc \uni0431.sc \uni0432.sc \uni0433.sc \uni0434.sc 
-	\uni0435.sc \uni0436.sc \uni0437.sc \uni0438.sc \uni0439.sc \uni043A.sc 
-	\uni043B.sc \uni043C.sc \uni043D.sc \uni043E.sc \uni043F.sc \uni0440.sc 
-	\uni0441.sc \uni0442.sc \uni0443.sc \uni0444.sc \uni0445.sc \uni0446.sc 
-	\uni0447.sc \uni0448.sc \uni0449.sc \uni044A.sc \uni044B.sc \uni044C.sc 
-	\uni044D.sc \uni044E.sc \uni044F.sc \uni0450.sc \uni0451.sc \uni0452.sc 
-	\uni0453.sc \uni0454.sc \uni0455.sc \uni0456.sc \uni0457.sc \uni0458.sc 
-	\uni0459.sc \uni045A.sc \uni045B.sc \uni045C.sc \uni045D.sc \uni045E.sc 
-	\uni045F.sc \uni0461.sc \uni0463.sc \uni0465.sc \uni0467.sc \uni0469.sc 
-	\uni046B.sc \uni046D.sc \uni046F.sc \uni0471.sc \uni0473.sc \uni0475.sc 
-	\uni0477.sc \uni047B.sc \uni047D.sc \uni047F.sc \uni0481.sc \uni048B.sc 
-	\uni048D.sc \uni048F.sc \uni0491.sc \uni0493.sc \uni0495.sc \uni0497.sc 
-	\uni0499.sc \uni049B.sc \uni049D.sc \uni049F.sc \uni04A1.sc \uni04A3.sc 
-	\uni04A5.sc \uni04A7.sc \uni04A9.sc \uni04AB.sc \uni04AD.sc \uni04AF.sc 
-	\uni04B1.sc \uni04B3.sc \uni04B5.sc \uni04B7.sc \uni04B9.sc \uni04BB.sc 
-	\uni04BD.sc \uni04BF.sc \uni04C2.sc \uni04C4.sc \uni04C6.sc \uni04C8.sc 
-	\uni04CA.sc \uni04CC.sc \uni04CE.sc \uni04D1.sc \uni04D3.sc \uni04D5.sc 
-	\uni04D7.sc \uni04D9.sc \uni04DB.sc \uni04DD.sc \uni04DF.sc \uni04E3.sc 
-	\uni04E5.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni04ED.sc \uni04EF.sc 
-	\uni04F1.sc \uni04F3.sc \uni04F5.sc \uni04F7.sc \uni04F9.sc \uni04FB.sc 
-	\uni04FD.sc \uni04FF.sc \uni0501.sc \uni0503.sc \uni0505.sc \uni0507.sc 
-	\uni0509.sc \uni050B.sc \uni050D.sc \uni050F.sc \uni0511.sc \uni0513.sc 
-	\uni0515.sc \uni0517.sc \uni0519.sc \uni051B.sc \uni051D.sc \uni051F.sc 
-	\uni0521.sc \uni0523.sc \uni0525.sc \uni0527.sc \uni0529.sc \uni052B.sc 
-	\uni052D.sc \uni052F.sc \uni1D7D.sc \uni1E01.sc \uni1E03.sc \uni1E05.sc 
-	\uni1E07.sc \uni1E09.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc \uni1E11.sc 
-	\uni1E13.sc \uni1E15.sc \uni1E17.sc \uni1E19.sc \uni1E1B.sc \uni1E1D.sc 
-	\uni1E1F.sc \uni1E21.sc \uni1E23.sc \uni1E25.sc \uni1E27.sc \uni1E29.sc 
-	\uni1E2B.sc \uni1E2D.sc \uni1E2F.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc 
-	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc \uni1E3F.sc \uni1E41.sc 
-	\uni1E43.sc \uni1E45.sc \uni1E47.sc \uni1E49.sc \uni1E4B.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1E55.sc \uni1E57.sc \uni1E59.sc 
-	\uni1E5B.sc \uni1E5D.sc \uni1E5F.sc \uni1E61.sc \uni1E63.sc \uni1E65.sc 
-	\uni1E67.sc \uni1E69.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc 
-	\uni1E73.sc \uni1E75.sc \uni1E77.sc \uni1E79.sc \uni1E7B.sc \uni1E7D.sc 
-	\uni1E7F.sc \wgrave.sc \wacute.sc \wdieresis.sc \uni1E87.sc \uni1E89.sc 
-	\uni1E8B.sc \uni1E8D.sc \uni1E8F.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc 
-	\uni1E96.sc \uni1E97.sc \uni1E98.sc \uni1E99.sc \uni1E9A.sc \germandbls.sc 
-	\uni1E9F.sc \uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc \uni1EA9.sc 
-	\uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc \uni1EB3.sc \uni1EB5.sc 
-	\uni1EB7.sc \uni1EB9.sc \uni1EBB.sc \uni1EBD.sc \uni1EBF.sc \uni1EC1.sc 
-	\uni1EC3.sc \uni1EC5.sc \uni1EC7.sc \uni1EC9.sc \uni1ECB.sc \uni1ECD.sc 
-	\uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc \uni1EE5.sc 
-	\uni1EE7.sc \uni1EE9.sc \uni1EEB.sc \uni1EED.sc \uni1EEF.sc \uni1EF1.sc 
-	\ygrave.sc \uni1EF5.sc \uni1EF7.sc \uni1EF9.sc \uni1EFB.sc \uni1EFD.sc 
-	\uni1EFF.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc \uni1F03.sc \uni1F04.sc 
-	\uni1F05.sc \uni1F06.sc \uni1F07.sc \uni1F10.sc \uni1F11.sc \uni1F12.sc 
-	\uni1F13.sc \uni1F14.sc \uni1F15.sc \uni1F20.sc \uni1F21.sc \uni1F22.sc 
-	\uni1F23.sc \uni1F24.sc \uni1F25.sc \uni1F26.sc \uni1F27.sc \uni1F30.sc 
-	\uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
-	\uni1F37.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc \uni1F54.sc 
-	\uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc 
-	\uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F70.sc 
-	\uni1F71.sc \uni1F72.sc \uni1F73.sc \uni1F74.sc \uni1F75.sc \uni1F76.sc 
-	\uni1F77.sc \uni1F78.sc \uni1F79.sc \uni1F7A.sc \uni1F7B.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1F80.sc \uni1F81.sc \uni1F82.sc \uni1F83.sc \uni1F84.sc 
-	\uni1F85.sc \uni1F86.sc \uni1F87.sc \uni1F90.sc \uni1F91.sc \uni1F92.sc 
-	\uni1F93.sc \uni1F94.sc \uni1F95.sc \uni1F96.sc \uni1F97.sc \uni1FA0.sc 
-	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc \uni1FB4.sc 
-	\uni1FB6.sc \uni1FB7.sc \uni1FC2.sc \uni1FC3.sc \uni1FC4.sc \uni1FC6.sc 
-	\uni1FC7.sc \uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni1FE0.sc \uni1FE1.sc \uni1FE2.sc \uni1FE3.sc \uni1FE4.sc 
-	\uni1FE5.sc \uni1FE6.sc \uni1FE7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
-	\uni1FF6.sc \uni1FF7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \uni2178.sc \uni2179.sc 
-	\uni217A.sc \uni217B.sc \uni217C.sc \uni217D.sc \uni217E.sc \uni217F.sc 
-	\uni2C73.sc \uniA78C.sc \uniA7B5.sc \uniA7B7.sc \uniA7C8.sc \zero.pnum 
-	\one.pnum \two.pnum \three.pnum \four.pnum \five.pnum \six.pnum \seven.pnum 
-	\eight.pnum \nine.pnum \zero.tnum \one.tnum \two.tnum \three.tnum \four.tnum 
-	\five.tnum \six.tnum \seven.tnum \eight.tnum \nine.tnum \zero.onum \one.onum 
-	\two.onum \three.onum \four.onum \five.onum \six.onum \seven.onum \eight.onum 
-	\nine.onum \zero.onum.tnum \one.onum.tnum \two.onum.tnum \three.onum.tnum 
-	\four.onum.tnum \five.onum.tnum \six.onum.tnum \seven.onum.tnum 
-	\eight.onum.tnum \nine.onum.tnum \zero.numr \one.numr \two.numr \three.numr 
-	\four.numr \five.numr \six.numr \seven.numr \eight.numr \nine.numr \zero.dnom 
-	\one.dnom \two.dnom \three.dnom \four.dnom \five.dnom \six.dnom \seven.dnom 
-	\eight.dnom \nine.dnom \zero.superior.pnum \one.superior.pnum 
-	\two.superior.pnum \three.superior.pnum \four.superior.pnum 
-	\five.superior.pnum \six.superior.pnum \seven.superior.pnum 
-	\eight.superior.pnum \nine.superior.pnum \zero.subscript.pnum 
-	\one.subscript.pnum \two.subscript.pnum \three.subscript.pnum 
-	\four.subscript.pnum \five.subscript.pnum \six.subscript.pnum 
-	\seven.subscript.pnum \eight.subscript.pnum \nine.subscript.pnum 
-	\zero.numr.pnum \one.numr.pnum \two.numr.pnum \three.numr.pnum 
-	\four.numr.pnum \five.numr.pnum \six.numr.pnum \seven.numr.pnum 
-	\eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum \one.dnom.pnum 
-	\two.dnom.pnum \three.dnom.pnum \four.dnom.pnum \five.dnom.pnum 
-	\six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum \nine.dnom.pnum 
-	\zero.superior.tnum \one.superior.tnum \two.superior.tnum 
+	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni27F0 \uni27F1 
+	\uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 
+	\uni1F09 \uni1F0A \uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 
+	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C 
+	\uni1F1D \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 
+	\uni1F28 \uni1F29 \uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 
+	\uni1F31 \uni1F32 \uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 
+	\uni1F3A \uni1F3B \uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 
+	\uni1F43 \uni1F44 \uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
+	\uni1F50 \uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 
+	\uni1F5B \uni1F5D \uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 
+	\uni1F66 \uni1F67 \uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E 
+	\uni1F6F \uni1F70 \uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 
+	\uni1F78 \uni1F79 \uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 
+	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C 
+	\uni1F8D \uni1F8E \uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 
+	\uni1F96 \uni1F97 \uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E 
+	\uni1F9F \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 
+	\uni1FA8 \uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 
+	\uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 
+	\uni1FBA \uni1FBC \uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 
+	\uni1FCA \uni1FCC \uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 
+	\uni1FDA \uni1FCB \uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 
+	\uni1FE7 \uni1FE3 \uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 
+	\uni1FF4 \uni1FF6 \uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB 
+	\uni1FC9 \uni2E17 \uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 
+	\uni214C \omicron \uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 
+	\uni2C65 \uni2C66 \uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE 
+	\uni1D49 \uni1D43 \uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 
+	\uni2C6D \uni2C72 \uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 
+	\uni1D7D \uniA7B4 \uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc 
+	\j.sc \k.sc \l.sc \m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc 
+	\x.sc \y.sc \z.sc \agrave.sc \aacute.sc \acircumflex.sc \atilde.sc 
+	\adieresis.sc \aring.sc \ae.sc \ccedilla.sc \egrave.sc \eacute.sc 
+	\ecircumflex.sc \edieresis.sc \igrave.sc \iacute.sc \icircumflex.sc 
+	\idieresis.sc \ntilde.sc \ograve.sc \oacute.sc \ocircumflex.sc \otilde.sc 
+	\odieresis.sc \oslash.sc \ugrave.sc \uacute.sc \ucircumflex.sc \udieresis.sc 
+	\yacute.sc \thorn.sc \ydieresis.sc \amacron.sc \abreve.sc \aogonek.sc 
+	\cacute.sc \ccircumflex.sc \cdotaccent.sc \ccaron.sc \dcaron.sc \dcroat.sc 
+	\emacron.sc \ebreve.sc \edotaccent.sc \eogonek.sc \ecaron.sc \gcircumflex.sc 
+	\gbreve.sc \gdotaccent.sc \gcommaaccent.sc \hcircumflex.sc \hbar.sc 
+	\itilde.sc \imacron.sc \ibreve.sc \iogonek.sc \ij.sc \jcircumflex.sc 
+	\kcommaaccent.sc \kgreenlandic.sc \lacute.sc \lcommaaccent.sc \lcaron.sc 
+	\ldot.sc \lslash.sc \nacute.sc \ncommaaccent.sc \ncaron.sc \napostrophe.sc 
+	\eng.sc \omacron.sc \obreve.sc \ohungarumlaut.sc \oe.sc \racute.sc 
+	\rcommaaccent.sc \rcaron.sc \sacute.sc \scircumflex.sc \scedilla.sc 
+	\scaron.sc \uni0163.sc \tcaron.sc \tbar.sc \utilde.sc \umacron.sc \ubreve.sc 
+	\uring.sc \uhungarumlaut.sc \uogonek.sc \wcircumflex.sc \ycircumflex.sc 
+	\zacute.sc \zdotaccent.sc \zcaron.sc \uni0180.sc \uni0183.sc \uni0185.sc 
+	\uni0188.sc \uni018C.sc \florin.sc \uni0195.sc \uni0199.sc \uni019A.sc 
+	\uni019B.sc \uni019E.sc \ohorn.sc \uni01A3.sc \uni01A5.sc \uni01A8.sc 
+	\uni01AB.sc \uni01AD.sc \uhorn.sc \uni01B4.sc \uni01B6.sc \uni01B9.sc 
+	\uni01BD.sc \uni01BF.sc \uni01C5.sc \uni01C6.sc \uni01C8.sc \uni01C9.sc 
+	\uni01CB.sc \uni01CC.sc \uni01CE.sc \uni01D0.sc \uni01D2.sc \uni01D4.sc 
+	\uni01D6.sc \uni01D8.sc \uni01DA.sc \uni01DC.sc \uni01DD.sc \uni01DF.sc 
+	\uni01E1.sc \uni01E3.sc \uni01E5.sc \gcaron.sc \uni01E9.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F0.sc \uni01F2.sc \uni01F3.sc \uni01F5.sc \uni01F9.sc 
+	\aringacute.sc \aeacute.sc \oslashacute.sc \uni0201.sc \uni0203.sc 
+	\uni0205.sc \uni0207.sc \uni0209.sc \uni020B.sc \uni020D.sc \uni020F.sc 
+	\uni0211.sc \uni0213.sc \uni0215.sc \uni0217.sc \scommaaccent.sc \uni021B.sc 
+	\uni021D.sc \uni021F.sc \uni0221.sc \uni0223.sc \uni0225.sc \uni0227.sc 
+	\uni0229.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni0233.sc 
+	\uni0234.sc \uni0235.sc \uni0236.sc \uni0237.sc \uni023C.sc \uni0242.sc 
+	\uni0247.sc \uni0249.sc \uni024B.sc \uni024D.sc \uni024F.sc \uni0250.sc 
+	\uni0251.sc \uni0253.sc \uni0254.sc \uni0256.sc \uni0257.sc \uni0259.sc 
+	\uni025B.sc \uni0260.sc \uni0263.sc \uni0264.sc \uni0266.sc \uni0268.sc 
+	\uni0269.sc \uni026A.sc \uni026F.sc \uni0272.sc \uni0275.sc \uni027D.sc 
+	\uni0283.sc \uni0288.sc \uni0289.sc \uni028A.sc \uni028B.sc \uni028C.sc 
+	\uni0292.sc \uni0298.sc \uni029D.sc \uni02A3.sc \uni02A4.sc \uni02A5.sc 
+	\uni02A6.sc \uni02A7.sc \uni02A8.sc \uni02A9.sc \uni02AA.sc \uni02AB.sc 
+	\uni0377.sc \uni037B.sc \uni037C.sc \uni037D.sc \iotadieresistonos.sc 
+	\alphatonos.sc \epsilontonos.sc \etatonos.sc \iotatonos.sc 
+	\upsilondieresistonos.sc \alpha.sc \beta.sc \gamma.sc \delta.sc \epsilon.sc 
+	\zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc \lambda.sc \uni03BC.sc \nu.sc 
+	\xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc \tau.sc \upsilon.sc \phi.sc \chi.sc 
+	\psi.sc \omega.sc \iotadieresis.sc \upsilondieresis.sc \omicrontonos.sc 
+	\upsilontonos.sc \omegatonos.sc \uni03D9.sc \uni03DB.sc \uni03DD.sc 
+	\uni03F2.sc \uni03F3.sc \uni03F8.sc \uni03FC.sc \uni0430.sc \uni0431.sc 
+	\uni0432.sc \uni0433.sc \uni0434.sc \uni0435.sc \uni0436.sc \uni0437.sc 
+	\uni0438.sc \uni0439.sc \uni043A.sc \uni043B.sc \uni043C.sc \uni043D.sc 
+	\uni043E.sc \uni043F.sc \uni0440.sc \uni0441.sc \uni0442.sc \uni0443.sc 
+	\uni0444.sc \uni0445.sc \uni0446.sc \uni0447.sc \uni0448.sc \uni0449.sc 
+	\uni044A.sc \uni044B.sc \uni044C.sc \uni044D.sc \uni044E.sc \uni044F.sc 
+	\uni0450.sc \uni0451.sc \uni0452.sc \uni0453.sc \uni0454.sc \uni0455.sc 
+	\uni0456.sc \uni0457.sc \uni0458.sc \uni0459.sc \uni045A.sc \uni045B.sc 
+	\uni045C.sc \uni045D.sc \uni045E.sc \uni045F.sc \uni0461.sc \uni0463.sc 
+	\uni0465.sc \uni0467.sc \uni0469.sc \uni046B.sc \uni046D.sc \uni046F.sc 
+	\uni0471.sc \uni0473.sc \uni0475.sc \uni0477.sc \uni047B.sc \uni047D.sc 
+	\uni047F.sc \uni0481.sc \uni048B.sc \uni048D.sc \uni048F.sc \uni0491.sc 
+	\uni0493.sc \uni0495.sc \uni0497.sc \uni0499.sc \uni049B.sc \uni049D.sc 
+	\uni049F.sc \uni04A1.sc \uni04A3.sc \uni04A5.sc \uni04A7.sc \uni04A9.sc 
+	\uni04AB.sc \uni04AD.sc \uni04AF.sc \uni04B1.sc \uni04B3.sc \uni04B5.sc 
+	\uni04B7.sc \uni04B9.sc \uni04BB.sc \uni04BD.sc \uni04BF.sc \uni04C2.sc 
+	\uni04C4.sc \uni04C6.sc \uni04C8.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
+	\uni04D1.sc \uni04D3.sc \uni04D5.sc \uni04D7.sc \uni04D9.sc \uni04DB.sc 
+	\uni04DD.sc \uni04DF.sc \uni04E3.sc \uni04E5.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni04EF.sc \uni04F1.sc \uni04F3.sc \uni04F5.sc 
+	\uni04F7.sc \uni04F9.sc \uni04FB.sc \uni04FD.sc \uni04FF.sc \uni0501.sc 
+	\uni0503.sc \uni0505.sc \uni0507.sc \uni0509.sc \uni050B.sc \uni050D.sc 
+	\uni050F.sc \uni0511.sc \uni0513.sc \uni0515.sc \uni0517.sc \uni0519.sc 
+	\uni051B.sc \uni051D.sc \uni051F.sc \uni0521.sc \uni0523.sc \uni0525.sc 
+	\uni0527.sc \uni0529.sc \uni052B.sc \uni052D.sc \uni052F.sc \uni1D7D.sc 
+	\uni1E01.sc \uni1E03.sc \uni1E05.sc \uni1E07.sc \uni1E09.sc \uni1E0B.sc 
+	\uni1E0D.sc \uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E15.sc \uni1E17.sc 
+	\uni1E19.sc \uni1E1B.sc \uni1E1D.sc \uni1E1F.sc \uni1E21.sc \uni1E23.sc 
+	\uni1E25.sc \uni1E27.sc \uni1E29.sc \uni1E2B.sc \uni1E2D.sc \uni1E2F.sc 
+	\uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc 
+	\uni1E3D.sc \uni1E3F.sc \uni1E41.sc \uni1E43.sc \uni1E45.sc \uni1E47.sc 
+	\uni1E49.sc \uni1E4B.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1E55.sc \uni1E57.sc \uni1E59.sc \uni1E5B.sc \uni1E5D.sc \uni1E5F.sc 
+	\uni1E61.sc \uni1E63.sc \uni1E65.sc \uni1E67.sc \uni1E69.sc \uni1E6B.sc 
+	\uni1E6D.sc \uni1E6F.sc \uni1E71.sc \uni1E73.sc \uni1E75.sc \uni1E77.sc 
+	\uni1E79.sc \uni1E7B.sc \uni1E7D.sc \uni1E7F.sc \wgrave.sc \wacute.sc 
+	\wdieresis.sc \uni1E87.sc \uni1E89.sc \uni1E8B.sc \uni1E8D.sc \uni1E8F.sc 
+	\uni1E91.sc \uni1E93.sc \uni1E95.sc \uni1E96.sc \uni1E97.sc \uni1E98.sc 
+	\uni1E99.sc \uni1E9A.sc \germandbls.sc \uni1E9F.sc \uni1EA1.sc \uni1EA3.sc 
+	\uni1EA5.sc \uni1EA7.sc \uni1EA9.sc \uni1EAB.sc \uni1EAD.sc \uni1EAF.sc 
+	\uni1EB1.sc \uni1EB3.sc \uni1EB5.sc \uni1EB7.sc \uni1EB9.sc \uni1EBB.sc 
+	\uni1EBD.sc \uni1EBF.sc \uni1EC1.sc \uni1EC3.sc \uni1EC5.sc \uni1EC7.sc 
+	\uni1EC9.sc \uni1ECB.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1EE5.sc \uni1EE7.sc \uni1EE9.sc \uni1EEB.sc 
+	\uni1EED.sc \uni1EEF.sc \uni1EF1.sc \ygrave.sc \uni1EF5.sc \uni1EF7.sc 
+	\uni1EF9.sc \uni1EFB.sc \uni1EFD.sc \uni1EFF.sc \uni1F00.sc \uni1F01.sc 
+	\uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc 
+	\uni1F10.sc \uni1F11.sc \uni1F12.sc \uni1F13.sc \uni1F14.sc \uni1F15.sc 
+	\uni1F20.sc \uni1F21.sc \uni1F22.sc \uni1F23.sc \uni1F24.sc \uni1F25.sc 
+	\uni1F26.sc \uni1F27.sc \uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc 
+	\uni1F34.sc \uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F40.sc \uni1F41.sc 
+	\uni1F42.sc \uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F50.sc \uni1F51.sc 
+	\uni1F52.sc \uni1F53.sc \uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc 
+	\uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F70.sc \uni1F71.sc \uni1F72.sc \uni1F73.sc 
+	\uni1F74.sc \uni1F75.sc \uni1F76.sc \uni1F77.sc \uni1F78.sc \uni1F79.sc 
+	\uni1F7A.sc \uni1F7B.sc \uni1F7C.sc \uni1F7D.sc \uni1F80.sc \uni1F81.sc 
+	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc \uni1F87.sc 
+	\uni1F90.sc \uni1F91.sc \uni1F92.sc \uni1F93.sc \uni1F94.sc \uni1F95.sc 
+	\uni1F96.sc \uni1F97.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FB0.sc \uni1FB1.sc 
+	\uni1FB2.sc \uni1FB3.sc \uni1FB4.sc \uni1FB6.sc \uni1FB7.sc \uni1FC2.sc 
+	\uni1FC3.sc \uni1FC4.sc \uni1FC6.sc \uni1FC7.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni1FE0.sc \uni1FE1.sc 
+	\uni1FE2.sc \uni1FE3.sc \uni1FE4.sc \uni1FE5.sc \uni1FE6.sc \uni1FE7.sc 
+	\uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2174.sc \uni2175.sc \uni2176.sc 
+	\uni2177.sc \uni2178.sc \uni2179.sc \uni217A.sc \uni217B.sc \uni217C.sc 
+	\uni217D.sc \uni217E.sc \uni217F.sc \uni2C73.sc \uniA78C.sc \uniA7B5.sc 
+	\uniA7B7.sc \uniA7C8.sc \zero.pnum \one.pnum \two.pnum \three.pnum \four.pnum 
+	\five.pnum \six.pnum \seven.pnum \eight.pnum \nine.pnum \zero.tnum \one.tnum 
+	\two.tnum \three.tnum \four.tnum \five.tnum \six.tnum \seven.tnum \eight.tnum 
+	\nine.tnum \zero.onum \one.onum \two.onum \three.onum \four.onum \five.onum 
+	\six.onum \seven.onum \eight.onum \nine.onum \zero.onum.tnum \one.onum.tnum 
+	\two.onum.tnum \three.onum.tnum \four.onum.tnum \five.onum.tnum 
+	\six.onum.tnum \seven.onum.tnum \eight.onum.tnum \nine.onum.tnum \zero.numr 
+	\one.numr \two.numr \three.numr \four.numr \five.numr \six.numr \seven.numr 
+	\eight.numr \nine.numr \zero.dnom \one.dnom \two.dnom \three.dnom \four.dnom 
+	\five.dnom \six.dnom \seven.dnom \eight.dnom \nine.dnom \zero.superior.pnum 
+	\one.superior.pnum \two.superior.pnum \three.superior.pnum 
+	\four.superior.pnum \five.superior.pnum \six.superior.pnum 
+	\seven.superior.pnum \eight.superior.pnum \nine.superior.pnum 
+	\zero.subscript.pnum \one.subscript.pnum \two.subscript.pnum 
+	\three.subscript.pnum \four.subscript.pnum \five.subscript.pnum 
+	\six.subscript.pnum \seven.subscript.pnum \eight.subscript.pnum 
+	\nine.subscript.pnum \zero.numr.pnum \one.numr.pnum \two.numr.pnum 
+	\three.numr.pnum \four.numr.pnum \five.numr.pnum \six.numr.pnum 
+	\seven.numr.pnum \eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum 
+	\one.dnom.pnum \two.dnom.pnum \three.dnom.pnum \four.dnom.pnum 
+	\five.dnom.pnum \six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum 
+	\nine.dnom.pnum \zero.superior.tnum \one.superior.tnum \two.superior.tnum 
 	\three.superior.tnum \four.superior.tnum \five.superior.tnum 
 	\six.superior.tnum \seven.superior.tnum \eight.superior.tnum 
 	\nine.superior.tnum \zero.subscript.tnum \one.subscript.tnum 

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/11 21:16:52</string>
+    <string>2025/03/12 18:13:00</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Thin.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-Thin.ufo/glyphs/contents.plist
@@ -3036,6 +3036,8 @@
     <string>uni20B_E_.glif</string>
     <key>uni20BF</key>
     <string>uni20B_F_.glif</string>
+    <key>uni20C0</key>
+    <string>uni20C_0.glif</string>
     <key>uni2100</key>
     <string>uni2100.glif</string>
     <key>uni2101</key>
@@ -4428,6 +4430,10 @@
     <string>uni27F_2.glif</string>
     <key>uni27F3</key>
     <string>uni27F_3.glif</string>
+    <key>uni27F0</key>
+    <string>uni27F_0.glif</string>
+    <key>uni27F1</key>
+    <string>uni27F_1.glif</string>
     <key>uni1F00</key>
     <string>uni1F_00.glif</string>
     <key>uni1F01</key>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni20C_0.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni20C_0.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni20C0" format="2">
+  <advance width="1101"/>
+  <unicode hex="20C0"/>
+  <outline>
+    <contour>
+      <point x="180" y="-160" type="line"/>
+      <point x="921" y="-160" type="line"/>
+      <point x="921" y="-200" type="line"/>
+      <point x="180" y="-200" type="line"/>
+    </contour>
+    <contour>
+      <point x="185" y="520" type="curve" smooth="yes"/>
+      <point x="185" y="184"/>
+      <point x="410" y="30"/>
+      <point x="578" y="30" type="curve" smooth="yes"/>
+      <point x="698" y="30"/>
+      <point x="846" y="108"/>
+      <point x="922" y="274" type="curve"/>
+      <point x="961" y="252" type="line"/>
+      <point x="887" y="90"/>
+      <point x="745" y="-10"/>
+      <point x="578" y="-10" type="curve" smooth="yes"/>
+      <point x="331" y="-10"/>
+      <point x="140" y="208"/>
+      <point x="140" y="520" type="curve" smooth="yes"/>
+      <point x="140" y="832"/>
+      <point x="331" y="1050"/>
+      <point x="578" y="1050" type="curve" smooth="yes"/>
+      <point x="745" y="1050"/>
+      <point x="887" y="950"/>
+      <point x="961" y="788" type="curve"/>
+      <point x="922" y="766" type="line"/>
+      <point x="846" y="932"/>
+      <point x="698" y="1010"/>
+      <point x="578" y="1010" type="curve" smooth="yes"/>
+      <point x="410" y="1010"/>
+      <point x="185" y="856"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni27F_0.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni27F_0.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F0" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F0"/>
+  <outline>
+    <contour>
+      <point x="1284" y="992" type="line"/>
+      <point x="1284" y="0" type="line"/>
+      <point x="1248" y="0" type="line"/>
+      <point x="1248" y="1022" type="line"/>
+    </contour>
+    <contour>
+      <point x="372" y="1032" type="line"/>
+      <point x="372" y="0" type="line"/>
+      <point x="336" y="0" type="line"/>
+      <point x="336" y="992" type="line"/>
+    </contour>
+    <contour>
+      <point x="980" y="1292" type="line"/>
+      <point x="980" y="0" type="line"/>
+      <point x="944" y="0" type="line"/>
+      <point x="944" y="1322" type="line"/>
+    </contour>
+    <contour>
+      <point x="826" y="1480" type="line"/>
+      <point x="1568" y="738" type="line"/>
+      <point x="1538" y="709" type="line"/>
+      <point x="810" y="1440" type="line"/>
+      <point x="82" y="709" type="line"/>
+      <point x="52" y="738" type="line"/>
+      <point x="794" y="1480" type="line"/>
+    </contour>
+    <contour>
+      <point x="676" y="1332" type="line"/>
+      <point x="676" y="0" type="line"/>
+      <point x="640" y="0" type="line"/>
+      <point x="640" y="1292" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni27F_1.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni27F_1.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F1" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F1"/>
+  <outline>
+    <contour>
+      <point x="336" y="488" type="line"/>
+      <point x="336" y="1480" type="line"/>
+      <point x="372" y="1480" type="line"/>
+      <point x="372" y="458" type="line"/>
+    </contour>
+    <contour>
+      <point x="1248" y="448" type="line"/>
+      <point x="1248" y="1480" type="line"/>
+      <point x="1284" y="1480" type="line"/>
+      <point x="1284" y="488" type="line"/>
+    </contour>
+    <contour>
+      <point x="640" y="188" type="line"/>
+      <point x="640" y="1480" type="line"/>
+      <point x="676" y="1480" type="line"/>
+      <point x="676" y="158" type="line"/>
+    </contour>
+    <contour>
+      <point x="794" y="0" type="line"/>
+      <point x="52" y="742" type="line"/>
+      <point x="82" y="771" type="line"/>
+      <point x="810" y="40" type="line"/>
+      <point x="1538" y="771" type="line"/>
+      <point x="1568" y="742" type="line"/>
+      <point x="826" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="944" y="148" type="line"/>
+      <point x="944" y="1480" type="line"/>
+      <point x="980" y="1480" type="line"/>
+      <point x="980" y="188" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -11125,42 +11125,42 @@ feature mkmk {
 	\uni20A0 \colonmonetary \uni20A2 \franc \lira \uni20A5 \uni20A6 \peseta \uni20A8 
 	\uni20A9 \uni20AA \dong \Euro \uni20AD \uni20AE \uni20AF \uni20B0 \uni20B1 
 	\uni20B2 \uni20B3 \uni20B4 \uni20B5 \uni20B6 \uni20B7 \uni20B8 \uni20B9 \uni20BA 
-	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni2100 \uni2101 \uni2102 \uni2105 
-	\uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 \uni2141 
-	\uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 \uni2124 
-	\uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 \uni211B 
-	\Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 \uni2133 
-	\uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 \uni2116 
-	\uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 \trademark 
-	\uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 \uni212A 
-	\uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 \uni2138 
-	\uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D \uni217E 
-	\uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 \uni2174 
-	\uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 \uni2188 
-	\uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 \uni2197 
-	\uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 \uni21A2 
-	\uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 \uni21AB 
-	\uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 \uni21B1 
-	\uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 \uni21E4 
-	\uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF \uni21C0 
-	\uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 \uni21C8 
-	\uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 \uni21D6 
-	\uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC \uni21DD 
-	\uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 \uni21E7 
-	\uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 \uni21F1 
-	\uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 \uni21FA 
-	\uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 \partialdiff 
-	\existential \uni2204 \emptyset \Delta \gradient \element \uni220A \notelement 
-	\suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation \minus 
-	\uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 \radical 
-	\uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 \uni2222 
-	\uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor \integral 
-	\logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 \uni2232 
-	\uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 \uni223A 
-	\uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 \uni2242 
-	\uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D \uni224F 
-	\uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
-	\uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
+	\uni20BB \uni20BC \uni20BD \uni20BE \uni20BF \uni20C0 \uni2100 \uni2101 \uni2102 
+	\uni2105 \uni2106 \uni210D \uni2119 \uni211A \uni211D \uni213E \uni213F \uni2140 
+	\uni2141 \uni2142 \uni213C \uni213D \uni2145 \uni2146 \uni2147 \uni2148 \uni2149 
+	\uni2124 \uni2115 \uni210B \uni210C \uni210E \uni2110 \Ifraktur \uni2112 
+	\uni211B \Rfraktur \uni2128 \uni212C \uni212D \uni212F \uni2130 \uni2131 
+	\uni2133 \uni2134 \uni2104 \uni2107 \uni2108 \uni210A \uni210F \uni2113 \uni2114 
+	\uni2116 \uni2117 \weierstrass \prescription \uni211F \uni2120 \uni2121 
+	\trademark \uni2139 \uni213A \uni213B \uni2123 \uni2125 \Omega \uni2127 \uni2129 
+	\uni212A \uni212B \uni2132 \uni2143 \uni2144 \estimated \aleph \uni2136 \uni2137 
+	\uni2138 \uni214B \uni214A \uni214D \uni2160 \uni214E \uni214F \uni217C \uni217D 
+	\uni217E \uni217F \uni2164 \uni2169 \uni216C \uni216D \uni216E \uni216F \uni2170 
+	\uni2174 \uni2179 \uni2180 \uni2181 \uni2183 \uni2184 \uni2185 \uni2182 \uni2187 
+	\uni2188 \uni218A \uni218B \uni2186 \arrowup \arrowdown \arrowupdn \uni2196 
+	\uni2197 \uni2198 \uni2199 \uni219C \uni219D \uni219E \uni21A0 \uni219F \uni21A1 
+	\uni21A2 \uni21A3 \uni21A4 \uni21A5 \uni21A6 \uni21A7 \arrowupdnbse \uni21A9 
+	\uni21AB \uni21AC \uni21AA \uni21AD \uni21AE \uni219A \uni219B \uni21AF \uni21B0 
+	\uni21B1 \uni21B2 \uni21B3 \uni21B4 \carriagereturn \uni21B6 \uni21B7 \uni21B8 
+	\uni21E4 \uni21E5 \uni21B9 \uni21BA \uni21BB \uni21BC \uni21BD \uni21BE \uni21BF 
+	\uni21C0 \uni21C1 \uni21C2 \uni21C3 \uni21C4 \uni21C5 \uni21C6 \uni21C7 \uni21C9 
+	\uni21C8 \uni21CA \uni21CB \arrowdblup \arrowdbldown \uni21CC \uni21CF \uni21D5 
+	\uni21D6 \uni21D7 \uni21D8 \uni21D9 \uni21CD \uni21CE \uni21DA \uni21DB \uni21DC 
+	\uni21DD \uni21DE \uni21DF \uni21E0 \uni21E2 \uni21E1 \uni21E3 \uni21E6 \uni21E8 
+	\uni21E7 \uni21E9 \uni21EA \uni21EB \uni21EC \uni21ED \uni21EE \uni21EF \uni21F0 
+	\uni21F1 \uni21F2 \uni21F3 \uni21F4 \uni21F5 \uni21F6 \uni21F9 \uni21F7 \uni21F8 
+	\uni21FA \uni21FB \uni21FC \uni21FD \uni21FE \uni21FF \universal \uni2201 
+	\partialdiff \existential \uni2204 \emptyset \Delta \gradient \element \uni220A 
+	\notelement \suchthat \uni220C \uni220D \uni220E \product \uni2210 \summation 
+	\minus \uni2213 \uni2214 \uni2215 \uni2216 \asteriskmath \uni2218 \uni2219 
+	\radical \uni221B \uni221C \infinity \proportional \orthogonal \angle \uni2221 
+	\uni2222 \uni2223 \uni2224 \uni2225 \uni2226 \intersection \union \logicalor 
+	\integral \logicaland \uni222C \uni222D \uni222E \uni2230 \uni222F \uni2231 
+	\uni2232 \uni2233 \therefore \uni2235 \uni2236 \uni2237 \uni2238 \uni2239 
+	\uni223A \uni223B \similar \uni223D \uni223E \uni223F \uni2240 \uni2241 \uni2243 
+	\uni2242 \uni2244 \congruent \approxequal \uni224A \uni224B \uni224C \uni224D 
+	\uni224F \uni224E \uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 
+	\uni2257 \uni2258 \uni225C \uni2259 \uni225A \uni225B \uni225D \uni225E \uni225F 
 	\equivalence \uni2262 \uni2263 \lessequal \greaterequal \uni2266 \uni2267 
 	\uni2268 \uni2269 \uni226A \uni226B \uni226C \uni2272 \uni2273 \uni2276 \uni2277 
 	\uni226E \uni226F \uni227A \uni227B \uni227C \uni227D \uni227E \uni227F 
@@ -11204,175 +11204,175 @@ feature mkmk {
 	\uni24A5 \uni24A6 \uni24A7 \uni24A8 \uni24A9 \uni24AA \uni24AB \uni24AC \uni24AD 
 	\uni24AE \uni24AF \uni24B0 \uni24B1 \uni24B2 \uni24B3 \uni24B4 \uni24B5 \uni24F5 
 	\uni24F6 \uni24F7 \uni24F8 \uni24F9 \uni24FA \uni24FB \uni24FC \uni24FD \uni24FE 
-	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni1F00 \uni1F01 
-	\uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 \uni1F09 \uni1F0A 
-	\uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 \uni1F12 \uni1F13 
-	\uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C \uni1F1D \uni1F20 
-	\uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 \uni1F28 \uni1F29 
-	\uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 \uni1F31 \uni1F32 
-	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 \uni1F3A \uni1F3B 
-	\uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 
-	\uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D \uni1F50 \uni1F51 
-	\uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 \uni1F5B \uni1F5D 
-	\uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 
-	\uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1F70 
-	\uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 \uni1F78 \uni1F79 
-	\uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
-	\uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C \uni1F8D \uni1F8E 
-	\uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 \uni1F96 \uni1F97 
-	\uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E \uni1F9F \uni1FA0 
-	\uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 \uni1FA8 \uni1FA9 
-	\uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 \uni1FB0 \uni1FB1 
-	\uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 \uni1FBA \uni1FBC 
-	\uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 \uni1FCA \uni1FCC 
-	\uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 \uni1FDA \uni1FCB 
-	\uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 \uni1FE7 \uni1FE3 
-	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 
-	\uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB \uni1FC9 \uni2E17 
-	\uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 \uni214C \omicron 
-	\uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 \uni2C65 \uni2C66 
-	\uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE \uni1D49 \uni1D43 
-	\uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 \uni2C6D \uni2C72 
-	\uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 \uni1D7D \uniA7B4 
-	\uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc \j.sc \k.sc \l.sc 
-	\m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc \x.sc \y.sc \z.sc 
-	\agrave.sc \aacute.sc \acircumflex.sc \atilde.sc \adieresis.sc \aring.sc 
-	\ae.sc \ccedilla.sc \egrave.sc \eacute.sc \ecircumflex.sc \edieresis.sc 
-	\igrave.sc \iacute.sc \icircumflex.sc \idieresis.sc \ntilde.sc \ograve.sc 
-	\oacute.sc \ocircumflex.sc \otilde.sc \odieresis.sc \oslash.sc \ugrave.sc 
-	\uacute.sc \ucircumflex.sc \udieresis.sc \yacute.sc \thorn.sc \ydieresis.sc 
-	\amacron.sc \abreve.sc \aogonek.sc \cacute.sc \ccircumflex.sc \cdotaccent.sc 
-	\ccaron.sc \dcaron.sc \dcroat.sc \emacron.sc \ebreve.sc \edotaccent.sc 
-	\eogonek.sc \ecaron.sc \gcircumflex.sc \gbreve.sc \gdotaccent.sc 
-	\gcommaaccent.sc \hcircumflex.sc \hbar.sc \itilde.sc \imacron.sc \ibreve.sc 
-	\iogonek.sc \ij.sc \jcircumflex.sc \kcommaaccent.sc \kgreenlandic.sc 
-	\lacute.sc \lcommaaccent.sc \lcaron.sc \ldot.sc \lslash.sc \nacute.sc 
-	\ncommaaccent.sc \ncaron.sc \napostrophe.sc \eng.sc \omacron.sc \obreve.sc 
-	\ohungarumlaut.sc \oe.sc \racute.sc \rcommaaccent.sc \rcaron.sc \sacute.sc 
-	\scircumflex.sc \scedilla.sc \scaron.sc \uni0163.sc \tcaron.sc \tbar.sc 
-	\utilde.sc \umacron.sc \ubreve.sc \uring.sc \uhungarumlaut.sc \uogonek.sc 
-	\wcircumflex.sc \ycircumflex.sc \zacute.sc \zdotaccent.sc \zcaron.sc 
-	\uni0180.sc \uni0183.sc \uni0185.sc \uni0188.sc \uni018C.sc \florin.sc 
-	\uni0195.sc \uni0199.sc \uni019A.sc \uni019B.sc \uni019E.sc \ohorn.sc 
-	\uni01A3.sc \uni01A5.sc \uni01A8.sc \uni01AB.sc \uni01AD.sc \uhorn.sc 
-	\uni01B4.sc \uni01B6.sc \uni01B9.sc \uni01BD.sc \uni01BF.sc \uni01C5.sc 
-	\uni01C6.sc \uni01C8.sc \uni01C9.sc \uni01CB.sc \uni01CC.sc \uni01CE.sc 
-	\uni01D0.sc \uni01D2.sc \uni01D4.sc \uni01D6.sc \uni01D8.sc \uni01DA.sc 
-	\uni01DC.sc \uni01DD.sc \uni01DF.sc \uni01E1.sc \uni01E3.sc \uni01E5.sc 
-	\gcaron.sc \uni01E9.sc \uni01EB.sc \uni01ED.sc \uni01F0.sc \uni01F2.sc 
-	\uni01F3.sc \uni01F5.sc \uni01F9.sc \aringacute.sc \aeacute.sc 
-	\oslashacute.sc \uni0201.sc \uni0203.sc \uni0205.sc \uni0207.sc \uni0209.sc 
-	\uni020B.sc \uni020D.sc \uni020F.sc \uni0211.sc \uni0213.sc \uni0215.sc 
-	\uni0217.sc \scommaaccent.sc \uni021B.sc \uni021D.sc \uni021F.sc \uni0221.sc 
-	\uni0223.sc \uni0225.sc \uni0227.sc \uni0229.sc \uni022B.sc \uni022D.sc 
-	\uni022F.sc \uni0231.sc \uni0233.sc \uni0234.sc \uni0235.sc \uni0236.sc 
-	\uni0237.sc \uni023C.sc \uni0242.sc \uni0247.sc \uni0249.sc \uni024B.sc 
-	\uni024D.sc \uni024F.sc \uni0250.sc \uni0251.sc \uni0253.sc \uni0254.sc 
-	\uni0256.sc \uni0257.sc \uni0259.sc \uni025B.sc \uni0260.sc \uni0263.sc 
-	\uni0264.sc \uni0266.sc \uni0268.sc \uni0269.sc \uni026A.sc \uni026F.sc 
-	\uni0272.sc \uni0275.sc \uni027D.sc \uni0283.sc \uni0288.sc \uni0289.sc 
-	\uni028A.sc \uni028B.sc \uni028C.sc \uni0292.sc \uni0298.sc \uni029D.sc 
-	\uni02A3.sc \uni02A4.sc \uni02A5.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni02A9.sc \uni02AA.sc \uni02AB.sc \uni0377.sc \uni037B.sc \uni037C.sc 
-	\uni037D.sc \iotadieresistonos.sc \alphatonos.sc \epsilontonos.sc 
-	\etatonos.sc \iotatonos.sc \upsilondieresistonos.sc \alpha.sc \beta.sc 
-	\gamma.sc \delta.sc \epsilon.sc \zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc 
-	\lambda.sc \uni03BC.sc \nu.sc \xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc 
-	\tau.sc \upsilon.sc \phi.sc \chi.sc \psi.sc \omega.sc \iotadieresis.sc 
-	\upsilondieresis.sc \omicrontonos.sc \upsilontonos.sc \omegatonos.sc 
-	\uni03D9.sc \uni03DB.sc \uni03DD.sc \uni03F2.sc \uni03F3.sc \uni03F8.sc 
-	\uni03FC.sc \uni0430.sc \uni0431.sc \uni0432.sc \uni0433.sc \uni0434.sc 
-	\uni0435.sc \uni0436.sc \uni0437.sc \uni0438.sc \uni0439.sc \uni043A.sc 
-	\uni043B.sc \uni043C.sc \uni043D.sc \uni043E.sc \uni043F.sc \uni0440.sc 
-	\uni0441.sc \uni0442.sc \uni0443.sc \uni0444.sc \uni0445.sc \uni0446.sc 
-	\uni0447.sc \uni0448.sc \uni0449.sc \uni044A.sc \uni044B.sc \uni044C.sc 
-	\uni044D.sc \uni044E.sc \uni044F.sc \uni0450.sc \uni0451.sc \uni0452.sc 
-	\uni0453.sc \uni0454.sc \uni0455.sc \uni0456.sc \uni0457.sc \uni0458.sc 
-	\uni0459.sc \uni045A.sc \uni045B.sc \uni045C.sc \uni045D.sc \uni045E.sc 
-	\uni045F.sc \uni0461.sc \uni0463.sc \uni0465.sc \uni0467.sc \uni0469.sc 
-	\uni046B.sc \uni046D.sc \uni046F.sc \uni0471.sc \uni0473.sc \uni0475.sc 
-	\uni0477.sc \uni047B.sc \uni047D.sc \uni047F.sc \uni0481.sc \uni048B.sc 
-	\uni048D.sc \uni048F.sc \uni0491.sc \uni0493.sc \uni0495.sc \uni0497.sc 
-	\uni0499.sc \uni049B.sc \uni049D.sc \uni049F.sc \uni04A1.sc \uni04A3.sc 
-	\uni04A5.sc \uni04A7.sc \uni04A9.sc \uni04AB.sc \uni04AD.sc \uni04AF.sc 
-	\uni04B1.sc \uni04B3.sc \uni04B5.sc \uni04B7.sc \uni04B9.sc \uni04BB.sc 
-	\uni04BD.sc \uni04BF.sc \uni04C2.sc \uni04C4.sc \uni04C6.sc \uni04C8.sc 
-	\uni04CA.sc \uni04CC.sc \uni04CE.sc \uni04D1.sc \uni04D3.sc \uni04D5.sc 
-	\uni04D7.sc \uni04D9.sc \uni04DB.sc \uni04DD.sc \uni04DF.sc \uni04E3.sc 
-	\uni04E5.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni04ED.sc \uni04EF.sc 
-	\uni04F1.sc \uni04F3.sc \uni04F5.sc \uni04F7.sc \uni04F9.sc \uni04FB.sc 
-	\uni04FD.sc \uni04FF.sc \uni0501.sc \uni0503.sc \uni0505.sc \uni0507.sc 
-	\uni0509.sc \uni050B.sc \uni050D.sc \uni050F.sc \uni0511.sc \uni0513.sc 
-	\uni0515.sc \uni0517.sc \uni0519.sc \uni051B.sc \uni051D.sc \uni051F.sc 
-	\uni0521.sc \uni0523.sc \uni0525.sc \uni0527.sc \uni0529.sc \uni052B.sc 
-	\uni052D.sc \uni052F.sc \uni1D7D.sc \uni1E01.sc \uni1E03.sc \uni1E05.sc 
-	\uni1E07.sc \uni1E09.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc \uni1E11.sc 
-	\uni1E13.sc \uni1E15.sc \uni1E17.sc \uni1E19.sc \uni1E1B.sc \uni1E1D.sc 
-	\uni1E1F.sc \uni1E21.sc \uni1E23.sc \uni1E25.sc \uni1E27.sc \uni1E29.sc 
-	\uni1E2B.sc \uni1E2D.sc \uni1E2F.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc 
-	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc \uni1E3F.sc \uni1E41.sc 
-	\uni1E43.sc \uni1E45.sc \uni1E47.sc \uni1E49.sc \uni1E4B.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1E55.sc \uni1E57.sc \uni1E59.sc 
-	\uni1E5B.sc \uni1E5D.sc \uni1E5F.sc \uni1E61.sc \uni1E63.sc \uni1E65.sc 
-	\uni1E67.sc \uni1E69.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc 
-	\uni1E73.sc \uni1E75.sc \uni1E77.sc \uni1E79.sc \uni1E7B.sc \uni1E7D.sc 
-	\uni1E7F.sc \wgrave.sc \wacute.sc \wdieresis.sc \uni1E87.sc \uni1E89.sc 
-	\uni1E8B.sc \uni1E8D.sc \uni1E8F.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc 
-	\uni1E96.sc \uni1E97.sc \uni1E98.sc \uni1E99.sc \uni1E9A.sc \germandbls.sc 
-	\uni1E9F.sc \uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc \uni1EA9.sc 
-	\uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc \uni1EB3.sc \uni1EB5.sc 
-	\uni1EB7.sc \uni1EB9.sc \uni1EBB.sc \uni1EBD.sc \uni1EBF.sc \uni1EC1.sc 
-	\uni1EC3.sc \uni1EC5.sc \uni1EC7.sc \uni1EC9.sc \uni1ECB.sc \uni1ECD.sc 
-	\uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc \uni1EE5.sc 
-	\uni1EE7.sc \uni1EE9.sc \uni1EEB.sc \uni1EED.sc \uni1EEF.sc \uni1EF1.sc 
-	\ygrave.sc \uni1EF5.sc \uni1EF7.sc \uni1EF9.sc \uni1EFB.sc \uni1EFD.sc 
-	\uni1EFF.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc \uni1F03.sc \uni1F04.sc 
-	\uni1F05.sc \uni1F06.sc \uni1F07.sc \uni1F10.sc \uni1F11.sc \uni1F12.sc 
-	\uni1F13.sc \uni1F14.sc \uni1F15.sc \uni1F20.sc \uni1F21.sc \uni1F22.sc 
-	\uni1F23.sc \uni1F24.sc \uni1F25.sc \uni1F26.sc \uni1F27.sc \uni1F30.sc 
-	\uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
-	\uni1F37.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc \uni1F54.sc 
-	\uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc 
-	\uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F70.sc 
-	\uni1F71.sc \uni1F72.sc \uni1F73.sc \uni1F74.sc \uni1F75.sc \uni1F76.sc 
-	\uni1F77.sc \uni1F78.sc \uni1F79.sc \uni1F7A.sc \uni1F7B.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1F80.sc \uni1F81.sc \uni1F82.sc \uni1F83.sc \uni1F84.sc 
-	\uni1F85.sc \uni1F86.sc \uni1F87.sc \uni1F90.sc \uni1F91.sc \uni1F92.sc 
-	\uni1F93.sc \uni1F94.sc \uni1F95.sc \uni1F96.sc \uni1F97.sc \uni1FA0.sc 
-	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc \uni1FB4.sc 
-	\uni1FB6.sc \uni1FB7.sc \uni1FC2.sc \uni1FC3.sc \uni1FC4.sc \uni1FC6.sc 
-	\uni1FC7.sc \uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni1FE0.sc \uni1FE1.sc \uni1FE2.sc \uni1FE3.sc \uni1FE4.sc 
-	\uni1FE5.sc \uni1FE6.sc \uni1FE7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
-	\uni1FF6.sc \uni1FF7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \uni2178.sc \uni2179.sc 
-	\uni217A.sc \uni217B.sc \uni217C.sc \uni217D.sc \uni217E.sc \uni217F.sc 
-	\uni2C73.sc \uniA78C.sc \uniA7B5.sc \uniA7B7.sc \uniA7C8.sc \zero.pnum 
-	\one.pnum \two.pnum \three.pnum \four.pnum \five.pnum \six.pnum \seven.pnum 
-	\eight.pnum \nine.pnum \zero.tnum \one.tnum \two.tnum \three.tnum \four.tnum 
-	\five.tnum \six.tnum \seven.tnum \eight.tnum \nine.tnum \zero.onum \one.onum 
-	\two.onum \three.onum \four.onum \five.onum \six.onum \seven.onum \eight.onum 
-	\nine.onum \zero.onum.tnum \one.onum.tnum \two.onum.tnum \three.onum.tnum 
-	\four.onum.tnum \five.onum.tnum \six.onum.tnum \seven.onum.tnum 
-	\eight.onum.tnum \nine.onum.tnum \zero.numr \one.numr \two.numr \three.numr 
-	\four.numr \five.numr \six.numr \seven.numr \eight.numr \nine.numr \zero.dnom 
-	\one.dnom \two.dnom \three.dnom \four.dnom \five.dnom \six.dnom \seven.dnom 
-	\eight.dnom \nine.dnom \zero.superior.pnum \one.superior.pnum 
-	\two.superior.pnum \three.superior.pnum \four.superior.pnum 
-	\five.superior.pnum \six.superior.pnum \seven.superior.pnum 
-	\eight.superior.pnum \nine.superior.pnum \zero.subscript.pnum 
-	\one.subscript.pnum \two.subscript.pnum \three.subscript.pnum 
-	\four.subscript.pnum \five.subscript.pnum \six.subscript.pnum 
-	\seven.subscript.pnum \eight.subscript.pnum \nine.subscript.pnum 
-	\zero.numr.pnum \one.numr.pnum \two.numr.pnum \three.numr.pnum 
-	\four.numr.pnum \five.numr.pnum \six.numr.pnum \seven.numr.pnum 
-	\eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum \one.dnom.pnum 
-	\two.dnom.pnum \three.dnom.pnum \four.dnom.pnum \five.dnom.pnum 
-	\six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum \nine.dnom.pnum 
-	\zero.superior.tnum \one.superior.tnum \two.superior.tnum 
+	\uni27FB \uni27FC \uni27FE \uni27FD \uni27FF \uni27F2 \uni27F3 \uni27F0 \uni27F1 
+	\uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F08 
+	\uni1F09 \uni1F0A \uni1F0B \uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F10 \uni1F11 
+	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F18 \uni1F19 \uni1F1A \uni1F1B \uni1F1C 
+	\uni1F1D \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 \uni1F26 \uni1F27 
+	\uni1F28 \uni1F29 \uni1F2A \uni1F2B \uni1F2C \uni1F2D \uni1F2E \uni1F2F \uni1F30 
+	\uni1F31 \uni1F32 \uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F38 \uni1F39 
+	\uni1F3A \uni1F3B \uni1F3C \uni1F3D \uni1F3E \uni1F3F \uni1F40 \uni1F41 \uni1F42 
+	\uni1F43 \uni1F44 \uni1F45 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
+	\uni1F50 \uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F59 
+	\uni1F5B \uni1F5D \uni1F5F \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 \uni1F65 
+	\uni1F66 \uni1F67 \uni1F68 \uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E 
+	\uni1F6F \uni1F70 \uni1F71 \uni1F72 \uni1F73 \uni1F74 \uni1F75 \uni1F76 \uni1F77 
+	\uni1F78 \uni1F79 \uni1F7A \uni1F7B \uni1F7C \uni1F7D \uni1F81 \uni1F82 \uni1F83 
+	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1F88 \uni1F89 \uni1F8A \uni1F8B \uni1F8C 
+	\uni1F8D \uni1F8E \uni1F8F \uni1F90 \uni1F91 \uni1F92 \uni1F93 \uni1F94 \uni1F95 
+	\uni1F96 \uni1F97 \uni1F98 \uni1F99 \uni1F9A \uni1F9B \uni1F9C \uni1F9D \uni1F9E 
+	\uni1F9F \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 \uni1FA7 
+	\uni1FA8 \uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1F80 
+	\uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 \uni1FB7 \uni1FB8 \uni1FB9 
+	\uni1FBA \uni1FBC \uni1FBB \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 \uni1FC7 \uni1FC8 
+	\uni1FCA \uni1FCC \uni1FD0 \uni1FD1 \uni1FD2 \uni1FD6 \uni1FD7 \uni1FD8 \uni1FD9 
+	\uni1FDA \uni1FCB \uni1FD3 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE4 \uni1FE5 \uni1FE6 
+	\uni1FE7 \uni1FE3 \uni1FE8 \uni1FE9 \uni1FEA \uni1FEC \uni1FEB \uni1FF2 \uni1FF3 
+	\uni1FF4 \uni1FF6 \uni1FF7 \uni1FF8 \uni1FFA \uni1FFC \uni1FF9 \uni1FFB \uni1FDB 
+	\uni1FC9 \uni2E17 \uni27E8 \uni27E9 \uni27EA \uni27EB \uniA78B \uniA78C \uni00A0 
+	\uni214C \omicron \uni0440 \Beta \uni0443 \uni0412 \uni25CC \uni27F4 \uni2C64 
+	\uni2C65 \uni2C66 \uniA78D \uniA7AA \uniA7AE \uniA7AD \uniA7B2 \uni02D7 \uni02EE 
+	\uni1D49 \uni1D43 \uni1D4B \uni1D52 \uni1D53 \uni1D58 \uni1DA4 \uni1DB6 \uni2C63 
+	\uni2C6D \uni2C72 \uni2C73 \uniA789 \uniA78A \uniA7B6 \uniA7B7 \uniA7C7 \uniA7C8 
+	\uni1D7D \uniA7B4 \uniA7B5 \a.sc \b.sc \c.sc \d.sc \e.sc \f.sc \g.sc \h.sc \i.sc 
+	\j.sc \k.sc \l.sc \m.sc \n.sc \o.sc \p.sc \q.sc \r.sc \s.sc \t.sc \u.sc \v.sc \w.sc 
+	\x.sc \y.sc \z.sc \agrave.sc \aacute.sc \acircumflex.sc \atilde.sc 
+	\adieresis.sc \aring.sc \ae.sc \ccedilla.sc \egrave.sc \eacute.sc 
+	\ecircumflex.sc \edieresis.sc \igrave.sc \iacute.sc \icircumflex.sc 
+	\idieresis.sc \ntilde.sc \ograve.sc \oacute.sc \ocircumflex.sc \otilde.sc 
+	\odieresis.sc \oslash.sc \ugrave.sc \uacute.sc \ucircumflex.sc \udieresis.sc 
+	\yacute.sc \thorn.sc \ydieresis.sc \amacron.sc \abreve.sc \aogonek.sc 
+	\cacute.sc \ccircumflex.sc \cdotaccent.sc \ccaron.sc \dcaron.sc \dcroat.sc 
+	\emacron.sc \ebreve.sc \edotaccent.sc \eogonek.sc \ecaron.sc \gcircumflex.sc 
+	\gbreve.sc \gdotaccent.sc \gcommaaccent.sc \hcircumflex.sc \hbar.sc 
+	\itilde.sc \imacron.sc \ibreve.sc \iogonek.sc \ij.sc \jcircumflex.sc 
+	\kcommaaccent.sc \kgreenlandic.sc \lacute.sc \lcommaaccent.sc \lcaron.sc 
+	\ldot.sc \lslash.sc \nacute.sc \ncommaaccent.sc \ncaron.sc \napostrophe.sc 
+	\eng.sc \omacron.sc \obreve.sc \ohungarumlaut.sc \oe.sc \racute.sc 
+	\rcommaaccent.sc \rcaron.sc \sacute.sc \scircumflex.sc \scedilla.sc 
+	\scaron.sc \uni0163.sc \tcaron.sc \tbar.sc \utilde.sc \umacron.sc \ubreve.sc 
+	\uring.sc \uhungarumlaut.sc \uogonek.sc \wcircumflex.sc \ycircumflex.sc 
+	\zacute.sc \zdotaccent.sc \zcaron.sc \uni0180.sc \uni0183.sc \uni0185.sc 
+	\uni0188.sc \uni018C.sc \florin.sc \uni0195.sc \uni0199.sc \uni019A.sc 
+	\uni019B.sc \uni019E.sc \ohorn.sc \uni01A3.sc \uni01A5.sc \uni01A8.sc 
+	\uni01AB.sc \uni01AD.sc \uhorn.sc \uni01B4.sc \uni01B6.sc \uni01B9.sc 
+	\uni01BD.sc \uni01BF.sc \uni01C5.sc \uni01C6.sc \uni01C8.sc \uni01C9.sc 
+	\uni01CB.sc \uni01CC.sc \uni01CE.sc \uni01D0.sc \uni01D2.sc \uni01D4.sc 
+	\uni01D6.sc \uni01D8.sc \uni01DA.sc \uni01DC.sc \uni01DD.sc \uni01DF.sc 
+	\uni01E1.sc \uni01E3.sc \uni01E5.sc \gcaron.sc \uni01E9.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F0.sc \uni01F2.sc \uni01F3.sc \uni01F5.sc \uni01F9.sc 
+	\aringacute.sc \aeacute.sc \oslashacute.sc \uni0201.sc \uni0203.sc 
+	\uni0205.sc \uni0207.sc \uni0209.sc \uni020B.sc \uni020D.sc \uni020F.sc 
+	\uni0211.sc \uni0213.sc \uni0215.sc \uni0217.sc \scommaaccent.sc \uni021B.sc 
+	\uni021D.sc \uni021F.sc \uni0221.sc \uni0223.sc \uni0225.sc \uni0227.sc 
+	\uni0229.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni0233.sc 
+	\uni0234.sc \uni0235.sc \uni0236.sc \uni0237.sc \uni023C.sc \uni0242.sc 
+	\uni0247.sc \uni0249.sc \uni024B.sc \uni024D.sc \uni024F.sc \uni0250.sc 
+	\uni0251.sc \uni0253.sc \uni0254.sc \uni0256.sc \uni0257.sc \uni0259.sc 
+	\uni025B.sc \uni0260.sc \uni0263.sc \uni0264.sc \uni0266.sc \uni0268.sc 
+	\uni0269.sc \uni026A.sc \uni026F.sc \uni0272.sc \uni0275.sc \uni027D.sc 
+	\uni0283.sc \uni0288.sc \uni0289.sc \uni028A.sc \uni028B.sc \uni028C.sc 
+	\uni0292.sc \uni0298.sc \uni029D.sc \uni02A3.sc \uni02A4.sc \uni02A5.sc 
+	\uni02A6.sc \uni02A7.sc \uni02A8.sc \uni02A9.sc \uni02AA.sc \uni02AB.sc 
+	\uni0377.sc \uni037B.sc \uni037C.sc \uni037D.sc \iotadieresistonos.sc 
+	\alphatonos.sc \epsilontonos.sc \etatonos.sc \iotatonos.sc 
+	\upsilondieresistonos.sc \alpha.sc \beta.sc \gamma.sc \delta.sc \epsilon.sc 
+	\zeta.sc \eta.sc \theta.sc \iota.sc \kappa.sc \lambda.sc \uni03BC.sc \nu.sc 
+	\xi.sc \omicron.sc \pi.sc \rho.sc \sigma.sc \tau.sc \upsilon.sc \phi.sc \chi.sc 
+	\psi.sc \omega.sc \iotadieresis.sc \upsilondieresis.sc \omicrontonos.sc 
+	\upsilontonos.sc \omegatonos.sc \uni03D9.sc \uni03DB.sc \uni03DD.sc 
+	\uni03F2.sc \uni03F3.sc \uni03F8.sc \uni03FC.sc \uni0430.sc \uni0431.sc 
+	\uni0432.sc \uni0433.sc \uni0434.sc \uni0435.sc \uni0436.sc \uni0437.sc 
+	\uni0438.sc \uni0439.sc \uni043A.sc \uni043B.sc \uni043C.sc \uni043D.sc 
+	\uni043E.sc \uni043F.sc \uni0440.sc \uni0441.sc \uni0442.sc \uni0443.sc 
+	\uni0444.sc \uni0445.sc \uni0446.sc \uni0447.sc \uni0448.sc \uni0449.sc 
+	\uni044A.sc \uni044B.sc \uni044C.sc \uni044D.sc \uni044E.sc \uni044F.sc 
+	\uni0450.sc \uni0451.sc \uni0452.sc \uni0453.sc \uni0454.sc \uni0455.sc 
+	\uni0456.sc \uni0457.sc \uni0458.sc \uni0459.sc \uni045A.sc \uni045B.sc 
+	\uni045C.sc \uni045D.sc \uni045E.sc \uni045F.sc \uni0461.sc \uni0463.sc 
+	\uni0465.sc \uni0467.sc \uni0469.sc \uni046B.sc \uni046D.sc \uni046F.sc 
+	\uni0471.sc \uni0473.sc \uni0475.sc \uni0477.sc \uni047B.sc \uni047D.sc 
+	\uni047F.sc \uni0481.sc \uni048B.sc \uni048D.sc \uni048F.sc \uni0491.sc 
+	\uni0493.sc \uni0495.sc \uni0497.sc \uni0499.sc \uni049B.sc \uni049D.sc 
+	\uni049F.sc \uni04A1.sc \uni04A3.sc \uni04A5.sc \uni04A7.sc \uni04A9.sc 
+	\uni04AB.sc \uni04AD.sc \uni04AF.sc \uni04B1.sc \uni04B3.sc \uni04B5.sc 
+	\uni04B7.sc \uni04B9.sc \uni04BB.sc \uni04BD.sc \uni04BF.sc \uni04C2.sc 
+	\uni04C4.sc \uni04C6.sc \uni04C8.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
+	\uni04D1.sc \uni04D3.sc \uni04D5.sc \uni04D7.sc \uni04D9.sc \uni04DB.sc 
+	\uni04DD.sc \uni04DF.sc \uni04E3.sc \uni04E5.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni04EF.sc \uni04F1.sc \uni04F3.sc \uni04F5.sc 
+	\uni04F7.sc \uni04F9.sc \uni04FB.sc \uni04FD.sc \uni04FF.sc \uni0501.sc 
+	\uni0503.sc \uni0505.sc \uni0507.sc \uni0509.sc \uni050B.sc \uni050D.sc 
+	\uni050F.sc \uni0511.sc \uni0513.sc \uni0515.sc \uni0517.sc \uni0519.sc 
+	\uni051B.sc \uni051D.sc \uni051F.sc \uni0521.sc \uni0523.sc \uni0525.sc 
+	\uni0527.sc \uni0529.sc \uni052B.sc \uni052D.sc \uni052F.sc \uni1D7D.sc 
+	\uni1E01.sc \uni1E03.sc \uni1E05.sc \uni1E07.sc \uni1E09.sc \uni1E0B.sc 
+	\uni1E0D.sc \uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E15.sc \uni1E17.sc 
+	\uni1E19.sc \uni1E1B.sc \uni1E1D.sc \uni1E1F.sc \uni1E21.sc \uni1E23.sc 
+	\uni1E25.sc \uni1E27.sc \uni1E29.sc \uni1E2B.sc \uni1E2D.sc \uni1E2F.sc 
+	\uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc 
+	\uni1E3D.sc \uni1E3F.sc \uni1E41.sc \uni1E43.sc \uni1E45.sc \uni1E47.sc 
+	\uni1E49.sc \uni1E4B.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1E55.sc \uni1E57.sc \uni1E59.sc \uni1E5B.sc \uni1E5D.sc \uni1E5F.sc 
+	\uni1E61.sc \uni1E63.sc \uni1E65.sc \uni1E67.sc \uni1E69.sc \uni1E6B.sc 
+	\uni1E6D.sc \uni1E6F.sc \uni1E71.sc \uni1E73.sc \uni1E75.sc \uni1E77.sc 
+	\uni1E79.sc \uni1E7B.sc \uni1E7D.sc \uni1E7F.sc \wgrave.sc \wacute.sc 
+	\wdieresis.sc \uni1E87.sc \uni1E89.sc \uni1E8B.sc \uni1E8D.sc \uni1E8F.sc 
+	\uni1E91.sc \uni1E93.sc \uni1E95.sc \uni1E96.sc \uni1E97.sc \uni1E98.sc 
+	\uni1E99.sc \uni1E9A.sc \germandbls.sc \uni1E9F.sc \uni1EA1.sc \uni1EA3.sc 
+	\uni1EA5.sc \uni1EA7.sc \uni1EA9.sc \uni1EAB.sc \uni1EAD.sc \uni1EAF.sc 
+	\uni1EB1.sc \uni1EB3.sc \uni1EB5.sc \uni1EB7.sc \uni1EB9.sc \uni1EBB.sc 
+	\uni1EBD.sc \uni1EBF.sc \uni1EC1.sc \uni1EC3.sc \uni1EC5.sc \uni1EC7.sc 
+	\uni1EC9.sc \uni1ECB.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1EE5.sc \uni1EE7.sc \uni1EE9.sc \uni1EEB.sc 
+	\uni1EED.sc \uni1EEF.sc \uni1EF1.sc \ygrave.sc \uni1EF5.sc \uni1EF7.sc 
+	\uni1EF9.sc \uni1EFB.sc \uni1EFD.sc \uni1EFF.sc \uni1F00.sc \uni1F01.sc 
+	\uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc 
+	\uni1F10.sc \uni1F11.sc \uni1F12.sc \uni1F13.sc \uni1F14.sc \uni1F15.sc 
+	\uni1F20.sc \uni1F21.sc \uni1F22.sc \uni1F23.sc \uni1F24.sc \uni1F25.sc 
+	\uni1F26.sc \uni1F27.sc \uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc 
+	\uni1F34.sc \uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F40.sc \uni1F41.sc 
+	\uni1F42.sc \uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F50.sc \uni1F51.sc 
+	\uni1F52.sc \uni1F53.sc \uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc 
+	\uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F70.sc \uni1F71.sc \uni1F72.sc \uni1F73.sc 
+	\uni1F74.sc \uni1F75.sc \uni1F76.sc \uni1F77.sc \uni1F78.sc \uni1F79.sc 
+	\uni1F7A.sc \uni1F7B.sc \uni1F7C.sc \uni1F7D.sc \uni1F80.sc \uni1F81.sc 
+	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc \uni1F87.sc 
+	\uni1F90.sc \uni1F91.sc \uni1F92.sc \uni1F93.sc \uni1F94.sc \uni1F95.sc 
+	\uni1F96.sc \uni1F97.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FB0.sc \uni1FB1.sc 
+	\uni1FB2.sc \uni1FB3.sc \uni1FB4.sc \uni1FB6.sc \uni1FB7.sc \uni1FC2.sc 
+	\uni1FC3.sc \uni1FC4.sc \uni1FC6.sc \uni1FC7.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni1FE0.sc \uni1FE1.sc 
+	\uni1FE2.sc \uni1FE3.sc \uni1FE4.sc \uni1FE5.sc \uni1FE6.sc \uni1FE7.sc 
+	\uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2174.sc \uni2175.sc \uni2176.sc 
+	\uni2177.sc \uni2178.sc \uni2179.sc \uni217A.sc \uni217B.sc \uni217C.sc 
+	\uni217D.sc \uni217E.sc \uni217F.sc \uni2C73.sc \uniA78C.sc \uniA7B5.sc 
+	\uniA7B7.sc \uniA7C8.sc \zero.pnum \one.pnum \two.pnum \three.pnum \four.pnum 
+	\five.pnum \six.pnum \seven.pnum \eight.pnum \nine.pnum \zero.tnum \one.tnum 
+	\two.tnum \three.tnum \four.tnum \five.tnum \six.tnum \seven.tnum \eight.tnum 
+	\nine.tnum \zero.onum \one.onum \two.onum \three.onum \four.onum \five.onum 
+	\six.onum \seven.onum \eight.onum \nine.onum \zero.onum.tnum \one.onum.tnum 
+	\two.onum.tnum \three.onum.tnum \four.onum.tnum \five.onum.tnum 
+	\six.onum.tnum \seven.onum.tnum \eight.onum.tnum \nine.onum.tnum \zero.numr 
+	\one.numr \two.numr \three.numr \four.numr \five.numr \six.numr \seven.numr 
+	\eight.numr \nine.numr \zero.dnom \one.dnom \two.dnom \three.dnom \four.dnom 
+	\five.dnom \six.dnom \seven.dnom \eight.dnom \nine.dnom \zero.superior.pnum 
+	\one.superior.pnum \two.superior.pnum \three.superior.pnum 
+	\four.superior.pnum \five.superior.pnum \six.superior.pnum 
+	\seven.superior.pnum \eight.superior.pnum \nine.superior.pnum 
+	\zero.subscript.pnum \one.subscript.pnum \two.subscript.pnum 
+	\three.subscript.pnum \four.subscript.pnum \five.subscript.pnum 
+	\six.subscript.pnum \seven.subscript.pnum \eight.subscript.pnum 
+	\nine.subscript.pnum \zero.numr.pnum \one.numr.pnum \two.numr.pnum 
+	\three.numr.pnum \four.numr.pnum \five.numr.pnum \six.numr.pnum 
+	\seven.numr.pnum \eight.numr.pnum \nine.numr.pnum \zero.dnom.pnum 
+	\one.dnom.pnum \two.dnom.pnum \three.dnom.pnum \four.dnom.pnum 
+	\five.dnom.pnum \six.dnom.pnum \seven.dnom.pnum \eight.dnom.pnum 
+	\nine.dnom.pnum \zero.superior.tnum \one.superior.tnum \two.superior.tnum 
 	\three.superior.tnum \four.superior.tnum \five.superior.tnum 
 	\six.superior.tnum \seven.superior.tnum \eight.superior.tnum 
 	\nine.superior.tnum \zero.subscript.tnum \one.subscript.tnum 

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/11 21:27:12</string>
+    <string>2025/03/12 18:11:19</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/contents.plist
@@ -3036,6 +3036,8 @@
     <string>uni20B_E_.glif</string>
     <key>uni20BF</key>
     <string>uni20B_F_.glif</string>
+    <key>uni20C0</key>
+    <string>uni20C_0.glif</string>
     <key>uni2100</key>
     <string>uni2100.glif</string>
     <key>uni2101</key>
@@ -4428,6 +4430,10 @@
     <string>uni27F_2.glif</string>
     <key>uni27F3</key>
     <string>uni27F_3.glif</string>
+    <key>uni27F0</key>
+    <string>uni27F_0.glif</string>
+    <key>uni27F1</key>
+    <string>uni27F_1.glif</string>
     <key>uni1F00</key>
     <string>uni1F_00.glif</string>
     <key>uni1F01</key>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni20C_0.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni20C_0.glif
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni20C0" format="2">
+  <advance width="1101"/>
+  <unicode hex="20C0"/>
+  <outline>
+    <contour>
+      <point x="22" y="-160" type="line"/>
+      <point x="763" y="-160" type="line"/>
+      <point x="756" y="-200" type="line"/>
+      <point x="15" y="-200" type="line"/>
+    </contour>
+    <contour>
+      <point x="626" y="1010" type="curve" smooth="yes"/>
+      <point x="391" y="1010"/>
+      <point x="136" y="750"/>
+      <point x="136" y="404" type="curve" smooth="yes"/>
+      <point x="136" y="149"/>
+      <point x="306" y="30"/>
+      <point x="453" y="30" type="curve" smooth="yes"/>
+      <point x="573" y="30"/>
+      <point x="735" y="108"/>
+      <point x="840" y="274" type="curve"/>
+      <point x="875" y="252" type="line"/>
+      <point x="772" y="90"/>
+      <point x="613" y="-10"/>
+      <point x="446" y="-10" type="curve" smooth="yes"/>
+      <point x="233" y="-10"/>
+      <point x="91" y="152"/>
+      <point x="91" y="397" type="curve" smooth="yes"/>
+      <point x="91" y="729"/>
+      <point x="327" y="1050"/>
+      <point x="633" y="1050" type="curve" smooth="yes"/>
+      <point x="800" y="1050"/>
+      <point x="925" y="950"/>
+      <point x="970" y="788" type="curve"/>
+      <point x="927" y="766" type="line"/>
+      <point x="880" y="932"/>
+      <point x="746" y="1010"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni27F_0.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni27F_0.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F0" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F0"/>
+  <outline>
+    <contour>
+      <point x="1329" y="992" type="line"/>
+      <point x="1154" y="0" type="line"/>
+      <point x="1118" y="0" type="line"/>
+      <point x="1298" y="1022" type="line"/>
+    </contour>
+    <contour>
+      <point x="424" y="1032" type="line"/>
+      <point x="242" y="0" type="line"/>
+      <point x="206" y="0" type="line"/>
+      <point x="381" y="992" type="line"/>
+    </contour>
+    <contour>
+      <point x="1078" y="1292" type="line"/>
+      <point x="850" y="0" type="line"/>
+      <point x="814" y="0" type="line"/>
+      <point x="1047" y="1322" type="line"/>
+    </contour>
+    <contour>
+      <point x="957" y="1480" type="line"/>
+      <point x="1568" y="738" type="line"/>
+      <point x="1533" y="709" type="line"/>
+      <point x="934" y="1440" type="line"/>
+      <point x="77" y="709" type="line"/>
+      <point x="52" y="738" type="line"/>
+      <point x="925" y="1480" type="line"/>
+    </contour>
+    <contour>
+      <point x="781" y="1332" type="line"/>
+      <point x="546" y="0" type="line"/>
+      <point x="510" y="0" type="line"/>
+      <point x="738" y="1292" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni27F_1.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni27F_1.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni27F1" format="2">
+  <advance width="1620"/>
+  <unicode hex="27F1"/>
+  <outline>
+    <contour>
+      <point x="292" y="488" type="line"/>
+      <point x="467" y="1480" type="line"/>
+      <point x="503" y="1480" type="line"/>
+      <point x="323" y="458" type="line"/>
+    </contour>
+    <contour>
+      <point x="1197" y="448" type="line"/>
+      <point x="1379" y="1480" type="line"/>
+      <point x="1415" y="1480" type="line"/>
+      <point x="1240" y="488" type="line"/>
+    </contour>
+    <contour>
+      <point x="543" y="188" type="line"/>
+      <point x="771" y="1480" type="line"/>
+      <point x="807" y="1480" type="line"/>
+      <point x="574" y="158" type="line"/>
+    </contour>
+    <contour>
+      <point x="664" y="0" type="line"/>
+      <point x="53" y="742" type="line"/>
+      <point x="88" y="771" type="line"/>
+      <point x="687" y="40" type="line"/>
+      <point x="1544" y="771" type="line"/>
+      <point x="1569" y="742" type="line"/>
+      <point x="696" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="840" y="148" type="line"/>
+      <point x="1075" y="1480" type="line"/>
+      <point x="1111" y="1480" type="line"/>
+      <point x="883" y="188" type="line"/>
+    </contour>
+  </outline>
+</glyph>


### PR DESCRIPTION
Adds uni20C0 (`⃀`), uni27F0 (`⟰`) and uni27F1 (`⟱`) to complete the following Unicode blocs:
* [Currency Symbols](https://en.wikipedia.org/wiki/Currency_Symbols_(Unicode_block))
* [Supplemental Arrows-A](https://en.wikipedia.org/wiki/Supplemental_Arrows-A)

This PR only changes the UFOs files.