### PR TITLE
Fix fake error messages on ufo_digits_glyphs when building fractions and small digits

### DIFF
--- a/scripts/ufo_digits_glyphs.py
+++ b/scripts/ufo_digits_glyphs.py
@@ -754,23 +754,24 @@ def build_single_glyph(glyph_name, weight, is_italic, ufo_dir, index, nb_glyphs)
     elif base_name in FRACTIONS_UNICODE:
         build_fraction(glyph_name, weight, is_italic, ufo_dir)
     # from this point we're sure the glyph name starts by "uniXXXX"
-    try:
-        int(base_name[3:], 16)
-    except:
-        print(f"{sys.argv[0]}: I don't know how to build {glyph_name}")
     else:
-        if int(base_name[3:], 16) in CIRCLED_UNICODE:
-            build_circled_number(glyph_name, weight, is_italic, ufo_dir, "circle")
-        elif int(base_name[3:], 16) in BLACK_CIRCLE_UNICODE:
-            build_circled_number(glyph_name, weight, is_italic, ufo_dir, "black_circle")
-        elif int(base_name[3:], 16) in DOUBLE_CIRCLE_UNICODE:
-            build_circled_number(glyph_name, weight, is_italic, ufo_dir, "double_circle")
-        elif int(base_name[3:], 16) in PARENTHESIZED_UNICODE:
-            build_parenthesized_number(glyph_name, weight, is_italic, ufo_dir)
-        elif int(base_name[3:], 16) in FULL_STOP_UNICODE:
-            build_full_stop_number(glyph_name, weight, is_italic, ufo_dir)
-        else:
+        try:
+            int(base_name[3:], 16)
+        except:
             print(f"{sys.argv[0]}: I don't know how to build {glyph_name}")
+        else:
+            if int(base_name[3:], 16) in CIRCLED_UNICODE:
+                build_circled_number(glyph_name, weight, is_italic, ufo_dir, "circle")
+            elif int(base_name[3:], 16) in BLACK_CIRCLE_UNICODE:
+                build_circled_number(glyph_name, weight, is_italic, ufo_dir, "black_circle")
+            elif int(base_name[3:], 16) in DOUBLE_CIRCLE_UNICODE:
+                build_circled_number(glyph_name, weight, is_italic, ufo_dir, "double_circle")
+            elif int(base_name[3:], 16) in PARENTHESIZED_UNICODE:
+                build_parenthesized_number(glyph_name, weight, is_italic, ufo_dir)
+            elif int(base_name[3:], 16) in FULL_STOP_UNICODE:
+                build_full_stop_number(glyph_name, weight, is_italic, ufo_dir)
+            else:
+                print(f"{sys.argv[0]}: I don't know how to build {glyph_name}")
 
     return
 


### PR DESCRIPTION
I thought the script was broken in some sense, but technically the script was working fine but showed for fractions error messages because I forgot an `else` in the code.

:clueless: