### PR TITLE
Fix uni0249 and uni2049 + set advance when building accented glyph

### DIFF
--- a/scripts/composite_glyphs.csv
+++ b/scripts/composite_glyphs.csv
@@ -83,7 +83,7 @@ ellipsis;0;period;period;period;
 exclamdbl;0;exclam;exclam;;
 uni2047;0;question;question;;
 uni2048;0;question;exclam;;
-uni0249;0;exclam;question;;
+uni2049;0;exclam;question;;
 uni2103;0;degree;C;;
 uni2107;1;uni0190;;;
 uni2108;1;uni042D;;;

--- a/scripts/ufo_accented_glyphs.py
+++ b/scripts/ufo_accented_glyphs.py
@@ -103,12 +103,13 @@ def build_accented_glyph(glyph_name, ufo_dir):
         # Load anchor points
         new_component_anchors = get_glyph_anchor_points(components_list[i], ufo_dir)
 
-        # Place component
+        # Place component (and update glyph width on base)
         x_offset = 0
         y_offset = 0
         if i == 0:  # find the offset of the new component (ignore the step below for the base)
             glyph_component[components_list[i]] = (0, 0)
             base_metrics = get_glyph_metrics(components_list[i], ufo_dir)
+            xml_tree.getroot().find("advance").attrib["width"] = str(base_metrics["glyph_width"])
         else:
             # Find a matching anchor
             placed_component = False

--- a/sources/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlack.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/13 23:26:39</string>
+    <string>2025/03/29 16:19:53</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0249.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0249.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0249" format="2">
-  <advance width="1756"/>
+  <advance width="812"/>
   <unicode hex="0249"/>
   <anchor x="306" y="-360" name="bottom_center"/>
   <anchor x="410" y="1440" name="top_center"/>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni2049.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni2049.glif
@@ -3,7 +3,7 @@
   <advance width="1756"/>
   <unicode hex="2049"/>
   <outline>
-    <component base="question" xOffset="552"/>
     <component base="exclam"/>
+    <component base="question" xOffset="552"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/13 23:26:31</string>
+    <string>2025/03/29 16:20:02</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0249.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0249.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0249" format="2">
-  <advance width="1756"/>
+  <advance width="812"/>
   <unicode hex="0249"/>
   <anchor x="113" y="-360" name="bottom_center"/>
   <anchor x="534" y="1440" name="top_center"/>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2049.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2049.glif
@@ -3,7 +3,7 @@
   <advance width="1756"/>
   <unicode hex="2049"/>
   <outline>
-    <component base="question" xOffset="552"/>
     <component base="exclam"/>
+    <component base="question" xOffset="552"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/features.fea
+++ b/sources/Giphurs-Italic.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-Italic.ufo/fontinfo.plist
+++ b/sources/Giphurs-Italic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/13 23:26:09</string>
+    <string>2025/03/29 16:19:05</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni0249.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni0249.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0249" format="2">
-  <advance width="1676"/>
+  <advance width="670"/>
   <unicode hex="0249"/>
   <anchor x="82" y="-360" name="bottom_center"/>
   <anchor x="448" y="1376" name="top_center"/>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2049.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2049.glif
@@ -3,7 +3,7 @@
   <advance width="1676"/>
   <unicode hex="2049"/>
   <outline>
-    <component base="question" xOffset="532"/>
     <component base="exclam"/>
+    <component base="question" xOffset="532"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/features.fea
+++ b/sources/Giphurs-Regular.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-Regular.ufo/fontinfo.plist
+++ b/sources/Giphurs-Regular.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/13 23:26:24</string>
+    <string>2025/03/29 16:14:43</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni0249.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni0249.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0249" format="2">
-  <advance width="1676"/>
+  <advance width="670"/>
   <unicode hex="0249"/>
   <anchor x="275" y="-360" name="bottom_center"/>
   <anchor x="335" y="1376" name="top_center"/>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni2049.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni2049.glif
@@ -3,7 +3,7 @@
   <advance width="1676"/>
   <unicode hex="2049"/>
   <outline>
-    <component base="question" xOffset="532"/>
     <component base="exclam"/>
+    <component base="question" xOffset="532"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/features.fea
+++ b/sources/Giphurs-Thin.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/13 23:25:56</string>
+    <string>2025/03/29 16:14:33</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni0249.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni0249.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0249" format="2">
-  <advance width="1591"/>
+  <advance width="570"/>
   <unicode hex="0249"/>
   <anchor x="192" y="-360" name="bottom_center"/>
   <anchor x="302" y="1376" name="top_center"/>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni2049.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni2049.glif
@@ -3,7 +3,7 @@
   <advance width="1591"/>
   <unicode hex="2049"/>
   <outline>
-    <component base="question" xOffset="488"/>
     <component base="exclam"/>
+    <component base="question" xOffset="488"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/13 23:25:48</string>
+    <string>2025/03/29 16:14:24</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni0249.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni0249.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0249" format="2">
-  <advance width="1591"/>
+  <advance width="570"/>
   <unicode hex="0249"/>
   <anchor x="-1" y="-360" name="bottom_center"/>
   <anchor x="415" y="1376" name="top_center"/>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2049.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2049.glif
@@ -3,7 +3,7 @@
   <advance width="1591"/>
   <unicode hex="2049"/>
   <outline>
-    <component base="question" xOffset="488"/>
     <component base="exclam"/>
+    <component base="question" xOffset="488"/>
   </outline>
 </glyph>


### PR DESCRIPTION
Fixes #64.

Also fix the advance not being updated on some case when building accented glyph. This wasn't visible before because most accented glyphs (if not all) had already the correct width, but I saw it when building `uni0249` where there was still the width of `uni2049`.

This PR only change the scripts and UFOs, not the font files. The fonts generated by this PR has been tested.