### PR TITLE
Add multithreading support for accented and composite glyphs

### DIFF
--- a/scripts/ufo_accented_glyphs.py
+++ b/scripts/ufo_accented_glyphs.py
@@ -37,8 +37,7 @@ def build_accented_glyph(glyph_name, ufo_dir, style, allow_left_overflow, allow_
     global COMPONENTS_LIST, COMPONENTS_LIST_DELIM, MKMK_ANCHORS_REPLACE
 
     # Load file to edit
-    glif_filename = get_glif_from_name(glyph_name, ufo_dir)
-    xml_tree = ET.parse(glif_filename)
+    xml_tree = ET.parse(get_glif_from_name(glyph_name, ufo_dir))
     xml_root = xml_tree.getroot()
 
     # Place components and anchors and get metrics of the base (when recalculate kerning)
@@ -140,15 +139,15 @@ def build_accented_glyph(glyph_name, ufo_dir, style, allow_left_overflow, allow_
         else:
             ET.SubElement(xml_outline, "component", {"base": component, "xOffset": str(glyph_component[component][0]), "yOffset": str(glyph_component[component][1])})
 
+    # Save the file
+    xml_tree.write(get_glif_from_name(glyph_name, ufo_dir), encoding='utf-8', xml_declaration=True)
+
     # Update kern if needed
     current_glyph_metrics = get_glyph_metrics(glyph_name, ufo_dir)
     if (not allow_right_overflow) and current_glyph_metrics["x_max"] > base_metrics["glyph_width"]:
-        xml_root = move_glyph_xml(xml_root, current_glyph_metrics["x_max"] - base_metrics["glyph_width"], 0, False, False, True)
+        move_glyph(glyph_name, ufo_dir, current_glyph_metrics["x_max"] - base_metrics["glyph_width"], 0, False, False, True)
     if (not allow_left_overflow) and current_glyph_metrics["x_min"] < 0:
-        xml_root = move_glyph_xml(xml_root, ufo_dir, abs(current_glyph_metrics["x_min"]), 0, True, True, not allow_right_overflow)
-
-    # Save the file
-    xml_tree.write(glif_filename, encoding='utf-8', xml_declaration=True)
+        move_glyph(glyph_name, ufo_dir, abs(current_glyph_metrics["x_min"]), 0, True, True, not allow_right_overflow)
 
     #print(f"Done with {glyph_name} ({len(glyph_component)} components, {len(glyph_anchors)} anchors)")
     return 0

--- a/scripts/ufo_accented_glyphs.py
+++ b/scripts/ufo_accented_glyphs.py
@@ -26,7 +26,7 @@ MKMK_ANCHORS_REPLACE = {
 }
 
 
-def build_accented_glyph(glyph_name, ufo_dir, style=1):
+def build_accented_glyph(glyph_name, ufo_dir, style, allow_left_overflow, allow_right_overflow, components_list):
     """
     Edit a .glif file and change generate the components.
 
@@ -36,59 +36,9 @@ def build_accented_glyph(glyph_name, ufo_dir, style=1):
     """
     global COMPONENTS_LIST, COMPONENTS_LIST_DELIM, MKMK_ANCHORS_REPLACE
 
-    # Check if style is correct
-    assert style in [1, 2]
-
     # Load file to edit
     xml_tree = ET.parse(get_glif_from_name(glyph_name, ufo_dir))
     xml_root = xml_tree.getroot()
-
-    # Find the glyph and its components
-    components_list = []
-    allow_left_overflow = False
-    allow_right_overflow = False
-    with open(COMPONENTS_LIST, "r") as csv_file:
-        csv_lines = csv_file.readlines()
-        i = 1
-        components_list = []
-
-        # find the glyph on the list (find its index -> i)
-        glyph_found = False
-        while i < len(csv_lines) and not glyph_found:
-            line_glyph_name = csv_lines[i].split(COMPONENTS_LIST_DELIM)[0]
-            line_styles = csv_lines[i].split(COMPONENTS_LIST_DELIM)[1]
-            line_non_italic_support = bool(int(line_styles) & 1)
-            line_italic_support = bool(int(line_styles) & 2)
-            if line_glyph_name == glyph_name and ((style == 1 and line_non_italic_support) or (style == 2 and line_italic_support)):
-                glyph_found = True
-            else:
-                i += 1
-
-        if i >= len(csv_lines):  # end of file reached
-            print(f"ERROR: Glyph {glyph_name} not found on {COMPONENTS_LIST} for style={style}")
-            return 1
-
-        csv_entry = csv_lines[i].split(COMPONENTS_LIST_DELIM)
-
-        if len(csv_entry) < 5:  # 0 components found or missing parameters
-            print(f"ERROR: Invalid entry for {glyph_name} (line {i+1})")
-            return 2
-        
-        # retrieve overflow parameters
-        allow_left_overflow = bool(int(csv_entry[2].strip()))
-        allow_right_overflow = bool(int(csv_entry[3].strip()))
-
-        # retrieve the components names
-        j = 4
-        while j < len(csv_entry):
-            component = csv_entry[j].strip()
-            if component != "":
-                components_list.append(component)
-            j += 1
-
-        if glyph_name in components_list:  # avoid infinite recursion
-            print(f"ERROR: Glyph {glyph_name} contains itself as component (line {i+1})")
-            return 3
 
     # Place components and anchors and get metrics of the base (when recalculate kerning)
     glyph_component = {}  # {"component": (xOffset, yOffset)}
@@ -202,40 +152,134 @@ def build_accented_glyph(glyph_name, ufo_dir, style=1):
     #print(f"Done with {glyph_name} ({len(glyph_component)} components, {len(glyph_anchors)} anchors)")
     return 0
 
+def check_csv_entry(csv_line, glyph_name=None, style=None):
+    """
+    Read a line of COMPOSITE_GLYPHS_LIST given as a string.
+    It is possible to check if it corresponds to a specific glyph name and/or a style
+    If the line is valid and applies to the style given, then returns 0,
+    otherwise returns a non-zero value, depending on the issue.
+    """
+    csv_data = csv_line.strip().split(COMPONENTS_LIST_DELIM)
+    for i in range(len(csv_data)):  # remove whitespaces
+        csv_data[i] = csv_data[i].strip()
+
+    # Number of columns check:
+    if len(csv_data) < 5:
+        return 1  # Not enough parameters
+    
+    # Style entry check
+    csv_style_value = None
+    try:
+        csv_style_value = int(csv_data[1])
+    except:
+        return 2  # Style field is not an integer
+
+    # Self reference check (to avoid infinite recursion)
+    if csv_data[0] in csv_data[4:]:
+        return 3  # Glyph refers itself as component
+
+    # Glyph name matching check
+    if not glyph_name is None:
+        if glyph_name != csv_data[0]:
+            return 4  # Glyph name is not matching
+
+    # Style support check
+    if not style is None:
+        line_non_italic_support = bool(int(csv_style_value) & 1)
+        line_italic_support = bool(int(csv_style_value) & 2)
+        if not((style == 1 and line_non_italic_support) or (style == 2 and line_italic_support)):
+            return 5  # Unsupported style
+    
+    # All good :)
+    return 0
+
 def main():
+    # Read parameters
     if len(sys.argv) < 3:
         print(f"ERROR: {sys.argv[0]}: Not enough parameters.")
         print(f"Usage: {sys.argv[0]} <ufo_directory> <style> [<glyph_name>]")
         print("* style: 1 = non-italic ; 2 = italic")
         print("If a glyph name isn't provided, all accented glyphs from the font will be built")
-    else:
-        if len(sys.argv) == 3:  # no specific glyph -> do all
-            # get the list of what to do
-            glyphs_list = []
-            with open(COMPONENTS_LIST, "r") as csv_file:
-                first_line_seen = False
-                for csv_line in csv_file:
-                    if not first_line_seen:  # then this is the first line (-> skip)
-                        first_line_seen = True
-                    else:
-                        glyphs_list.append(csv_line.split(";")[0].strip())
-            # act on each glyph
-            print("Starting...")
-            nb_glyphs = len(glyphs_list)
-            success_count = 0
-            for index, glyph in enumerate(glyphs_list):
-                sys.stdout.write('\033[2K\033[1G')
-                print(f"[{index}/{nb_glyphs} ({int((index-1)/nb_glyphs*100)}%)] Working on {glyph}...", end="\r")
-                build_status = build_accented_glyph(glyph, sys.argv[1], int(sys.argv[2]))
-                if build_status == 0:
-                    success_count += 1
-            print(f"Done with {sys.argv[1]} ({success_count}/{len(glyphs_list)} files changed)")
-        else:
-            build_status = build_accented_glyph(sys.argv[3], sys.argv[1], int(sys.argv[2]))
-            if build_status == 0:
-                print(f"Done building {sys.argv[3]}")
+        return
+
+    ufo_dir = sys.argv[1]
+    style = int(sys.argv[2])
+    glyph_name = None if len(sys.argv) == 3 else sys.argv[3]
+
+    # Get the list of glyphs to do. Result is in 'glyphs_list', a 2d matrix, with each rows looking like the CSV file:
+    # [0] Glyph Name (str)
+    # [1] Supported styles (int)
+    # [2] Allow left overflow (bool)
+    # [3] Allow right overflow (bool)
+    # [4+] Components (str)
+    glyphs_list_data = []
+    with open(COMPONENTS_LIST, "r") as csv_file:
+        csv_lines = csv_file.readlines()
+        first_line_seen = False
+        for line_number, csv_line in enumerate(csv_lines, start=1):
+            if not first_line_seen:  # then this is the first line (-> skip)
+                first_line_seen = True
             else:
-                print(f"Failed building {sys.argv[3]}")
+                csv_line_check = check_csv_entry(csv_line, glyph_name, style)
+                # -- Valid line
+                if csv_line_check == 0:
+                    csv_line_splitted = csv_line.strip().split(COMPONENTS_LIST_DELIM)  # all elements are strings!
+                    new_entry = []
+                    for i in range(len(csv_line_splitted)):  # remove whitespaces
+                        if not csv_line_splitted[i] == "":
+                            if i == 1:  # Styles -> int
+                                csv_line_splitted[i] = int(csv_line_splitted[i])
+                            elif i == 2 or i == 3:  # Allow left/right overflow -> bool
+                                csv_line_splitted[i] = not csv_line_splitted[i].lower() in ["", "0", "no"]
+                            new_entry.append(csv_line_splitted[i])
+                    glyphs_list_data.append(new_entry)
+                # -- Errors on the line
+                elif csv_line_check == 1:
+                    print(f"WARNING: Not enough parameters at line {line_number}, skipping.")
+                elif csv_line_check == 2:
+                    print(f"WARNING: 'Style' field isn't an integer at line {line_number}, skipping.")
+                elif csv_line_check == 3:
+                    print(f"WARNING: The glyph at line {line_number} contains itself as component, skipping.")
+                # -- The style and eventually the glyph name don't match
+                # do nothing
+    
+    # Check the possible errors before build and correct them if possible
+    # -- The glyph specified doesn't exists [FATAL]
+    if not glyph_name is None and len(glyphs_list_data) == 0:
+        print(f"ERROR: Don't know how to build {glyph_name} for style={style}")
+        exit(1)
+    # -- A specified glyph appears twice (NOT checked if building all glyphs)
+    if not glyph_name is None and len(glyphs_list_data) > 1:
+        print(f"WARNING: More than 1 recipe found for {glyph_name} for style={style}: only the first one will be used")
+        glyphs_list_data = [glyphs_list_data[0]]
+    # -- 0 glyphs to build [FATAL]
+    if len(glyphs_list_data) == 0:
+        print(f"ERROR: No glyph to build for style={style}")
+        exit(2)
+    
+    # Build the composite glyphs
+    print("Starting...")
+    nb_glyphs = len(glyphs_list_data)
+    sucess_count = 0
+    for index, glyph_data in enumerate(glyphs_list_data, start=0):
+        current_glyph_name = glyph_data[0]
+        current_glyph_left_overflow = glyph_data[2]
+        current_glyph_right_overflow = glyph_data[3]
+        current_glyph_components = glyph_data[4:]
+
+        sys.stdout.write('\033[2K\033[1G')
+        print(f"[{index}/{nb_glyphs} ({int((index-1)/nb_glyphs*100)}%)] Working on {current_glyph_name}...", end="\r")
+
+        build_status = build_accented_glyph(current_glyph_name, ufo_dir, style, current_glyph_left_overflow, current_glyph_right_overflow, current_glyph_components)
+        if build_status == 0:
+            sucess_count += 1
+
+    # End message
+    if glyph_name is None:
+        print(f"Done with {sys.argv[1]} ({sucess_count}/{nb_glyphs} files changed)")
+    else:
+        print(f"Done building {glyph_name} in {sys.argv[1]} ({sucess_count}/{nb_glyphs} files changed)")
+
         
 if __name__ == "__main__":
     main()

--- a/scripts/ufo_accented_glyphs.py
+++ b/scripts/ufo_accented_glyphs.py
@@ -11,7 +11,7 @@ Fields on COMPONENTS_LIST:
 glyph_name, allow_left_overflow, allow_right_overflow, base, component_1, component_2, ...
 """
 
-from multiprocessing import Process, Value
+from multiprocessing import Process
 import sys
 from ufo_utils import *
 import xml.etree.ElementTree as ET
@@ -263,7 +263,7 @@ def main():
         print(f"ERROR: No glyph to build for style={style}")
         exit(2)
     
-    # Build the composite glyphs
+    # Build the accented glyphs
     print("Starting...")
     nb_glyphs = len(glyphs_list_data)
     if USE_MULTITHREADING:
@@ -283,7 +283,7 @@ def main():
         print(f"Done with {sys.argv[1]} ({nb_glyphs} files changed)", flush=True)
     else:
         print(f"Done building {glyph_name} in {sys.argv[1]} ({nb_glyphs} files changed)", flush=True)
-        pass
+
 
 def build_single_glyph(glyph_data, ufo_dir, style, index, nb_glyphs):
     """

--- a/scripts/ufo_accented_glyphs.py
+++ b/scripts/ufo_accented_glyphs.py
@@ -37,7 +37,8 @@ def build_accented_glyph(glyph_name, ufo_dir, style, allow_left_overflow, allow_
     global COMPONENTS_LIST, COMPONENTS_LIST_DELIM, MKMK_ANCHORS_REPLACE
 
     # Load file to edit
-    xml_tree = ET.parse(get_glif_from_name(glyph_name, ufo_dir))
+    glif_filename = get_glif_from_name(glyph_name, ufo_dir)
+    xml_tree = ET.parse(glif_filename)
     xml_root = xml_tree.getroot()
 
     # Place components and anchors and get metrics of the base (when recalculate kerning)
@@ -139,15 +140,15 @@ def build_accented_glyph(glyph_name, ufo_dir, style, allow_left_overflow, allow_
         else:
             ET.SubElement(xml_outline, "component", {"base": component, "xOffset": str(glyph_component[component][0]), "yOffset": str(glyph_component[component][1])})
 
-    # Save the file
-    xml_tree.write(get_glif_from_name(glyph_name, ufo_dir), encoding='utf-8', xml_declaration=True)
-
     # Update kern if needed
     current_glyph_metrics = get_glyph_metrics(glyph_name, ufo_dir)
     if (not allow_right_overflow) and current_glyph_metrics["x_max"] > base_metrics["glyph_width"]:
-        move_glyph(glyph_name, ufo_dir, current_glyph_metrics["x_max"] - base_metrics["glyph_width"], 0, False, False, True)
+        xml_root = move_glyph_xml(xml_root, current_glyph_metrics["x_max"] - base_metrics["glyph_width"], 0, False, False, True)
     if (not allow_left_overflow) and current_glyph_metrics["x_min"] < 0:
-        move_glyph(glyph_name, ufo_dir, abs(current_glyph_metrics["x_min"]), 0, True, True, not allow_right_overflow)
+        xml_root = move_glyph_xml(xml_root, ufo_dir, abs(current_glyph_metrics["x_min"]), 0, True, True, not allow_right_overflow)
+
+    # Save the file
+    xml_tree.write(glif_filename, encoding='utf-8', xml_declaration=True)
 
     #print(f"Done with {glyph_name} ({len(glyph_component)} components, {len(glyph_anchors)} anchors)")
     return 0

--- a/scripts/ufo_composite_glyphs.py
+++ b/scripts/ufo_composite_glyphs.py
@@ -21,57 +21,17 @@ import xml.etree.ElementTree as ET
 COMPOSITE_GLYPHS_LIST = "scripts/composite_glyphs.csv"
 COMPOSITE_GLYPHS_LIST_DELIM = ";"
 
-def build_composite_glyph(glyph_name, ufo_dir, style=1):
+def build_composite_glyph(glyph_name, ufo_dir, style, copy_anchors, components_list):
     """
     Build the composite glyph `glyph_name` using its components listed from `COMPOSITE_GLYPHS_LIST`.
     
     Changes UFO .glif file of destination glyph.
 
+    For 'style' argument: 1 = non-italic, 2 = italic.
+
     Return `0` if sucess, non-zero integer if it fails.
     """
-    # Get compoents
-    copy_anchors = False
-    with open(COMPOSITE_GLYPHS_LIST, "r") as csv_file:
-        csv_lines = csv_file.readlines()
-        line_number = 1
-        components_list = []
 
-        # find the glyph on the list (find its index -> line_number)
-        glyph_found = False
-        while line_number < len(csv_lines) and not glyph_found:  # find the glyph on the list
-            line_glyph_name = csv_lines[line_number].split(COMPOSITE_GLYPHS_LIST_DELIM)[0]
-            line_styles = csv_lines[line_number].split(COMPOSITE_GLYPHS_LIST_DELIM)[1]
-            line_non_italic_support = bool(int(line_styles) & 1)
-            line_italic_support = bool(int(line_styles) & 2)
-            if line_glyph_name == glyph_name and ((style == 1 and line_non_italic_support) or (style == 2 and line_italic_support)):
-                glyph_found = True
-            else:
-                line_number += 1
-
-        if line_number >= len(csv_lines):  # end of file reached
-            print(f"ERROR: Glyph {glyph_name} not found on {COMPOSITE_GLYPHS_LIST} for style={style}")
-            return 1
-        
-        csv_entry = csv_lines[line_number].split(COMPOSITE_GLYPHS_LIST_DELIM)
-
-        if len(csv_entry) < 4:  # 0 components found or missing parameters
-            print(f"ERROR: Invalid entry for {glyph_name} (line {line_number+1})")
-            return 2
-
-        # Read the "Copy anchors" parameter
-        copy_anchors = bool(int(csv_entry[2]))
-
-        column_number = 3
-        while column_number < len(csv_entry):
-            cell_value = csv_entry[column_number].strip()
-            if cell_value != "":
-                components_list.append(cell_value)
-            column_number += 1
-
-        if glyph_name in components_list:  # avoid infinite recursion
-            print(f"ERROR: Glyph {glyph_name} contains itself as component (line {line_number+1})")
-            return 3
-    
     # Place components
     x_cursor = 0
     for component_number in range(0, len(components_list), 1):
@@ -139,40 +99,131 @@ def copy_single_glyph(glyph_src, glyph_dst, ufo_dir, copy_anchors=True, replace_
     dst_xml_tree.write(get_glif_from_name(glyph_dst, ufo_dir), encoding='utf-8', xml_declaration=True)
     return
 
+def check_csv_entry(csv_line, glyph_name=None, style=None):
+    """
+    Read a line of COMPOSITE_GLYPHS_LIST given as a string.
+    It is possible to check if it corresponds to a specific glyph name and/or a style
+    If the line is valid and applies to the style given, then returns 0,
+    otherwise returns a non-zero value, depending on the issue.
+    """
+    csv_data = csv_line.split(COMPOSITE_GLYPHS_LIST_DELIM)
+    for i in range(len(csv_data)):  # remove whitespaces
+        csv_data[i] = csv_data[i].strip()
+
+    # Number of columns check:
+    if len(csv_data) < 4:
+        return 1  # Not enough parameters
+    
+    # Style entry check
+    csv_style_value = None
+    try:
+        csv_style_value = int(csv_data[1])
+    except:
+        return 2  # Style field is not an integer
+
+    # Self reference check (to avoid infinite recursion)
+    if csv_data[0] in csv_data[3:]:
+        return 3  # Glyph refers itself as component
+
+    # Glyph name matching check
+    if not glyph_name is None:
+        if glyph_name != csv_data[0]:
+            return 4  # Glyph name is not matching
+
+    # Style support check
+    if not style is None:
+        line_non_italic_support = bool(int(csv_style_value) & 1)
+        line_italic_support = bool(int(csv_style_value) & 2)
+        if not((style == 1 and line_non_italic_support) or (style == 2 and line_italic_support)):
+            return 5  # Unsupported style
+    
+    # All good :)
+    return 0
+
 def main():
+    # Read parameters
     if len(sys.argv) < 3:
         print(f"ERROR: {sys.argv[0]}: Not enough parameters.")
         print(f"Usage: {sys.argv[0]} <ufo_directory> <style> [<glyph_name>]")
         print("* style: 1 = non-italic ; 2 = italic")
         print("If a glyph name isn't provided, all composite glyphs from the font will be built.")
-    else:
-        if len(sys.argv) == 3:  # no specific glyph -> do all
-            # get the list of what to do
-            glyphs_list = []
-            with open(COMPOSITE_GLYPHS_LIST, "r") as csv_file:
-                first_line_seen = False
-                for csv_line in csv_file:
-                    if not first_line_seen:  # then this is the first line (-> skip)
-                        first_line_seen = True
-                    else:
-                        glyphs_list.append(csv_line.split(";")[0].strip())
-            # act on each glyph
-            print("Starting...")
-            nb_glyphs = len(glyphs_list)
-            sucess_count = 0
-            for index, glyph in enumerate(glyphs_list, start=1):
-                sys.stdout.write('\033[2K\033[1G')
-                print(f"[{index}/{nb_glyphs} ({int((index-1)/nb_glyphs*100)}%)] Working on {glyph}...", end="\r")
-                build_status = build_composite_glyph(glyph, sys.argv[1], int(sys.argv[2]))
-                if build_status == 0:
-                    sucess_count += 1
-            print(f"Done with {sys.argv[1]} ({sucess_count}/{len(glyphs_list)} files changed)")
-        else:  # single glyph
-            build_status = build_composite_glyph(sys.argv[3], sys.argv[1], int(sys.argv[2]))
-            if build_status == 0:
-                print(f"Done building {sys.argv[3]}")
+        return
+    
+    ufo_dir = sys.argv[1]
+    style = int(sys.argv[2])
+    glyph_name = None if len(sys.argv) == 3 else sys.argv[3]
+
+    # Get the list of glyphs to do. Result is in 'glyphs_list', a 2d matrix, with each rows looking like the CSV file:
+    # [0] Glyph Name (str)
+    # [1] Supported style (int)
+    # [2] Copy Anchors (bool)
+    # [3+] Components (str)
+    glyphs_list_data = []
+    with open(COMPOSITE_GLYPHS_LIST, "r") as csv_file:
+        csv_lines = csv_file.readlines()
+        first_line_seen = False
+        for line_number, csv_line in enumerate(csv_lines, start=1):
+            if not first_line_seen:  # then this is the first line (-> skip)
+                first_line_seen = True
             else:
-                print(f"Failed building {sys.argv[3]}")
+                csv_line_check = check_csv_entry(csv_line, glyph_name, style)
+                # -- Valid line
+                if csv_line_check == 0:
+                    csv_line_splitted = csv_line.strip().split(COMPOSITE_GLYPHS_LIST_DELIM)  # all elements are strings!
+                    new_entry = []
+                    for i in range(len(csv_line_splitted)):  # remove whitespaces
+                        if not csv_line_splitted[i] == "":
+                            if i == 1:  # Styles -> int
+                                csv_line_splitted[i] = int(csv_line_splitted[i])
+                            elif i == 2:  # Copy anchors -> bool
+                                csv_line_splitted[i] = not csv_line_splitted[i].lower() in ["", "0", "no"]
+                            new_entry.append(csv_line_splitted[i])
+                    glyphs_list_data.append(new_entry)
+                # -- Errors on the line
+                elif csv_line_check == 1:
+                    print(f"WARNING: Not enough parameters at line {line_number}, skipping.")
+                elif csv_line_check == 2:
+                    print(f"WARNING: 'Style' field isn't an integer at line {line_number}, skipping.")
+                elif csv_line_check == 3:
+                    print(f"WARNING: The glyph at line {line_number} contains itself as component, skipping.")
+                # -- The style and eventually the glyph name don't match
+                # do nothing
+    
+    # Check the possible errors before build and correct them if possible
+    # -- The glyph specified doesn't exists [FATAL]
+    if not glyph_name is None and len(glyphs_list_data) == 0:
+        print(f"ERROR: Don't know how to build {glyph_name} for style={style}")
+        exit(1)
+    # -- A specified glyph appears twice (NOT checked if building all glyphs)
+    if not glyph_name is None and len(glyphs_list_data) > 1:
+        print(f"WARNING: More than 1 recipe found for {glyph_name} for style={style}: only the first one will be used")
+        glyphs_list_data = [glyphs_list_data[0]]
+    # -- 0 glyphs to build [FATAL]
+    if len(glyphs_list_data) == 0:
+        print(f"ERROR: No glyph to build for style={style}")
+        exit(2)
+    
+    # Build the composite glyphs
+    print("Starting...")
+    nb_glyphs = len(glyphs_list_data)
+    sucess_count = 0
+    for index, glyph_data in enumerate(glyphs_list_data, start=0):
+        current_glyph_name = glyph_data[0]
+        current_glyph_copy_anchors = glyph_data[2]
+        current_glyph_components = glyph_data[3:]
+
+        sys.stdout.write('\033[2K\033[1G')
+        print(f"[{index}/{nb_glyphs} ({int((index-1)/nb_glyphs*100)}%)] Working on {current_glyph_name}...", end="\r")
+
+        build_status = build_composite_glyph(current_glyph_name, ufo_dir, style, current_glyph_copy_anchors, current_glyph_components)
+        if build_status == 0:
+            sucess_count += 1
+
+    # End message
+    if glyph_name is None:
+        print(f"Done with {sys.argv[1]} ({sucess_count}/{nb_glyphs} files changed)")
+    else:
+        print(f"Done building {glyph_name} in {sys.argv[1]} ({sucess_count}/{nb_glyphs} files changed)")
 
 if __name__ == "__main__":
     main()

--- a/scripts/ufo_utils.py
+++ b/scripts/ufo_utils.py
@@ -275,38 +275,6 @@ def move_glyph(glyph_name, ufo_dir, x, y, move_points=True, move_anchors=True, m
     xml_tree.write(filename, encoding="UTF-8", xml_declaration=True)
     return
 
-def move_glyph_xml(glif_xml_root, x, y, move_points=True, move_anchors=True, move_width=False):
-    """
-    Implementation of move_glyph which takes the contents of a .glif file (ElementTree).
-    
-    Does not write on the .glif, but returns the modified ElementTree object.
-    """
-    for element in glif_xml_root.findall("./*"):
-        if element.tag == "advance" and move_width:
-            element.attrib["width"] = str(int(element.attrib["width"]) + x)
-        elif element.tag == "anchor" and move_anchors:
-            element.attrib["x"] = str(int(element.attrib["x"]) + x)
-            element.attrib["y"] = str(int(element.attrib["y"]) + y)
-        elif element.tag == "outline" and move_points:
-            for outline_element in element.findall("./*"):
-                if outline_element.tag == "contour":
-                    for contour_element in outline_element.findall("./*"):
-                        if contour_element.tag == "point":
-                            contour_element.attrib["x"] = str(int(contour_element.attrib["x"]) + x)
-                            contour_element.attrib["y"] = str(int(contour_element.attrib["y"]) + y)
-                elif outline_element.tag == "component":
-                    if "xOffset" in outline_element.attrib:
-                        outline_element.attrib["xOffset"] = str(int(outline_element.attrib["xOffset"]) + x)
-                    else:
-                        outline_element.attrib["xOffset"] = str(x)
-                    if "yOffset" in outline_element.attrib:
-                        outline_element.attrib["yOffset"] = str(int(outline_element.attrib["yOffset"]) + y)
-                    else:
-                        outline_element.attrib["yOffset"] = str(y)
-        # ignore other type of elements, keeping them as is
-
-    return glif_xml_root
-
 def unlink_references(glyph_name, ufo_dir):
     """
     Replace all components of a glyph (references towards other glyphs) by points.


### PR DESCRIPTION
Building accented glyphs for all of the 6 UFOs is longer than the font compilation itself. This pissed me off after doing it dozens of time.

I tried to decrease the amount of times the files are accessed (there was some repetitions in the code thinking about it), and seeing this isn't much faster, added mulithreading, making the scripts blazing fast for my 16-core laptop.

Didn't touch digits glyphs script because I don't need it at the moment and the code for this script is so horrible to maintain I'd need to rewrite a large part of the script to make it usable and implement multithreading.

The UFOs files are unchanged with these changes that's why they aren't included in this PR.