### PR TITLE
Attempt #1 to improve the look of 1/10 fraction with italics

### DIFF
--- a/scripts/ufo_digits_glyphs.py
+++ b/scripts/ufo_digits_glyphs.py
@@ -354,6 +354,8 @@ def build_glyph(type: str, ufo_dir: str, glyph_name: str, weight: str, digit_1: 
         if digit_2 != 0:  # dnom (hide if 0)
             if digit_2 == 10:  # 1/10
                 advance += base_1_x_metrics["left_kern"] + base_1_x_metrics["raw_width"] - FRAC_BAR_OVERLAP + base_2_x_metrics["glyph_width"]
+                if is_italic:
+                    advance -= base_1_x_metrics["right_kern"] + base_2_x_metrics["left_kern"]
                 if ss_d1 != "ss06":  # add extra kern if there isn't a bar under the digit 1
                     advance += base_2_x_metrics["left_kern"]
 
@@ -388,6 +390,7 @@ def build_glyph(type: str, ufo_dir: str, glyph_name: str, weight: str, digit_1: 
                 if is_italic:
                     x21 -= abs(y2) / tan(pi/2-ITALIC_SLANT)
                     x22 -= abs(y2) / tan(pi/2-ITALIC_SLANT)
+                    x22 -= base_1_x_metrics["right_kern"] + base_2_x_metrics["left_kern"]
                 ET.SubElement(xml_outline, "component", {"base": base_1, "xOffset": str(x21), "yOffset": str(y2)})
                 ET.SubElement(xml_outline, "component", {"base": base_2, "xOffset": str(x22), "yOffset": str(y2)})
             else:

--- a/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/29 16:20:02</string>
+    <string>2025/03/29 18:29:11</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv10.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv10.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10" format="2">
-  <advance width="2811"/>
+  <advance width="2714"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1872.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1775.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv10.ss06.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv10.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10.ss06" format="2">
-  <advance width="2763"/>
+  <advance width="2696"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1757.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv10.ss06.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv10.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10.ss06.zero" format="2">
-  <advance width="2763"/>
+  <advance width="2696"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1757.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv10.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv10.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10.zero" format="2">
-  <advance width="2811"/>
+  <advance width="2714"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1872.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1775.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv20.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv20.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20" format="2">
-  <advance width="2831"/>
+  <advance width="2714"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1892.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1775.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv20.ss06.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv20.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20.ss06" format="2">
-  <advance width="2763"/>
+  <advance width="2676"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1737.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv20.ss06.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv20.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20.ss06.zero" format="2">
-  <advance width="2763"/>
+  <advance width="2676"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1737.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv20.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.cv20.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20.zero" format="2">
-  <advance width="2831"/>
+  <advance width="2714"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1892.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1775.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01" format="2">
-  <advance width="2844"/>
+  <advance width="2714"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1905.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1775.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.ss06.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.ss06" format="2">
-  <advance width="2763"/>
+  <advance width="2663"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1724.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.ss06.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.ss06.zero" format="2">
-  <advance width="2763"/>
+  <advance width="2663"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1724.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv01.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.zero" format="2">
-  <advance width="2844"/>
+  <advance width="2714"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1905.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1775.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.cv11.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.cv11.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11" format="2">
-  <advance width="2784"/>
+  <advance width="2660"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1845.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1721.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.cv11.ss06.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.cv11.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11.ss06" format="2">
-  <advance width="2763"/>
+  <advance width="2696"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1757.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.cv11.ss06.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.cv11.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11.ss06.zero" format="2">
-  <advance width="2763"/>
+  <advance width="2696"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1757.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.cv11.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.cv11.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11.zero" format="2">
-  <advance width="2784"/>
+  <advance width="2660"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1845.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1721.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10" format="2">
-  <advance width="2816"/>
+  <advance width="2724"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1877.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1785.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.ss06.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.ss06" format="2">
-  <advance width="2763"/>
+  <advance width="2696"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1757.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.ss06.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.ss06.zero" format="2">
-  <advance width="2763"/>
+  <advance width="2696"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1757.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv10.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.zero" format="2">
-  <advance width="2816"/>
+  <advance width="2724"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1877.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1785.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.cv20.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.cv20.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20" format="2">
-  <advance width="2804"/>
+  <advance width="2660"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1865.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1721.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.cv20.ss06.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.cv20.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20.ss06" format="2">
-  <advance width="2763"/>
+  <advance width="2676"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1737.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.cv20.ss06.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.cv20.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20.ss06.zero" format="2">
-  <advance width="2763"/>
+  <advance width="2676"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1737.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.cv20.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.cv20.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20.zero" format="2">
-  <advance width="2804"/>
+  <advance width="2660"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1865.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1721.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11" format="2">
-  <advance width="2817"/>
+  <advance width="2660"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1878.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1721.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.ss06.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.ss06" format="2">
-  <advance width="2763"/>
+  <advance width="2663"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1724.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.ss06.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.ss06.zero" format="2">
-  <advance width="2763"/>
+  <advance width="2663"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1724.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv11.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.zero" format="2">
-  <advance width="2817"/>
+  <advance width="2660"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1878.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1721.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv20.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv20.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20" format="2">
-  <advance width="2836"/>
+  <advance width="2724"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1897.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1785.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv20.ss06.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv20.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20.ss06" format="2">
-  <advance width="2763"/>
+  <advance width="2676"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1737.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv20.ss06.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv20.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20.ss06.zero" format="2">
-  <advance width="2763"/>
+  <advance width="2676"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1737.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv20.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.cv20.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20.zero" format="2">
-  <advance width="2836"/>
+  <advance width="2724"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1897.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1785.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152" format="2">
-  <advance width="2849"/>
+  <advance width="2724"/>
   <unicode hex="2152"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1910.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1785.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.ss06.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.ss06" format="2">
-  <advance width="2763"/>
+  <advance width="2663"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1724.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.ss06.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.ss06.zero" format="2">
-  <advance width="2763"/>
+  <advance width="2663"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1824.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1724.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.zero.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni2152.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.zero" format="2">
-  <advance width="2849"/>
+  <advance width="2724"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="1017.18" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1910.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1785.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/features.fea
+++ b/sources/Giphurs-Italic.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-Italic.ufo/fontinfo.plist
+++ b/sources/Giphurs-Italic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/29 16:19:05</string>
+    <string>2025/03/29 18:28:36</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv10.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv10.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10" format="2">
-  <advance width="2733"/>
+  <advance width="2514"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1794" yOffset="-810"/>
+    <component base="one.cv01.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1575.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv10.ss06.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv10.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10.ss06" format="2">
-  <advance width="2673"/>
+  <advance width="2513"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv01.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1574.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv10.ss06.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv10.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10.ss06.zero" format="2">
-  <advance width="2673"/>
+  <advance width="2513"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv01.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1574.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv10.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv10.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10.zero" format="2">
-  <advance width="2733"/>
+  <advance width="2514"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1794" yOffset="-810"/>
+    <component base="one.cv01.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1575.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv20.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv20.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20" format="2">
-  <advance width="2762"/>
+  <advance width="2514"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1823" yOffset="-810"/>
+    <component base="one.cv01.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1575.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv20.ss06.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv20.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20.ss06" format="2">
-  <advance width="2673"/>
+  <advance width="2484"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv01.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1545.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv20.ss06.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv20.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20.ss06.zero" format="2">
-  <advance width="2673"/>
+  <advance width="2484"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv01.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1545.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv20.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.cv20.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20.zero" format="2">
-  <advance width="2762"/>
+  <advance width="2514"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1823" yOffset="-810"/>
+    <component base="one.cv01.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1575.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01" format="2">
-  <advance width="2765"/>
+  <advance width="2514"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1826" yOffset="-810"/>
+    <component base="one.cv01.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1575.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.ss06.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.ss06" format="2">
-  <advance width="2673"/>
+  <advance width="2481"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv01.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1542.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.ss06.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.ss06.zero" format="2">
-  <advance width="2673"/>
+  <advance width="2481"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv01.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1542.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv01.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.zero" format="2">
-  <advance width="2765"/>
+  <advance width="2514"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv01.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1826" yOffset="-810"/>
+    <component base="one.cv01.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1575.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.cv11.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.cv11.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11" format="2">
-  <advance width="2717"/>
+  <advance width="2482"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1778" yOffset="-810"/>
+    <component base="one.cv11.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1543.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.cv11.ss06.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.cv11.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11.ss06" format="2">
-  <advance width="2673"/>
+  <advance width="2513"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv11.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1574.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.cv11.ss06.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.cv11.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11.ss06.zero" format="2">
-  <advance width="2673"/>
+  <advance width="2513"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv11.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1574.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.cv11.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.cv11.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11.zero" format="2">
-  <advance width="2717"/>
+  <advance width="2482"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1778" yOffset="-810"/>
+    <component base="one.cv11.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1543.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10" format="2">
-  <advance width="2699"/>
+  <advance width="2446"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1760" yOffset="-810"/>
+    <component base="one.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1507.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.ss06.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.ss06" format="2">
-  <advance width="2673"/>
+  <advance width="2513"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1574.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.ss06.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.ss06.zero" format="2">
-  <advance width="2673"/>
+  <advance width="2513"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1574.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv10.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.zero" format="2">
-  <advance width="2699"/>
+  <advance width="2446"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1760" yOffset="-810"/>
+    <component base="one.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1507.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.cv20.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.cv20.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20" format="2">
-  <advance width="2746"/>
+  <advance width="2482"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1807" yOffset="-810"/>
+    <component base="one.cv11.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1543.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.cv20.ss06.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.cv20.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20.ss06" format="2">
-  <advance width="2673"/>
+  <advance width="2484"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv11.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1545.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.cv20.ss06.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.cv20.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20.ss06.zero" format="2">
-  <advance width="2673"/>
+  <advance width="2484"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv11.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1545.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.cv20.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.cv20.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20.zero" format="2">
-  <advance width="2746"/>
+  <advance width="2482"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1807" yOffset="-810"/>
+    <component base="one.cv11.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1543.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11" format="2">
-  <advance width="2749"/>
+  <advance width="2482"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1810" yOffset="-810"/>
+    <component base="one.cv11.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1543.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.ss06.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.ss06" format="2">
-  <advance width="2673"/>
+  <advance width="2481"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv11.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1542.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.ss06.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.ss06.zero" format="2">
-  <advance width="2673"/>
+  <advance width="2481"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.cv11.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1542.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv11.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.zero" format="2">
-  <advance width="2749"/>
+  <advance width="2482"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.cv11.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1810" yOffset="-810"/>
+    <component base="one.cv11.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1543.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv20.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv20.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20" format="2">
-  <advance width="2728"/>
+  <advance width="2446"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1789" yOffset="-810"/>
+    <component base="one.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1507.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv20.ss06.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv20.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20.ss06" format="2">
-  <advance width="2673"/>
+  <advance width="2484"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1545.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv20.ss06.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv20.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20.ss06.zero" format="2">
-  <advance width="2673"/>
+  <advance width="2484"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1545.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv20.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.cv20.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20.zero" format="2">
-  <advance width="2728"/>
+  <advance width="2446"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1789" yOffset="-810"/>
+    <component base="one.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1507.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152" format="2">
-  <advance width="2731"/>
+  <advance width="2446"/>
   <unicode hex="2152"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1792" yOffset="-810"/>
+    <component base="one.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1507.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.ss06.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.ss06" format="2">
-  <advance width="2673"/>
+  <advance width="2481"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1542.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.ss06.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.ss06.zero" format="2">
-  <advance width="2673"/>
+  <advance width="2481"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.ss06.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1734" yOffset="-810"/>
+    <component base="one.ss06.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1542.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni2152.zero.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni2152.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.zero" format="2">
-  <advance width="2731"/>
+  <advance width="2446"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
-    <component base="one.superior" xOffset="979" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1792" yOffset="-810"/>
+    <component base="one.superior" xOffset="979.175" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1507.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -4437,8 +4437,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4497,8 +4497,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4587,13 +4587,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5548,8 +5548,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/03/29 16:55:08</string>
+    <string>2025/03/29 18:28:27</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv10.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv10.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10" format="2">
-  <advance width="2727"/>
+  <advance width="2420"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1788.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1481.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv10.ss06.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv10.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10.ss06" format="2">
-  <advance width="2605"/>
+  <advance width="2327"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1666.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1388.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv10.ss06.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv10.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10.ss06.zero" format="2">
-  <advance width="2605"/>
+  <advance width="2415"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1666.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1476.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv10.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv10.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv10.zero" format="2">
-  <advance width="2639"/>
+  <advance width="2420"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1700.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1481.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv20.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv20.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20" format="2">
-  <advance width="2762"/>
+  <advance width="2420"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1823.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1481.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv20.ss06.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv20.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20.ss06" format="2">
-  <advance width="2605"/>
+  <advance width="2292"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1666.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1353.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv20.ss06.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv20.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20.ss06.zero" format="2">
-  <advance width="2605"/>
+  <advance width="2292"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1666.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1353.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv20.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.cv20.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.cv20.zero" format="2">
-  <advance width="2762"/>
+  <advance width="2420"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1823.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1481.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01" format="2">
-  <advance width="2775"/>
+  <advance width="2420"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1836.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1481.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.ss06.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.ss06" format="2">
-  <advance width="2605"/>
+  <advance width="2279"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1666.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1340.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.ss06.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.ss06.zero" format="2">
-  <advance width="2605"/>
+  <advance width="2279"/>
   <outline>
     <component base="one.cv01.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1666.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1340.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv01.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv01.zero" format="2">
-  <advance width="2775"/>
+  <advance width="2420"/>
   <outline>
     <component base="one.cv01.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv01.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1836.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1481.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.cv11.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.cv11.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11" format="2">
-  <advance width="2703"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1764.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.cv11.ss06.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.cv11.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11.ss06" format="2">
-  <advance width="2606"/>
+  <advance width="2329"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1390.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.cv11.ss06.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.cv11.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11.ss06.zero" format="2">
-  <advance width="2606"/>
+  <advance width="2417"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1478.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.cv11.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.cv11.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.cv11.zero" format="2">
-  <advance width="2615"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1676.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10" format="2">
-  <advance width="2703"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1764.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.ss06.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.ss06" format="2">
-  <advance width="2606"/>
+  <advance width="2329"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.cv10.superior" xOffset="1390.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.ss06.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.ss06.zero" format="2">
-  <advance width="2606"/>
+  <advance width="2417"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1478.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv10.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv10.zero" format="2">
-  <advance width="2615"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv10.zero.superior" xOffset="1676.18" yOffset="-810"/>
+    <component base="zero.cv10.zero.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.cv20.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.cv20.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20" format="2">
-  <advance width="2738"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1799.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.cv20.ss06.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.cv20.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20.ss06" format="2">
-  <advance width="2606"/>
+  <advance width="2294"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1355.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.cv20.ss06.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.cv20.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20.ss06.zero" format="2">
-  <advance width="2606"/>
+  <advance width="2294"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1355.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.cv20.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.cv20.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.cv20.zero" format="2">
-  <advance width="2738"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1799.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11" format="2">
-  <advance width="2751"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1812.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.ss06.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.ss06" format="2">
-  <advance width="2606"/>
+  <advance width="2281"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1342.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.ss06.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.ss06.zero" format="2">
-  <advance width="2606"/>
+  <advance width="2281"/>
   <outline>
     <component base="one.cv11.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1342.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv11.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv11.zero" format="2">
-  <advance width="2751"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.cv11.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.cv11.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1812.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv20.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv20.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20" format="2">
-  <advance width="2738"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1799.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv20.ss06.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv20.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20.ss06" format="2">
-  <advance width="2606"/>
+  <advance width="2294"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.cv20.superior" xOffset="1355.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv20.ss06.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv20.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20.ss06.zero" format="2">
-  <advance width="2606"/>
+  <advance width="2294"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1355.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv20.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.cv20.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.cv20.zero" format="2">
-  <advance width="2738"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.cv20.zero.superior" xOffset="1799.18" yOffset="-810"/>
+    <component base="zero.cv20.zero.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.glif
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152" format="2">
-  <advance width="2751"/>
+  <advance width="2372"/>
   <unicode hex="2152"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1812.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.ss06.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.ss06.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.ss06" format="2">
-  <advance width="2606"/>
+  <advance width="2281"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.superior" xOffset="1342.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.ss06.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.ss06.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.ss06.zero" format="2">
-  <advance width="2606"/>
+  <advance width="2281"/>
   <outline>
     <component base="one.ss06.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.ss06.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1667.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1342.18" yOffset="-810"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.zero.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni2152.zero.glif
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni2152.zero" format="2">
-  <advance width="2751"/>
+  <advance width="2372"/>
   <outline>
     <component base="one.superior" xOffset="-33" yOffset="-188"/>
     <component base="fraction" xOffset="481"/>
     <component base="one.superior" xOffset="997.175" yOffset="-810"/>
-    <component base="zero.zero.superior" xOffset="1812.18" yOffset="-810"/>
+    <component base="zero.zero.superior" xOffset="1433.18" yOffset="-810"/>
   </outline>
 </glyph>


### PR DESCRIPTION
*Don't mind the branch name I forgot to change it...*

|Before|After|
|----|----|
|![Image](https://github.com/user-attachments/assets/279d1399-ba80-4e49-a51a-d953098146b7)|![Screenshot_20250329_192852](https://github.com/user-attachments/assets/98c2c9ad-e4c2-425f-aefb-b4a41bf2c58f)|

Tried my best, although it's not perfect, the glyph width won't match non-italics but I don't think this isn't such of a big deal for this fraction and particular.

Non-italics should remain unchanged.

This PR changes the `ufo_digits_glyphs.py` script and UFOs of italics only.
