### PR TITLE
Rebuild composite and accented glyphs for non-italics & fix inconsistencies with uni0503 uni0505 uni0509 uni050B uni050F

### DIFF
--- a/sources/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlack.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -8597,7 +8597,7 @@ lookup mark_Mark_positioning {
 	<anchor 1122 1040> mark @top_right
 	<anchor 596 0> mark @bottom_center
 	<anchor 1146 0> mark @bottom_right;
-  pos base [\d ] <anchor 555 -20> mark @bottom_cedilla
+  pos base [\d \uni0501 ] <anchor 555 -20> mark @bottom_cedilla
 	<anchor 555 0> mark @bottom_center
 	<anchor 1000 1380> mark @top_center
 	<anchor 1180 1480> mark @top_right;
@@ -8702,7 +8702,7 @@ lookup mark_Mark_positioning {
   pos base [\C \uni0421 \uni216D ] <anchor 810 -20> mark @bottom_cedilla
 	<anchor 810 0> mark @bottom_center
 	<anchor 810 1380> mark @top_center;
-  pos base [\G \Q \uni01B1 \Theta \uni0424 \uni04D8 \uni04E8 \uni051A \uni2127 \G.cv21 ] <anchor 810 1380> mark @top_center
+  pos base [\G \Q \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \G.cv21 ] <anchor 810 1380> mark @top_center
 	<anchor 810 0> mark @bottom_center;
   pos base [\U ] <anchor 741 -20> mark @bottom_cedilla
 	<anchor 741 1380> mark @top_center
@@ -8903,7 +8903,7 @@ lookup mark_Mark_positioning {
 	<anchor 810 1716> mark @top_center;
   pos base [\gcircumflex \gbreve \gcaron \uni01F5 ] <anchor 589 -360> mark @bottom_center
 	<anchor 589 1376> mark @top_center;
-  pos base [\Gdotaccent \uni04DA \uni04EA \Gdotaccent.cv21 ] <anchor 810 0> mark @bottom_center
+  pos base [\Gdotaccent \uni04EA \Gdotaccent.cv21 ] <anchor 810 0> mark @bottom_center
 	<anchor 810 1780> mark @top_center;
   pos base [\gdotaccent ] <anchor 589 -360> mark @bottom_center
 	<anchor 589 1440> mark @top_center;
@@ -9048,7 +9048,7 @@ lookup mark_Mark_positioning {
   pos base [\uni018E ] <anchor 627 1380> mark @top_center
 	<anchor 627 0> mark @bottom_center
 	<anchor 627 -20> mark @bottom_cedilla;
-  pos base [\uni018F \Ohorn ] <anchor 1042 0> mark @bottom_right
+  pos base [\uni018F \Ohorn \uni04D8 ] <anchor 1042 0> mark @bottom_right
 	<anchor 810 -20> mark @bottom_cedilla
 	<anchor 810 0> mark @bottom_center
 	<anchor 810 1380> mark @top_center;
@@ -9215,7 +9215,7 @@ lookup mark_Mark_positioning {
 	<anchor 539 1040> mark @top_center
 	<anchor 537 0> mark @bottom_center
 	<anchor 537 -20> mark @bottom_cedilla;
-  pos base [\uni0259 ] <anchor 791 0> mark @bottom_right
+  pos base [\uni0259 \uni04D9 ] <anchor 791 0> mark @bottom_right
 	<anchor 600 0> mark @bottom_center
 	<anchor 600 1040> mark @top_center
 	<anchor 600 -20> mark @bottom_cedilla;
@@ -9459,7 +9459,9 @@ lookup mark_Mark_positioning {
 	<anchor 907 1816> mark @top_center;
   pos base [\uni04C1 ] <anchor 1112 0> mark @bottom_cedilla
 	<anchor 1110 1716> mark @top_center;
-  pos base [\uni04DB \uni04EB ] <anchor 600 0> mark @bottom_center
+  pos base [\uni04DB ] <anchor 791 0> mark @bottom_right
+	<anchor 600 0> mark @bottom_center
+	<anchor 600 -20> mark @bottom_cedilla
 	<anchor 600 1440> mark @top_center;
   pos base [\uni04C2 ] <anchor 928 0> mark @bottom_center
 	<anchor 928 1376> mark @top_center;
@@ -9493,8 +9495,14 @@ lookup mark_Mark_positioning {
 	<anchor 1002 1780> mark @top_center;
   pos base [\uni04F9 ] <anchor 851 0> mark @bottom_center
 	<anchor 851 1440> mark @top_center;
-  pos base [\uni04D9 \uni04E9 ] <anchor 600 1040> mark @top_center
+  pos base [\uni04DA ] <anchor 1042 0> mark @bottom_right
+	<anchor 810 -20> mark @bottom_cedilla
+	<anchor 810 0> mark @bottom_center
+	<anchor 810 1780> mark @top_center;
+  pos base [\uni04E9 ] <anchor 600 1040> mark @top_center
 	<anchor 600 0> mark @bottom_center;
+  pos base [\uni04EB ] <anchor 600 0> mark @bottom_center
+	<anchor 600 1440> mark @top_center;
   pos base [\uni1E02 ] <anchor 692 0> mark @bottom_center
 	<anchor 692 1780> mark @top_center;
   pos base [\uni1E03 ] <anchor 695 0> mark @bottom_center

--- a/sources/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlack.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 16:52:55</string>
+    <string>2025/04/27 17:13:34</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/26 18:43:11</string>
+    <string>2025/04/27 16:52:55</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni04D_8.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni04D_8.glif
@@ -2,48 +2,11 @@
 <glyph name="uni04D8" format="2">
   <advance width="1620"/>
   <unicode hex="04D8"/>
+  <anchor x="1042" y="0" name="bottom_right"/>
+  <anchor x="810" y="-20" name="bottom_cedilla"/>
   <anchor x="810" y="0" name="bottom_center"/>
   <anchor x="810" y="1380" name="top_center"/>
   <outline>
-    <contour>
-      <point x="65" y="908" type="line"/>
-      <point x="55" y="854"/>
-      <point x="50" y="798"/>
-      <point x="50" y="740" type="curve" smooth="yes"/>
-      <point x="50" y="290"/>
-      <point x="350" y="-30"/>
-      <point x="810" y="-30" type="curve" smooth="yes"/>
-      <point x="1270" y="-30"/>
-      <point x="1570" y="290"/>
-      <point x="1570" y="740" type="curve" smooth="yes"/>
-      <point x="1570" y="1190"/>
-      <point x="1270" y="1510"/>
-      <point x="810" y="1510" type="curve" smooth="yes"/>
-      <point x="495" y="1510"/>
-      <point x="255" y="1360"/>
-      <point x="135" y="1120" type="curve"/>
-      <point x="460" y="930" type="line"/>
-      <point x="511" y="1078"/>
-      <point x="629" y="1174"/>
-      <point x="810" y="1174" type="curve" smooth="yes"/>
-      <point x="1060" y="1174"/>
-      <point x="1190" y="990"/>
-      <point x="1190" y="740" type="curve" smooth="yes"/>
-      <point x="1190" y="490"/>
-      <point x="1060" y="306"/>
-      <point x="810" y="306" type="curve" smooth="yes"/>
-      <point x="560" y="306"/>
-      <point x="430" y="490"/>
-      <point x="430" y="740" type="curve" smooth="yes"/>
-      <point x="430" y="800"/>
-      <point x="438" y="857"/>
-      <point x="453" y="908" type="curve"/>
-    </contour>
-    <contour>
-      <point x="1396" y="572" type="line"/>
-      <point x="1396" y="908" type="line"/>
-      <point x="453" y="908" type="line"/>
-      <point x="216" y="572" type="line"/>
-    </contour>
+    <component base="uni018F"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni04D_9.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni04D_9.glif
@@ -2,48 +2,11 @@
 <glyph name="uni04D9" format="2">
   <advance width="1200"/>
   <unicode hex="04D9"/>
-  <anchor x="600" y="1040" name="top_center"/>
+  <anchor x="791" y="0" name="bottom_right"/>
   <anchor x="600" y="0" name="bottom_center"/>
+  <anchor x="600" y="1040" name="top_center"/>
+  <anchor x="600" y="-20" name="bottom_cedilla"/>
   <outline>
-    <contour>
-      <point x="1024" y="380" type="line"/>
-      <point x="118" y="380" type="line"/>
-      <point x="420" y="640" type="line"/>
-      <point x="1024" y="640" type="line"/>
-    </contour>
-    <contour>
-      <point x="411" y="672" type="curve"/>
-      <point x="104" y="798" type="line"/>
-      <point x="196" y="975"/>
-      <point x="378" y="1070"/>
-      <point x="600" y="1070" type="curve" smooth="yes"/>
-      <point x="921" y="1070"/>
-      <point x="1150" y="840"/>
-      <point x="1150" y="520" type="curve" smooth="yes"/>
-      <point x="1150" y="200"/>
-      <point x="920" y="-30"/>
-      <point x="600" y="-30" type="curve" smooth="yes"/>
-      <point x="280" y="-30"/>
-      <point x="50" y="200"/>
-      <point x="50" y="520" type="curve" smooth="yes"/>
-      <point x="50" y="561"/>
-      <point x="55" y="602"/>
-      <point x="62" y="640" type="curve"/>
-      <point x="420" y="640" type="line"/>
-      <point x="406" y="605"/>
-      <point x="380" y="564"/>
-      <point x="380" y="520" type="curve" smooth="yes"/>
-      <point x="380" y="383"/>
-      <point x="463" y="290"/>
-      <point x="600" y="290" type="curve" smooth="yes"/>
-      <point x="737" y="290"/>
-      <point x="830" y="383"/>
-      <point x="830" y="520" type="curve" smooth="yes"/>
-      <point x="830" y="650"/>
-      <point x="738" y="750"/>
-      <point x="600" y="750" type="curve" smooth="yes"/>
-      <point x="486" y="750"/>
-      <point x="429" y="711"/>
-    </contour>
+    <component base="uni0259"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni04D_A_.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni04D_A_.glif
@@ -2,6 +2,8 @@
 <glyph name="uni04DA" format="2">
   <advance width="1620"/>
   <unicode hex="04DA"/>
+  <anchor x="1042" y="0" name="bottom_right"/>
+  <anchor x="810" y="-20" name="bottom_cedilla"/>
   <anchor x="810" y="0" name="bottom_center"/>
   <anchor x="810" y="1780" name="top_center"/>
   <outline>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni04D_B_.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni04D_B_.glif
@@ -2,7 +2,9 @@
 <glyph name="uni04DB" format="2">
   <advance width="1200"/>
   <unicode hex="04DB"/>
+  <anchor x="791" y="0" name="bottom_right"/>
   <anchor x="600" y="0" name="bottom_center"/>
+  <anchor x="600" y="-20" name="bottom_cedilla"/>
   <anchor x="600" y="1440" name="top_center"/>
   <outline>
     <component base="uni04D9"/>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0501.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0501.glif
@@ -1,31 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0501" format="2">
-  <advance width="1140"/>
+  <advance width="1250"/>
   <unicode hex="0501"/>
+  <anchor x="555" y="-20" name="bottom_cedilla"/>
+  <anchor x="555" y="0" name="bottom_center"/>
+  <anchor x="1000" y="1380" name="top_center"/>
+  <anchor x="1180" y="1480" name="top_right"/>
   <outline>
-    <contour>
-      <point x="476" y="679" type="line"/>
-      <point x="182" y="679"/>
-      <point x="50" y="534"/>
-      <point x="50" y="340" type="curve" smooth="yes"/>
-      <point x="50" y="126"/>
-      <point x="182" y="0"/>
-      <point x="476" y="0" type="curve"/>
-      <point x="1070" y="0" type="line"/>
-      <point x="1070" y="1040" type="line"/>
-      <point x="710" y="1040" type="line"/>
-      <point x="710" y="679" type="line"/>
-    </contour>
-    <contour>
-      <point x="476" y="378" type="curve"/>
-      <point x="710" y="378" type="line"/>
-      <point x="710" y="318" type="line"/>
-      <point x="476" y="318" type="line"/>
-      <point x="430" y="318"/>
-      <point x="410" y="326"/>
-      <point x="410" y="348" type="curve" smooth="yes"/>
-      <point x="410" y="370"/>
-      <point x="430" y="378"/>
-    </contour>
+    <component base="d"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0503.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0503.glif
@@ -1,55 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0503" format="2">
-  <advance width="1650"/>
+  <advance width="1760"/>
   <unicode hex="0503"/>
   <outline>
     <contour>
-      <point x="1580" y="729" type="line"/>
-      <point x="1580" y="348" type="line"/>
-      <point x="1580" y="80"/>
-      <point x="1408" y="-26"/>
-      <point x="1145" y="-26" type="curve" smooth="yes"/>
-      <point x="882" y="-26"/>
-      <point x="710" y="80"/>
-      <point x="710" y="348" type="curve"/>
-      <point x="1070" y="348" type="line"/>
-      <point x="1070" y="312"/>
-      <point x="1089" y="294"/>
-      <point x="1145" y="294" type="curve" smooth="yes"/>
-      <point x="1201" y="294"/>
-      <point x="1220" y="312"/>
-      <point x="1220" y="348" type="curve" smooth="yes"/>
-      <point x="1220" y="729" type="line"/>
+      <point x="820" y="510" type="curve" smooth="yes"/>
+      <point x="820" y="640"/>
+      <point x="757" y="750"/>
+      <point x="620" y="750" type="curve" smooth="yes"/>
+      <point x="483" y="750"/>
+      <point x="410" y="650"/>
+      <point x="410" y="520" type="curve" smooth="yes"/>
+      <point x="410" y="390"/>
+      <point x="483" y="290"/>
+      <point x="620" y="290" type="curve" smooth="yes"/>
+      <point x="751" y="290"/>
+      <point x="820" y="380"/>
     </contour>
     <contour>
-      <point x="710" y="378" type="line"/>
-      <point x="476" y="378" type="line"/>
-      <point x="430" y="378"/>
-      <point x="410" y="355"/>
-      <point x="410" y="333" type="curve" smooth="yes"/>
-      <point x="410" y="311"/>
-      <point x="430" y="288"/>
-      <point x="476" y="288" type="curve"/>
-      <point x="633" y="288" type="line" smooth="yes"/>
-      <point x="678" y="288"/>
-      <point x="710" y="303"/>
-      <point x="710" y="348" type="curve"/>
-    </contour>
-    <contour>
-      <point x="710" y="679" type="line"/>
-      <point x="710" y="1040" type="line"/>
-      <point x="1070" y="1040" type="line"/>
-      <point x="1070" y="348" type="line" smooth="yes"/>
-      <point x="1070" y="108"/>
-      <point x="912" y="-30"/>
-      <point x="632" y="-30" type="curve" smooth="yes"/>
-      <point x="476" y="-30" type="line"/>
-      <point x="182" y="-30"/>
-      <point x="50" y="111"/>
-      <point x="50" y="325" type="curve" smooth="yes"/>
-      <point x="50" y="519"/>
-      <point x="182" y="679"/>
-      <point x="476" y="679" type="curve"/>
+      <point x="889" y="165" type="curve"/>
+      <point x="869" y="85"/>
+      <point x="725" y="-30"/>
+      <point x="555" y="-30" type="curve" smooth="yes"/>
+      <point x="235" y="-30"/>
+      <point x="50" y="200"/>
+      <point x="50" y="520" type="curve" smooth="yes"/>
+      <point x="50" y="840"/>
+      <point x="235" y="1070"/>
+      <point x="555" y="1070" type="curve" smooth="yes"/>
+      <point x="705" y="1070"/>
+      <point x="810" y="959"/>
+      <point x="820" y="920" type="curve"/>
+      <point x="820" y="1480" type="line"/>
+      <point x="1180" y="1480" type="line"/>
+      <point x="1180" y="344" type="line"/>
+      <point x="1180" y="308"/>
+      <point x="1199" y="290"/>
+      <point x="1255" y="290" type="curve" smooth="yes"/>
+      <point x="1311" y="290"/>
+      <point x="1330" y="308"/>
+      <point x="1330" y="344" type="curve" smooth="yes"/>
+      <point x="1330" y="740" type="line"/>
+      <point x="1690" y="740" type="line"/>
+      <point x="1690" y="344" type="line"/>
+      <point x="1690" y="76"/>
+      <point x="1518" y="-30"/>
+      <point x="1255" y="-30" type="curve" smooth="yes"/>
+      <point x="1071" y="-30"/>
+      <point x="956" y="42"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0505.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0505.glif
@@ -17,8 +17,8 @@
       <point x="1375" y="-30"/>
       <point x="1547" y="76"/>
       <point x="1547" y="344" type="curve"/>
-      <point x="1547" y="699" type="line"/>
-      <point x="1187" y="699" type="line"/>
+      <point x="1547" y="740" type="line"/>
+      <point x="1187" y="740" type="line"/>
       <point x="1187" y="344" type="line" smooth="yes"/>
       <point x="1187" y="308"/>
       <point x="1168" y="290"/>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0509.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0509.glif
@@ -24,8 +24,8 @@
       <point x="1411" y="-30"/>
       <point x="1583" y="76"/>
       <point x="1583" y="344" type="curve"/>
-      <point x="1583" y="699" type="line"/>
-      <point x="1223" y="699" type="line"/>
+      <point x="1583" y="740" type="line"/>
+      <point x="1223" y="740" type="line"/>
       <point x="1223" y="344" type="line" smooth="yes"/>
       <point x="1223" y="308"/>
       <point x="1204" y="290"/>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni050B_.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni050B_.glif
@@ -22,8 +22,8 @@
       <point x="1463" y="-30"/>
       <point x="1635" y="76"/>
       <point x="1635" y="344" type="curve"/>
-      <point x="1635" y="699" type="line"/>
-      <point x="1275" y="699" type="line"/>
+      <point x="1635" y="740" type="line"/>
+      <point x="1275" y="740" type="line"/>
       <point x="1275" y="344" type="line" smooth="yes"/>
       <point x="1275" y="308"/>
       <point x="1256" y="290"/>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni050F_.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni050F_.glif
@@ -18,8 +18,8 @@
       <point x="1087" y="-30"/>
       <point x="1259" y="76"/>
       <point x="1259" y="344" type="curve"/>
-      <point x="1259" y="699" type="line"/>
-      <point x="899" y="699" type="line"/>
+      <point x="1259" y="680" type="line"/>
+      <point x="899" y="680" type="line"/>
       <point x="899" y="344" type="line" smooth="yes"/>
       <point x="899" y="308"/>
       <point x="880" y="290"/>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 16:27:46</string>
+    <string>2025/04/27 17:29:32</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0503.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0503.glif
@@ -4,15 +4,21 @@
   <unicode hex="0503"/>
   <outline>
     <contour>
-      <point x="788" y="92" type="curve"/>
-      <point x="688" y="14"/>
-      <point x="562" y="-31"/>
-      <point x="420" y="-31" type="curve" smooth="yes"/>
-      <point x="188" y="-31"/>
+      <point x="1621" y="344" type="line" smooth="yes"/>
+      <point x="1574" y="76"/>
+      <point x="1383" y="-30"/>
+      <point x="1120" y="-30" type="curve" smooth="yes"/>
+      <point x="936" y="-30"/>
+      <point x="833" y="42"/>
+      <point x="788" y="165" type="curve"/>
+      <point x="754" y="85"/>
+      <point x="590" y="-30"/>
+      <point x="420" y="-30" type="curve" smooth="yes"/>
+      <point x="145" y="-30"/>
       <point x="0" y="140"/>
-      <point x="0" y="390" type="curve" smooth="yes"/>
-      <point x="0" y="789"/>
-      <point x="255" y="1066"/>
+      <point x="-0" y="390" type="curve" smooth="yes"/>
+      <point x="0" y="702"/>
+      <point x="203" y="1070"/>
       <point x="614" y="1070" type="curve" smooth="yes"/>
       <point x="764" y="1070"/>
       <point x="849" y="959"/>
@@ -21,33 +27,27 @@
       <point x="1311" y="1480" type="line"/>
       <point x="1111" y="344" type="line" smooth="yes"/>
       <point x="1110" y="339"/>
-      <point x="1110" y="334"/>
-      <point x="1110" y="330" type="curve" smooth="yes"/>
-      <point x="1110" y="303"/>
+      <point x="1109" y="334"/>
+      <point x="1109" y="330" type="curve" smooth="yes"/>
+      <point x="1109" y="303"/>
       <point x="1128" y="290"/>
       <point x="1176" y="290" type="curve" smooth="yes"/>
       <point x="1232" y="290"/>
       <point x="1255" y="308"/>
       <point x="1261" y="344" type="curve" smooth="yes"/>
-      <point x="1323" y="699" type="line"/>
-      <point x="1683" y="699" type="line"/>
-      <point x="1621" y="344" type="line"/>
-      <point x="1574" y="76"/>
-      <point x="1383" y="-30"/>
-      <point x="1120" y="-30" type="curve" smooth="yes"/>
-      <point x="965" y="-30"/>
-      <point x="848" y="6"/>
+      <point x="1330" y="740" type="line"/>
+      <point x="1690" y="740" type="line"/>
     </contour>
     <contour>
       <point x="541" y="290" type="curve" smooth="yes"/>
-      <point x="691" y="291"/>
-      <point x="782" y="407"/>
+      <point x="715" y="290"/>
+      <point x="786" y="445"/>
       <point x="786" y="573" type="curve" smooth="yes"/>
       <point x="786" y="674"/>
       <point x="736" y="750"/>
       <point x="622" y="750" type="curve" smooth="yes"/>
-      <point x="468" y="747"/>
-      <point x="373" y="629"/>
+      <point x="448" y="750"/>
+      <point x="367" y="592"/>
       <point x="367" y="465" type="curve" smooth="yes"/>
       <point x="367" y="363"/>
       <point x="424" y="290"/>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0505.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0505.glif
@@ -10,8 +10,8 @@
       <point x="466" y="674" type="line"/>
     </contour>
     <contour>
-      <point x="603" y="327" type="curve" smooth="yes"/>
-      <point x="603" y="312"/>
+      <point x="604" y="327" type="curve" smooth="yes"/>
+      <point x="604" y="312"/>
       <point x="595" y="286"/>
       <point x="595" y="240" type="curve" smooth="yes"/>
       <point x="595" y="54"/>
@@ -20,35 +20,35 @@
       <point x="1240" y="-30"/>
       <point x="1431" y="76"/>
       <point x="1478" y="344" type="curve" smooth="yes"/>
-      <point x="1540" y="699" type="line"/>
-      <point x="1180" y="699" type="line"/>
+      <point x="1547" y="740" type="line"/>
+      <point x="1187" y="740" type="line"/>
       <point x="1118" y="344" type="line" smooth="yes"/>
       <point x="1112" y="308"/>
       <point x="1089" y="290"/>
       <point x="1033" y="290" type="curve" smooth="yes"/>
       <point x="985" y="290"/>
-      <point x="967" y="303"/>
-      <point x="967" y="330" type="curve" smooth="yes"/>
-      <point x="967" y="344"/>
-      <point x="973" y="360"/>
-      <point x="973" y="394" type="curve" smooth="yes"/>
-      <point x="973" y="549"/>
+      <point x="966" y="303"/>
+      <point x="966" y="330" type="curve" smooth="yes"/>
+      <point x="966" y="343"/>
+      <point x="972" y="361"/>
+      <point x="972" y="395" type="curve" smooth="yes"/>
+      <point x="972" y="550"/>
       <point x="835" y="674"/>
       <point x="466" y="674" type="curve"/>
       <point x="420" y="414" type="line"/>
       <point x="572" y="414"/>
-      <point x="603" y="366"/>
+      <point x="604" y="366"/>
     </contour>
     <contour>
-      <point x="542" y="719" type="curve" smooth="yes"/>
-      <point x="542" y="687"/>
-      <point x="512" y="674"/>
+      <point x="541" y="719" type="curve" smooth="yes"/>
+      <point x="541" y="689"/>
+      <point x="517" y="674"/>
       <point x="466" y="674" type="curve"/>
       <point x="443" y="542" type="line"/>
-      <point x="575" y="542"/>
-      <point x="914" y="566"/>
-      <point x="914" y="812" type="curve" smooth="yes"/>
-      <point x="914" y="953"/>
+      <point x="574" y="542"/>
+      <point x="915" y="566"/>
+      <point x="915" y="812" type="curve" smooth="yes"/>
+      <point x="915" y="953"/>
       <point x="773" y="1070"/>
       <point x="536" y="1070" type="curve" smooth="yes"/>
       <point x="278" y="1070"/>
@@ -59,7 +59,7 @@
       <point x="429" y="750"/>
       <point x="479" y="750" type="curve" smooth="yes"/>
       <point x="524" y="750"/>
-      <point x="542" y="739"/>
+      <point x="541" y="739"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0509.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0509.glif
@@ -4,7 +4,7 @@
   <unicode hex="0509"/>
   <outline>
     <contour>
-      <point x="1004" y="344" type="curve"/>
+      <point x="1004" y="344" type="curve" smooth="yes"/>
       <point x="1126" y="1040" type="line"/>
       <point x="324" y="1040" type="line"/>
       <point x="144" y="420" type="line" smooth="yes"/>
@@ -17,26 +17,26 @@
       <point x="497" y="420" type="curve" smooth="yes"/>
       <point x="578" y="720" type="line"/>
       <point x="710" y="720" type="line"/>
-      <point x="644" y="344" type="line"/>
+      <point x="644" y="344" type="line" smooth="yes"/>
       <point x="638" y="312"/>
-      <point x="636" y="282"/>
-      <point x="636" y="254" type="curve" smooth="yes"/>
-      <point x="636" y="52"/>
+      <point x="635" y="282"/>
+      <point x="635" y="254" type="curve" smooth="yes"/>
+      <point x="635" y="52"/>
       <point x="782" y="-30"/>
       <point x="1013" y="-30" type="curve" smooth="yes"/>
       <point x="1276" y="-30"/>
       <point x="1467" y="76"/>
-      <point x="1514" y="344" type="curve"/>
-      <point x="1576" y="699" type="line"/>
-      <point x="1216" y="699" type="line"/>
+      <point x="1514" y="344" type="curve" smooth="yes"/>
+      <point x="1583" y="740" type="line"/>
+      <point x="1223" y="740" type="line"/>
       <point x="1154" y="344" type="line" smooth="yes"/>
       <point x="1148" y="308"/>
       <point x="1125" y="290"/>
       <point x="1069" y="290" type="curve" smooth="yes"/>
       <point x="1021" y="290"/>
-      <point x="1003" y="303"/>
-      <point x="1003" y="330" type="curve" smooth="yes"/>
-      <point x="1003" y="334"/>
+      <point x="1002" y="303"/>
+      <point x="1002" y="330" type="curve" smooth="yes"/>
+      <point x="1002" y="334"/>
       <point x="1003" y="339"/>
     </contour>
   </outline>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni050B_.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni050B_.glif
@@ -4,7 +4,7 @@
   <unicode hex="050B"/>
   <outline>
     <contour>
-      <point x="1056" y="344" type="curve"/>
+      <point x="1056" y="344" type="curve" smooth="yes"/>
       <point x="1178" y="1040" type="line"/>
       <point x="818" y="1040" type="line"/>
       <point x="755" y="680" type="line"/>
@@ -16,25 +16,25 @@
       <point x="363" y="360" type="line"/>
       <point x="698" y="360" type="line"/>
       <point x="696" y="344" type="line" smooth="yes"/>
-      <point x="690" y="312"/>
-      <point x="688" y="282"/>
-      <point x="688" y="254" type="curve" smooth="yes"/>
-      <point x="688" y="52"/>
+      <point x="691" y="317"/>
+      <point x="687" y="289"/>
+      <point x="687" y="254" type="curve" smooth="yes"/>
+      <point x="687" y="52"/>
       <point x="834" y="-30"/>
       <point x="1065" y="-30" type="curve" smooth="yes"/>
       <point x="1328" y="-30"/>
       <point x="1519" y="76"/>
-      <point x="1566" y="344" type="curve"/>
-      <point x="1628" y="699" type="line"/>
-      <point x="1268" y="699" type="line"/>
+      <point x="1566" y="344" type="curve" smooth="yes"/>
+      <point x="1635" y="740" type="line"/>
+      <point x="1275" y="740" type="line"/>
       <point x="1206" y="344" type="line" smooth="yes"/>
       <point x="1200" y="308"/>
       <point x="1177" y="290"/>
       <point x="1121" y="290" type="curve" smooth="yes"/>
       <point x="1073" y="290"/>
-      <point x="1055" y="303"/>
-      <point x="1055" y="330" type="curve" smooth="yes"/>
-      <point x="1055" y="334"/>
+      <point x="1054" y="303"/>
+      <point x="1054" y="330" type="curve" smooth="yes"/>
+      <point x="1054" y="334"/>
       <point x="1055" y="339"/>
     </contour>
   </outline>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni050F_.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni050F_.glif
@@ -13,24 +13,24 @@
       <point x="386" y="720" type="line"/>
       <point x="320" y="344" type="line" smooth="yes"/>
       <point x="314" y="312"/>
-      <point x="312" y="282"/>
-      <point x="312" y="254" type="curve" smooth="yes"/>
-      <point x="312" y="52"/>
+      <point x="311" y="282"/>
+      <point x="311" y="254" type="curve" smooth="yes"/>
+      <point x="311" y="52"/>
       <point x="458" y="-30"/>
       <point x="689" y="-30" type="curve" smooth="yes"/>
       <point x="952" y="-30"/>
       <point x="1143" y="76"/>
       <point x="1190" y="344" type="curve" smooth="yes"/>
-      <point x="1252" y="699" type="line"/>
-      <point x="892" y="699" type="line"/>
+      <point x="1249" y="680" type="line"/>
+      <point x="889" y="680" type="line"/>
       <point x="830" y="344" type="line" smooth="yes"/>
       <point x="824" y="308"/>
       <point x="801" y="290"/>
       <point x="745" y="290" type="curve" smooth="yes"/>
       <point x="697" y="290"/>
-      <point x="679" y="303"/>
-      <point x="679" y="330" type="curve" smooth="yes"/>
-      <point x="679" y="334"/>
+      <point x="678" y="303"/>
+      <point x="678" y="330" type="curve" smooth="yes"/>
+      <point x="678" y="334"/>
       <point x="679" y="339"/>
     </contour>
   </outline>

--- a/sources/Giphurs-Italic.ufo/features.fea
+++ b/sources/Giphurs-Italic.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-Italic.ufo/fontinfo.plist
+++ b/sources/Giphurs-Italic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 16:27:37</string>
+    <string>2025/04/27 17:27:39</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni0503.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni0503.glif
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0503" format="2">
-  <advance width="1682"/>
+  <advance width="1729"/>
   <unicode hex="0503"/>
   <outline>
     <contour>
-      <point x="798" y="138" type="curve"/>
-      <point x="722" y="53"/>
-      <point x="581" y="-20"/>
+      <point x="1521" y="354" type="line" smooth="yes"/>
+      <point x="1474" y="86"/>
+      <point x="1311" y="-20"/>
+      <point x="1092" y="-20" type="curve" smooth="yes"/>
+      <point x="935" y="-20"/>
+      <point x="827" y="19"/>
+      <point x="795" y="142" type="curve"/>
+      <point x="725" y="57"/>
+      <point x="569" y="-20"/>
       <point x="444" y="-20" type="curve" smooth="yes"/>
       <point x="201" y="-20"/>
       <point x="51" y="151"/>
@@ -19,24 +25,18 @@
       <point x="896" y="920" type="curve"/>
       <point x="995" y="1480" type="line"/>
       <point x="1175" y="1480" type="line"/>
-      <point x="972" y="324" type="line" smooth="yes"/>
-      <point x="967" y="298"/>
-      <point x="965" y="275"/>
-      <point x="965" y="255" type="curve" smooth="yes"/>
-      <point x="965" y="163"/>
-      <point x="1015" y="131"/>
-      <point x="1120" y="131" type="curve" smooth="yes"/>
-      <point x="1248" y="131"/>
-      <point x="1315" y="198"/>
-      <point x="1341" y="344" type="curve" smooth="yes"/>
-      <point x="1408" y="725" type="line"/>
-      <point x="1588" y="725" type="line"/>
-      <point x="1521" y="344" type="line"/>
-      <point x="1474" y="76"/>
-      <point x="1311" y="-30"/>
-      <point x="1092" y="-30" type="curve" smooth="yes"/>
-      <point x="944" y="-30"/>
-      <point x="837" y="30"/>
+      <point x="973" y="334" type="line" smooth="yes"/>
+      <point x="968" y="308"/>
+      <point x="966" y="285"/>
+      <point x="966" y="265" type="curve" smooth="yes"/>
+      <point x="966" y="173"/>
+      <point x="1016" y="141"/>
+      <point x="1121" y="141" type="curve" smooth="yes"/>
+      <point x="1249" y="141"/>
+      <point x="1315" y="208"/>
+      <point x="1341" y="354" type="curve" smooth="yes"/>
+      <point x="1409" y="740" type="line"/>
+      <point x="1589" y="740" type="line"/>
     </contour>
     <contour>
       <point x="473" y="140" type="curve" smooth="yes"/>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni0505.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni0505.glif
@@ -11,44 +11,44 @@
     </contour>
     <contour>
       <point x="665" y="335" type="curve" smooth="yes"/>
-      <point x="665" y="316"/>
-      <point x="653" y="277"/>
-      <point x="653" y="217" type="curve" smooth="yes"/>
-      <point x="653" y="28"/>
-      <point x="774" y="-36"/>
-      <point x="963" y="-36" type="curve" smooth="yes"/>
-      <point x="1182" y="-36"/>
-      <point x="1345" y="70"/>
-      <point x="1392" y="338" type="curve" smooth="yes"/>
-      <point x="1459" y="719" type="line"/>
-      <point x="1279" y="719" type="line"/>
-      <point x="1212" y="338" type="line" smooth="yes"/>
-      <point x="1186" y="192"/>
-      <point x="1119" y="125"/>
-      <point x="991" y="125" type="curve" smooth="yes"/>
-      <point x="886" y="125"/>
-      <point x="836" y="157"/>
-      <point x="836" y="249" type="curve" smooth="yes"/>
-      <point x="836" y="298"/>
-      <point x="847" y="323"/>
+      <point x="665" y="317"/>
+      <point x="655" y="286"/>
+      <point x="655" y="233" type="curve" smooth="yes"/>
+      <point x="655" y="56"/>
+      <point x="774" y="-20"/>
+      <point x="965" y="-20" type="curve" smooth="yes"/>
+      <point x="1184" y="-20"/>
+      <point x="1347" y="86"/>
+      <point x="1394" y="354" type="curve" smooth="yes"/>
+      <point x="1462" y="740" type="line"/>
+      <point x="1282" y="740" type="line"/>
+      <point x="1214" y="354" type="line" smooth="yes"/>
+      <point x="1188" y="208"/>
+      <point x="1122" y="141"/>
+      <point x="994" y="141" type="curve" smooth="yes"/>
+      <point x="885" y="141"/>
+      <point x="839" y="193"/>
+      <point x="839" y="273" type="curve" smooth="yes"/>
+      <point x="839" y="310"/>
+      <point x="847" y="326"/>
       <point x="847" y="366" type="curve" smooth="yes"/>
       <point x="847" y="510"/>
       <point x="719" y="607"/>
       <point x="449" y="607" type="curve"/>
       <point x="419" y="439" type="line"/>
       <point x="562" y="439"/>
-      <point x="665" y="413"/>
+      <point x="665" y="412"/>
     </contour>
     <contour>
-      <point x="657" y="777" type="curve" smooth="yes"/>
-      <point x="657" y="740"/>
-      <point x="643" y="607"/>
+      <point x="656" y="777" type="curve" smooth="yes"/>
+      <point x="656" y="745"/>
+      <point x="647" y="607"/>
       <point x="449" y="607" type="curve"/>
       <point x="433" y="515" type="line"/>
       <point x="545" y="515"/>
-      <point x="843" y="542"/>
-      <point x="843" y="823" type="curve" smooth="yes"/>
-      <point x="843" y="979"/>
+      <point x="843" y="541"/>
+      <point x="843" y="822" type="curve" smooth="yes"/>
+      <point x="843" y="978"/>
       <point x="710" y="1075"/>
       <point x="525" y="1075" type="curve" smooth="yes"/>
       <point x="334" y="1075"/>
@@ -59,7 +59,7 @@
       <point x="391" y="914"/>
       <point x="496" y="914" type="curve" smooth="yes"/>
       <point x="590" y="914"/>
-      <point x="657" y="860"/>
+      <point x="656" y="860"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni0509.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni0509.glif
@@ -4,40 +4,40 @@
   <unicode hex="0509"/>
   <outline>
     <contour>
-      <point x="822" y="324" type="curve" smooth="yes"/>
+      <point x="824" y="334" type="curve" smooth="yes"/>
       <point x="948" y="1040" type="line"/>
       <point x="280" y="1040" type="line"/>
-      <point x="98" y="377" type="line" smooth="yes"/>
+      <point x="98" y="377" type="line"/>
       <point x="47" y="187"/>
       <point x="-40" y="140"/>
       <point x="-100" y="140" type="curve"/>
       <point x="-128" y="-19" type="line"/>
       <point x="13" y="-19"/>
-      <point x="198" y="87"/>
-      <point x="278" y="377" type="curve" smooth="yes"/>
+      <point x="204" y="85"/>
+      <point x="278" y="377" type="curve"/>
       <point x="417" y="880" type="line"/>
       <point x="740" y="880" type="line"/>
-      <point x="642" y="324" type="line"/>
-      <point x="635" y="287"/>
-      <point x="632" y="253"/>
-      <point x="632" y="223" type="curve" smooth="yes"/>
-      <point x="632" y="34"/>
-      <point x="753" y="-30"/>
-      <point x="942" y="-30" type="curve" smooth="yes"/>
-      <point x="1161" y="-30"/>
-      <point x="1324" y="76"/>
-      <point x="1371" y="344" type="curve"/>
-      <point x="1438" y="725" type="line"/>
-      <point x="1258" y="725" type="line"/>
-      <point x="1191" y="344" type="line" smooth="yes"/>
-      <point x="1165" y="198"/>
-      <point x="1098" y="131"/>
-      <point x="970" y="131" type="curve" smooth="yes"/>
-      <point x="865" y="131"/>
-      <point x="815" y="163"/>
-      <point x="815" y="255" type="curve" smooth="yes"/>
-      <point x="815" y="275"/>
-      <point x="817" y="298"/>
+      <point x="644" y="334" type="line" smooth="yes"/>
+      <point x="637" y="297"/>
+      <point x="634" y="263"/>
+      <point x="634" y="232" type="curve" smooth="yes"/>
+      <point x="634" y="44"/>
+      <point x="755" y="-20"/>
+      <point x="943" y="-20" type="curve" smooth="yes"/>
+      <point x="1162" y="-20"/>
+      <point x="1325" y="86"/>
+      <point x="1372" y="354" type="curve" smooth="yes"/>
+      <point x="1440" y="740" type="line"/>
+      <point x="1260" y="740" type="line"/>
+      <point x="1192" y="354" type="line" smooth="yes"/>
+      <point x="1166" y="208"/>
+      <point x="1100" y="141"/>
+      <point x="972" y="141" type="curve" smooth="yes"/>
+      <point x="867" y="141"/>
+      <point x="817" y="173"/>
+      <point x="817" y="265" type="curve" smooth="yes"/>
+      <point x="817" y="285"/>
+      <point x="819" y="308"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni050B_.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni050B_.glif
@@ -4,7 +4,7 @@
   <unicode hex="050B"/>
   <outline>
     <contour>
-      <point x="944" y="314" type="curve"/>
+      <point x="948" y="334" type="curve" smooth="yes"/>
       <point x="1072" y="1040" type="line"/>
       <point x="892" y="1040" type="line"/>
       <point x="815" y="600" type="line"/>
@@ -15,27 +15,27 @@
       <point x="190" y="0" type="line"/>
       <point x="267" y="439" type="line"/>
       <point x="786" y="439" type="line"/>
-      <point x="764" y="314" type="line"/>
-      <point x="757" y="277"/>
-      <point x="754" y="243"/>
-      <point x="754" y="213" type="curve" smooth="yes"/>
-      <point x="754" y="24"/>
-      <point x="875" y="-40"/>
-      <point x="1064" y="-40" type="curve" smooth="yes"/>
-      <point x="1283" y="-40"/>
-      <point x="1446" y="66"/>
-      <point x="1493" y="334" type="curve" smooth="yes"/>
-      <point x="1560" y="715" type="line"/>
-      <point x="1380" y="715" type="line"/>
-      <point x="1313" y="334" type="line" smooth="yes"/>
-      <point x="1287" y="188"/>
-      <point x="1220" y="121"/>
-      <point x="1092" y="121" type="curve" smooth="yes"/>
-      <point x="987" y="121"/>
-      <point x="937" y="153"/>
-      <point x="937" y="245" type="curve" smooth="yes"/>
-      <point x="937" y="265"/>
-      <point x="939" y="288"/>
+      <point x="768" y="334" type="line" smooth="yes"/>
+      <point x="761" y="297"/>
+      <point x="758" y="263"/>
+      <point x="758" y="232" type="curve" smooth="yes"/>
+      <point x="758" y="44"/>
+      <point x="879" y="-20"/>
+      <point x="1067" y="-20" type="curve" smooth="yes"/>
+      <point x="1286" y="-20"/>
+      <point x="1449" y="86"/>
+      <point x="1496" y="354" type="curve" smooth="yes"/>
+      <point x="1564" y="740" type="line"/>
+      <point x="1384" y="740" type="line"/>
+      <point x="1316" y="354" type="line" smooth="yes"/>
+      <point x="1290" y="208"/>
+      <point x="1224" y="141"/>
+      <point x="1096" y="141" type="curve" smooth="yes"/>
+      <point x="991" y="141"/>
+      <point x="941" y="173"/>
+      <point x="941" y="265" type="curve" smooth="yes"/>
+      <point x="941" y="285"/>
+      <point x="943" y="308"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni050F_.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni050F_.glif
@@ -11,7 +11,7 @@
       <point x="193" y="1040" type="line"/>
       <point x="165" y="880" type="line"/>
       <point x="491" y="880" type="line"/>
-      <point x="395" y="334" type="line"/>
+      <point x="395" y="334" type="line" smooth="yes"/>
       <point x="388" y="297"/>
       <point x="385" y="263"/>
       <point x="385" y="232" type="curve" smooth="yes"/>
@@ -20,9 +20,9 @@
       <point x="694" y="-20" type="curve" smooth="yes"/>
       <point x="913" y="-20"/>
       <point x="1076" y="86"/>
-      <point x="1123" y="354" type="curve"/>
-      <point x="1191" y="735" type="line"/>
-      <point x="1011" y="735" type="line"/>
+      <point x="1123" y="354" type="curve" smooth="yes"/>
+      <point x="1191" y="740" type="line"/>
+      <point x="1011" y="740" type="line"/>
       <point x="943" y="354" type="line" smooth="yes"/>
       <point x="917" y="208"/>
       <point x="851" y="141"/>

--- a/sources/Giphurs-Regular.ufo/features.fea
+++ b/sources/Giphurs-Regular.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -8558,7 +8558,7 @@ lookup mark_Mark_positioning {
 	<anchor 1016 1040> mark @top_right
 	<anchor 578 0> mark @bottom_center
 	<anchor 578 1040> mark @top_center;
-  pos base [\d ] <anchor 1044 1480> mark @top_right
+  pos base [\d \uni0501 ] <anchor 1044 1480> mark @top_right
 	<anchor 954 1380> mark @top_center
 	<anchor 578 0> mark @bottom_center
 	<anchor 578 -20> mark @bottom_cedilla;
@@ -8663,7 +8663,7 @@ lookup mark_Mark_positioning {
   pos base [\C \uni0421 \uni216D ] <anchor 801 1380> mark @top_center
 	<anchor 801 0> mark @bottom_center
 	<anchor 801 -20> mark @bottom_cedilla;
-  pos base [\G \Q \Oslash \uni01B1 \Theta \uni0424 \uni04D8 \uni04E8 \uni051A \uni2127 \uni1FFC \G.cv21 ] <anchor 801 0> mark @bottom_center
+  pos base [\G \Q \Oslash \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \uni1FFC \G.cv21 ] <anchor 801 0> mark @bottom_center
 	<anchor 801 1380> mark @top_center;
   pos base [\U ] <anchor 699 -20> mark @bottom_cedilla
 	<anchor 861 0> mark @bottom_right
@@ -8757,7 +8757,7 @@ lookup mark_Mark_positioning {
 	<anchor 1477 1380> mark @top_center;
   pos base [\ae \uni04D5 ] <anchor 920 1040> mark @top_center
 	<anchor 920 0> mark @bottom_center;
-  pos base [\oslash \sigma1 \uni03DB \uni0454 \uni04D9 \uni04E9 ] <anchor 598 1040> mark @top_center
+  pos base [\oslash \sigma1 \uni03DB \uni0454 \uni04E9 ] <anchor 598 1040> mark @top_center
 	<anchor 598 0> mark @bottom_center;
   pos base [\Amacron \uni1FB9 ] <anchor 1188 -20> mark @bottom_cedilla
 	<anchor 1286 0> mark @bottom_right
@@ -8802,7 +8802,7 @@ lookup mark_Mark_positioning {
   pos base [\eogonek ] <anchor 598 1040> mark @top_center
 	<anchor 615 -336> mark @bottom_center
 	<anchor 598 -20> mark @bottom_cedilla;
-  pos base [\Gcircumflex \Gbreve \Gdotaccent \Gcaron \uni01F4 \Oslashacute \uni04DA \uni04EA \Gcircumflex.cv21 \Gbreve.cv21 \Gdotaccent.cv21 \Gcaron.cv21 \uni01F4.cv21 ] <anchor 801 0> mark @bottom_center
+  pos base [\Gcircumflex \Gbreve \Gdotaccent \Gcaron \uni01F4 \Oslashacute \uni04EA \Gcircumflex.cv21 \Gbreve.cv21 \Gdotaccent.cv21 \Gcaron.cv21 \uni01F4.cv21 ] <anchor 801 0> mark @bottom_center
 	<anchor 801 1716> mark @top_center;
   pos base [\gcircumflex \gbreve \gdotaccent \gcaron \uni01F5 ] <anchor 520 -361> mark @bottom_center
 	<anchor 520 1376> mark @top_center;
@@ -8937,7 +8937,7 @@ lookup mark_Mark_positioning {
   pos base [\uni018E ] <anchor 604 -20> mark @bottom_cedilla
 	<anchor 604 0> mark @bottom_center
 	<anchor 604 1380> mark @top_center;
-  pos base [\uni018F \Ohorn ] <anchor 968 0> mark @bottom_right
+  pos base [\uni018F \Ohorn \uni04D8 ] <anchor 968 0> mark @bottom_right
 	<anchor 801 -20> mark @bottom_cedilla
 	<anchor 801 0> mark @bottom_center
 	<anchor 801 1380> mark @top_center;
@@ -8958,7 +8958,7 @@ lookup mark_Mark_positioning {
 	<anchor 1380 1480> mark @top_right
 	<anchor 801 0> mark @bottom_center
 	<anchor 968 0> mark @bottom_right;
-  pos base [\ohorn \uni0259 ] <anchor 598 -20> mark @bottom_cedilla
+  pos base [\ohorn \uni0259 \uni04D9 ] <anchor 598 -20> mark @bottom_cedilla
 	<anchor 598 1040> mark @top_center
 	<anchor 598 0> mark @bottom_center
 	<anchor 738 0> mark @bottom_right;
@@ -9038,7 +9038,7 @@ lookup mark_Mark_positioning {
 	<anchor 1477 1716> mark @top_center;
   pos base [\aeacute ] <anchor 920 0> mark @bottom_center
 	<anchor 920 1376> mark @top_center;
-  pos base [\oslashacute \uni04DB \uni04EB ] <anchor 598 0> mark @bottom_center
+  pos base [\oslashacute \uni04EB ] <anchor 598 0> mark @bottom_center
 	<anchor 598 1376> mark @top_center;
   pos base [\uni0228 ] <anchor 604 1380> mark @top_center
 	<anchor 619 -336> mark @bottom_center
@@ -9309,6 +9309,10 @@ lookup mark_Mark_positioning {
 	<anchor 836 1786> mark @top_center;
   pos base [\uni04C1 \uni04DC ] <anchor 968 0> mark @bottom_cedilla
 	<anchor 966 1716> mark @top_center;
+  pos base [\uni04DB \uni1EDB \uni1EDD \uni1EE1 ] <anchor 738 0> mark @bottom_right
+	<anchor 598 0> mark @bottom_center
+	<anchor 598 -20> mark @bottom_cedilla
+	<anchor 598 1376> mark @top_center;
   pos base [\uni04C2 \uni04DD ] <anchor 814 0> mark @bottom_center
 	<anchor 814 1376> mark @top_center;
   pos base [\uni04DE ] <anchor 644 0> mark @bottom_cedilla
@@ -9332,6 +9336,10 @@ lookup mark_Mark_positioning {
 	<anchor 879 1716> mark @top_center;
   pos base [\uni04F9 ] <anchor 757 0> mark @bottom_center
 	<anchor 757 1376> mark @top_center;
+  pos base [\uni04DA \uni1EDA \uni1EDC \uni1EE0 ] <anchor 968 0> mark @bottom_right
+	<anchor 801 -20> mark @bottom_cedilla
+	<anchor 801 0> mark @bottom_center
+	<anchor 801 1716> mark @top_center;
   pos base [\uni1E02 ] <anchor 628 0> mark @bottom_center
 	<anchor 628 1716> mark @top_center;
   pos base [\uni1E03 ] <anchor 606 0> mark @bottom_center
@@ -9717,14 +9725,6 @@ lookup mark_Mark_positioning {
 	<anchor 1048 1040> mark @top_right
 	<anchor 738 0> mark @bottom_right
 	<anchor 598 -336> mark @bottom_center
-	<anchor 598 1376> mark @top_center;
-  pos base [\uni1EDA \uni1EDC \uni1EE0 ] <anchor 801 -20> mark @bottom_cedilla
-	<anchor 968 0> mark @bottom_right
-	<anchor 801 0> mark @bottom_center
-	<anchor 801 1716> mark @top_center;
-  pos base [\uni1EDB \uni1EDD \uni1EE1 ] <anchor 598 -20> mark @bottom_cedilla
-	<anchor 598 0> mark @bottom_center
-	<anchor 738 0> mark @bottom_right
 	<anchor 598 1376> mark @top_center;
   pos base [\uni1EDE ] <anchor 801 -20> mark @bottom_cedilla
 	<anchor 968 0> mark @bottom_right

--- a/sources/Giphurs-Regular.ufo/features.fea
+++ b/sources/Giphurs-Regular.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-Regular.ufo/fontinfo.plist
+++ b/sources/Giphurs-Regular.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/26 18:42:53</string>
+    <string>2025/04/27 16:52:47</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Regular.ufo/fontinfo.plist
+++ b/sources/Giphurs-Regular.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 16:52:47</string>
+    <string>2025/04/27 17:04:56</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni04D_8.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni04D_8.glif
@@ -2,48 +2,11 @@
 <glyph name="uni04D8" format="2">
   <advance width="1602"/>
   <unicode hex="04D8"/>
-  <anchor x="801" y="1380" name="top_center"/>
+  <anchor x="968" y="0" name="bottom_right"/>
+  <anchor x="801" y="-20" name="bottom_cedilla"/>
   <anchor x="801" y="0" name="bottom_center"/>
+  <anchor x="801" y="1380" name="top_center"/>
   <outline>
-    <contour>
-      <point x="104" y="824" type="line"/>
-      <point x="102" y="797"/>
-      <point x="100" y="769"/>
-      <point x="100" y="740" type="curve" smooth="yes"/>
-      <point x="100" y="301"/>
-      <point x="406" y="-20"/>
-      <point x="801" y="-20" type="curve" smooth="yes"/>
-      <point x="1196" y="-20"/>
-      <point x="1502" y="291"/>
-      <point x="1502" y="730" type="curve" smooth="yes"/>
-      <point x="1502" y="1169"/>
-      <point x="1196" y="1500"/>
-      <point x="801" y="1500" type="curve" smooth="yes"/>
-      <point x="533" y="1500"/>
-      <point x="282" y="1351"/>
-      <point x="164" y="1119" type="curve"/>
-      <point x="325" y="1027" type="line"/>
-      <point x="408" y="1214"/>
-      <point x="600" y="1332"/>
-      <point x="801" y="1332" type="curve" smooth="yes"/>
-      <point x="1091" y="1332"/>
-      <point x="1312" y="1090"/>
-      <point x="1312" y="740" type="curve" smooth="yes"/>
-      <point x="1312" y="390"/>
-      <point x="1091" y="148"/>
-      <point x="801" y="148" type="curve" smooth="yes"/>
-      <point x="511" y="148"/>
-      <point x="290" y="390"/>
-      <point x="290" y="740" type="curve" smooth="yes"/>
-      <point x="290" y="769"/>
-      <point x="291" y="797"/>
-      <point x="294" y="824" type="curve"/>
-    </contour>
-    <contour>
-      <point x="1406" y="656" type="line"/>
-      <point x="1406" y="824" type="line"/>
-      <point x="294" y="824" type="line"/>
-      <point x="198" y="656" type="line"/>
-    </contour>
+    <component base="uni018F"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni04D_9.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni04D_9.glif
@@ -2,48 +2,11 @@
 <glyph name="uni04D9" format="2">
   <advance width="1196"/>
   <unicode hex="04D9"/>
+  <anchor x="738" y="0" name="bottom_right"/>
   <anchor x="598" y="0" name="bottom_center"/>
   <anchor x="598" y="1040" name="top_center"/>
+  <anchor x="598" y="-20" name="bottom_cedilla"/>
   <outline>
-    <contour>
-      <point x="1022" y="440" type="line"/>
-      <point x="216" y="440" type="line"/>
-      <point x="286" y="600" type="line"/>
-      <point x="1022" y="600" type="line"/>
-    </contour>
-    <contour>
-      <point x="286" y="700" type="curve"/>
-      <point x="133" y="788" type="line"/>
-      <point x="216" y="966"/>
-      <point x="399" y="1060"/>
-      <point x="598" y="1060" type="curve" smooth="yes"/>
-      <point x="879" y="1060"/>
-      <point x="1096" y="832"/>
-      <point x="1096" y="520" type="curve" smooth="yes"/>
-      <point x="1096" y="208"/>
-      <point x="879" y="-20"/>
-      <point x="598" y="-20" type="curve" smooth="yes"/>
-      <point x="317" y="-20"/>
-      <point x="100" y="208"/>
-      <point x="100" y="520" type="curve" smooth="yes"/>
-      <point x="100" y="547"/>
-      <point x="102" y="574"/>
-      <point x="105" y="600" type="curve"/>
-      <point x="286" y="600" type="line"/>
-      <point x="282" y="574"/>
-      <point x="280" y="548"/>
-      <point x="280" y="520" type="curve" smooth="yes"/>
-      <point x="280" y="300"/>
-      <point x="407" y="140"/>
-      <point x="598" y="140" type="curve" smooth="yes"/>
-      <point x="789" y="140"/>
-      <point x="916" y="300"/>
-      <point x="916" y="520" type="curve" smooth="yes"/>
-      <point x="916" y="740"/>
-      <point x="789" y="900"/>
-      <point x="598" y="900" type="curve" smooth="yes"/>
-      <point x="457" y="900"/>
-      <point x="335" y="833"/>
-    </contour>
+    <component base="uni0259"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni04D_A_.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni04D_A_.glif
@@ -2,6 +2,8 @@
 <glyph name="uni04DA" format="2">
   <advance width="1602"/>
   <unicode hex="04DA"/>
+  <anchor x="968" y="0" name="bottom_right"/>
+  <anchor x="801" y="-20" name="bottom_cedilla"/>
   <anchor x="801" y="0" name="bottom_center"/>
   <anchor x="801" y="1716" name="top_center"/>
   <outline>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni04D_B_.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni04D_B_.glif
@@ -2,7 +2,9 @@
 <glyph name="uni04DB" format="2">
   <advance width="1196"/>
   <unicode hex="04DB"/>
+  <anchor x="738" y="0" name="bottom_right"/>
   <anchor x="598" y="0" name="bottom_center"/>
+  <anchor x="598" y="-20" name="bottom_cedilla"/>
   <anchor x="598" y="1376" name="top_center"/>
   <outline>
     <component base="uni04D9"/>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni0501.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni0501.glif
@@ -1,31 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0501" format="2">
-  <advance width="1090"/>
+  <advance width="1184"/>
   <unicode hex="0501"/>
+  <anchor x="1044" y="1480" name="top_right"/>
+  <anchor x="954" y="1380" name="top_center"/>
+  <anchor x="578" y="0" name="bottom_center"/>
+  <anchor x="578" y="-20" name="bottom_cedilla"/>
   <outline>
-    <contour>
-      <point x="490" y="630" type="line" smooth="yes"/>
-      <point x="245" y="630"/>
-      <point x="100" y="505"/>
-      <point x="100" y="315" type="curve" smooth="yes"/>
-      <point x="100" y="125"/>
-      <point x="245" y="0"/>
-      <point x="490" y="0" type="curve" smooth="yes"/>
-      <point x="950" y="0" type="line"/>
-      <point x="950" y="1040" type="line"/>
-      <point x="770" y="1040" type="line"/>
-      <point x="770" y="630" type="line"/>
-    </contour>
-    <contour>
-      <point x="490" y="470" type="curve" smooth="yes"/>
-      <point x="770" y="470" type="line"/>
-      <point x="770" y="160" type="line"/>
-      <point x="490" y="160" type="line" smooth="yes"/>
-      <point x="346" y="160"/>
-      <point x="280" y="230"/>
-      <point x="280" y="315" type="curve" smooth="yes"/>
-      <point x="280" y="400"/>
-      <point x="346" y="470"/>
-    </contour>
+    <component base="d"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni0503.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni0503.glif
@@ -1,55 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0503" format="2">
-  <advance width="1633"/>
+  <advance width="1729"/>
   <unicode hex="0503"/>
   <outline>
     <contour>
-      <point x="1493" y="758" type="line"/>
-      <point x="1493" y="346" type="line"/>
-      <point x="1493" y="88"/>
-      <point x="1350" y="-14"/>
-      <point x="1132" y="-14" type="curve" smooth="yes"/>
-      <point x="914" y="-14"/>
-      <point x="770" y="88"/>
-      <point x="770" y="346" type="curve"/>
-      <point x="950" y="365" type="line"/>
-      <point x="950" y="214"/>
-      <point x="1005" y="145"/>
-      <point x="1132" y="145" type="curve" smooth="yes"/>
-      <point x="1259" y="145"/>
-      <point x="1313" y="214"/>
-      <point x="1313" y="365" type="curve" smooth="yes"/>
-      <point x="1313" y="758" type="line"/>
+      <point x="876" y="520" type="curve" smooth="yes"/>
+      <point x="876" y="750"/>
+      <point x="758" y="900"/>
+      <point x="578" y="900" type="curve" smooth="yes"/>
+      <point x="398" y="900"/>
+      <point x="280" y="750"/>
+      <point x="280" y="520" type="curve" smooth="yes"/>
+      <point x="280" y="290"/>
+      <point x="398" y="140"/>
+      <point x="578" y="140" type="curve" smooth="yes"/>
+      <point x="758" y="140"/>
+      <point x="876" y="290"/>
     </contour>
     <contour>
-      <point x="770" y="470" type="line"/>
-      <point x="490" y="470" type="line" smooth="yes"/>
-      <point x="346" y="470"/>
-      <point x="280" y="390"/>
-      <point x="280" y="305" type="curve" smooth="yes"/>
-      <point x="280" y="220"/>
-      <point x="346" y="139"/>
-      <point x="490" y="139" type="curve"/>
-      <point x="573" y="139" type="line" smooth="yes"/>
-      <point x="700" y="139"/>
-      <point x="770" y="221"/>
-      <point x="770" y="359" type="curve" smooth="yes"/>
-    </contour>
-    <contour>
-      <point x="770" y="630" type="line"/>
-      <point x="770" y="1040" type="line"/>
-      <point x="950" y="1040" type="line"/>
-      <point x="950" y="359" type="line"/>
-      <point x="950" y="102"/>
-      <point x="785" y="-20"/>
-      <point x="573" y="-20" type="curve" smooth="yes"/>
-      <point x="490" y="-20" type="line"/>
-      <point x="245" y="-20"/>
-      <point x="100" y="115"/>
-      <point x="100" y="305" type="curve" smooth="yes"/>
-      <point x="100" y="495"/>
-      <point x="245" y="630"/>
-      <point x="490" y="630" type="curve" smooth="yes"/>
+      <point x="900" y="142" type="curve"/>
+      <point x="845" y="57"/>
+      <point x="703" y="-20"/>
+      <point x="578" y="-20" type="curve" smooth="yes"/>
+      <point x="297" y="-20"/>
+      <point x="100" y="208"/>
+      <point x="100" y="520" type="curve" smooth="yes"/>
+      <point x="100" y="832"/>
+      <point x="297" y="1060"/>
+      <point x="578" y="1060" type="curve" smooth="yes"/>
+      <point x="703" y="1060"/>
+      <point x="779" y="1005"/>
+      <point x="864" y="920" type="curve"/>
+      <point x="864" y="1480" type="line"/>
+      <point x="1044" y="1480" type="line"/>
+      <point x="1044" y="334" type="line"/>
+      <point x="1044" y="188"/>
+      <point x="1098" y="141"/>
+      <point x="1226" y="141" type="curve" smooth="yes"/>
+      <point x="1354" y="141"/>
+      <point x="1409" y="208"/>
+      <point x="1409" y="354" type="curve" smooth="yes"/>
+      <point x="1409" y="740" type="line"/>
+      <point x="1589" y="740" type="line"/>
+      <point x="1589" y="354" type="line"/>
+      <point x="1589" y="86"/>
+      <point x="1445" y="-20"/>
+      <point x="1226" y="-20" type="curve" smooth="yes"/>
+      <point x="1069" y="-20"/>
+      <point x="954" y="19"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni0505.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni0505.glif
@@ -11,20 +11,20 @@
     </contour>
     <contour>
       <point x="737" y="318" type="curve"/>
-      <point x="737" y="50"/>
-      <point x="880" y="-36"/>
-      <point x="1099" y="-36" type="curve" smooth="yes"/>
-      <point x="1318" y="-36"/>
-      <point x="1462" y="70"/>
-      <point x="1462" y="338" type="curve"/>
-      <point x="1462" y="719" type="line"/>
-      <point x="1282" y="719" type="line"/>
-      <point x="1282" y="338" type="line" smooth="yes"/>
-      <point x="1282" y="192"/>
-      <point x="1227" y="125"/>
-      <point x="1099" y="125" type="curve" smooth="yes"/>
-      <point x="971" y="125"/>
-      <point x="917" y="172"/>
+      <point x="737" y="80"/>
+      <point x="880" y="-20"/>
+      <point x="1099" y="-20" type="curve" smooth="yes"/>
+      <point x="1318" y="-20"/>
+      <point x="1462" y="86"/>
+      <point x="1462" y="354" type="curve"/>
+      <point x="1462" y="740" type="line"/>
+      <point x="1282" y="740" type="line"/>
+      <point x="1282" y="354" type="line" smooth="yes"/>
+      <point x="1282" y="208"/>
+      <point x="1227" y="141"/>
+      <point x="1099" y="141" type="curve" smooth="yes"/>
+      <point x="971" y="141"/>
+      <point x="917" y="212"/>
       <point x="917" y="318" type="curve"/>
       <point x="917" y="488"/>
       <point x="771" y="607"/>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni0509.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni0509.glif
@@ -4,7 +4,7 @@
   <unicode hex="0509"/>
   <outline>
     <contour>
-      <point x="895" y="324" type="curve" smooth="yes"/>
+      <point x="895" y="334" type="curve" smooth="yes"/>
       <point x="895" y="1040" type="line"/>
       <point x="227" y="1040" type="line"/>
       <point x="162" y="377" type="line" smooth="yes"/>
@@ -17,21 +17,21 @@
       <point x="342" y="377" type="curve"/>
       <point x="392" y="880" type="line"/>
       <point x="715" y="880" type="line"/>
-      <point x="715" y="324" type="line"/>
-      <point x="715" y="56"/>
-      <point x="858" y="-30"/>
-      <point x="1077" y="-30" type="curve" smooth="yes"/>
-      <point x="1296" y="-30"/>
-      <point x="1440" y="76"/>
-      <point x="1440" y="344" type="curve"/>
-      <point x="1440" y="725" type="line"/>
-      <point x="1260" y="725" type="line"/>
-      <point x="1260" y="344" type="line" smooth="yes"/>
-      <point x="1260" y="198"/>
-      <point x="1205" y="131"/>
-      <point x="1077" y="131" type="curve" smooth="yes"/>
-      <point x="949" y="131"/>
-      <point x="895" y="178"/>
+      <point x="715" y="334" type="line"/>
+      <point x="715" y="66"/>
+      <point x="858" y="-20"/>
+      <point x="1077" y="-20" type="curve" smooth="yes"/>
+      <point x="1296" y="-20"/>
+      <point x="1440" y="86"/>
+      <point x="1440" y="354" type="curve"/>
+      <point x="1440" y="740" type="line"/>
+      <point x="1260" y="740" type="line"/>
+      <point x="1260" y="354" type="line" smooth="yes"/>
+      <point x="1260" y="208"/>
+      <point x="1205" y="141"/>
+      <point x="1077" y="141" type="curve" smooth="yes"/>
+      <point x="949" y="141"/>
+      <point x="895" y="188"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni050B_.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni050B_.glif
@@ -4,7 +4,7 @@
   <unicode hex="050B"/>
   <outline>
     <contour>
-      <point x="1019" y="314" type="curve"/>
+      <point x="1019" y="334" type="curve"/>
       <point x="1019" y="1040" type="line"/>
       <point x="839" y="1040" type="line"/>
       <point x="839" y="600" type="line"/>
@@ -15,21 +15,21 @@
       <point x="320" y="0" type="line"/>
       <point x="320" y="439" type="line"/>
       <point x="839" y="439" type="line"/>
-      <point x="839" y="314" type="line"/>
-      <point x="839" y="46"/>
-      <point x="982" y="-40"/>
-      <point x="1201" y="-40" type="curve" smooth="yes"/>
-      <point x="1420" y="-40"/>
-      <point x="1564" y="66"/>
-      <point x="1564" y="334" type="curve"/>
-      <point x="1564" y="715" type="line"/>
-      <point x="1384" y="715" type="line"/>
-      <point x="1384" y="334" type="line" smooth="yes"/>
-      <point x="1384" y="188"/>
-      <point x="1329" y="121"/>
-      <point x="1201" y="121" type="curve" smooth="yes"/>
-      <point x="1073" y="121"/>
-      <point x="1019" y="168"/>
+      <point x="839" y="334" type="line"/>
+      <point x="839" y="66"/>
+      <point x="982" y="-20"/>
+      <point x="1201" y="-20" type="curve" smooth="yes"/>
+      <point x="1420" y="-20"/>
+      <point x="1564" y="86"/>
+      <point x="1564" y="354" type="curve"/>
+      <point x="1564" y="740" type="line"/>
+      <point x="1384" y="740" type="line"/>
+      <point x="1384" y="354" type="line" smooth="yes"/>
+      <point x="1384" y="208"/>
+      <point x="1329" y="141"/>
+      <point x="1201" y="141" type="curve" smooth="yes"/>
+      <point x="1073" y="141"/>
+      <point x="1019" y="188"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni050F_.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni050F_.glif
@@ -18,8 +18,8 @@
       <point x="1047" y="-20"/>
       <point x="1191" y="86"/>
       <point x="1191" y="354" type="curve"/>
-      <point x="1191" y="735" type="line"/>
-      <point x="1011" y="735" type="line"/>
+      <point x="1191" y="740" type="line"/>
+      <point x="1011" y="740" type="line"/>
       <point x="1011" y="354" type="line" smooth="yes"/>
       <point x="1011" y="208"/>
       <point x="956" y="141"/>

--- a/sources/Giphurs-Thin.ufo/features.fea
+++ b/sources/Giphurs-Thin.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -8601,7 +8601,7 @@ lookup mark_Mark_positioning {
 	<anchor 950 1040> mark @top_right
 	<anchor 565 1040> mark @top_center
 	<anchor 565 0> mark @bottom_center;
-  pos base [\d ] <anchor 972 1480> mark @top_right
+  pos base [\d \uni0501 ] <anchor 972 1480> mark @top_right
 	<anchor 560 -20> mark @bottom_cedilla
 	<anchor 949 1380> mark @top_center
 	<anchor 560 0> mark @bottom_center;
@@ -8706,7 +8706,7 @@ lookup mark_Mark_positioning {
   pos base [\C \uni0421 \uni216D ] <anchor 757 -20> mark @bottom_cedilla
 	<anchor 757 0> mark @bottom_center
 	<anchor 757 1380> mark @top_center;
-  pos base [\G \Q \Oslash \uni01B1 \Theta \uni0424 \uni04D8 \uni04E8 \uni051A \uni2127 \uni1FFC \G.cv21 ] <anchor 757 1380> mark @top_center
+  pos base [\G \Q \Oslash \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \uni1FFC \G.cv21 ] <anchor 757 1380> mark @top_center
 	<anchor 757 0> mark @bottom_center;
   pos base [\U ] <anchor 672 -10> mark @bottom_cedilla
 	<anchor 787 0> mark @bottom_right
@@ -8800,7 +8800,7 @@ lookup mark_Mark_positioning {
 	<anchor 1318 1380> mark @top_center;
   pos base [\ae \uni04D5 ] <anchor 900 1040> mark @top_center
 	<anchor 900 0> mark @bottom_center;
-  pos base [\oslash \uni028A \sigma1 \uni03DB \uni0454 \uni04D9 \uni04E9 ] <anchor 578 1040> mark @top_center
+  pos base [\oslash \uni028A \sigma1 \uni03DB \uni0454 \uni04E9 ] <anchor 578 1040> mark @top_center
 	<anchor 578 0> mark @bottom_center;
   pos base [\Aogonek ] <anchor 1165 -20> mark @bottom_cedilla
 	<anchor 655 -90> mark @bottom_ypogegrammeni
@@ -8827,7 +8827,7 @@ lookup mark_Mark_positioning {
   pos base [\eogonek ] <anchor 578 -20> mark @bottom_cedilla
 	<anchor 578 1040> mark @top_center
 	<anchor 610 -350> mark @bottom_center;
-  pos base [\Gcircumflex \Gbreve \Gdotaccent \Gcaron \uni01F4 \Oslashacute \uni04DA \uni04EA \uni1E20 \Gcircumflex.cv21 \Gbreve.cv21 \Gdotaccent.cv21 \Gcaron.cv21 \uni01F4.cv21 \uni1E20.cv21 ] <anchor 757 0> mark @bottom_center
+  pos base [\Gcircumflex \Gbreve \Gdotaccent \Gcaron \uni01F4 \Oslashacute \uni04EA \uni1E20 \Gcircumflex.cv21 \Gbreve.cv21 \Gdotaccent.cv21 \Gcaron.cv21 \uni01F4.cv21 \uni1E20.cv21 ] <anchor 757 0> mark @bottom_center
 	<anchor 757 1716> mark @top_center;
   pos base [\gcircumflex \gbreve \gdotaccent \gcaron \uni01F5 \uni1E21 ] <anchor 543 -361> mark @bottom_center
 	<anchor 543 1366> mark @top_center;
@@ -8934,7 +8934,7 @@ lookup mark_Mark_positioning {
   pos base [\uni018E ] <anchor 588 -20> mark @bottom_cedilla
 	<anchor 588 0> mark @bottom_center
 	<anchor 588 1380> mark @top_center;
-  pos base [\uni018F \Ohorn ] <anchor 863 0> mark @bottom_right
+  pos base [\uni018F \Ohorn \uni04D8 ] <anchor 863 0> mark @bottom_right
 	<anchor 757 1380> mark @top_center
 	<anchor 757 0> mark @bottom_center
 	<anchor 757 -20> mark @bottom_cedilla;
@@ -8955,7 +8955,7 @@ lookup mark_Mark_positioning {
 	<anchor 1267 1480> mark @top_right
 	<anchor 757 0> mark @bottom_center
 	<anchor 863 0> mark @bottom_right;
-  pos base [\ohorn \uni0259 ] <anchor 578 -20> mark @bottom_cedilla
+  pos base [\ohorn \uni0259 \uni04D9 ] <anchor 578 -20> mark @bottom_cedilla
 	<anchor 578 1040> mark @top_center
 	<anchor 578 0> mark @bottom_center
 	<anchor 667 0> mark @bottom_right;
@@ -9033,7 +9033,7 @@ lookup mark_Mark_positioning {
 	<anchor 585 1376> mark @top_center;
   pos base [\uni0292 \uni04E1 ] <anchor 585 1040> mark @top_center
 	<anchor 585 -360> mark @bottom_center;
-  pos base [\oslashacute \uni04DB \uni04EB ] <anchor 578 0> mark @bottom_center
+  pos base [\oslashacute \uni04EB ] <anchor 578 0> mark @bottom_center
 	<anchor 578 1376> mark @top_center;
   pos base [\uni0228 ] <anchor 588 1380> mark @top_center
 	<anchor 603 -350> mark @bottom_center
@@ -9284,6 +9284,10 @@ lookup mark_Mark_positioning {
 	<anchor 866 1772> mark @top_center;
   pos base [\uni04C1 \uni04DC ] <anchor 909 0> mark @bottom_cedilla
 	<anchor 908 1716> mark @top_center;
+  pos base [\uni04DB \uni1EDB \uni1EDD \uni1EE1 ] <anchor 667 0> mark @bottom_right
+	<anchor 578 0> mark @bottom_center
+	<anchor 578 -20> mark @bottom_cedilla
+	<anchor 578 1376> mark @top_center;
   pos base [\uni04C2 \uni04DD ] <anchor 717 0> mark @bottom_center
 	<anchor 717 1376> mark @top_center;
   pos base [\uni04DE ] <anchor 615 0> mark @bottom_cedilla
@@ -9300,6 +9304,10 @@ lookup mark_Mark_positioning {
 	<anchor 794 1716> mark @top_center;
   pos base [\uni04F9 ] <anchor 630 0> mark @bottom_center
 	<anchor 630 1376> mark @top_center;
+  pos base [\uni04DA \uni1EDA \uni1EDC \uni1EE0 ] <anchor 863 0> mark @bottom_right
+	<anchor 757 0> mark @bottom_center
+	<anchor 757 -20> mark @bottom_cedilla
+	<anchor 757 1716> mark @top_center;
   pos base [\uni1E02 ] <anchor 601 0> mark @bottom_center
 	<anchor 601 1716> mark @top_center;
   pos base [\uni1E03 ] <anchor 592 0> mark @bottom_center
@@ -9662,14 +9670,6 @@ lookup mark_Mark_positioning {
 	<anchor 974 1040> mark @top_right
 	<anchor 667 0> mark @bottom_right
 	<anchor 578 -336> mark @bottom_center
-	<anchor 578 1376> mark @top_center;
-  pos base [\uni1EDA \uni1EDC \uni1EE0 ] <anchor 757 -20> mark @bottom_cedilla
-	<anchor 863 0> mark @bottom_right
-	<anchor 757 0> mark @bottom_center
-	<anchor 757 1716> mark @top_center;
-  pos base [\uni1EDB \uni1EDD \uni1EE1 ] <anchor 578 -20> mark @bottom_cedilla
-	<anchor 578 0> mark @bottom_center
-	<anchor 667 0> mark @bottom_right
 	<anchor 578 1376> mark @top_center;
   pos base [\uni1EDE ] <anchor 757 -20> mark @bottom_cedilla
 	<anchor 863 0> mark @bottom_right

--- a/sources/Giphurs-Thin.ufo/features.fea
+++ b/sources/Giphurs-Thin.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 16:52:33</string>
+    <string>2025/04/27 17:20:41</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/26 18:41:34</string>
+    <string>2025/04/27 16:52:33</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni04D_8.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni04D_8.glif
@@ -2,48 +2,11 @@
 <glyph name="uni04D8" format="2">
   <advance width="1514"/>
   <unicode hex="04D8"/>
+  <anchor x="863" y="0" name="bottom_right"/>
   <anchor x="757" y="1380" name="top_center"/>
   <anchor x="757" y="0" name="bottom_center"/>
+  <anchor x="757" y="-20" name="bottom_cedilla"/>
   <outline>
-    <contour>
-      <point x="141" y="761" type="line"/>
-      <point x="140" y="754"/>
-      <point x="140" y="742"/>
-      <point x="140" y="740" type="curve" smooth="yes"/>
-      <point x="140" y="301"/>
-      <point x="409" y="-10"/>
-      <point x="757" y="-10" type="curve" smooth="yes"/>
-      <point x="1105" y="-10"/>
-      <point x="1374" y="301"/>
-      <point x="1374" y="740" type="curve" smooth="yes"/>
-      <point x="1374" y="1179"/>
-      <point x="1105" y="1490"/>
-      <point x="757" y="1490" type="curve" smooth="yes"/>
-      <point x="522" y="1490"/>
-      <point x="302" y="1348"/>
-      <point x="198" y="1120" type="curve"/>
-      <point x="238" y="1097" type="line"/>
-      <point x="345" y="1332"/>
-      <point x="574" y="1448"/>
-      <point x="757" y="1448" type="curve" smooth="yes"/>
-      <point x="1017" y="1448"/>
-      <point x="1328" y="1215"/>
-      <point x="1328" y="740" type="curve" smooth="yes"/>
-      <point x="1328" y="265"/>
-      <point x="1017" y="32"/>
-      <point x="757" y="32" type="curve" smooth="yes"/>
-      <point x="497" y="32"/>
-      <point x="186" y="265"/>
-      <point x="186" y="740" type="curve" smooth="yes"/>
-      <point x="186" y="742"/>
-      <point x="186" y="754"/>
-      <point x="187" y="761" type="curve"/>
-    </contour>
-    <contour>
-      <point x="1354" y="719" type="line"/>
-      <point x="1354" y="761" type="line"/>
-      <point x="187" y="761" type="line"/>
-      <point x="153" y="719" type="line"/>
-    </contour>
+    <component base="uni018F"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni04D_9.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni04D_9.glif
@@ -2,48 +2,11 @@
 <glyph name="uni04D9" format="2">
   <advance width="1156"/>
   <unicode hex="04D9"/>
+  <anchor x="667" y="0" name="bottom_right"/>
   <anchor x="578" y="0" name="bottom_center"/>
   <anchor x="578" y="1040" name="top_center"/>
+  <anchor x="578" y="-20" name="bottom_cedilla"/>
   <outline>
-    <contour>
-      <point x="991" y="500" type="line"/>
-      <point x="157" y="500" type="line"/>
-      <point x="185" y="540" type="line"/>
-      <point x="991" y="540" type="line"/>
-    </contour>
-    <contour>
-      <point x="204" y="766" type="curve"/>
-      <point x="165" y="788" type="line"/>
-      <point x="239" y="950"/>
-      <point x="381" y="1050"/>
-      <point x="578" y="1050" type="curve" smooth="yes"/>
-      <point x="825" y="1050"/>
-      <point x="1016" y="832"/>
-      <point x="1016" y="520" type="curve" smooth="yes"/>
-      <point x="1016" y="208"/>
-      <point x="825" y="-10"/>
-      <point x="578" y="-10" type="curve" smooth="yes"/>
-      <point x="331" y="-10"/>
-      <point x="140" y="208"/>
-      <point x="140" y="520" type="curve" smooth="yes"/>
-      <point x="140" y="527"/>
-      <point x="140" y="533"/>
-      <point x="140" y="540" type="curve"/>
-      <point x="185" y="540" type="line"/>
-      <point x="185" y="533"/>
-      <point x="185" y="527"/>
-      <point x="185" y="520" type="curve" smooth="yes"/>
-      <point x="185" y="184"/>
-      <point x="410" y="30"/>
-      <point x="578" y="30" type="curve" smooth="yes"/>
-      <point x="746" y="30"/>
-      <point x="971" y="184"/>
-      <point x="971" y="520" type="curve" smooth="yes"/>
-      <point x="971" y="856"/>
-      <point x="746" y="1010"/>
-      <point x="578" y="1010" type="curve" smooth="yes"/>
-      <point x="432" y="1010"/>
-      <point x="280" y="932"/>
-    </contour>
+    <component base="uni0259"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni04D_A_.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni04D_A_.glif
@@ -2,7 +2,9 @@
 <glyph name="uni04DA" format="2">
   <advance width="1514"/>
   <unicode hex="04DA"/>
+  <anchor x="863" y="0" name="bottom_right"/>
   <anchor x="757" y="0" name="bottom_center"/>
+  <anchor x="757" y="-20" name="bottom_cedilla"/>
   <anchor x="757" y="1716" name="top_center"/>
   <outline>
     <component base="uni04D8"/>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni04D_B_.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni04D_B_.glif
@@ -2,7 +2,9 @@
 <glyph name="uni04DB" format="2">
   <advance width="1156"/>
   <unicode hex="04DB"/>
+  <anchor x="667" y="0" name="bottom_right"/>
   <anchor x="578" y="0" name="bottom_center"/>
+  <anchor x="578" y="-20" name="bottom_cedilla"/>
   <anchor x="578" y="1376" name="top_center"/>
   <outline>
     <component base="uni04D9"/>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni0501.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni0501.glif
@@ -1,31 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0501" format="2">
-  <advance width="996"/>
+  <advance width="1152"/>
   <unicode hex="0501"/>
+  <anchor x="972" y="1480" name="top_right"/>
+  <anchor x="560" y="-20" name="bottom_cedilla"/>
+  <anchor x="949" y="1380" name="top_center"/>
+  <anchor x="560" y="0" name="bottom_center"/>
   <outline>
-    <contour>
-      <point x="479" y="566" type="line" smooth="yes"/>
-      <point x="270" y="566"/>
-      <point x="140" y="453"/>
-      <point x="140" y="283" type="curve" smooth="yes"/>
-      <point x="140" y="113"/>
-      <point x="270" y="0"/>
-      <point x="479" y="0" type="curve" smooth="yes"/>
-      <point x="816" y="0" type="line"/>
-      <point x="816" y="1040" type="line"/>
-      <point x="771" y="1040" type="line"/>
-      <point x="771" y="566" type="line"/>
-    </contour>
-    <contour>
-      <point x="479" y="526" type="curve" smooth="yes"/>
-      <point x="771" y="526" type="line"/>
-      <point x="771" y="40" type="line"/>
-      <point x="479" y="40" type="line" smooth="yes"/>
-      <point x="315" y="40"/>
-      <point x="184" y="132"/>
-      <point x="184" y="283" type="curve" smooth="yes"/>
-      <point x="184" y="434"/>
-      <point x="315" y="526"/>
-    </contour>
+    <component base="d"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni0503.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni0503.glif
@@ -1,55 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0503" format="2">
-  <advance width="1588"/>
+  <advance width="1743"/>
   <unicode hex="0503"/>
   <outline>
     <contour>
-      <point x="1408" y="762" type="line"/>
-      <point x="1408" y="350" type="line"/>
-      <point x="1408" y="92"/>
-      <point x="1262" y="-10"/>
-      <point x="1090" y="-10" type="curve" smooth="yes"/>
-      <point x="918" y="-10"/>
-      <point x="771" y="92"/>
-      <point x="771" y="350" type="curve"/>
-      <point x="816" y="369" type="line"/>
-      <point x="816" y="138"/>
-      <point x="928" y="30"/>
-      <point x="1090" y="30" type="curve" smooth="yes"/>
-      <point x="1252" y="30"/>
-      <point x="1363" y="138"/>
-      <point x="1363" y="349" type="curve" smooth="yes"/>
-      <point x="1363" y="762" type="line"/>
+      <point x="935" y="520" type="curve"/>
+      <point x="935" y="856"/>
+      <point x="735" y="1010"/>
+      <point x="560" y="1010" type="curve" smooth="yes"/>
+      <point x="385" y="1010"/>
+      <point x="185" y="856"/>
+      <point x="185" y="520" type="curve" smooth="yes"/>
+      <point x="185" y="184"/>
+      <point x="385" y="30"/>
+      <point x="560" y="30" type="curve" smooth="yes"/>
+      <point x="735" y="30"/>
+      <point x="935" y="184"/>
     </contour>
     <contour>
-      <point x="771" y="526" type="line"/>
-      <point x="479" y="526" type="line" smooth="yes"/>
-      <point x="315" y="526"/>
-      <point x="184" y="429"/>
-      <point x="184" y="278" type="curve" smooth="yes"/>
-      <point x="184" y="127"/>
-      <point x="315" y="30"/>
-      <point x="479" y="30" type="curve"/>
-      <point x="496" y="30" type="line"/>
-      <point x="658" y="30"/>
-      <point x="771" y="148"/>
-      <point x="771" y="359" type="curve"/>
-    </contour>
-    <contour>
-      <point x="771" y="566" type="line"/>
-      <point x="771" y="1040" type="line"/>
-      <point x="816" y="1040" type="line"/>
-      <point x="816" y="360" type="line"/>
-      <point x="816" y="102"/>
-      <point x="673" y="-10"/>
-      <point x="496" y="-10" type="curve"/>
-      <point x="479" y="-10" type="line"/>
-      <point x="270" y="-10"/>
-      <point x="140" y="108"/>
-      <point x="140" y="278" type="curve" smooth="yes"/>
-      <point x="140" y="448"/>
-      <point x="270" y="566"/>
-      <point x="479" y="566" type="curve" smooth="yes"/>
+      <point x="932" y="269" type="curve"/>
+      <point x="901" y="153"/>
+      <point x="770" y="-10"/>
+      <point x="560" y="-10" type="curve" smooth="yes"/>
+      <point x="313" y="-10"/>
+      <point x="140" y="208"/>
+      <point x="140" y="520" type="curve" smooth="yes"/>
+      <point x="140" y="832"/>
+      <point x="313" y="1050"/>
+      <point x="560" y="1050" type="curve" smooth="yes"/>
+      <point x="760" y="1050"/>
+      <point x="896" y="896"/>
+      <point x="927" y="780" type="curve"/>
+      <point x="927" y="1480" type="line"/>
+      <point x="972" y="1480" type="line"/>
+      <point x="972" y="349" type="line"/>
+      <point x="972" y="138"/>
+      <point x="1083" y="30"/>
+      <point x="1245" y="30" type="curve" smooth="yes"/>
+      <point x="1407" y="30"/>
+      <point x="1518" y="138"/>
+      <point x="1518" y="349" type="curve" smooth="yes"/>
+      <point x="1518" y="740" type="line"/>
+      <point x="1563" y="740" type="line"/>
+      <point x="1563" y="350" type="line"/>
+      <point x="1563" y="92"/>
+      <point x="1417" y="-10"/>
+      <point x="1245" y="-10" type="curve" smooth="yes"/>
+      <point x="1091" y="-10"/>
+      <point x="958" y="67"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni0505.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni0505.glif
@@ -17,8 +17,8 @@
       <point x="1273" y="-10"/>
       <point x="1419" y="92"/>
       <point x="1419" y="350" type="curve"/>
-      <point x="1419" y="762" type="line"/>
-      <point x="1374" y="762" type="line"/>
+      <point x="1419" y="740" type="line"/>
+      <point x="1374" y="740" type="line"/>
       <point x="1374" y="349" type="line" smooth="yes"/>
       <point x="1374" y="138"/>
       <point x="1263" y="30"/>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni0509.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni0509.glif
@@ -24,8 +24,8 @@
       <point x="1269" y="-10"/>
       <point x="1415" y="92"/>
       <point x="1415" y="350" type="curve"/>
-      <point x="1415" y="762" type="line"/>
-      <point x="1370" y="762" type="line"/>
+      <point x="1415" y="740" type="line"/>
+      <point x="1370" y="740" type="line"/>
       <point x="1370" y="349" type="line" smooth="yes"/>
       <point x="1370" y="138"/>
       <point x="1259" y="30"/>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni050B_.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni050B_.glif
@@ -22,8 +22,8 @@
       <point x="1398" y="-11"/>
       <point x="1544" y="92"/>
       <point x="1544" y="350" type="curve"/>
-      <point x="1544" y="762" type="line"/>
-      <point x="1499" y="762" type="line"/>
+      <point x="1544" y="740" type="line"/>
+      <point x="1499" y="740" type="line"/>
       <point x="1499" y="349" type="line" smooth="yes"/>
       <point x="1499" y="138"/>
       <point x="1388" y="30"/>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni050F_.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni050F_.glif
@@ -18,8 +18,8 @@
       <point x="1013" y="-10"/>
       <point x="1159" y="92"/>
       <point x="1159" y="350" type="curve"/>
-      <point x="1159" y="762" type="line"/>
-      <point x="1114" y="762" type="line"/>
+      <point x="1159" y="740" type="line"/>
+      <point x="1114" y="740" type="line"/>
       <point x="1114" y="349" type="line" smooth="yes"/>
       <point x="1114" y="138"/>
       <point x="1003" y="30"/>

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 16:27:28</string>
+    <string>2025/04/27 17:23:46</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni0503.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni0503.glif
@@ -4,6 +4,12 @@
   <unicode hex="0503"/>
   <outline>
     <contour>
+      <point x="1495" y="350" type="line" smooth="yes"/>
+      <point x="1450" y="91"/>
+      <point x="1285" y="-10"/>
+      <point x="1113" y="-10" type="curve" smooth="yes"/>
+      <point x="965" y="-10"/>
+      <point x="846" y="87"/>
       <point x="856" y="283" type="curve"/>
       <point x="773" y="141"/>
       <point x="638" y="-10"/>
@@ -27,16 +33,10 @@
       <point x="982" y="30"/>
       <point x="1120" y="30" type="curve" smooth="yes"/>
       <point x="1282" y="30"/>
-      <point x="1413" y="138"/>
+      <point x="1413" y="137"/>
       <point x="1450" y="349" type="curve" smooth="yes"/>
-      <point x="1522" y="762" type="line"/>
-      <point x="1567" y="762" type="line"/>
-      <point x="1495" y="350" type="line"/>
-      <point x="1450" y="92"/>
-      <point x="1285" y="-10"/>
-      <point x="1113" y="-10" type="curve" smooth="yes"/>
-      <point x="965" y="-10"/>
-      <point x="846" y="87"/>
+      <point x="1518" y="740" type="line"/>
+      <point x="1563" y="740" type="line"/>
     </contour>
     <contour>
       <point x="435" y="30" type="curve" smooth="yes"/>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni0505.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni0505.glif
@@ -10,8 +10,8 @@
       <point x="431" y="568" type="line"/>
     </contour>
     <contour>
-      <point x="712" y="352" type="curve" smooth="yes"/>
-      <point x="712" y="319"/>
+      <point x="712" y="353" type="curve" smooth="yes"/>
+      <point x="712" y="320"/>
       <point x="700" y="287"/>
       <point x="700" y="225" type="curve" smooth="yes"/>
       <point x="700" y="43"/>
@@ -20,8 +20,8 @@
       <point x="1141" y="-10"/>
       <point x="1306" y="92"/>
       <point x="1351" y="350" type="curve" smooth="yes"/>
-      <point x="1423" y="762" type="line"/>
-      <point x="1378" y="762" type="line"/>
+      <point x="1419" y="740" type="line"/>
+      <point x="1374" y="740" type="line"/>
       <point x="1306" y="349" type="line" smooth="yes"/>
       <point x="1269" y="138"/>
       <point x="1138" y="30"/>
@@ -37,18 +37,18 @@
       <point x="431" y="568" type="curve"/>
       <point x="424" y="528" type="line"/>
       <point x="621" y="528"/>
-      <point x="712" y="455"/>
+      <point x="712" y="456"/>
     </contour>
     <contour>
       <point x="747" y="826" type="curve" smooth="yes"/>
-      <point x="747" y="714"/>
-      <point x="650" y="568"/>
+      <point x="747" y="713"/>
+      <point x="649" y="568"/>
       <point x="431" y="568" type="curve"/>
       <point x="424" y="528" type="line"/>
-      <point x="665" y="528"/>
-      <point x="793" y="685"/>
-      <point x="793" y="838" type="curve" smooth="yes"/>
-      <point x="793" y="969"/>
+      <point x="664" y="528"/>
+      <point x="794" y="683"/>
+      <point x="794" y="837" type="curve" smooth="yes"/>
+      <point x="794" y="968"/>
       <point x="686" y="1050"/>
       <point x="516" y="1050" type="curve" smooth="yes"/>
       <point x="327" y="1050"/>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni0509.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni0509.glif
@@ -4,7 +4,7 @@
   <unicode hex="0509"/>
   <outline>
     <contour>
-      <point x="756" y="349" type="curve"/>
+      <point x="756" y="349" type="curve" smooth="yes"/>
       <point x="877" y="1040" type="line"/>
       <point x="349" y="1040" type="line"/>
       <point x="160" y="327" type="line" smooth="yes"/>
@@ -17,27 +17,27 @@
       <point x="205" y="327" type="curve" smooth="yes"/>
       <point x="387" y="998" type="line"/>
       <point x="825" y="998" type="line"/>
-      <point x="711" y="350" type="line"/>
+      <point x="711" y="350" type="line" smooth="yes"/>
       <point x="705" y="314"/>
-      <point x="702" y="282"/>
-      <point x="702" y="252" type="curve" smooth="yes"/>
-      <point x="702" y="66"/>
+      <point x="701" y="282"/>
+      <point x="701" y="252" type="curve" smooth="yes"/>
+      <point x="701" y="66"/>
       <point x="817" y="-10"/>
       <point x="965" y="-10" type="curve" smooth="yes"/>
       <point x="1137" y="-10"/>
       <point x="1302" y="92"/>
-      <point x="1347" y="350" type="curve"/>
-      <point x="1419" y="762" type="line"/>
-      <point x="1374" y="762" type="line"/>
+      <point x="1347" y="350" type="curve" smooth="yes"/>
+      <point x="1415" y="740" type="line"/>
+      <point x="1370" y="740" type="line"/>
       <point x="1302" y="349" type="line" smooth="yes"/>
       <point x="1265" y="138"/>
       <point x="1134" y="30"/>
       <point x="972" y="30" type="curve" smooth="yes"/>
       <point x="834" y="30"/>
-      <point x="748" y="108"/>
-      <point x="748" y="261" type="curve" smooth="yes"/>
-      <point x="748" y="288"/>
-      <point x="750" y="317"/>
+      <point x="747" y="108"/>
+      <point x="747" y="261" type="curve" smooth="yes"/>
+      <point x="747" y="288"/>
+      <point x="750" y="318"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni050B_.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni050B_.glif
@@ -4,7 +4,7 @@
   <unicode hex="050B"/>
   <outline>
     <contour>
-      <point x="885" y="349" type="curve"/>
+      <point x="885" y="349" type="curve" smooth="yes"/>
       <point x="1006" y="1040" type="line"/>
       <point x="961" y="1040" type="line"/>
       <point x="873" y="540" type="line"/>
@@ -15,27 +15,27 @@
       <point x="95" y="0" type="line"/>
       <point x="183" y="500" type="line"/>
       <point x="866" y="500" type="line"/>
-      <point x="840" y="349" type="line"/>
+      <point x="840" y="349" type="line" smooth="yes"/>
       <point x="834" y="313"/>
-      <point x="831" y="281"/>
-      <point x="831" y="251" type="curve" smooth="yes"/>
-      <point x="831" y="65"/>
+      <point x="830" y="281"/>
+      <point x="830" y="251" type="curve" smooth="yes"/>
+      <point x="830" y="65"/>
       <point x="946" y="-11"/>
       <point x="1094" y="-11" type="curve" smooth="yes"/>
       <point x="1266" y="-11"/>
       <point x="1431" y="92"/>
-      <point x="1476" y="350" type="curve"/>
-      <point x="1548" y="762" type="line"/>
-      <point x="1503" y="762" type="line"/>
+      <point x="1476" y="350" type="curve" smooth="yes"/>
+      <point x="1544" y="740" type="line"/>
+      <point x="1499" y="740" type="line"/>
       <point x="1431" y="349" type="line" smooth="yes"/>
       <point x="1394" y="138"/>
       <point x="1263" y="30"/>
       <point x="1101" y="30" type="curve" smooth="yes"/>
       <point x="963" y="30"/>
-      <point x="877" y="108"/>
-      <point x="877" y="261" type="curve" smooth="yes"/>
-      <point x="877" y="288"/>
-      <point x="879" y="317"/>
+      <point x="876" y="108"/>
+      <point x="876" y="261" type="curve" smooth="yes"/>
+      <point x="876" y="288"/>
+      <point x="879" y="318"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni050F_.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni050F_.glif
@@ -4,34 +4,34 @@
   <unicode hex="050F"/>
   <outline>
     <contour>
-      <point x="500" y="349" type="curve"/>
+      <point x="500" y="349" type="curve" smooth="yes"/>
       <point x="614" y="1000" type="line"/>
       <point x="958" y="1000" type="line"/>
       <point x="965" y="1040" type="line"/>
       <point x="233" y="1040" type="line"/>
       <point x="226" y="1000" type="line"/>
       <point x="570" y="1000" type="line"/>
-      <point x="456" y="350" type="line"/>
+      <point x="456" y="350" type="line" smooth="yes"/>
       <point x="450" y="314"/>
-      <point x="447" y="282"/>
-      <point x="447" y="252" type="curve" smooth="yes"/>
-      <point x="447" y="66"/>
+      <point x="446" y="281"/>
+      <point x="446" y="251" type="curve" smooth="yes"/>
+      <point x="446" y="65"/>
       <point x="561" y="-10"/>
       <point x="709" y="-10" type="curve" smooth="yes"/>
       <point x="881" y="-10"/>
       <point x="1046" y="92"/>
-      <point x="1091" y="350" type="curve"/>
-      <point x="1163" y="762" type="line"/>
-      <point x="1118" y="762" type="line"/>
+      <point x="1091" y="350" type="curve" smooth="yes"/>
+      <point x="1159" y="740" type="line"/>
+      <point x="1114" y="740" type="line"/>
       <point x="1046" y="349" type="line" smooth="yes"/>
       <point x="1009" y="138"/>
       <point x="878" y="30"/>
       <point x="716" y="30" type="curve" smooth="yes"/>
       <point x="578" y="30"/>
-      <point x="492" y="108"/>
-      <point x="492" y="261" type="curve" smooth="yes"/>
-      <point x="492" y="288"/>
-      <point x="494" y="317"/>
+      <point x="491" y="108"/>
+      <point x="491" y="261" type="curve" smooth="yes"/>
+      <point x="491" y="288"/>
+      <point x="494" y="318"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
1. Applies the new entries of composite_glyphs.csv composites glyphs from #82  to non-italics (already done for italics) by running `make ufo_composite_glyphs` (then `make ufo_accented_glyphs` and `make ufo_composite_glyphs` again)
2. Apply the new design of uni0503 to non-italics, and fix incosistencies between weights for : uni0505 uni0509 uni050B uni050F (some points were too low at , and the 2 points circled here weren't at the same height across weights) for all font files.
![image](https://github.com/user-attachments/assets/3b25f5f4-43a0-41e3-8a2a-44446c1cd91e)
