### PR TITLE
Redesign cyrillic letter Omega and Ot

### DIFF
--- a/sources/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlack.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -9453,10 +9453,10 @@ lookup mark_Mark_positioning {
 	<anchor 765 1716> mark @top_center;
   pos base [\uni0477 ] <anchor 587 0> mark @bottom_center
 	<anchor 667 1376> mark @top_center;
-  pos base [\uni047C ] <anchor 935 0> mark @bottom_center
-	<anchor 935 2156> mark @top_center;
-  pos base [\uni047D ] <anchor 907 0> mark @bottom_center
-	<anchor 907 1816> mark @top_center;
+  pos base [\uni047C ] <anchor 1197 0> mark @bottom_center
+	<anchor 1197 2156> mark @top_center;
+  pos base [\uni047D ] <anchor 974 0> mark @bottom_center
+	<anchor 974 1816> mark @top_center;
   pos base [\uni04C1 ] <anchor 1112 0> mark @bottom_cedilla
 	<anchor 1110 1716> mark @top_center;
   pos base [\uni04DB ] <anchor 791 0> mark @bottom_right

--- a/sources/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlack.ufo/features.fea
@@ -10235,13 +10235,13 @@ lookup mark_Mark_positioning {
 	<anchor 642 1040> mark @top_center;
   pos base [\uniA78D ] <anchor 743 0> mark @bottom_center
 	<anchor 743 1380> mark @top_center;
-  pos base [\uni2C6D ] <anchor 745 1380> mark @top_center
+  pos base [\uni2C6D ] <anchor 765 1380> mark @top_center
 	<anchor 762 -23> mark @bottom_center
 	<anchor 762 -80> mark @bottom_ypogegrammeni;
-  pos base [\uniA7B6 ] <anchor 935 1380> mark @top_center
-	<anchor 935 0> mark @bottom_center;
-  pos base [\uniA7B7 ] <anchor 907 0> mark @bottom_center
-	<anchor 907 1040> mark @top_center;
+  pos base [\uniA7B6 ] <anchor 1197 0> mark @bottom_center
+	<anchor 1197 1380> mark @top_center;
+  pos base [\uniA7B7 ] <anchor 974 0> mark @bottom_center
+	<anchor 974 1040> mark @top_center;
   pos base [\a.sc \alpha.sc \uni0430.sc ] <anchor 1096 -20> mark @bottom_cedilla
 	<anchor 665 -80> mark @bottom_ypogegrammeni
 	<anchor 1293 0> mark @bottom_right

--- a/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/28 12:41:23</string>
+    <string>2025/04/28 15:03:12</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 17:13:34</string>
+    <string>2025/04/28 12:41:23</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0460.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0460.glif
@@ -1,42 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0460" format="2">
-  <advance width="1870"/>
+  <advance width="2265"/>
   <unicode hex="0460"/>
   <outline>
     <contour>
-      <point x="1125" y="1480" type="line"/>
-      <point x="745" y="1480" type="line"/>
-      <point x="745" y="468" type="line" smooth="yes"/>
-      <point x="745" y="348"/>
-      <point x="688" y="296"/>
-      <point x="598" y="296" type="curve" smooth="yes"/>
-      <point x="508" y="296"/>
-      <point x="450" y="348"/>
-      <point x="450" y="468" type="curve" smooth="yes"/>
-      <point x="450" y="1480" type="line"/>
-      <point x="70" y="1480" type="line"/>
-      <point x="70" y="468" type="line" smooth="yes"/>
-      <point x="70" y="108"/>
-      <point x="322" y="-40"/>
-      <point x="598" y="-40" type="curve" smooth="yes"/>
-      <point x="722" y="-40"/>
-      <point x="841" y="-10"/>
-      <point x="935" y="56" type="curve"/>
-      <point x="1029" y="-10"/>
-      <point x="1148" y="-40"/>
-      <point x="1272" y="-40" type="curve" smooth="yes"/>
-      <point x="1548" y="-40"/>
-      <point x="1800" y="108"/>
-      <point x="1800" y="468" type="curve" smooth="yes"/>
-      <point x="1800" y="1480" type="line"/>
-      <point x="1420" y="1480" type="line"/>
-      <point x="1420" y="468" type="line" smooth="yes"/>
-      <point x="1420" y="348"/>
-      <point x="1362" y="296"/>
-      <point x="1272" y="296" type="curve" smooth="yes"/>
-      <point x="1182" y="296"/>
-      <point x="1125" y="348"/>
-      <point x="1125" y="468" type="curve" smooth="yes"/>
+      <point x="1790" y="0" type="curve"/>
+      <point x="1376" y="0" type="line"/>
+      <point x="1376" y="0"/>
+      <point x="951" y="640"/>
+      <point x="951" y="1480" type="curve"/>
+      <point x="1343" y="1480" type="line"/>
+      <point x="1343" y="840"/>
+      <point x="1583" y="460"/>
+      <point x="1583" y="460" type="curve"/>
+      <point x="1583" y="460"/>
+      <point x="1823" y="840"/>
+      <point x="1823" y="1480" type="curve"/>
+      <point x="2215" y="1480" type="line"/>
+      <point x="2215" y="640"/>
+      <point x="1790" y="0"/>
+    </contour>
+    <contour>
+      <point x="848" y="0" type="line"/>
+      <point x="475" y="0" type="line"/>
+      <point x="475" y="0"/>
+      <point x="50" y="640"/>
+      <point x="50" y="1480" type="curve"/>
+      <point x="442" y="1480" type="line"/>
+      <point x="442" y="840"/>
+      <point x="682" y="460"/>
+      <point x="682" y="460" type="curve"/>
+      <point x="979" y="1116" type="line"/>
+      <point x="1343" y="1116" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0461.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni0461.glif
@@ -1,42 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0461" format="2">
-  <advance width="1808"/>
+  <advance width="1836"/>
   <unicode hex="0461"/>
   <outline>
     <contour>
-      <point x="1084" y="1040" type="line"/>
-      <point x="724" y="1040" type="line"/>
-      <point x="724" y="468" type="line" smooth="yes"/>
-      <point x="724" y="348"/>
-      <point x="667" y="290"/>
-      <point x="577" y="290" type="curve" smooth="yes"/>
-      <point x="487" y="290"/>
-      <point x="430" y="348"/>
-      <point x="430" y="468" type="curve" smooth="yes"/>
+      <point x="1116" y="1040" type="line"/>
+      <point x="1116" y="620"/>
+      <point x="1261" y="340"/>
+      <point x="1261" y="340" type="curve"/>
+      <point x="1261" y="340"/>
+      <point x="1406" y="620"/>
+      <point x="1406" y="1040" type="curve"/>
+      <point x="1786" y="1040" type="line"/>
+      <point x="1786" y="420"/>
+      <point x="1492" y="0"/>
+      <point x="1492" y="0" type="curve"/>
+      <point x="1030" y="0" type="line"/>
+      <point x="1030" y="0"/>
+      <point x="736" y="420"/>
+      <point x="736" y="1040" type="curve"/>
+    </contour>
+    <contour>
       <point x="430" y="1040" type="line"/>
-      <point x="70" y="1040" type="line"/>
-      <point x="70" y="468" type="line" smooth="yes"/>
-      <point x="70" y="108"/>
-      <point x="301" y="-30"/>
-      <point x="577" y="-30" type="curve" smooth="yes"/>
-      <point x="702" y="-30"/>
-      <point x="818" y="-1"/>
-      <point x="907" y="63" type="curve"/>
-      <point x="998" y="-1"/>
-      <point x="1116" y="-30"/>
-      <point x="1241" y="-30" type="curve" smooth="yes"/>
-      <point x="1517" y="-30"/>
-      <point x="1738" y="108"/>
-      <point x="1738" y="468" type="curve" smooth="yes"/>
-      <point x="1738" y="1040" type="line"/>
-      <point x="1378" y="1040" type="line"/>
-      <point x="1378" y="468" type="line" smooth="yes"/>
-      <point x="1378" y="348"/>
-      <point x="1321" y="290"/>
-      <point x="1231" y="290" type="curve" smooth="yes"/>
-      <point x="1141" y="290"/>
-      <point x="1084" y="348"/>
-      <point x="1084" y="468" type="curve" smooth="yes"/>
+      <point x="430" y="620"/>
+      <point x="575" y="340"/>
+      <point x="575" y="340" type="curve"/>
+      <point x="766" y="810" type="line"/>
+      <point x="1126" y="810" type="line"/>
+      <point x="766" y="0" type="line"/>
+      <point x="344" y="0" type="line"/>
+      <point x="344" y="0"/>
+      <point x="50" y="420"/>
+      <point x="50" y="1040" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni047C_.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni047C_.glif
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047C" format="2">
-  <advance width="1870"/>
+  <advance width="2394"/>
   <unicode hex="047C"/>
-  <anchor x="935" y="0" name="bottom_center"/>
-  <anchor x="935" y="2156" name="top_center"/>
+  <anchor x="1197" y="0" name="bottom_center"/>
+  <anchor x="1197" y="2156" name="top_center"/>
   <outline>
     <component base="uniA7B6"/>
-    <component base="uni0486" xOffset="293" yOffset="340"/>
-    <component base="uni0487" xOffset="293" yOffset="780"/>
+    <component base="uni0486" xOffset="555" yOffset="340"/>
+    <component base="uni0487" xOffset="555" yOffset="780"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni047D_.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni047D_.glif
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047D" format="2">
-  <advance width="1808"/>
+  <advance width="1948"/>
   <unicode hex="047D"/>
-  <anchor x="907" y="0" name="bottom_center"/>
-  <anchor x="907" y="1816" name="top_center"/>
+  <anchor x="974" y="0" name="bottom_center"/>
+  <anchor x="974" y="1816" name="top_center"/>
   <outline>
     <component base="uniA7B7"/>
-    <component base="uni0486" xOffset="265"/>
-    <component base="uni0487" xOffset="265" yOffset="440"/>
+    <component base="uni0486" xOffset="332"/>
+    <component base="uni0487" xOffset="332" yOffset="440"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni047E_.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni047E_.glif
@@ -1,66 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047E" format="2">
-  <advance width="1870"/>
+  <advance width="2265"/>
   <unicode hex="047E"/>
   <outline>
     <contour>
-      <point x="630" y="1719" type="line"/>
-      <point x="630" y="1909" type="line"/>
-      <point x="1240" y="1909" type="line"/>
-      <point x="1240" y="1719" type="line"/>
+      <point x="1790" y="0" type="curve"/>
+      <point x="1376" y="0" type="line"/>
+      <point x="1376" y="0"/>
+      <point x="951" y="640"/>
+      <point x="951" y="1480" type="curve"/>
+      <point x="1343" y="1480" type="line"/>
+      <point x="1343" y="840"/>
+      <point x="1583" y="460"/>
+      <point x="1583" y="460" type="curve"/>
+      <point x="1583" y="460"/>
+      <point x="1823" y="840"/>
+      <point x="1823" y="1480" type="curve"/>
+      <point x="2215" y="1480" type="line"/>
+      <point x="2215" y="640"/>
+      <point x="1790" y="0"/>
     </contour>
     <contour>
-      <point x="440" y="1594" type="line"/>
-      <point x="440" y="1909" type="line"/>
-      <point x="630" y="1909" type="line"/>
-      <point x="630" y="1594" type="line"/>
+      <point x="848" y="0" type="line"/>
+      <point x="475" y="0" type="line"/>
+      <point x="475" y="0"/>
+      <point x="50" y="640"/>
+      <point x="50" y="1480" type="curve"/>
+      <point x="442" y="1480" type="line"/>
+      <point x="442" y="840"/>
+      <point x="682" y="460"/>
+      <point x="682" y="460" type="curve"/>
+      <point x="979" y="1116" type="line"/>
+      <point x="1343" y="1116" type="line"/>
     </contour>
     <contour>
-      <point x="1240" y="1594" type="line"/>
-      <point x="1240" y="1909" type="line"/>
-      <point x="1430" y="1909" type="line"/>
-      <point x="1430" y="1594" type="line"/>
+      <point x="782" y="1719" type="line"/>
+      <point x="842" y="1909" type="line"/>
+      <point x="1452" y="1909" type="line"/>
+      <point x="1512" y="1719" type="line"/>
     </contour>
     <contour>
-      <point x="840" y="1594" type="line"/>
-      <point x="840" y="1909" type="line"/>
-      <point x="1030" y="1909" type="line"/>
-      <point x="1030" y="1594" type="line"/>
+      <point x="652" y="1594" type="line"/>
+      <point x="652" y="1909" type="line"/>
+      <point x="842" y="1909" type="line"/>
+      <point x="842" y="1594" type="line"/>
     </contour>
     <contour>
-      <point x="1125" y="1480" type="line"/>
-      <point x="745" y="1480" type="line"/>
-      <point x="745" y="468" type="line" smooth="yes"/>
-      <point x="745" y="348"/>
-      <point x="688" y="296"/>
-      <point x="598" y="296" type="curve" smooth="yes"/>
-      <point x="508" y="296"/>
-      <point x="450" y="348"/>
-      <point x="450" y="468" type="curve" smooth="yes"/>
-      <point x="450" y="1480" type="line"/>
-      <point x="70" y="1480" type="line"/>
-      <point x="70" y="468" type="line" smooth="yes"/>
-      <point x="70" y="108"/>
-      <point x="322" y="-40"/>
-      <point x="598" y="-40" type="curve" smooth="yes"/>
-      <point x="722" y="-40"/>
-      <point x="841" y="-10"/>
-      <point x="935" y="56" type="curve"/>
-      <point x="1029" y="-10"/>
-      <point x="1148" y="-40"/>
-      <point x="1272" y="-40" type="curve" smooth="yes"/>
-      <point x="1548" y="-40"/>
-      <point x="1800" y="108"/>
-      <point x="1800" y="468" type="curve" smooth="yes"/>
-      <point x="1800" y="1480" type="line"/>
-      <point x="1420" y="1480" type="line"/>
-      <point x="1420" y="468" type="line" smooth="yes"/>
-      <point x="1420" y="348"/>
-      <point x="1362" y="296"/>
-      <point x="1272" y="296" type="curve" smooth="yes"/>
-      <point x="1182" y="296"/>
-      <point x="1125" y="348"/>
-      <point x="1125" y="468" type="curve" smooth="yes"/>
+      <point x="1452" y="1594" type="line"/>
+      <point x="1452" y="1909" type="line"/>
+      <point x="1642" y="1909" type="line"/>
+      <point x="1642" y="1594" type="line"/>
+    </contour>
+    <contour>
+      <point x="1052" y="1594" type="line"/>
+      <point x="1052" y="1809" type="line"/>
+      <point x="1242" y="1809" type="line"/>
+      <point x="1242" y="1594" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni047F_.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni047F_.glif
@@ -1,66 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047F" format="2">
-  <advance width="1808"/>
+  <advance width="1836"/>
   <unicode hex="047F"/>
   <outline>
     <contour>
-      <point x="599" y="1279" type="line"/>
-      <point x="599" y="1469" type="line"/>
-      <point x="1209" y="1469" type="line"/>
-      <point x="1209" y="1279" type="line"/>
+      <point x="1116" y="1040" type="line"/>
+      <point x="1116" y="620"/>
+      <point x="1261" y="340"/>
+      <point x="1261" y="340" type="curve"/>
+      <point x="1261" y="340"/>
+      <point x="1406" y="620"/>
+      <point x="1406" y="1040" type="curve"/>
+      <point x="1786" y="1040" type="line"/>
+      <point x="1786" y="420"/>
+      <point x="1492" y="0"/>
+      <point x="1492" y="0" type="curve"/>
+      <point x="1030" y="0" type="line"/>
+      <point x="1030" y="0"/>
+      <point x="736" y="420"/>
+      <point x="736" y="1040" type="curve"/>
     </contour>
     <contour>
-      <point x="409" y="1154" type="line"/>
-      <point x="409" y="1469" type="line"/>
-      <point x="599" y="1469" type="line"/>
-      <point x="599" y="1154" type="line"/>
-    </contour>
-    <contour>
-      <point x="1209" y="1154" type="line"/>
-      <point x="1209" y="1469" type="line"/>
-      <point x="1399" y="1469" type="line"/>
-      <point x="1399" y="1154" type="line"/>
-    </contour>
-    <contour>
-      <point x="809" y="1154" type="line"/>
-      <point x="809" y="1469" type="line"/>
-      <point x="999" y="1469" type="line"/>
-      <point x="999" y="1154" type="line"/>
-    </contour>
-    <contour>
-      <point x="1084" y="1040" type="line"/>
-      <point x="724" y="1040" type="line"/>
-      <point x="724" y="468" type="line" smooth="yes"/>
-      <point x="724" y="348"/>
-      <point x="667" y="290"/>
-      <point x="577" y="290" type="curve" smooth="yes"/>
-      <point x="487" y="290"/>
-      <point x="430" y="348"/>
-      <point x="430" y="468" type="curve" smooth="yes"/>
       <point x="430" y="1040" type="line"/>
-      <point x="70" y="1040" type="line"/>
-      <point x="70" y="468" type="line" smooth="yes"/>
-      <point x="70" y="108"/>
-      <point x="301" y="-30"/>
-      <point x="577" y="-30" type="curve" smooth="yes"/>
-      <point x="702" y="-30"/>
-      <point x="818" y="-1"/>
-      <point x="907" y="63" type="curve"/>
-      <point x="998" y="-1"/>
-      <point x="1116" y="-30"/>
-      <point x="1241" y="-30" type="curve" smooth="yes"/>
-      <point x="1517" y="-30"/>
-      <point x="1738" y="108"/>
-      <point x="1738" y="468" type="curve" smooth="yes"/>
-      <point x="1738" y="1040" type="line"/>
-      <point x="1378" y="1040" type="line"/>
-      <point x="1378" y="468" type="line" smooth="yes"/>
-      <point x="1378" y="348"/>
-      <point x="1321" y="290"/>
-      <point x="1231" y="290" type="curve" smooth="yes"/>
-      <point x="1141" y="290"/>
-      <point x="1084" y="348"/>
-      <point x="1084" y="468" type="curve" smooth="yes"/>
+      <point x="430" y="620"/>
+      <point x="575" y="340"/>
+      <point x="575" y="340" type="curve"/>
+      <point x="766" y="810" type="line"/>
+      <point x="1126" y="810" type="line"/>
+      <point x="766" y="0" type="line"/>
+      <point x="344" y="0" type="line"/>
+      <point x="344" y="0"/>
+      <point x="50" y="420"/>
+      <point x="50" y="1040" type="curve"/>
+    </contour>
+    <contour>
+      <point x="561" y="1290" type="line"/>
+      <point x="621" y="1480" type="line"/>
+      <point x="1231" y="1480" type="line"/>
+      <point x="1291" y="1290" type="line"/>
+    </contour>
+    <contour>
+      <point x="431" y="1165" type="line"/>
+      <point x="431" y="1480" type="line"/>
+      <point x="621" y="1480" type="line"/>
+      <point x="621" y="1165" type="line"/>
+    </contour>
+    <contour>
+      <point x="1231" y="1165" type="line"/>
+      <point x="1231" y="1480" type="line"/>
+      <point x="1421" y="1480" type="line"/>
+      <point x="1421" y="1165" type="line"/>
+    </contour>
+    <contour>
+      <point x="831" y="1165" type="line"/>
+      <point x="831" y="1380" type="line"/>
+      <point x="1021" y="1380" type="line"/>
+      <point x="1021" y="1165" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni2C_6D_.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni2C_6D_.glif
@@ -2,7 +2,7 @@
 <glyph name="uni2C6D" format="2">
   <advance width="1544"/>
   <unicode hex="2C6D"/>
-  <anchor x="745" y="1380" name="top_center"/>
+  <anchor x="765" y="1380" name="top_center"/>
   <anchor x="762" y="-23" name="bottom_center"/>
   <anchor x="762" y="-80" name="bottom_ypogegrammeni"/>
   <anchor x="-180" y="1040" name="greek_t"/>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uniA_7B_6.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uniA_7B_6.glif
@@ -1,56 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B6" format="2">
-  <advance width="1870"/>
+  <advance width="2394"/>
   <unicode hex="A7B6"/>
-  <anchor x="935" y="1380" name="top_center"/>
-  <anchor x="935" y="0" name="bottom_center"/>
+  <anchor x="1197" y="0" name="bottom_center"/>
+  <anchor x="1197" y="1380" name="top_center"/>
   <outline>
     <contour>
-      <point x="598" y="1510" type="line"/>
-      <point x="322" y="1510"/>
-      <point x="70" y="1362"/>
-      <point x="70" y="1002" type="curve" smooth="yes"/>
-      <point x="70" y="468" type="line" smooth="yes"/>
-      <point x="70" y="108"/>
-      <point x="322" y="-40"/>
-      <point x="598" y="-40" type="curve" smooth="yes"/>
-      <point x="722" y="-40"/>
-      <point x="841" y="-10"/>
-      <point x="935" y="56" type="curve"/>
-      <point x="1029" y="-10"/>
-      <point x="1148" y="-40"/>
-      <point x="1272" y="-40" type="curve" smooth="yes"/>
-      <point x="1548" y="-40"/>
-      <point x="1800" y="108"/>
-      <point x="1800" y="468" type="curve" smooth="yes"/>
-      <point x="1800" y="1002" type="line" smooth="yes"/>
-      <point x="1800" y="1362"/>
-      <point x="1548" y="1510"/>
-      <point x="1272" y="1510" type="curve"/>
-      <point x="1272" y="1174" type="line"/>
-      <point x="1362" y="1174"/>
-      <point x="1420" y="1122"/>
-      <point x="1420" y="1002" type="curve" smooth="yes"/>
-      <point x="1420" y="468" type="line" smooth="yes"/>
-      <point x="1420" y="348"/>
-      <point x="1362" y="296"/>
-      <point x="1272" y="296" type="curve" smooth="yes"/>
-      <point x="1182" y="296"/>
-      <point x="1125" y="348"/>
-      <point x="1125" y="468" type="curve" smooth="yes"/>
-      <point x="1125" y="1040" type="line"/>
-      <point x="745" y="1040" type="line"/>
-      <point x="745" y="468" type="line" smooth="yes"/>
-      <point x="745" y="348"/>
-      <point x="688" y="296"/>
-      <point x="598" y="296" type="curve" smooth="yes"/>
-      <point x="508" y="296"/>
-      <point x="450" y="348"/>
-      <point x="450" y="468" type="curve" smooth="yes"/>
-      <point x="450" y="1002" type="line" smooth="yes"/>
-      <point x="450" y="1122"/>
-      <point x="508" y="1174"/>
-      <point x="598" y="1174" type="curve"/>
+      <point x="1027" y="540" type="line"/>
+      <point x="1407" y="540" type="line"/>
+      <point x="1407" y="298" type="line"/>
+      <point x="1027" y="298" type="line"/>
+    </contour>
+    <contour>
+      <point x="1632" y="306" type="curve" smooth="yes"/>
+      <point x="1857" y="306"/>
+      <point x="1964" y="490"/>
+      <point x="1964" y="740" type="curve" smooth="yes"/>
+      <point x="1964" y="990"/>
+      <point x="1857" y="1174"/>
+      <point x="1632" y="1174" type="curve" smooth="yes"/>
+      <point x="1566" y="1174"/>
+      <point x="1511" y="1158"/>
+      <point x="1465" y="1130" type="curve"/>
+      <point x="1292" y="1427" type="line"/>
+      <point x="1391" y="1481"/>
+      <point x="1506" y="1510"/>
+      <point x="1632" y="1510" type="curve" smooth="yes"/>
+      <point x="2046" y="1510"/>
+      <point x="2344" y="1190"/>
+      <point x="2344" y="740" type="curve" smooth="yes"/>
+      <point x="2344" y="290"/>
+      <point x="2046" y="-30"/>
+      <point x="1632" y="-30" type="curve" smooth="yes"/>
+      <point x="1343" y="-30"/>
+      <point x="1111" y="125"/>
+      <point x="997" y="372" type="curve"/>
+      <point x="1335" y="520" type="line"/>
+      <point x="1383" y="390"/>
+      <point x="1481" y="306"/>
+    </contour>
+    <contour>
+      <point x="762" y="306" type="curve" smooth="yes"/>
+      <point x="905" y="306"/>
+      <point x="1002" y="380"/>
+      <point x="1052" y="500" type="curve"/>
+      <point x="1401" y="380" type="line"/>
+      <point x="1288" y="129"/>
+      <point x="1054" y="-30"/>
+      <point x="762" y="-30" type="curve" smooth="yes"/>
+      <point x="348" y="-30"/>
+      <point x="50" y="290"/>
+      <point x="50" y="740" type="curve" smooth="yes"/>
+      <point x="50" y="1190"/>
+      <point x="348" y="1510"/>
+      <point x="762" y="1510" type="curve" smooth="yes"/>
+      <point x="888" y="1510"/>
+      <point x="1003" y="1481"/>
+      <point x="1102" y="1427" type="curve"/>
+      <point x="929" y="1130" type="line"/>
+      <point x="883" y="1158"/>
+      <point x="828" y="1174"/>
+      <point x="762" y="1174" type="curve" smooth="yes"/>
+      <point x="537" y="1174"/>
+      <point x="430" y="990"/>
+      <point x="430" y="740" type="curve" smooth="yes"/>
+      <point x="430" y="490"/>
+      <point x="537" y="306"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uniA_7B_7.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uniA_7B_7.glif
@@ -35,7 +35,7 @@
       <point x="1080" y="-30"/>
       <point x="876" y="131"/>
       <point x="816" y="371" type="curve"/>
-      <point x="1158" y="520" type="line" smooth="yes"/>
+      <point x="1158" y="520" type="line"/>
       <point x="1158" y="383"/>
       <point x="1211" y="290"/>
     </contour>
@@ -43,7 +43,7 @@
       <point x="600" y="290" type="curve" smooth="yes"/>
       <point x="737" y="290"/>
       <point x="790" y="383"/>
-      <point x="790" y="520" type="curve" smooth="yes"/>
+      <point x="790" y="520" type="curve"/>
       <point x="1132" y="369" type="line"/>
       <point x="1072" y="129"/>
       <point x="867" y="-30"/>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uniA_7B_7.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uniA_7B_7.glif
@@ -1,56 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B7" format="2">
-  <advance width="1808"/>
+  <advance width="1948"/>
   <unicode hex="A7B7"/>
-  <anchor x="907" y="0" name="bottom_center"/>
-  <anchor x="907" y="1040" name="top_center"/>
+  <anchor x="974" y="0" name="bottom_center"/>
+  <anchor x="974" y="1040" name="top_center"/>
   <outline>
     <contour>
-      <point x="583" y="1070" type="line"/>
-      <point x="307" y="1070"/>
-      <point x="70" y="957"/>
-      <point x="70" y="597" type="curve" smooth="yes"/>
-      <point x="70" y="468" type="line" smooth="yes"/>
-      <point x="70" y="108"/>
-      <point x="301" y="-30"/>
-      <point x="577" y="-30" type="curve" smooth="yes"/>
-      <point x="702" y="-30"/>
-      <point x="818" y="-1"/>
-      <point x="907" y="63" type="curve"/>
-      <point x="998" y="-1"/>
-      <point x="1116" y="-30"/>
-      <point x="1241" y="-30" type="curve" smooth="yes"/>
-      <point x="1517" y="-30"/>
-      <point x="1738" y="108"/>
-      <point x="1738" y="468" type="curve" smooth="yes"/>
-      <point x="1738" y="572" type="line" smooth="yes"/>
-      <point x="1738" y="932"/>
-      <point x="1507" y="1070"/>
-      <point x="1231" y="1070" type="curve"/>
-      <point x="1231" y="750" type="line"/>
-      <point x="1321" y="750"/>
-      <point x="1378" y="692"/>
-      <point x="1378" y="572" type="curve" smooth="yes"/>
-      <point x="1378" y="468" type="line" smooth="yes"/>
-      <point x="1378" y="348"/>
-      <point x="1321" y="290"/>
-      <point x="1231" y="290" type="curve" smooth="yes"/>
-      <point x="1141" y="290"/>
-      <point x="1084" y="348"/>
-      <point x="1084" y="468" type="curve" smooth="yes"/>
-      <point x="1084" y="540" type="line"/>
-      <point x="724" y="540" type="line"/>
-      <point x="724" y="468" type="line" smooth="yes"/>
-      <point x="724" y="348"/>
-      <point x="667" y="290"/>
-      <point x="577" y="290" type="curve" smooth="yes"/>
-      <point x="487" y="290"/>
-      <point x="430" y="348"/>
-      <point x="430" y="468" type="curve" smooth="yes"/>
-      <point x="430" y="597" type="line" smooth="yes"/>
-      <point x="430" y="717"/>
-      <point x="493" y="750"/>
-      <point x="583" y="750" type="curve"/>
+      <point x="789" y="540" type="line"/>
+      <point x="1159" y="540" type="line"/>
+      <point x="1159" y="298" type="line"/>
+      <point x="789" y="298" type="line"/>
+    </contour>
+    <contour>
+      <point x="1348" y="290" type="curve" smooth="yes"/>
+      <point x="1485" y="290"/>
+      <point x="1538" y="383"/>
+      <point x="1538" y="520" type="curve" smooth="yes"/>
+      <point x="1538" y="657"/>
+      <point x="1485" y="750"/>
+      <point x="1348" y="750" type="curve" smooth="yes"/>
+      <point x="1297" y="750"/>
+      <point x="1257" y="737"/>
+      <point x="1228" y="714" type="curve"/>
+      <point x="1064" y="999" type="line"/>
+      <point x="1145" y="1046"/>
+      <point x="1242" y="1070"/>
+      <point x="1348" y="1070" type="curve" smooth="yes"/>
+      <point x="1668" y="1070"/>
+      <point x="1898" y="840"/>
+      <point x="1898" y="520" type="curve" smooth="yes"/>
+      <point x="1898" y="200"/>
+      <point x="1668" y="-30"/>
+      <point x="1348" y="-30" type="curve" smooth="yes"/>
+      <point x="1080" y="-30"/>
+      <point x="876" y="131"/>
+      <point x="816" y="371" type="curve"/>
+      <point x="1158" y="520" type="line" smooth="yes"/>
+      <point x="1158" y="383"/>
+      <point x="1211" y="290"/>
+    </contour>
+    <contour>
+      <point x="600" y="290" type="curve" smooth="yes"/>
+      <point x="737" y="290"/>
+      <point x="790" y="383"/>
+      <point x="790" y="520" type="curve" smooth="yes"/>
+      <point x="1132" y="369" type="line"/>
+      <point x="1072" y="129"/>
+      <point x="867" y="-30"/>
+      <point x="600" y="-30" type="curve" smooth="yes"/>
+      <point x="280" y="-30"/>
+      <point x="50" y="200"/>
+      <point x="50" y="520" type="curve" smooth="yes"/>
+      <point x="50" y="840"/>
+      <point x="280" y="1070"/>
+      <point x="600" y="1070" type="curve" smooth="yes"/>
+      <point x="706" y="1070"/>
+      <point x="803" y="1046"/>
+      <point x="884" y="999" type="curve"/>
+      <point x="720" y="714" type="line"/>
+      <point x="691" y="737"/>
+      <point x="651" y="750"/>
+      <point x="600" y="750" type="curve" smooth="yes"/>
+      <point x="463" y="750"/>
+      <point x="410" y="657"/>
+      <point x="410" y="520" type="curve" smooth="yes"/>
+      <point x="410" y="383"/>
+      <point x="463" y="290"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -10242,10 +10242,10 @@ lookup mark_Mark_positioning {
   pos base [\uni2C6D ] <anchor 858 1380> mark @top_center
 	<anchor 628 -23> mark @bottom_center
 	<anchor 618 -80> mark @bottom_ypogegrammeni;
-  pos base [\uniA7B6 ] <anchor 1048 1380> mark @top_center
-	<anchor 805 0> mark @bottom_center;
-  pos base [\uniA7B7 ] <anchor 777 0> mark @bottom_center
-	<anchor 960 1040> mark @top_center;
+  pos base [\uniA7B6 ] <anchor 1067 0> mark @bottom_center
+	<anchor 1310 1380> mark @top_center;
+  pos base [\uniA7B7 ] <anchor 844 0> mark @bottom_center
+	<anchor 1027 1040> mark @top_center;
   pos base [\a.sc \alphatonos.sc \alpha.sc \uni0430.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc \uni1F70.sc \uni1F71.sc ] <anchor 962 -20> mark @bottom_cedilla
 	<anchor 521 -80> mark @bottom_ypogegrammeni
 	<anchor 1163 0> mark @bottom_right

--- a/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -9427,10 +9427,10 @@ lookup mark_Mark_positioning {
 	<anchor 938 1716> mark @top_center;
   pos base [\uni0477 ] <anchor 457 0> mark @bottom_center
 	<anchor 780 1376> mark @top_center;
-  pos base [\uni047C ] <anchor 805 0> mark @bottom_center
-	<anchor 1186 2156> mark @top_center;
-  pos base [\uni047D ] <anchor 777 0> mark @bottom_center
-	<anchor 1098 1816> mark @top_center;
+  pos base [\uni047C ] <anchor 1067 0> mark @bottom_center
+	<anchor 1448 2156> mark @top_center;
+  pos base [\uni047D ] <anchor 844 0> mark @bottom_center
+	<anchor 1165 1816> mark @top_center;
   pos base [\uni04C1 ] <anchor 982 0> mark @bottom_cedilla
 	<anchor 1283 1716> mark @top_center;
   pos base [\uni04DB ] <anchor 407 0> mark @bottom_center

--- a/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/28 14:20:13</string>
+    <string>2025/04/28 15:03:21</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 17:29:32</string>
+    <string>2025/04/28 14:20:13</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0460.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0460.glif
@@ -1,51 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0460" format="2">
-  <advance width="1870"/>
+  <advance width="2265"/>
   <unicode hex="0460"/>
   <outline>
     <contour>
-      <point x="1256" y="1480" type="line"/>
-      <point x="876" y="1480" type="line"/>
-      <point x="698" y="468" type="line" smooth="yes"/>
-      <point x="677" y="348"/>
-      <point x="610" y="296"/>
-      <point x="520" y="296" type="curve" smooth="yes"/>
-      <point x="444" y="296"/>
-      <point x="398" y="333"/>
-      <point x="398" y="416" type="curve" smooth="yes"/>
-      <point x="398" y="432"/>
-      <point x="400" y="449"/>
-      <point x="403" y="468" type="curve" smooth="yes"/>
-      <point x="581" y="1480" type="line"/>
-      <point x="201" y="1480" type="line"/>
-      <point x="23" y="468" type="line" smooth="yes"/>
-      <point x="16" y="427"/>
-      <point x="12" y="388"/>
-      <point x="12" y="352" type="curve" smooth="yes"/>
-      <point x="12" y="76"/>
-      <point x="217" y="-40"/>
-      <point x="461" y="-40" type="curve" smooth="yes"/>
-      <point x="585" y="-40"/>
-      <point x="709" y="-10"/>
-      <point x="815" y="56" type="curve"/>
-      <point x="897" y="-10"/>
-      <point x="1011" y="-40"/>
-      <point x="1135" y="-40" type="curve" smooth="yes"/>
-      <point x="1411" y="-40"/>
-      <point x="1690" y="108"/>
-      <point x="1753" y="468" type="curve" smooth="yes"/>
-      <point x="1931" y="1480" type="line"/>
-      <point x="1551" y="1480" type="line"/>
-      <point x="1373" y="468" type="line" smooth="yes"/>
-      <point x="1352" y="348"/>
-      <point x="1284" y="296"/>
-      <point x="1194" y="296" type="curve" smooth="yes"/>
-      <point x="1118" y="296"/>
-      <point x="1073" y="333"/>
-      <point x="1073" y="416" type="curve" smooth="yes"/>
-      <point x="1073" y="432"/>
-      <point x="1075" y="449"/>
-      <point x="1078" y="468" type="curve" smooth="yes"/>
+      <point x="1660" y="0" type="curve"/>
+      <point x="1246" y="0" type="line"/>
+      <point x="1246" y="0"/>
+      <point x="1042" y="418"/>
+      <point x="1042" y="1022" type="curve" smooth="yes"/>
+      <point x="1042" y="1165"/>
+      <point x="1054" y="1319"/>
+      <point x="1082" y="1480" type="curve"/>
+      <point x="1474" y="1480" type="line"/>
+      <point x="1446" y="1323"/>
+      <point x="1436" y="1181"/>
+      <point x="1436" y="1057" type="curve" smooth="yes"/>
+      <point x="1436" y="676"/>
+      <point x="1534" y="460"/>
+      <point x="1534" y="460" type="curve"/>
+      <point x="1534" y="460"/>
+      <point x="1841" y="840"/>
+      <point x="1954" y="1480" type="curve"/>
+      <point x="2346" y="1480" type="line"/>
+      <point x="2198" y="640"/>
+      <point x="1660" y="0"/>
+    </contour>
+    <contour>
+      <point x="718" y="0" type="line"/>
+      <point x="345" y="0" type="line"/>
+      <point x="345" y="0"/>
+      <point x="141" y="418"/>
+      <point x="141" y="1022" type="curve" smooth="yes"/>
+      <point x="141" y="1165"/>
+      <point x="153" y="1319"/>
+      <point x="181" y="1480" type="curve"/>
+      <point x="573" y="1480" type="line"/>
+      <point x="545" y="1323"/>
+      <point x="535" y="1181"/>
+      <point x="535" y="1057" type="curve" smooth="yes"/>
+      <point x="535" y="676"/>
+      <point x="633" y="460"/>
+      <point x="633" y="460" type="curve"/>
+      <point x="1046" y="1116" type="line"/>
+      <point x="1410" y="1116" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0461.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni0461.glif
@@ -1,51 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0461" format="2">
-  <advance width="1808"/>
+  <advance width="1836"/>
   <unicode hex="0461"/>
   <outline>
     <contour>
-      <point x="1137" y="1040" type="line"/>
-      <point x="777" y="1040" type="line"/>
-      <point x="677" y="468" type="line" smooth="yes"/>
-      <point x="656" y="348"/>
-      <point x="588" y="290"/>
-      <point x="498" y="290" type="curve" smooth="yes"/>
-      <point x="423" y="290"/>
-      <point x="378" y="331"/>
-      <point x="378" y="415" type="curve" smooth="yes"/>
-      <point x="378" y="431"/>
-      <point x="380" y="449"/>
-      <point x="383" y="468" type="curve" smooth="yes"/>
+      <point x="1169" y="1040" type="line"/>
+      <point x="1148" y="923"/>
+      <point x="1141" y="816"/>
+      <point x="1141" y="724" type="curve" smooth="yes"/>
+      <point x="1141" y="485"/>
+      <point x="1191" y="340"/>
+      <point x="1191" y="340" type="curve"/>
+      <point x="1191" y="340"/>
+      <point x="1385" y="620"/>
+      <point x="1459" y="1040" type="curve"/>
+      <point x="1839" y="1040" type="line"/>
+      <point x="1730" y="420"/>
+      <point x="1362" y="0"/>
+      <point x="1362" y="0" type="curve"/>
+      <point x="900" y="0" type="line"/>
+      <point x="900" y="0"/>
+      <point x="759" y="269"/>
+      <point x="759" y="695" type="curve" smooth="yes"/>
+      <point x="759" y="801"/>
+      <point x="767" y="917"/>
+      <point x="789" y="1040" type="curve"/>
+    </contour>
+    <contour>
       <point x="483" y="1040" type="line"/>
-      <point x="123" y="1040" type="line"/>
-      <point x="23" y="468" type="line" smooth="yes"/>
-      <point x="15" y="424"/>
-      <point x="12" y="383"/>
-      <point x="12" y="345" type="curve" smooth="yes"/>
-      <point x="12" y="76"/>
-      <point x="200" y="-30"/>
-      <point x="442" y="-30" type="curve" smooth="yes"/>
-      <point x="567" y="-30"/>
-      <point x="688" y="-1"/>
-      <point x="788" y="63" type="curve"/>
-      <point x="868" y="-1"/>
-      <point x="981" y="-30"/>
-      <point x="1106" y="-30" type="curve" smooth="yes"/>
-      <point x="1382" y="-30"/>
-      <point x="1628" y="108"/>
-      <point x="1691" y="468" type="curve" smooth="yes"/>
-      <point x="1791" y="1040" type="line"/>
-      <point x="1431" y="1040" type="line"/>
-      <point x="1331" y="468" type="line" smooth="yes"/>
-      <point x="1310" y="348"/>
-      <point x="1242" y="290"/>
-      <point x="1152" y="290" type="curve" smooth="yes"/>
-      <point x="1077" y="290"/>
-      <point x="1032" y="331"/>
-      <point x="1032" y="415" type="curve" smooth="yes"/>
-      <point x="1032" y="431"/>
-      <point x="1034" y="449"/>
-      <point x="1037" y="468" type="curve" smooth="yes"/>
+      <point x="462" y="923"/>
+      <point x="455" y="816"/>
+      <point x="455" y="724" type="curve" smooth="yes"/>
+      <point x="455" y="485"/>
+      <point x="505" y="340"/>
+      <point x="505" y="340" type="curve"/>
+      <point x="779" y="810" type="line"/>
+      <point x="1139" y="810" type="line"/>
+      <point x="636" y="0" type="line"/>
+      <point x="214" y="0" type="line"/>
+      <point x="214" y="0"/>
+      <point x="73" y="269"/>
+      <point x="73" y="695" type="curve" smooth="yes"/>
+      <point x="73" y="801"/>
+      <point x="81" y="917"/>
+      <point x="103" y="1040" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni047C_.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni047C_.glif
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047C" format="2">
-  <advance width="1870"/>
+  <advance width="2394"/>
   <unicode hex="047C"/>
-  <anchor x="805" y="0" name="bottom_center"/>
-  <anchor x="1186" y="2156" name="top_center"/>
+  <anchor x="1067" y="0" name="bottom_center"/>
+  <anchor x="1448" y="2156" name="top_center"/>
   <outline>
     <component base="uniA7B6"/>
-    <component base="uni0486" xOffset="223" yOffset="340"/>
-    <component base="uni0487" xOffset="431" yOffset="780"/>
+    <component base="uni0486" xOffset="485" yOffset="340"/>
+    <component base="uni0487" xOffset="693" yOffset="780"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni047D_.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni047D_.glif
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047D" format="2">
-  <advance width="1808"/>
+  <advance width="1948"/>
   <unicode hex="047D"/>
-  <anchor x="777" y="0" name="bottom_center"/>
-  <anchor x="1098" y="1816" name="top_center"/>
+  <anchor x="844" y="0" name="bottom_center"/>
+  <anchor x="1165" y="1816" name="top_center"/>
   <outline>
     <component base="uniA7B7"/>
-    <component base="uni0486" xOffset="135"/>
-    <component base="uni0487" xOffset="343" yOffset="440"/>
+    <component base="uni0486" xOffset="202"/>
+    <component base="uni0487" xOffset="410" yOffset="440"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni047E_.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni047E_.glif
@@ -1,75 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047E" format="2">
-  <advance width="1870"/>
+  <advance width="2265"/>
   <unicode hex="047E"/>
   <outline>
     <contour>
-      <point x="783" y="1719" type="line"/>
-      <point x="837" y="1909" type="line"/>
-      <point x="1447" y="1909" type="line"/>
-      <point x="1433" y="1719" type="line"/>
+      <point x="1660" y="0" type="curve"/>
+      <point x="1246" y="0" type="line"/>
+      <point x="1246" y="0"/>
+      <point x="1042" y="418"/>
+      <point x="1042" y="1022" type="curve" smooth="yes"/>
+      <point x="1042" y="1165"/>
+      <point x="1054" y="1319"/>
+      <point x="1082" y="1480" type="curve"/>
+      <point x="1474" y="1480" type="line"/>
+      <point x="1446" y="1323"/>
+      <point x="1436" y="1181"/>
+      <point x="1436" y="1057" type="curve" smooth="yes"/>
+      <point x="1436" y="676"/>
+      <point x="1534" y="460"/>
+      <point x="1534" y="460" type="curve"/>
+      <point x="1534" y="460"/>
+      <point x="1841" y="840"/>
+      <point x="1954" y="1480" type="curve"/>
+      <point x="2346" y="1480" type="line"/>
+      <point x="2198" y="640"/>
+      <point x="1660" y="0"/>
     </contour>
     <contour>
-      <point x="591" y="1594" type="line"/>
-      <point x="647" y="1909" type="line"/>
-      <point x="837" y="1909" type="line"/>
-      <point x="781" y="1594" type="line"/>
+      <point x="718" y="0" type="line"/>
+      <point x="345" y="0" type="line"/>
+      <point x="345" y="0"/>
+      <point x="141" y="418"/>
+      <point x="141" y="1022" type="curve" smooth="yes"/>
+      <point x="141" y="1165"/>
+      <point x="153" y="1319"/>
+      <point x="181" y="1480" type="curve"/>
+      <point x="573" y="1480" type="line"/>
+      <point x="545" y="1323"/>
+      <point x="535" y="1181"/>
+      <point x="535" y="1057" type="curve" smooth="yes"/>
+      <point x="535" y="676"/>
+      <point x="633" y="460"/>
+      <point x="633" y="460" type="curve"/>
+      <point x="1046" y="1116" type="line"/>
+      <point x="1410" y="1116" type="line"/>
     </contour>
     <contour>
-      <point x="1391" y="1594" type="line"/>
-      <point x="1447" y="1909" type="line"/>
-      <point x="1637" y="1909" type="line"/>
-      <point x="1581" y="1594" type="line"/>
+      <point x="955" y="1719" type="line"/>
+      <point x="1049" y="1909" type="line"/>
+      <point x="1659" y="1909" type="line"/>
+      <point x="1685" y="1719" type="line"/>
     </contour>
     <contour>
-      <point x="991" y="1594" type="line"/>
-      <point x="1047" y="1909" type="line"/>
-      <point x="1237" y="1909" type="line"/>
-      <point x="1181" y="1594" type="line"/>
+      <point x="803" y="1594" type="line"/>
+      <point x="859" y="1909" type="line"/>
+      <point x="1049" y="1909" type="line"/>
+      <point x="993" y="1594" type="line"/>
     </contour>
     <contour>
-      <point x="1256" y="1480" type="line"/>
-      <point x="876" y="1480" type="line"/>
-      <point x="698" y="468" type="line" smooth="yes"/>
-      <point x="677" y="348"/>
-      <point x="610" y="296"/>
-      <point x="520" y="296" type="curve" smooth="yes"/>
-      <point x="444" y="296"/>
-      <point x="398" y="333"/>
-      <point x="398" y="416" type="curve" smooth="yes"/>
-      <point x="398" y="432"/>
-      <point x="400" y="449"/>
-      <point x="403" y="468" type="curve" smooth="yes"/>
-      <point x="581" y="1480" type="line"/>
-      <point x="201" y="1480" type="line"/>
-      <point x="23" y="468" type="line" smooth="yes"/>
-      <point x="16" y="427"/>
-      <point x="12" y="388"/>
-      <point x="12" y="352" type="curve" smooth="yes"/>
-      <point x="12" y="76"/>
-      <point x="217" y="-40"/>
-      <point x="461" y="-40" type="curve" smooth="yes"/>
-      <point x="585" y="-40"/>
-      <point x="709" y="-10"/>
-      <point x="815" y="56" type="curve"/>
-      <point x="897" y="-10"/>
-      <point x="1011" y="-40"/>
-      <point x="1135" y="-40" type="curve" smooth="yes"/>
-      <point x="1411" y="-40"/>
-      <point x="1690" y="108"/>
-      <point x="1753" y="468" type="curve" smooth="yes"/>
-      <point x="1931" y="1480" type="line"/>
-      <point x="1551" y="1480" type="line"/>
-      <point x="1373" y="468" type="line" smooth="yes"/>
-      <point x="1352" y="348"/>
-      <point x="1284" y="296"/>
-      <point x="1194" y="296" type="curve" smooth="yes"/>
-      <point x="1118" y="296"/>
-      <point x="1073" y="333"/>
-      <point x="1073" y="416" type="curve" smooth="yes"/>
-      <point x="1073" y="432"/>
-      <point x="1075" y="449"/>
-      <point x="1078" y="468" type="curve" smooth="yes"/>
+      <point x="1603" y="1594" type="line"/>
+      <point x="1659" y="1909" type="line"/>
+      <point x="1849" y="1909" type="line"/>
+      <point x="1793" y="1594" type="line"/>
+    </contour>
+    <contour>
+      <point x="1203" y="1594" type="line"/>
+      <point x="1241" y="1809" type="line"/>
+      <point x="1431" y="1809" type="line"/>
+      <point x="1393" y="1594" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni047F_.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni047F_.glif
@@ -1,75 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047F" format="2">
-  <advance width="1808"/>
+  <advance width="1836"/>
   <unicode hex="047F"/>
   <outline>
     <contour>
-      <point x="675" y="1279" type="line"/>
-      <point x="728" y="1469" type="line"/>
-      <point x="1338" y="1469" type="line"/>
-      <point x="1325" y="1279" type="line"/>
+      <point x="1169" y="1040" type="line"/>
+      <point x="1148" y="923"/>
+      <point x="1141" y="816"/>
+      <point x="1141" y="724" type="curve" smooth="yes"/>
+      <point x="1141" y="485"/>
+      <point x="1191" y="340"/>
+      <point x="1191" y="340" type="curve"/>
+      <point x="1191" y="340"/>
+      <point x="1385" y="620"/>
+      <point x="1459" y="1040" type="curve"/>
+      <point x="1839" y="1040" type="line"/>
+      <point x="1730" y="420"/>
+      <point x="1362" y="0"/>
+      <point x="1362" y="0" type="curve"/>
+      <point x="900" y="0" type="line"/>
+      <point x="900" y="0"/>
+      <point x="759" y="269"/>
+      <point x="759" y="695" type="curve" smooth="yes"/>
+      <point x="759" y="801"/>
+      <point x="767" y="917"/>
+      <point x="789" y="1040" type="curve"/>
     </contour>
     <contour>
-      <point x="482" y="1154" type="line"/>
-      <point x="538" y="1469" type="line"/>
-      <point x="728" y="1469" type="line"/>
-      <point x="672" y="1154" type="line"/>
-    </contour>
-    <contour>
-      <point x="1282" y="1154" type="line"/>
-      <point x="1338" y="1469" type="line"/>
-      <point x="1528" y="1469" type="line"/>
-      <point x="1472" y="1154" type="line"/>
-    </contour>
-    <contour>
-      <point x="882" y="1154" type="line"/>
-      <point x="938" y="1469" type="line"/>
-      <point x="1128" y="1469" type="line"/>
-      <point x="1072" y="1154" type="line"/>
-    </contour>
-    <contour>
-      <point x="1137" y="1040" type="line"/>
-      <point x="777" y="1040" type="line"/>
-      <point x="677" y="468" type="line" smooth="yes"/>
-      <point x="656" y="348"/>
-      <point x="588" y="290"/>
-      <point x="498" y="290" type="curve" smooth="yes"/>
-      <point x="423" y="290"/>
-      <point x="378" y="331"/>
-      <point x="378" y="415" type="curve" smooth="yes"/>
-      <point x="378" y="431"/>
-      <point x="380" y="449"/>
-      <point x="383" y="468" type="curve" smooth="yes"/>
       <point x="483" y="1040" type="line"/>
-      <point x="123" y="1040" type="line"/>
-      <point x="23" y="468" type="line" smooth="yes"/>
-      <point x="15" y="424"/>
-      <point x="12" y="383"/>
-      <point x="12" y="345" type="curve" smooth="yes"/>
-      <point x="12" y="76"/>
-      <point x="200" y="-30"/>
-      <point x="442" y="-30" type="curve" smooth="yes"/>
-      <point x="567" y="-30"/>
-      <point x="688" y="-1"/>
-      <point x="788" y="63" type="curve"/>
-      <point x="868" y="-1"/>
-      <point x="981" y="-30"/>
-      <point x="1106" y="-30" type="curve" smooth="yes"/>
-      <point x="1382" y="-30"/>
-      <point x="1628" y="108"/>
-      <point x="1691" y="468" type="curve" smooth="yes"/>
-      <point x="1791" y="1040" type="line"/>
-      <point x="1431" y="1040" type="line"/>
-      <point x="1331" y="468" type="line" smooth="yes"/>
-      <point x="1310" y="348"/>
-      <point x="1242" y="290"/>
-      <point x="1152" y="290" type="curve" smooth="yes"/>
-      <point x="1077" y="290"/>
-      <point x="1032" y="331"/>
-      <point x="1032" y="415" type="curve" smooth="yes"/>
-      <point x="1032" y="431"/>
-      <point x="1034" y="449"/>
-      <point x="1037" y="468" type="curve" smooth="yes"/>
+      <point x="462" y="923"/>
+      <point x="455" y="816"/>
+      <point x="455" y="724" type="curve" smooth="yes"/>
+      <point x="455" y="485"/>
+      <point x="505" y="340"/>
+      <point x="505" y="340" type="curve"/>
+      <point x="779" y="810" type="line"/>
+      <point x="1139" y="810" type="line"/>
+      <point x="636" y="0" type="line"/>
+      <point x="214" y="0" type="line"/>
+      <point x="214" y="0"/>
+      <point x="73" y="269"/>
+      <point x="73" y="695" type="curve" smooth="yes"/>
+      <point x="73" y="801"/>
+      <point x="81" y="917"/>
+      <point x="103" y="1040" type="curve"/>
+    </contour>
+    <contour>
+      <point x="658" y="1290" type="line"/>
+      <point x="752" y="1480" type="line"/>
+      <point x="1362" y="1480" type="line"/>
+      <point x="1388" y="1290" type="line"/>
+    </contour>
+    <contour>
+      <point x="506" y="1165" type="line"/>
+      <point x="562" y="1480" type="line"/>
+      <point x="752" y="1480" type="line"/>
+      <point x="696" y="1165" type="line"/>
+    </contour>
+    <contour>
+      <point x="1306" y="1165" type="line"/>
+      <point x="1362" y="1480" type="line"/>
+      <point x="1552" y="1480" type="line"/>
+      <point x="1496" y="1165" type="line"/>
+    </contour>
+    <contour>
+      <point x="906" y="1165" type="line"/>
+      <point x="944" y="1380" type="line"/>
+      <point x="1134" y="1380" type="line"/>
+      <point x="1096" y="1165" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uniA_7B_6.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uniA_7B_6.glif
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B6" format="2">
-  <advance width="1870"/>
+  <advance width="2394"/>
   <unicode hex="A7B6"/>
-  <anchor x="1048" y="1380" name="top_center"/>
-  <anchor x="805" y="0" name="bottom_center"/>
+  <anchor x="1067" y="0" name="bottom_center"/>
+  <anchor x="1310" y="1380" name="top_center"/>
   <outline>
     <contour>
-      <point x="734" y="1510" type="line"/>
-      <point x="458" y="1510"/>
-      <point x="180" y="1362"/>
-      <point x="117" y="1002" type="curve" smooth="yes"/>
-      <point x="23" y="468" type="line" smooth="yes"/>
-      <point x="16" y="427"/>
-      <point x="12" y="388"/>
-      <point x="12" y="352" type="curve" smooth="yes"/>
-      <point x="12" y="76"/>
-      <point x="217" y="-40"/>
-      <point x="461" y="-40" type="curve" smooth="yes"/>
-      <point x="585" y="-40"/>
-      <point x="709" y="-10"/>
-      <point x="815" y="56" type="curve"/>
-      <point x="897" y="-10"/>
-      <point x="1011" y="-40"/>
-      <point x="1135" y="-40" type="curve" smooth="yes"/>
-      <point x="1411" y="-40"/>
-      <point x="1690" y="108"/>
-      <point x="1753" y="468" type="curve" smooth="yes"/>
-      <point x="1847" y="1002" type="line" smooth="yes"/>
-      <point x="1854" y="1043"/>
-      <point x="1857" y="1082"/>
-      <point x="1857" y="1118" type="curve" smooth="yes"/>
-      <point x="1857" y="1394"/>
-      <point x="1652" y="1510"/>
-      <point x="1408" y="1510" type="curve"/>
-      <point x="1349" y="1174" type="line"/>
-      <point x="1425" y="1174"/>
-      <point x="1472" y="1137"/>
-      <point x="1472" y="1053" type="curve" smooth="yes"/>
-      <point x="1472" y="1038"/>
-      <point x="1470" y="1021"/>
-      <point x="1467" y="1002" type="curve" smooth="yes"/>
-      <point x="1373" y="468" type="line" smooth="yes"/>
-      <point x="1352" y="348"/>
-      <point x="1284" y="296"/>
-      <point x="1194" y="296" type="curve" smooth="yes"/>
-      <point x="1118" y="296"/>
-      <point x="1073" y="333"/>
-      <point x="1073" y="416" type="curve" smooth="yes"/>
-      <point x="1073" y="432"/>
-      <point x="1075" y="449"/>
-      <point x="1078" y="468" type="curve" smooth="yes"/>
-      <point x="1178" y="1040" type="line"/>
-      <point x="798" y="1040" type="line"/>
-      <point x="698" y="468" type="line" smooth="yes"/>
-      <point x="677" y="348"/>
-      <point x="610" y="296"/>
-      <point x="520" y="296" type="curve" smooth="yes"/>
-      <point x="444" y="296"/>
-      <point x="398" y="333"/>
-      <point x="398" y="417" type="curve" smooth="yes"/>
-      <point x="398" y="432"/>
-      <point x="400" y="449"/>
-      <point x="403" y="468" type="curve" smooth="yes"/>
-      <point x="497" y="1002" type="line" smooth="yes"/>
-      <point x="518" y="1122"/>
-      <point x="585" y="1174"/>
-      <point x="675" y="1174" type="curve"/>
+      <point x="992" y="540" type="line"/>
+      <point x="1372" y="540" type="line"/>
+      <point x="1330" y="298" type="line"/>
+      <point x="950" y="298" type="line"/>
+    </contour>
+    <contour>
+      <point x="2359" y="905" type="curve" smooth="yes"/>
+      <point x="2359" y="431"/>
+      <point x="2002" y="-30"/>
+      <point x="1497" y="-30" type="curve" smooth="yes"/>
+      <point x="1208" y="-30"/>
+      <point x="1003" y="125"/>
+      <point x="933" y="372" type="curve"/>
+      <point x="1297" y="520" type="line"/>
+      <point x="1322" y="390"/>
+      <point x="1405" y="306"/>
+      <point x="1556" y="306" type="curve" smooth="yes"/>
+      <point x="1874" y="306"/>
+      <point x="1977" y="665"/>
+      <point x="1977" y="869" type="curve" smooth="yes"/>
+      <point x="1977" y="1051"/>
+      <point x="1893" y="1174"/>
+      <point x="1709" y="1174" type="curve" smooth="yes"/>
+      <point x="1643" y="1174"/>
+      <point x="1585" y="1158"/>
+      <point x="1534" y="1130" type="curve"/>
+      <point x="1414" y="1427" type="line"/>
+      <point x="1523" y="1481"/>
+      <point x="1642" y="1510"/>
+      <point x="1768" y="1510" type="curve" smooth="yes"/>
+      <point x="2129" y="1510"/>
+      <point x="2359" y="1266"/>
+    </contour>
+    <contour>
+      <point x="839" y="1174" type="curve" smooth="yes"/>
+      <point x="521" y="1174"/>
+      <point x="418" y="815"/>
+      <point x="418" y="611" type="curve" smooth="yes"/>
+      <point x="418" y="429"/>
+      <point x="502" y="306"/>
+      <point x="686" y="306" type="curve" smooth="yes"/>
+      <point x="829" y="306"/>
+      <point x="939" y="380"/>
+      <point x="1010" y="500" type="curve"/>
+      <point x="1338" y="380" type="line"/>
+      <point x="1181" y="129"/>
+      <point x="919" y="-30"/>
+      <point x="627" y="-30" type="curve" smooth="yes"/>
+      <point x="266" y="-30"/>
+      <point x="35" y="214"/>
+      <point x="35" y="575" type="curve" smooth="yes"/>
+      <point x="35" y="1049"/>
+      <point x="393" y="1510"/>
+      <point x="898" y="1510" type="curve" smooth="yes"/>
+      <point x="1024" y="1510"/>
+      <point x="1135" y="1481"/>
+      <point x="1224" y="1427" type="curve"/>
+      <point x="998" y="1130" type="line"/>
+      <point x="957" y="1158"/>
+      <point x="905" y="1174"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uniA_7B_7.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uniA_7B_7.glif
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B7" format="2">
-  <advance width="1808"/>
+  <advance width="1948"/>
   <unicode hex="A7B7"/>
-  <anchor x="777" y="0" name="bottom_center"/>
-  <anchor x="960" y="1040" name="top_center"/>
+  <anchor x="844" y="0" name="bottom_center"/>
+  <anchor x="1027" y="1040" name="top_center"/>
   <outline>
     <contour>
-      <point x="642" y="1070" type="line"/>
-      <point x="366" y="1070"/>
-      <point x="108" y="957"/>
-      <point x="45" y="597" type="curve" smooth="yes"/>
-      <point x="23" y="468" type="line" smooth="yes"/>
-      <point x="15" y="424"/>
-      <point x="11" y="383"/>
-      <point x="11" y="345" type="curve" smooth="yes"/>
-      <point x="11" y="76"/>
-      <point x="200" y="-30"/>
-      <point x="442" y="-30" type="curve" smooth="yes"/>
-      <point x="567" y="-30"/>
-      <point x="688" y="-1"/>
-      <point x="788" y="63" type="curve"/>
-      <point x="868" y="-1"/>
-      <point x="981" y="-30"/>
-      <point x="1106" y="-30" type="curve" smooth="yes"/>
-      <point x="1382" y="-30"/>
-      <point x="1628" y="108"/>
-      <point x="1691" y="468" type="curve" smooth="yes"/>
-      <point x="1709" y="572" type="line" smooth="yes"/>
-      <point x="1717" y="616"/>
-      <point x="1720" y="657"/>
-      <point x="1720" y="695" type="curve" smooth="yes"/>
-      <point x="1720" y="964"/>
-      <point x="1532" y="1070"/>
-      <point x="1290" y="1070" type="curve"/>
-      <point x="1233" y="750" type="line"/>
-      <point x="1309" y="750"/>
-      <point x="1354" y="709"/>
-      <point x="1354" y="625" type="curve" smooth="yes"/>
-      <point x="1354" y="609"/>
-      <point x="1352" y="591"/>
-      <point x="1349" y="572" type="curve" smooth="yes"/>
-      <point x="1331" y="468" type="line" smooth="yes"/>
-      <point x="1310" y="348"/>
-      <point x="1242" y="290"/>
-      <point x="1152" y="290" type="curve" smooth="yes"/>
-      <point x="1076" y="290"/>
-      <point x="1031" y="331"/>
-      <point x="1031" y="415" type="curve" smooth="yes"/>
-      <point x="1031" y="431"/>
-      <point x="1034" y="449"/>
-      <point x="1037" y="468" type="curve" smooth="yes"/>
-      <point x="1049" y="540" type="line"/>
-      <point x="689" y="540" type="line"/>
-      <point x="677" y="468" type="line" smooth="yes"/>
-      <point x="656" y="348"/>
-      <point x="588" y="290"/>
-      <point x="498" y="290" type="curve" smooth="yes"/>
-      <point x="422" y="290"/>
-      <point x="377" y="331"/>
-      <point x="377" y="415" type="curve" smooth="yes"/>
-      <point x="377" y="431"/>
-      <point x="380" y="449"/>
-      <point x="383" y="468" type="curve" smooth="yes"/>
-      <point x="405" y="597" type="line" smooth="yes"/>
-      <point x="426" y="717"/>
-      <point x="495" y="750"/>
-      <point x="585" y="750" type="curve"/>
+      <point x="754" y="540" type="line"/>
+      <point x="1124" y="540" type="line"/>
+      <point x="1082" y="298" type="line"/>
+      <point x="712" y="298" type="line"/>
+    </contour>
+    <contour>
+      <point x="1870" y="629" type="curve" smooth="yes"/>
+      <point x="1870" y="290"/>
+      <point x="1596" y="-30"/>
+      <point x="1213" y="-30" type="curve" smooth="yes"/>
+      <point x="945" y="-30"/>
+      <point x="769" y="131"/>
+      <point x="751" y="371" type="curve"/>
+      <point x="1120" y="520" type="line"/>
+      <point x="1102" y="417"/>
+      <point x="1109" y="290"/>
+      <point x="1269" y="290" type="curve" smooth="yes"/>
+      <point x="1500" y="290"/>
+      <point x="1507" y="562"/>
+      <point x="1507" y="592" type="curve" smooth="yes"/>
+      <point x="1507" y="689"/>
+      <point x="1461" y="750"/>
+      <point x="1350" y="750" type="curve" smooth="yes"/>
+      <point x="1299" y="750"/>
+      <point x="1257" y="737"/>
+      <point x="1224" y="714" type="curve"/>
+      <point x="1110" y="999" type="line"/>
+      <point x="1199" y="1046"/>
+      <point x="1301" y="1070"/>
+      <point x="1407" y="1070" type="curve" smooth="yes"/>
+      <point x="1689" y="1070"/>
+      <point x="1870" y="891"/>
+    </contour>
+    <contour>
+      <point x="602" y="750" type="curve" smooth="yes"/>
+      <point x="371" y="750"/>
+      <point x="365" y="478"/>
+      <point x="365" y="448" type="curve" smooth="yes"/>
+      <point x="365" y="351"/>
+      <point x="410" y="290"/>
+      <point x="521" y="290" type="curve" smooth="yes"/>
+      <point x="658" y="290"/>
+      <point x="728" y="383"/>
+      <point x="752" y="520" type="curve"/>
+      <point x="1067" y="369" type="line"/>
+      <point x="965" y="129"/>
+      <point x="732" y="-30"/>
+      <point x="465" y="-30" type="curve" smooth="yes"/>
+      <point x="183" y="-30"/>
+      <point x="2" y="149"/>
+      <point x="2" y="411" type="curve" smooth="yes"/>
+      <point x="2" y="750"/>
+      <point x="276" y="1070"/>
+      <point x="659" y="1070" type="curve" smooth="yes"/>
+      <point x="765" y="1070"/>
+      <point x="857" y="1046"/>
+      <point x="930" y="999" type="curve"/>
+      <point x="716" y="714" type="line"/>
+      <point x="691" y="737"/>
+      <point x="653" y="750"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/features.fea
+++ b/sources/Giphurs-Italic.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -8573,7 +8573,7 @@ lookup mark_Mark_positioning {
   pos base [\h ] <anchor 343 1380> mark @top_center
 	<anchor 468 0> mark @bottom_center
 	<anchor 96 -20> mark @bottom_cedilla;
-  pos base [\m \uni026F \uni0442 \uniA7B7 \uni0442.loclBGR \uni0448.loclBGR \uni0449.loclBGR ] <anchor 889 1040> mark @top_center
+  pos base [\m \uni026F \uni0442 \uni0442.loclBGR \uni0448.loclBGR \uni0449.loclBGR ] <anchor 889 1040> mark @top_center
 	<anchor 706 0> mark @bottom_center;
   pos base [\e \uni0435 ] <anchor 651 1040> mark @top_center
 	<anchor 468 0> mark @bottom_center
@@ -10052,8 +10052,10 @@ lookup mark_Mark_positioning {
   pos base [\uni2C6D ] <anchor 631 0> mark @bottom_center
 	<anchor 874 1380> mark @top_center
 	<anchor 615 -90> mark @bottom_ypogegrammeni;
-  pos base [\uniA7B6 ] <anchor 974 1380> mark @top_center
-	<anchor 731 0> mark @bottom_center;
+  pos base [\uniA7B6 ] <anchor 1270 1380> mark @top_center
+	<anchor 1027 0> mark @bottom_center;
+  pos base [\uniA7B7 ] <anchor 795 0> mark @bottom_center
+	<anchor 978 1040> mark @top_center;
   pos base [\a.sc \alphatonos.sc \alpha.sc \uni0430.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc \uni1F70.sc \uni1F71.sc ] <anchor 890 -20> mark @bottom_cedilla
 	<anchor 677 1200> mark @top_center
 	<anchor 451 -80> mark @bottom_ypogegrammeni

--- a/sources/Giphurs-Italic.ufo/features.fea
+++ b/sources/Giphurs-Italic.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -9349,10 +9349,10 @@ lookup mark_Mark_positioning {
 	<anchor 900 1736> mark @top_center;
   pos base [\uni0477 ] <anchor 400 0> mark @bottom_center
 	<anchor 688 1376> mark @top_center;
-  pos base [\uni047C ] <anchor 731 0> mark @bottom_center
-	<anchor 1107 2126> mark @top_center;
-  pos base [\uni047D ] <anchor 706 0> mark @bottom_center
-	<anchor 1022 1786> mark @top_center;
+  pos base [\uni047C ] <anchor 1027 0> mark @bottom_center
+	<anchor 1403 2126> mark @top_center;
+  pos base [\uni047D ] <anchor 795 0> mark @bottom_center
+	<anchor 1111 1786> mark @top_center;
   pos base [\uni04C1 \uni04DC ] <anchor 838 0> mark @bottom_cedilla
 	<anchor 1139 1716> mark @top_center;
   pos base [\uni04DB ] <anchor 427 0> mark @bottom_center

--- a/sources/Giphurs-Italic.ufo/fontinfo.plist
+++ b/sources/Giphurs-Italic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/28 14:08:23</string>
+    <string>2025/04/28 15:03:05</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Italic.ufo/fontinfo.plist
+++ b/sources/Giphurs-Italic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 17:27:39</string>
+    <string>2025/04/28 14:08:23</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni0460.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni0460.glif
@@ -1,51 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0460" format="2">
-  <advance width="1721"/>
+  <advance width="2044"/>
   <unicode hex="0460"/>
   <outline>
     <contour>
-      <point x="1086" y="1480" type="line"/>
-      <point x="896" y="1480" type="line"/>
-      <point x="718" y="468" type="line" smooth="yes"/>
-      <point x="679" y="249"/>
-      <point x="606" y="158"/>
-      <point x="446" y="158" type="curve" smooth="yes"/>
-      <point x="323" y="158"/>
-      <point x="269" y="212"/>
-      <point x="269" y="337" type="curve" smooth="yes"/>
-      <point x="269" y="374"/>
-      <point x="274" y="418"/>
-      <point x="283" y="468" type="curve" smooth="yes"/>
-      <point x="461" y="1480" type="line"/>
-      <point x="271" y="1480" type="line"/>
-      <point x="93" y="468" type="line" smooth="yes"/>
-      <point x="83" y="413"/>
-      <point x="79" y="364"/>
-      <point x="79" y="319" type="curve" smooth="yes"/>
-      <point x="79" y="72"/>
-      <point x="219" y="-20"/>
-      <point x="414" y="-20" type="curve" smooth="yes"/>
-      <point x="541" y="-20"/>
-      <point x="660" y="22"/>
-      <point x="751" y="121" type="curve"/>
-      <point x="808" y="22"/>
-      <point x="912" y="-20"/>
-      <point x="1039" y="-20" type="curve" smooth="yes"/>
-      <point x="1269" y="-20"/>
-      <point x="1471" y="108"/>
-      <point x="1534" y="468" type="curve" smooth="yes"/>
-      <point x="1712" y="1480" type="line"/>
-      <point x="1522" y="1480" type="line"/>
-      <point x="1344" y="468" type="line" smooth="yes"/>
-      <point x="1305" y="249"/>
-      <point x="1231" y="158"/>
-      <point x="1071" y="158" type="curve" smooth="yes"/>
-      <point x="948" y="158"/>
-      <point x="894" y="212"/>
-      <point x="894" y="337" type="curve" smooth="yes"/>
-      <point x="894" y="374"/>
-      <point x="899" y="418"/>
-      <point x="908" y="468" type="curve" smooth="yes"/>
+      <point x="1402" y="0" type="curve"/>
+      <point x="1206" y="0" type="line"/>
+      <point x="1206" y="0"/>
+      <point x="1014" y="411"/>
+      <point x="1014" y="1007" type="curve" smooth="yes"/>
+      <point x="1014" y="1154"/>
+      <point x="1026" y="1313"/>
+      <point x="1055" y="1480" type="curve"/>
+      <point x="1251" y="1480" type="line"/>
+      <point x="1221" y="1312"/>
+      <point x="1210" y="1156"/>
+      <point x="1210" y="1014" type="curve" smooth="yes"/>
+      <point x="1210" y="531"/>
+      <point x="1343" y="220"/>
+      <point x="1343" y="220" type="curve"/>
+      <point x="1343" y="220"/>
+      <point x="1749" y="740"/>
+      <point x="1879" y="1480" type="curve"/>
+      <point x="2075" y="1480" type="line"/>
+      <point x="1927" y="640"/>
+      <point x="1402" y="0"/>
+    </contour>
+    <contour>
+      <point x="578" y="0" type="line"/>
+      <point x="382" y="0" type="line"/>
+      <point x="382" y="0"/>
+      <point x="190" y="411"/>
+      <point x="190" y="1007" type="curve" smooth="yes"/>
+      <point x="190" y="1154"/>
+      <point x="202" y="1313"/>
+      <point x="231" y="1480" type="curve"/>
+      <point x="427" y="1480" type="line"/>
+      <point x="397" y="1312"/>
+      <point x="386" y="1156"/>
+      <point x="386" y="1014" type="curve" smooth="yes"/>
+      <point x="386" y="531"/>
+      <point x="519" y="220"/>
+      <point x="519" y="220" type="curve"/>
+      <point x="1019" y="1116" type="line"/>
+      <point x="1210" y="1116" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni0461.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni0461.glif
@@ -1,51 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0461" format="2">
-  <advance width="1672"/>
+  <advance width="1632"/>
   <unicode hex="0461"/>
   <outline>
     <contour>
-      <point x="979" y="1040" type="line"/>
-      <point x="800" y="1040" type="line"/>
-      <point x="700" y="468" type="line" smooth="yes"/>
-      <point x="661" y="249"/>
-      <point x="588" y="140"/>
-      <point x="428" y="140" type="curve" smooth="yes"/>
-      <point x="307" y="140"/>
-      <point x="258" y="202"/>
-      <point x="258" y="327" type="curve" smooth="yes"/>
-      <point x="258" y="367"/>
-      <point x="263" y="414"/>
-      <point x="273" y="468" type="curve" smooth="yes"/>
-      <point x="373" y="1040" type="line"/>
-      <point x="193" y="1040" type="line"/>
-      <point x="93" y="468" type="line" smooth="yes"/>
-      <point x="83" y="409"/>
-      <point x="78" y="357"/>
-      <point x="78" y="310" type="curve" smooth="yes"/>
-      <point x="78" y="70"/>
-      <point x="207" y="-20"/>
-      <point x="399" y="-20" type="curve" smooth="yes"/>
-      <point x="526" y="-20"/>
-      <point x="639" y="19"/>
-      <point x="726" y="114" type="curve"/>
-      <point x="779" y="19"/>
-      <point x="878" y="-20"/>
-      <point x="1005" y="-20" type="curve" smooth="yes"/>
-      <point x="1235" y="-20"/>
-      <point x="1422" y="108"/>
-      <point x="1485" y="468" type="curve" smooth="yes"/>
+      <point x="958" y="1040" type="line"/>
+      <point x="938" y="928"/>
+      <point x="931" y="825"/>
+      <point x="931" y="733" type="curve" smooth="yes"/>
+      <point x="931" y="397"/>
+      <point x="1033" y="200"/>
+      <point x="1034" y="200" type="curve" smooth="yes"/>
+      <point x="1034" y="200"/>
+      <point x="1313" y="520"/>
+      <point x="1405" y="1040" type="curve"/>
       <point x="1585" y="1040" type="line"/>
-      <point x="1405" y="1040" type="line"/>
-      <point x="1305" y="468" type="line" smooth="yes"/>
-      <point x="1266" y="249"/>
-      <point x="1194" y="140"/>
-      <point x="1034" y="140" type="curve" smooth="yes"/>
-      <point x="913" y="140"/>
-      <point x="864" y="202"/>
-      <point x="864" y="327" type="curve" smooth="yes"/>
-      <point x="864" y="367"/>
-      <point x="869" y="414"/>
-      <point x="879" y="468" type="curve" smooth="yes"/>
+      <point x="1476" y="420"/>
+      <point x="1081" y="0"/>
+      <point x="1081" y="0" type="curve"/>
+      <point x="916" y="0" type="line"/>
+      <point x="916" y="0"/>
+      <point x="750" y="282"/>
+      <point x="750" y="724" type="curve" smooth="yes"/>
+      <point x="750" y="822"/>
+      <point x="758" y="928"/>
+      <point x="778" y="1040" type="curve"/>
+    </contour>
+    <contour>
+      <point x="333" y="1040" type="line"/>
+      <point x="313" y="928"/>
+      <point x="306" y="824"/>
+      <point x="306" y="732" type="curve" smooth="yes"/>
+      <point x="306" y="396"/>
+      <point x="408" y="200"/>
+      <point x="408" y="200" type="curve"/>
+      <point x="760" y="810" type="line"/>
+      <point x="932" y="810" type="line"/>
+      <point x="465" y="0" type="line"/>
+      <point x="291" y="0" type="line"/>
+      <point x="291" y="0"/>
+      <point x="125" y="282"/>
+      <point x="125" y="724" type="curve" smooth="yes"/>
+      <point x="125" y="822"/>
+      <point x="133" y="928"/>
+      <point x="153" y="1040" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni047C_.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni047C_.glif
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047C" format="2">
-  <advance width="1722"/>
+  <advance width="2314"/>
   <unicode hex="047C"/>
-  <anchor x="731" y="0" name="bottom_center"/>
-  <anchor x="1107" y="2126" name="top_center"/>
+  <anchor x="1027" y="0" name="bottom_center"/>
+  <anchor x="1403" y="2126" name="top_center"/>
   <outline>
     <component base="uniA7B6"/>
-    <component base="uni0486" xOffset="149" yOffset="340"/>
-    <component base="uni0487" xOffset="352" yOffset="750"/>
+    <component base="uni0486" xOffset="445" yOffset="340"/>
+    <component base="uni0487" xOffset="648" yOffset="750"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni047D_.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni047D_.glif
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047D" format="2">
-  <advance width="1672"/>
+  <advance width="1850"/>
   <unicode hex="047D"/>
-  <anchor x="706" y="0" name="bottom_center"/>
-  <anchor x="1022" y="1786" name="top_center"/>
+  <anchor x="795" y="0" name="bottom_center"/>
+  <anchor x="1111" y="1786" name="top_center"/>
   <outline>
     <component base="uniA7B7"/>
-    <component base="uni0486" xOffset="64"/>
-    <component base="uni0487" xOffset="267" yOffset="410"/>
+    <component base="uni0486" xOffset="153"/>
+    <component base="uni0487" xOffset="356" yOffset="410"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni047E_.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni047E_.glif
@@ -1,75 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047E" format="2">
-  <advance width="1721"/>
+  <advance width="2044"/>
   <unicode hex="047E"/>
   <outline>
     <contour>
-      <point x="714" y="1751" type="line"/>
-      <point x="756" y="1878" type="line"/>
-      <point x="1366" y="1878" type="line"/>
-      <point x="1364" y="1751" type="line"/>
+      <point x="1404" y="10" type="curve"/>
+      <point x="1208" y="10" type="line"/>
+      <point x="1208" y="10"/>
+      <point x="1016" y="421"/>
+      <point x="1016" y="1017" type="curve" smooth="yes"/>
+      <point x="1016" y="1164"/>
+      <point x="1028" y="1323"/>
+      <point x="1057" y="1490" type="curve"/>
+      <point x="1253" y="1490" type="line"/>
+      <point x="1223" y="1322"/>
+      <point x="1212" y="1166"/>
+      <point x="1212" y="1024" type="curve" smooth="yes"/>
+      <point x="1212" y="541"/>
+      <point x="1345" y="230"/>
+      <point x="1345" y="230" type="curve"/>
+      <point x="1345" y="230"/>
+      <point x="1751" y="750"/>
+      <point x="1881" y="1490" type="curve"/>
+      <point x="2077" y="1490" type="line"/>
+      <point x="1929" y="650"/>
+      <point x="1404" y="10"/>
     </contour>
     <contour>
-      <point x="572" y="1626" type="line"/>
-      <point x="616" y="1878" type="line"/>
-      <point x="756" y="1878" type="line"/>
-      <point x="712" y="1626" type="line"/>
+      <point x="580" y="10" type="line"/>
+      <point x="384" y="10" type="line"/>
+      <point x="384" y="10"/>
+      <point x="192" y="421"/>
+      <point x="192" y="1017" type="curve" smooth="yes"/>
+      <point x="192" y="1164"/>
+      <point x="204" y="1323"/>
+      <point x="233" y="1490" type="curve"/>
+      <point x="429" y="1490" type="line"/>
+      <point x="399" y="1322"/>
+      <point x="388" y="1166"/>
+      <point x="388" y="1024" type="curve" smooth="yes"/>
+      <point x="388" y="541"/>
+      <point x="521" y="230"/>
+      <point x="521" y="230" type="curve"/>
+      <point x="1021" y="1126" type="line"/>
+      <point x="1212" y="1126" type="line"/>
     </contour>
     <contour>
-      <point x="1322" y="1626" type="line"/>
-      <point x="1366" y="1878" type="line"/>
-      <point x="1506" y="1878" type="line"/>
-      <point x="1462" y="1626" type="line"/>
+      <point x="866" y="1751" type="line"/>
+      <point x="918" y="1878" type="line"/>
+      <point x="1528" y="1878" type="line"/>
+      <point x="1536" y="1751" type="line"/>
     </contour>
     <contour>
-      <point x="947" y="1626" type="line"/>
-      <point x="991" y="1878" type="line"/>
-      <point x="1131" y="1878" type="line"/>
-      <point x="1087" y="1626" type="line"/>
+      <point x="734" y="1626" type="line"/>
+      <point x="778" y="1878" type="line"/>
+      <point x="918" y="1878" type="line"/>
+      <point x="874" y="1626" type="line"/>
     </contour>
     <contour>
-      <point x="1089" y="1500" type="line"/>
-      <point x="899" y="1500" type="line"/>
-      <point x="718" y="468" type="line" smooth="yes"/>
-      <point x="679" y="249"/>
-      <point x="604" y="148"/>
-      <point x="444" y="148" type="curve" smooth="yes"/>
-      <point x="321" y="148"/>
-      <point x="269" y="207"/>
-      <point x="269" y="334" type="curve" smooth="yes"/>
-      <point x="269" y="372"/>
-      <point x="274" y="417"/>
-      <point x="283" y="468" type="curve" smooth="yes"/>
-      <point x="464" y="1500" type="line"/>
-      <point x="274" y="1500" type="line"/>
-      <point x="93" y="468" type="line" smooth="yes"/>
-      <point x="83" y="413"/>
-      <point x="79" y="363"/>
-      <point x="79" y="318" type="curve" smooth="yes"/>
-      <point x="79" y="69"/>
-      <point x="218" y="-30"/>
-      <point x="413" y="-30" type="curve" smooth="yes"/>
-      <point x="540" y="-30"/>
-      <point x="659" y="12"/>
-      <point x="750" y="111" type="curve"/>
-      <point x="807" y="12"/>
-      <point x="911" y="-30"/>
-      <point x="1038" y="-30" type="curve" smooth="yes"/>
-      <point x="1268" y="-30"/>
-      <point x="1471" y="108"/>
-      <point x="1534" y="468" type="curve" smooth="yes"/>
-      <point x="1715" y="1500" type="line"/>
-      <point x="1525" y="1500" type="line"/>
-      <point x="1344" y="468" type="line" smooth="yes"/>
-      <point x="1305" y="249"/>
-      <point x="1229" y="148"/>
-      <point x="1069" y="148" type="curve" smooth="yes"/>
-      <point x="946" y="148"/>
-      <point x="894" y="207"/>
-      <point x="894" y="334" type="curve" smooth="yes"/>
-      <point x="894" y="372"/>
-      <point x="899" y="417"/>
-      <point x="908" y="468" type="curve" smooth="yes"/>
+      <point x="1484" y="1626" type="line"/>
+      <point x="1528" y="1878" type="line"/>
+      <point x="1668" y="1878" type="line"/>
+      <point x="1624" y="1626" type="line"/>
+    </contour>
+    <contour>
+      <point x="1109" y="1626" type="line"/>
+      <point x="1143" y="1818" type="line"/>
+      <point x="1283" y="1818" type="line"/>
+      <point x="1249" y="1626" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni047F_.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni047F_.glif
@@ -1,75 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047F" format="2">
-  <advance width="1672"/>
+  <advance width="1632"/>
   <unicode hex="047F"/>
   <outline>
     <contour>
-      <point x="611" y="1311" type="line"/>
-      <point x="654" y="1438" type="line"/>
-      <point x="1264" y="1438" type="line"/>
-      <point x="1261" y="1311" type="line"/>
-    </contour>
-    <contour>
-      <point x="469" y="1186" type="line"/>
-      <point x="514" y="1438" type="line"/>
-      <point x="654" y="1438" type="line"/>
-      <point x="609" y="1186" type="line"/>
-    </contour>
-    <contour>
-      <point x="1219" y="1186" type="line"/>
-      <point x="1264" y="1438" type="line"/>
-      <point x="1404" y="1438" type="line"/>
-      <point x="1359" y="1186" type="line"/>
-    </contour>
-    <contour>
-      <point x="844" y="1186" type="line"/>
-      <point x="889" y="1438" type="line"/>
-      <point x="1029" y="1438" type="line"/>
-      <point x="984" y="1186" type="line"/>
-    </contour>
-    <contour>
-      <point x="979" y="1040" type="line"/>
-      <point x="800" y="1040" type="line"/>
-      <point x="700" y="468" type="line" smooth="yes"/>
-      <point x="661" y="249"/>
-      <point x="588" y="140"/>
-      <point x="428" y="140" type="curve" smooth="yes"/>
-      <point x="307" y="140"/>
-      <point x="258" y="202"/>
-      <point x="258" y="327" type="curve" smooth="yes"/>
-      <point x="258" y="367"/>
-      <point x="263" y="414"/>
-      <point x="273" y="468" type="curve" smooth="yes"/>
-      <point x="373" y="1040" type="line"/>
-      <point x="193" y="1040" type="line"/>
-      <point x="93" y="468" type="line" smooth="yes"/>
-      <point x="83" y="409"/>
-      <point x="78" y="357"/>
-      <point x="78" y="310" type="curve" smooth="yes"/>
-      <point x="78" y="70"/>
-      <point x="207" y="-20"/>
-      <point x="399" y="-20" type="curve" smooth="yes"/>
-      <point x="526" y="-20"/>
-      <point x="639" y="19"/>
-      <point x="726" y="114" type="curve"/>
-      <point x="779" y="19"/>
-      <point x="878" y="-20"/>
-      <point x="1005" y="-20" type="curve" smooth="yes"/>
-      <point x="1235" y="-20"/>
-      <point x="1422" y="108"/>
-      <point x="1485" y="468" type="curve" smooth="yes"/>
+      <point x="958" y="1040" type="line"/>
+      <point x="938" y="928"/>
+      <point x="931" y="825"/>
+      <point x="931" y="733" type="curve" smooth="yes"/>
+      <point x="931" y="397"/>
+      <point x="1033" y="200"/>
+      <point x="1034" y="200" type="curve" smooth="yes"/>
+      <point x="1034" y="200"/>
+      <point x="1313" y="520"/>
+      <point x="1405" y="1040" type="curve"/>
       <point x="1585" y="1040" type="line"/>
-      <point x="1405" y="1040" type="line"/>
-      <point x="1305" y="468" type="line" smooth="yes"/>
-      <point x="1266" y="249"/>
-      <point x="1194" y="140"/>
-      <point x="1034" y="140" type="curve" smooth="yes"/>
-      <point x="913" y="140"/>
-      <point x="864" y="202"/>
-      <point x="864" y="327" type="curve" smooth="yes"/>
-      <point x="864" y="367"/>
-      <point x="869" y="414"/>
-      <point x="879" y="468" type="curve" smooth="yes"/>
+      <point x="1476" y="420"/>
+      <point x="1081" y="0"/>
+      <point x="1081" y="0" type="curve"/>
+      <point x="916" y="0" type="line"/>
+      <point x="916" y="0"/>
+      <point x="750" y="282"/>
+      <point x="750" y="724" type="curve" smooth="yes"/>
+      <point x="750" y="822"/>
+      <point x="758" y="928"/>
+      <point x="778" y="1040" type="curve"/>
+    </contour>
+    <contour>
+      <point x="333" y="1040" type="line"/>
+      <point x="313" y="928"/>
+      <point x="306" y="824"/>
+      <point x="306" y="732" type="curve" smooth="yes"/>
+      <point x="306" y="396"/>
+      <point x="408" y="200"/>
+      <point x="408" y="200" type="curve"/>
+      <point x="760" y="810" type="line"/>
+      <point x="932" y="810" type="line"/>
+      <point x="465" y="0" type="line"/>
+      <point x="291" y="0" type="line"/>
+      <point x="291" y="0"/>
+      <point x="125" y="282"/>
+      <point x="125" y="724" type="curve" smooth="yes"/>
+      <point x="125" y="822"/>
+      <point x="133" y="928"/>
+      <point x="153" y="1040" type="curve"/>
+    </contour>
+    <contour>
+      <point x="581" y="1311" type="line"/>
+      <point x="634" y="1438" type="line"/>
+      <point x="1244" y="1438" type="line"/>
+      <point x="1251" y="1311" type="line"/>
+    </contour>
+    <contour>
+      <point x="449" y="1186" type="line"/>
+      <point x="494" y="1438" type="line"/>
+      <point x="634" y="1438" type="line"/>
+      <point x="589" y="1186" type="line"/>
+    </contour>
+    <contour>
+      <point x="1199" y="1186" type="line"/>
+      <point x="1244" y="1438" type="line"/>
+      <point x="1384" y="1438" type="line"/>
+      <point x="1339" y="1186" type="line"/>
+    </contour>
+    <contour>
+      <point x="824" y="1186" type="line"/>
+      <point x="858" y="1378" type="line"/>
+      <point x="998" y="1378" type="line"/>
+      <point x="964" y="1186" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uniA_7B_6.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uniA_7B_6.glif
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B6" format="2">
-  <advance width="1722"/>
+  <advance width="2314"/>
   <unicode hex="A7B6"/>
-  <anchor x="974" y="1380" name="top_center"/>
-  <anchor x="731" y="0" name="bottom_center"/>
+  <anchor x="1270" y="1380" name="top_center"/>
+  <anchor x="1027" y="0" name="bottom_center"/>
   <outline>
     <contour>
-      <point x="681" y="1500" type="line"/>
-      <point x="451" y="1500"/>
-      <point x="250" y="1362"/>
-      <point x="187" y="1002" type="curve" smooth="yes"/>
-      <point x="93" y="468" type="line" smooth="yes"/>
-      <point x="83" y="413"/>
-      <point x="79" y="363"/>
-      <point x="79" y="318" type="curve" smooth="yes"/>
-      <point x="79" y="69"/>
-      <point x="218" y="-30"/>
-      <point x="413" y="-30" type="curve" smooth="yes"/>
-      <point x="540" y="-30"/>
-      <point x="660" y="12"/>
-      <point x="751" y="111" type="curve"/>
-      <point x="808" y="12"/>
-      <point x="912" y="-30"/>
-      <point x="1039" y="-30" type="curve" smooth="yes"/>
-      <point x="1269" y="-30"/>
-      <point x="1472" y="108"/>
-      <point x="1535" y="468" type="curve" smooth="yes"/>
-      <point x="1629" y="1002" type="line" smooth="yes"/>
-      <point x="1639" y="1057"/>
-      <point x="1643" y="1107"/>
-      <point x="1643" y="1152" type="curve" smooth="yes"/>
-      <point x="1643" y="1401"/>
-      <point x="1504" y="1500"/>
-      <point x="1309" y="1500" type="curve"/>
-      <point x="1278" y="1322" type="line"/>
-      <point x="1401" y="1322"/>
-      <point x="1453" y="1263"/>
-      <point x="1453" y="1136" type="curve" smooth="yes"/>
-      <point x="1453" y="1098"/>
-      <point x="1448" y="1053"/>
-      <point x="1439" y="1002" type="curve" smooth="yes"/>
-      <point x="1345" y="468" type="line" smooth="yes"/>
-      <point x="1306" y="249"/>
-      <point x="1230" y="148"/>
-      <point x="1070" y="148" type="curve" smooth="yes"/>
-      <point x="947" y="148"/>
-      <point x="895" y="207"/>
-      <point x="895" y="334" type="curve" smooth="yes"/>
-      <point x="895" y="372"/>
-      <point x="900" y="417"/>
-      <point x="909" y="468" type="curve" smooth="yes"/>
-      <point x="1003" y="1002" type="line"/>
-      <point x="813" y="1002" type="line"/>
-      <point x="719" y="468" type="line" smooth="yes"/>
-      <point x="680" y="249"/>
-      <point x="604" y="148"/>
-      <point x="444" y="148" type="curve" smooth="yes"/>
-      <point x="321" y="148"/>
-      <point x="269" y="207"/>
-      <point x="269" y="334" type="curve" smooth="yes"/>
-      <point x="269" y="372"/>
-      <point x="274" y="417"/>
-      <point x="283" y="468" type="curve" smooth="yes"/>
-      <point x="377" y="1002" type="line" smooth="yes"/>
-      <point x="416" y="1221"/>
-      <point x="490" y="1322"/>
-      <point x="650" y="1322" type="curve"/>
+      <point x="1027" y="540" type="line"/>
+      <point x="1217" y="540" type="line"/>
+      <point x="1146" y="138" type="line"/>
+      <point x="956" y="138" type="line"/>
+    </contour>
+    <contour>
+      <point x="2230" y="914" type="curve" smooth="yes"/>
+      <point x="2230" y="453"/>
+      <point x="1906" y="-20"/>
+      <point x="1419" y="-20" type="curve" smooth="yes"/>
+      <point x="1204" y="-20"/>
+      <point x="1044" y="76"/>
+      <point x="956" y="232" type="curve"/>
+      <point x="1107" y="367" type="line"/>
+      <point x="1164" y="230"/>
+      <point x="1280" y="148"/>
+      <point x="1449" y="148" type="curve" smooth="yes"/>
+      <point x="1834" y="148"/>
+      <point x="2039" y="558"/>
+      <point x="2039" y="897" type="curve" smooth="yes"/>
+      <point x="2039" y="1160"/>
+      <point x="1902" y="1332"/>
+      <point x="1658" y="1332" type="curve" smooth="yes"/>
+      <point x="1578" y="1332"/>
+      <point x="1502" y="1312"/>
+      <point x="1434" y="1279" type="curve"/>
+      <point x="1374" y="1427" type="line"/>
+      <point x="1470" y="1474"/>
+      <point x="1575" y="1500"/>
+      <point x="1687" y="1500" type="curve" smooth="yes"/>
+      <point x="2028" y="1500"/>
+      <point x="2230" y="1261"/>
+    </contour>
+    <contour>
+      <point x="866" y="1332" type="curve" smooth="yes"/>
+      <point x="482" y="1332"/>
+      <point x="275" y="923"/>
+      <point x="275" y="583" type="curve" smooth="yes"/>
+      <point x="275" y="319"/>
+      <point x="413" y="148"/>
+      <point x="657" y="148" type="curve" smooth="yes"/>
+      <point x="827" y="148"/>
+      <point x="973" y="231"/>
+      <point x="1079" y="370" type="curve"/>
+      <point x="1178" y="230" type="line"/>
+      <point x="1034" y="73"/>
+      <point x="841" y="-20"/>
+      <point x="627" y="-20" type="curve" smooth="yes"/>
+      <point x="286" y="-20"/>
+      <point x="84" y="219"/>
+      <point x="84" y="566" type="curve" smooth="yes"/>
+      <point x="84" y="1027"/>
+      <point x="408" y="1500"/>
+      <point x="895" y="1500" type="curve" smooth="yes"/>
+      <point x="1007" y="1500"/>
+      <point x="1104" y="1474"/>
+      <point x="1184" y="1427" type="curve"/>
+      <point x="1072" y="1279" type="line"/>
+      <point x="1016" y="1312"/>
+      <point x="946" y="1332"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uniA_7B_7.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uniA_7B_7.glif
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B7" format="2">
-  <advance width="1672"/>
+  <advance width="1850"/>
   <unicode hex="A7B7"/>
-  <anchor x="706" y="0" name="bottom_center"/>
-  <anchor x="889" y="1040" name="top_center"/>
+  <anchor x="795" y="0" name="bottom_center"/>
+  <anchor x="978" y="1040" name="top_center"/>
   <outline>
     <contour>
-      <point x="590" y="1060" type="line"/>
-      <point x="360" y="1060"/>
-      <point x="174" y="932"/>
-      <point x="111" y="572" type="curve" smooth="yes"/>
-      <point x="93" y="468" type="line" smooth="yes"/>
-      <point x="83" y="409"/>
-      <point x="78" y="357"/>
-      <point x="78" y="310" type="curve" smooth="yes"/>
-      <point x="78" y="70"/>
-      <point x="207" y="-20"/>
-      <point x="399" y="-20" type="curve" smooth="yes"/>
-      <point x="526" y="-20"/>
-      <point x="639" y="19"/>
-      <point x="726" y="114" type="curve"/>
-      <point x="779" y="19"/>
-      <point x="878" y="-20"/>
-      <point x="1005" y="-20" type="curve" smooth="yes"/>
-      <point x="1235" y="-20"/>
-      <point x="1422" y="108"/>
-      <point x="1485" y="468" type="curve" smooth="yes"/>
-      <point x="1503" y="572" type="line" smooth="yes"/>
-      <point x="1513" y="631"/>
-      <point x="1518" y="683"/>
-      <point x="1518" y="730" type="curve" smooth="yes"/>
-      <point x="1518" y="971"/>
-      <point x="1389" y="1060"/>
-      <point x="1196" y="1060" type="curve"/>
-      <point x="1168" y="900" type="line"/>
-      <point x="1289" y="900"/>
-      <point x="1338" y="838"/>
-      <point x="1338" y="713" type="curve" smooth="yes"/>
-      <point x="1338" y="673"/>
-      <point x="1333" y="626"/>
-      <point x="1323" y="572" type="curve" smooth="yes"/>
-      <point x="1305" y="468" type="line"/>
-      <point x="1266" y="249"/>
-      <point x="1194" y="140"/>
-      <point x="1034" y="140" type="curve" smooth="yes"/>
-      <point x="913" y="140"/>
-      <point x="864" y="202"/>
-      <point x="864" y="327" type="curve" smooth="yes"/>
-      <point x="864" y="367"/>
-      <point x="869" y="414"/>
-      <point x="879" y="468" type="curve" smooth="yes"/>
-      <point x="897" y="572" type="line"/>
-      <point x="717" y="572" type="line"/>
-      <point x="700" y="468" type="line"/>
-      <point x="661" y="249"/>
-      <point x="588" y="140"/>
-      <point x="428" y="140" type="curve" smooth="yes"/>
-      <point x="307" y="140"/>
-      <point x="258" y="202"/>
-      <point x="258" y="327" type="curve" smooth="yes"/>
-      <point x="258" y="367"/>
-      <point x="263" y="414"/>
-      <point x="273" y="468" type="curve" smooth="yes"/>
-      <point x="291" y="572" type="line"/>
-      <point x="330" y="791"/>
-      <point x="402" y="900"/>
-      <point x="562" y="900" type="curve"/>
+      <point x="790" y="540" type="line"/>
+      <point x="980" y="540" type="line"/>
+      <point x="909" y="138" type="line"/>
+      <point x="719" y="138" type="line"/>
+    </contour>
+    <contour>
+      <point x="1722" y="631" type="curve" smooth="yes"/>
+      <point x="1722" y="293"/>
+      <point x="1452" y="-20"/>
+      <point x="1118" y="-20" type="curve" smooth="yes"/>
+      <point x="936" y="-20"/>
+      <point x="799" y="75"/>
+      <point x="739" y="227" type="curve"/>
+      <point x="897" y="339" type="line"/>
+      <point x="926" y="219"/>
+      <point x="1014" y="140"/>
+      <point x="1147" y="140" type="curve" smooth="yes"/>
+      <point x="1387" y="140"/>
+      <point x="1540" y="384"/>
+      <point x="1540" y="611" type="curve" smooth="yes"/>
+      <point x="1540" y="782"/>
+      <point x="1444" y="900"/>
+      <point x="1281" y="900" type="curve" smooth="yes"/>
+      <point x="1223" y="900"/>
+      <point x="1168" y="885"/>
+      <point x="1118" y="858" type="curve"/>
+      <point x="1061" y="999" type="line"/>
+      <point x="1138" y="1038"/>
+      <point x="1222" y="1060"/>
+      <point x="1309" y="1060" type="curve" smooth="yes"/>
+      <point x="1556" y="1060"/>
+      <point x="1722" y="885"/>
+    </contour>
+    <contour>
+      <point x="627" y="900" type="curve" smooth="yes"/>
+      <point x="387" y="900"/>
+      <point x="234" y="656"/>
+      <point x="234" y="429" type="curve" smooth="yes"/>
+      <point x="234" y="258"/>
+      <point x="330" y="140"/>
+      <point x="493" y="140" type="curve" smooth="yes"/>
+      <point x="629" y="140"/>
+      <point x="747" y="221"/>
+      <point x="817" y="348" type="curve"/>
+      <point x="931" y="226" type="line"/>
+      <point x="817" y="75"/>
+      <point x="645" y="-20"/>
+      <point x="464" y="-20" type="curve" smooth="yes"/>
+      <point x="218" y="-20"/>
+      <point x="52" y="155"/>
+      <point x="52" y="409" type="curve" smooth="yes"/>
+      <point x="52" y="746"/>
+      <point x="321" y="1060"/>
+      <point x="655" y="1060" type="curve" smooth="yes"/>
+      <point x="742" y="1060"/>
+      <point x="818" y="1038"/>
+      <point x="881" y="999" type="curve"/>
+      <point x="774" y="858" type="line"/>
+      <point x="734" y="885"/>
+      <point x="685" y="900"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/features.fea
+++ b/sources/Giphurs-Regular.ufo/features.fea
@@ -8571,7 +8571,7 @@ lookup mark_Mark_positioning {
   pos base [\h ] <anchor 230 1380> mark @top_center
 	<anchor 598 0> mark @bottom_center
 	<anchor 230 -20> mark @bottom_cedilla;
-  pos base [\m \uni026F \uniA7B7 \uni0442.loclBGR \uni0448.loclBGR \uni0449.loclBGR ] <anchor 836 1040> mark @top_center
+  pos base [\m \uni026F \uni0442.loclBGR \uni0448.loclBGR \uni0449.loclBGR ] <anchor 836 1040> mark @top_center
 	<anchor 836 0> mark @bottom_center;
   pos base [\e \uni0435 ] <anchor 598 1040> mark @top_center
 	<anchor 598 0> mark @bottom_center
@@ -9931,8 +9931,10 @@ lookup mark_Mark_positioning {
   pos base [\uni2C6D ] <anchor 761 0> mark @bottom_center
 	<anchor 761 1380> mark @top_center
 	<anchor 761 -90> mark @bottom_ypogegrammeni;
-  pos base [\uniA7B6 ] <anchor 861 1380> mark @top_center
-	<anchor 861 0> mark @bottom_center;
+  pos base [\uniA7B6 ] <anchor 1157 1380> mark @top_center
+	<anchor 1157 0> mark @bottom_center;
+  pos base [\uniA7B7 ] <anchor 925 0> mark @bottom_center
+	<anchor 925 1040> mark @top_center;
   pos base [\a.sc \alpha.sc \uni0430.sc ] <anchor 1024 -20> mark @bottom_cedilla
 	<anchor 595 1200> mark @top_center
 	<anchor 595 -80> mark @bottom_ypogegrammeni

--- a/sources/Giphurs-Regular.ufo/features.fea
+++ b/sources/Giphurs-Regular.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -9303,10 +9303,10 @@ lookup mark_Mark_positioning {
 	<anchor 723 1736> mark @top_center;
   pos base [\uni0477 ] <anchor 530 0> mark @bottom_center
 	<anchor 575 1376> mark @top_center;
-  pos base [\uni047C ] <anchor 861 0> mark @bottom_center
-	<anchor 861 2126> mark @top_center;
-  pos base [\uni047D ] <anchor 836 0> mark @bottom_center
-	<anchor 836 1786> mark @top_center;
+  pos base [\uni047C ] <anchor 1157 0> mark @bottom_center
+	<anchor 1157 2126> mark @top_center;
+  pos base [\uni047D ] <anchor 925 0> mark @bottom_center
+	<anchor 925 1786> mark @top_center;
   pos base [\uni04C1 \uni04DC ] <anchor 968 0> mark @bottom_cedilla
 	<anchor 966 1716> mark @top_center;
   pos base [\uni04DB \uni1EDB \uni1EDD \uni1EE1 ] <anchor 738 0> mark @bottom_right

--- a/sources/Giphurs-Regular.ufo/fontinfo.plist
+++ b/sources/Giphurs-Regular.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 17:04:56</string>
+    <string>2025/04/28 11:10:26</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Regular.ufo/fontinfo.plist
+++ b/sources/Giphurs-Regular.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/28 11:10:26</string>
+    <string>2025/04/28 15:02:58</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni0460.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni0460.glif
@@ -1,42 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0460" format="2">
-  <advance width="1721"/>
+  <advance width="2044"/>
   <unicode hex="0460"/>
   <outline>
     <contour>
-      <point x="955" y="1480" type="line"/>
-      <point x="765" y="1480" type="line"/>
-      <point x="765" y="468" type="line" smooth="yes"/>
-      <point x="765" y="249"/>
-      <point x="708" y="158"/>
-      <point x="548" y="158" type="curve" smooth="yes"/>
-      <point x="388" y="158"/>
-      <point x="330" y="249"/>
-      <point x="330" y="468" type="curve" smooth="yes"/>
-      <point x="330" y="1480" type="line"/>
-      <point x="140" y="1480" type="line"/>
-      <point x="140" y="468" type="line" smooth="yes"/>
-      <point x="140" y="108"/>
-      <point x="318" y="-20"/>
-      <point x="548" y="-20" type="curve" smooth="yes"/>
-      <point x="675" y="-20"/>
-      <point x="786" y="22"/>
-      <point x="860" y="121" type="curve"/>
-      <point x="934" y="22"/>
-      <point x="1046" y="-20"/>
-      <point x="1173" y="-20" type="curve" smooth="yes"/>
-      <point x="1403" y="-20"/>
-      <point x="1581" y="108"/>
-      <point x="1581" y="468" type="curve" smooth="yes"/>
-      <point x="1581" y="1480" type="line"/>
-      <point x="1391" y="1480" type="line"/>
-      <point x="1391" y="468" type="line" smooth="yes"/>
-      <point x="1391" y="249"/>
-      <point x="1333" y="158"/>
-      <point x="1173" y="158" type="curve" smooth="yes"/>
-      <point x="1013" y="158"/>
-      <point x="955" y="249"/>
-      <point x="955" y="468" type="curve" smooth="yes"/>
+      <point x="1532" y="0" type="curve"/>
+      <point x="1336" y="0" type="line"/>
+      <point x="1336" y="0"/>
+      <point x="924" y="640"/>
+      <point x="924" y="1480" type="curve"/>
+      <point x="1120" y="1480" type="line"/>
+      <point x="1120" y="740"/>
+      <point x="1434" y="220"/>
+      <point x="1434" y="220" type="curve"/>
+      <point x="1434" y="220"/>
+      <point x="1748" y="740"/>
+      <point x="1748" y="1480" type="curve"/>
+      <point x="1944" y="1480" type="line"/>
+      <point x="1944" y="640"/>
+      <point x="1532" y="0"/>
+    </contour>
+    <contour>
+      <point x="708" y="0" type="line"/>
+      <point x="512" y="0" type="line"/>
+      <point x="512" y="0"/>
+      <point x="100" y="640"/>
+      <point x="100" y="1480" type="curve"/>
+      <point x="296" y="1480" type="line"/>
+      <point x="296" y="740"/>
+      <point x="610" y="220"/>
+      <point x="610" y="220" type="curve"/>
+      <point x="952" y="1116" type="line"/>
+      <point x="1143" y="1116" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni0461.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni0461.glif
@@ -1,42 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0461" format="2">
-  <advance width="1672"/>
+  <advance width="1632"/>
   <unicode hex="0461"/>
   <outline>
     <contour>
-      <point x="926" y="1040" type="line"/>
-      <point x="747" y="1040" type="line"/>
-      <point x="747" y="468" type="line" smooth="yes"/>
-      <point x="747" y="249"/>
-      <point x="693" y="140"/>
-      <point x="533" y="140" type="curve" smooth="yes"/>
-      <point x="373" y="140"/>
-      <point x="320" y="249"/>
-      <point x="320" y="468" type="curve" smooth="yes"/>
-      <point x="320" y="1040" type="line"/>
-      <point x="140" y="1040" type="line"/>
-      <point x="140" y="468" type="line" smooth="yes"/>
-      <point x="140" y="108"/>
-      <point x="303" y="-20"/>
-      <point x="533" y="-20" type="curve" smooth="yes"/>
-      <point x="660" y="-20"/>
-      <point x="766" y="19"/>
-      <point x="836" y="114" type="curve"/>
-      <point x="906" y="19"/>
-      <point x="1012" y="-20"/>
-      <point x="1139" y="-20" type="curve" smooth="yes"/>
-      <point x="1369" y="-20"/>
-      <point x="1532" y="108"/>
-      <point x="1532" y="468" type="curve" smooth="yes"/>
+      <point x="905" y="1040" type="line"/>
+      <point x="905" y="520"/>
+      <point x="1128" y="200"/>
+      <point x="1129" y="200" type="curve"/>
+      <point x="1129" y="200"/>
+      <point x="1352" y="520"/>
+      <point x="1352" y="1040" type="curve"/>
       <point x="1532" y="1040" type="line"/>
-      <point x="1352" y="1040" type="line"/>
-      <point x="1352" y="468" type="line" smooth="yes"/>
-      <point x="1352" y="249"/>
-      <point x="1299" y="140"/>
-      <point x="1139" y="140" type="curve" smooth="yes"/>
-      <point x="979" y="140"/>
-      <point x="926" y="249"/>
-      <point x="926" y="468" type="curve" smooth="yes"/>
+      <point x="1532" y="420"/>
+      <point x="1211" y="0"/>
+      <point x="1211" y="0" type="curve"/>
+      <point x="1046" y="0" type="line"/>
+      <point x="1046" y="0"/>
+      <point x="725" y="420"/>
+      <point x="725" y="1040" type="curve"/>
+    </contour>
+    <contour>
+      <point x="280" y="1040" type="line"/>
+      <point x="280" y="520"/>
+      <point x="503" y="200"/>
+      <point x="503" y="200" type="curve"/>
+      <point x="747" y="810" type="line"/>
+      <point x="919" y="810" type="line"/>
+      <point x="595" y="0" type="line"/>
+      <point x="421" y="0" type="line"/>
+      <point x="421" y="0"/>
+      <point x="100" y="420"/>
+      <point x="100" y="1040" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni047C_.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni047C_.glif
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047C" format="2">
-  <advance width="1722"/>
+  <advance width="2314"/>
   <unicode hex="047C"/>
-  <anchor x="861" y="0" name="bottom_center"/>
-  <anchor x="861" y="2126" name="top_center"/>
+  <anchor x="1157" y="0" name="bottom_center"/>
+  <anchor x="1157" y="2126" name="top_center"/>
   <outline>
     <component base="uniA7B6"/>
-    <component base="uni0486" xOffset="219" yOffset="340"/>
-    <component base="uni0487" xOffset="219" yOffset="750"/>
+    <component base="uni0486" xOffset="515" yOffset="340"/>
+    <component base="uni0487" xOffset="515" yOffset="750"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni047D_.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni047D_.glif
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047D" format="2">
-  <advance width="1672"/>
+  <advance width="1850"/>
   <unicode hex="047D"/>
-  <anchor x="836" y="0" name="bottom_center"/>
-  <anchor x="836" y="1786" name="top_center"/>
+  <anchor x="925" y="0" name="bottom_center"/>
+  <anchor x="925" y="1786" name="top_center"/>
   <outline>
     <component base="uniA7B7"/>
-    <component base="uni0486" xOffset="194"/>
-    <component base="uni0487" xOffset="194" yOffset="410"/>
+    <component base="uni0486" xOffset="283"/>
+    <component base="uni0487" xOffset="283" yOffset="410"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni047E_.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni047E_.glif
@@ -1,66 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047E" format="2">
-  <advance width="1721"/>
+  <advance width="2044"/>
   <unicode hex="047E"/>
   <outline>
     <contour>
-      <point x="555" y="1751" type="line"/>
-      <point x="555" y="1878" type="line"/>
-      <point x="1165" y="1878" type="line"/>
-      <point x="1165" y="1751" type="line"/>
+      <point x="1532" y="10" type="curve"/>
+      <point x="1336" y="10" type="line"/>
+      <point x="1336" y="10"/>
+      <point x="924" y="650"/>
+      <point x="924" y="1490" type="curve"/>
+      <point x="1120" y="1490" type="line"/>
+      <point x="1120" y="750"/>
+      <point x="1434" y="230"/>
+      <point x="1434" y="230" type="curve"/>
+      <point x="1434" y="230"/>
+      <point x="1748" y="750"/>
+      <point x="1748" y="1490" type="curve"/>
+      <point x="1944" y="1490" type="line"/>
+      <point x="1944" y="650"/>
+      <point x="1532" y="10"/>
     </contour>
     <contour>
-      <point x="415" y="1626" type="line"/>
-      <point x="415" y="1878" type="line"/>
-      <point x="555" y="1878" type="line"/>
-      <point x="555" y="1626" type="line"/>
+      <point x="708" y="10" type="line"/>
+      <point x="512" y="10" type="line"/>
+      <point x="512" y="10"/>
+      <point x="100" y="650"/>
+      <point x="100" y="1490" type="curve"/>
+      <point x="296" y="1490" type="line"/>
+      <point x="296" y="750"/>
+      <point x="610" y="230"/>
+      <point x="610" y="230" type="curve"/>
+      <point x="952" y="1126" type="line"/>
+      <point x="1143" y="1126" type="line"/>
     </contour>
     <contour>
-      <point x="1165" y="1626" type="line"/>
-      <point x="1165" y="1878" type="line"/>
-      <point x="1305" y="1878" type="line"/>
-      <point x="1305" y="1626" type="line"/>
+      <point x="687" y="1751" type="line"/>
+      <point x="717" y="1878" type="line"/>
+      <point x="1327" y="1878" type="line"/>
+      <point x="1357" y="1751" type="line"/>
     </contour>
     <contour>
-      <point x="790" y="1626" type="line"/>
-      <point x="790" y="1878" type="line"/>
-      <point x="930" y="1878" type="line"/>
-      <point x="930" y="1626" type="line"/>
+      <point x="577" y="1626" type="line"/>
+      <point x="577" y="1878" type="line"/>
+      <point x="717" y="1878" type="line"/>
+      <point x="717" y="1626" type="line"/>
     </contour>
     <contour>
-      <point x="955" y="1500" type="line"/>
-      <point x="765" y="1500" type="line"/>
-      <point x="765" y="468" type="line" smooth="yes"/>
-      <point x="765" y="249"/>
-      <point x="708" y="148"/>
-      <point x="548" y="148" type="curve" smooth="yes"/>
-      <point x="388" y="148"/>
-      <point x="330" y="249"/>
-      <point x="330" y="468" type="curve" smooth="yes"/>
-      <point x="330" y="1500" type="line"/>
-      <point x="140" y="1500" type="line"/>
-      <point x="140" y="468" type="line" smooth="yes"/>
-      <point x="140" y="108"/>
-      <point x="318" y="-30"/>
-      <point x="548" y="-30" type="curve" smooth="yes"/>
-      <point x="675" y="-30"/>
-      <point x="786" y="12"/>
-      <point x="860" y="111" type="curve"/>
-      <point x="934" y="12"/>
-      <point x="1046" y="-30"/>
-      <point x="1173" y="-30" type="curve" smooth="yes"/>
-      <point x="1403" y="-30"/>
-      <point x="1581" y="108"/>
-      <point x="1581" y="468" type="curve" smooth="yes"/>
-      <point x="1581" y="1500" type="line"/>
-      <point x="1391" y="1500" type="line"/>
-      <point x="1391" y="468" type="line" smooth="yes"/>
-      <point x="1391" y="249"/>
-      <point x="1333" y="148"/>
-      <point x="1173" y="148" type="curve" smooth="yes"/>
-      <point x="1013" y="148"/>
-      <point x="955" y="249"/>
-      <point x="955" y="468" type="curve" smooth="yes"/>
+      <point x="1327" y="1626" type="line"/>
+      <point x="1327" y="1878" type="line"/>
+      <point x="1467" y="1878" type="line"/>
+      <point x="1467" y="1626" type="line"/>
+    </contour>
+    <contour>
+      <point x="952" y="1626" type="line"/>
+      <point x="952" y="1818" type="line"/>
+      <point x="1092" y="1818" type="line"/>
+      <point x="1092" y="1626" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni047F_.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni047F_.glif
@@ -1,66 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047F" format="2">
-  <advance width="1672"/>
+  <advance width="1632"/>
   <unicode hex="047F"/>
   <outline>
     <contour>
-      <point x="530" y="1311" type="line"/>
-      <point x="530" y="1438" type="line"/>
-      <point x="1140" y="1438" type="line"/>
-      <point x="1140" y="1311" type="line"/>
-    </contour>
-    <contour>
-      <point x="390" y="1186" type="line"/>
-      <point x="390" y="1438" type="line"/>
-      <point x="530" y="1438" type="line"/>
-      <point x="530" y="1186" type="line"/>
-    </contour>
-    <contour>
-      <point x="1140" y="1186" type="line"/>
-      <point x="1140" y="1438" type="line"/>
-      <point x="1280" y="1438" type="line"/>
-      <point x="1280" y="1186" type="line"/>
-    </contour>
-    <contour>
-      <point x="765" y="1186" type="line"/>
-      <point x="765" y="1438" type="line"/>
-      <point x="905" y="1438" type="line"/>
-      <point x="905" y="1186" type="line"/>
-    </contour>
-    <contour>
-      <point x="926" y="1040" type="line"/>
-      <point x="747" y="1040" type="line"/>
-      <point x="747" y="468" type="line" smooth="yes"/>
-      <point x="747" y="249"/>
-      <point x="693" y="140"/>
-      <point x="533" y="140" type="curve" smooth="yes"/>
-      <point x="373" y="140"/>
-      <point x="320" y="249"/>
-      <point x="320" y="468" type="curve" smooth="yes"/>
-      <point x="320" y="1040" type="line"/>
-      <point x="140" y="1040" type="line"/>
-      <point x="140" y="468" type="line" smooth="yes"/>
-      <point x="140" y="108"/>
-      <point x="303" y="-20"/>
-      <point x="533" y="-20" type="curve" smooth="yes"/>
-      <point x="660" y="-20"/>
-      <point x="766" y="19"/>
-      <point x="836" y="114" type="curve"/>
-      <point x="906" y="19"/>
-      <point x="1012" y="-20"/>
-      <point x="1139" y="-20" type="curve" smooth="yes"/>
-      <point x="1369" y="-20"/>
-      <point x="1532" y="108"/>
-      <point x="1532" y="468" type="curve" smooth="yes"/>
+      <point x="905" y="1040" type="line"/>
+      <point x="905" y="520"/>
+      <point x="1128" y="200"/>
+      <point x="1129" y="200" type="curve"/>
+      <point x="1129" y="200"/>
+      <point x="1352" y="520"/>
+      <point x="1352" y="1040" type="curve"/>
       <point x="1532" y="1040" type="line"/>
-      <point x="1352" y="1040" type="line"/>
-      <point x="1352" y="468" type="line" smooth="yes"/>
-      <point x="1352" y="249"/>
-      <point x="1299" y="140"/>
-      <point x="1139" y="140" type="curve" smooth="yes"/>
-      <point x="979" y="140"/>
-      <point x="926" y="249"/>
-      <point x="926" y="468" type="curve" smooth="yes"/>
+      <point x="1532" y="420"/>
+      <point x="1211" y="0"/>
+      <point x="1211" y="0" type="curve"/>
+      <point x="1046" y="0" type="line"/>
+      <point x="1046" y="0"/>
+      <point x="725" y="420"/>
+      <point x="725" y="1040" type="curve"/>
+    </contour>
+    <contour>
+      <point x="280" y="1040" type="line"/>
+      <point x="280" y="520"/>
+      <point x="503" y="200"/>
+      <point x="503" y="200" type="curve"/>
+      <point x="747" y="810" type="line"/>
+      <point x="919" y="810" type="line"/>
+      <point x="595" y="0" type="line"/>
+      <point x="421" y="0" type="line"/>
+      <point x="421" y="0"/>
+      <point x="100" y="420"/>
+      <point x="100" y="1040" type="curve"/>
+    </contour>
+    <contour>
+      <point x="480" y="1311" type="line"/>
+      <point x="510" y="1438" type="line"/>
+      <point x="1120" y="1438" type="line"/>
+      <point x="1150" y="1311" type="line"/>
+    </contour>
+    <contour>
+      <point x="370" y="1186" type="line"/>
+      <point x="370" y="1438" type="line"/>
+      <point x="510" y="1438" type="line"/>
+      <point x="510" y="1186" type="line"/>
+    </contour>
+    <contour>
+      <point x="1120" y="1186" type="line"/>
+      <point x="1120" y="1438" type="line"/>
+      <point x="1260" y="1438" type="line"/>
+      <point x="1260" y="1186" type="line"/>
+    </contour>
+    <contour>
+      <point x="745" y="1186" type="line"/>
+      <point x="745" y="1378" type="line"/>
+      <point x="885" y="1378" type="line"/>
+      <point x="885" y="1186" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uniA_7B_6.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uniA_7B_6.glif
@@ -1,56 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B6" format="2">
-  <advance width="1722"/>
+  <advance width="2314"/>
   <unicode hex="A7B6"/>
-  <anchor x="861" y="1380" name="top_center"/>
-  <anchor x="861" y="0" name="bottom_center"/>
+  <anchor x="1157" y="1380" name="top_center"/>
+  <anchor x="1157" y="0" name="bottom_center"/>
   <outline>
     <contour>
-      <point x="547" y="1500" type="line"/>
-      <point x="317" y="1500"/>
-      <point x="140" y="1362"/>
-      <point x="140" y="1002" type="curve" smooth="yes"/>
-      <point x="140" y="468" type="line" smooth="yes"/>
-      <point x="140" y="108"/>
-      <point x="318" y="-30"/>
-      <point x="548" y="-30" type="curve" smooth="yes"/>
-      <point x="675" y="-30"/>
-      <point x="787" y="12"/>
-      <point x="861" y="111" type="curve"/>
-      <point x="935" y="12"/>
-      <point x="1047" y="-30"/>
-      <point x="1174" y="-30" type="curve" smooth="yes"/>
-      <point x="1404" y="-30"/>
-      <point x="1582" y="108"/>
-      <point x="1582" y="468" type="curve" smooth="yes"/>
-      <point x="1582" y="1002" type="line" smooth="yes"/>
-      <point x="1582" y="1362"/>
-      <point x="1405" y="1500"/>
-      <point x="1175" y="1500" type="curve"/>
-      <point x="1175" y="1322" type="line"/>
-      <point x="1335" y="1322"/>
-      <point x="1392" y="1221"/>
-      <point x="1392" y="1002" type="curve" smooth="yes"/>
-      <point x="1392" y="468" type="line" smooth="yes"/>
-      <point x="1392" y="249"/>
-      <point x="1334" y="148"/>
-      <point x="1174" y="148" type="curve" smooth="yes"/>
-      <point x="1014" y="148"/>
-      <point x="956" y="249"/>
-      <point x="956" y="468" type="curve" smooth="yes"/>
-      <point x="956" y="1002" type="line"/>
-      <point x="766" y="1002" type="line"/>
-      <point x="766" y="468" type="line" smooth="yes"/>
-      <point x="766" y="249"/>
-      <point x="708" y="148"/>
-      <point x="548" y="148" type="curve" smooth="yes"/>
-      <point x="388" y="148"/>
-      <point x="330" y="249"/>
-      <point x="330" y="468" type="curve" smooth="yes"/>
-      <point x="330" y="1002" type="line" smooth="yes"/>
-      <point x="330" y="1221"/>
-      <point x="387" y="1322"/>
-      <point x="547" y="1322" type="curve"/>
+      <point x="1062" y="540" type="line"/>
+      <point x="1252" y="540" type="line"/>
+      <point x="1252" y="138" type="line"/>
+      <point x="1062" y="138" type="line"/>
+    </contour>
+    <contour>
+      <point x="1553" y="148" type="curve" smooth="yes"/>
+      <point x="1843" y="148"/>
+      <point x="2024" y="390"/>
+      <point x="2024" y="740" type="curve" smooth="yes"/>
+      <point x="2024" y="1090"/>
+      <point x="1843" y="1332"/>
+      <point x="1553" y="1332" type="curve" smooth="yes"/>
+      <point x="1473" y="1332"/>
+      <point x="1400" y="1312"/>
+      <point x="1338" y="1279" type="curve"/>
+      <point x="1252" y="1427" type="line"/>
+      <point x="1340" y="1474"/>
+      <point x="1441" y="1500"/>
+      <point x="1553" y="1500" type="curve" smooth="yes"/>
+      <point x="1948" y="1500"/>
+      <point x="2214" y="1179"/>
+      <point x="2214" y="740" type="curve" smooth="yes"/>
+      <point x="2214" y="301"/>
+      <point x="1948" y="-20"/>
+      <point x="1553" y="-20" type="curve" smooth="yes"/>
+      <point x="1338" y="-20"/>
+      <point x="1161" y="76"/>
+      <point x="1045" y="232" type="curve"/>
+      <point x="1172" y="367" type="line"/>
+      <point x="1253" y="230"/>
+      <point x="1384" y="148"/>
+    </contour>
+    <contour>
+      <point x="761" y="148" type="curve" smooth="yes"/>
+      <point x="931" y="148"/>
+      <point x="1063" y="231"/>
+      <point x="1144" y="370" type="curve"/>
+      <point x="1267" y="230" type="line"/>
+      <point x="1151" y="73"/>
+      <point x="975" y="-20"/>
+      <point x="761" y="-20" type="curve" smooth="yes"/>
+      <point x="366" y="-20"/>
+      <point x="100" y="301"/>
+      <point x="100" y="740" type="curve" smooth="yes"/>
+      <point x="100" y="1179"/>
+      <point x="366" y="1500"/>
+      <point x="761" y="1500" type="curve" smooth="yes"/>
+      <point x="873" y="1500"/>
+      <point x="974" y="1474"/>
+      <point x="1062" y="1427" type="curve"/>
+      <point x="976" y="1279" type="line"/>
+      <point x="914" y="1312"/>
+      <point x="841" y="1332"/>
+      <point x="761" y="1332" type="curve" smooth="yes"/>
+      <point x="471" y="1332"/>
+      <point x="290" y="1090"/>
+      <point x="290" y="740" type="curve" smooth="yes"/>
+      <point x="290" y="390"/>
+      <point x="471" y="148"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uniA_7B_7.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uniA_7B_7.glif
@@ -1,56 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B7" format="2">
-  <advance width="1672"/>
+  <advance width="1850"/>
   <unicode hex="A7B7"/>
-  <anchor x="836" y="0" name="bottom_center"/>
-  <anchor x="836" y="1040" name="top_center"/>
+  <anchor x="925" y="0" name="bottom_center"/>
+  <anchor x="925" y="1040" name="top_center"/>
   <outline>
     <contour>
-      <point x="533" y="1060" type="line"/>
-      <point x="303" y="1060"/>
-      <point x="140" y="932"/>
-      <point x="140" y="572" type="curve" smooth="yes"/>
-      <point x="140" y="468" type="line" smooth="yes"/>
-      <point x="140" y="108"/>
-      <point x="303" y="-20"/>
-      <point x="533" y="-20" type="curve" smooth="yes"/>
-      <point x="660" y="-20"/>
-      <point x="766" y="19"/>
-      <point x="836" y="114" type="curve"/>
-      <point x="906" y="19"/>
-      <point x="1012" y="-20"/>
-      <point x="1139" y="-20" type="curve" smooth="yes"/>
-      <point x="1369" y="-20"/>
-      <point x="1532" y="108"/>
-      <point x="1532" y="468" type="curve" smooth="yes"/>
-      <point x="1532" y="572" type="line" smooth="yes"/>
-      <point x="1532" y="932"/>
-      <point x="1369" y="1060"/>
-      <point x="1139" y="1060" type="curve"/>
-      <point x="1139" y="900" type="line"/>
-      <point x="1299" y="900"/>
-      <point x="1352" y="791"/>
-      <point x="1352" y="572" type="curve" smooth="yes"/>
-      <point x="1352" y="468" type="line" smooth="yes"/>
-      <point x="1352" y="249"/>
-      <point x="1299" y="140"/>
-      <point x="1139" y="140" type="curve" smooth="yes"/>
-      <point x="979" y="140"/>
-      <point x="926" y="249"/>
-      <point x="926" y="468" type="curve" smooth="yes"/>
-      <point x="926" y="572" type="line"/>
-      <point x="746" y="572" type="line"/>
-      <point x="747" y="468" type="line" smooth="yes"/>
-      <point x="747" y="249"/>
-      <point x="693" y="140"/>
-      <point x="533" y="140" type="curve" smooth="yes"/>
-      <point x="373" y="140"/>
-      <point x="320" y="249"/>
-      <point x="320" y="468" type="curve" smooth="yes"/>
-      <point x="320" y="572" type="line" smooth="yes"/>
-      <point x="320" y="791"/>
-      <point x="373" y="900"/>
-      <point x="533" y="900" type="curve"/>
+      <point x="825" y="540" type="line"/>
+      <point x="1015" y="540" type="line"/>
+      <point x="1015" y="138" type="line"/>
+      <point x="825" y="138" type="line"/>
+    </contour>
+    <contour>
+      <point x="1252" y="140" type="curve" smooth="yes"/>
+      <point x="1443" y="140"/>
+      <point x="1570" y="300"/>
+      <point x="1570" y="520" type="curve" smooth="yes"/>
+      <point x="1570" y="740"/>
+      <point x="1443" y="900"/>
+      <point x="1252" y="900" type="curve" smooth="yes"/>
+      <point x="1194" y="900"/>
+      <point x="1142" y="885"/>
+      <point x="1097" y="858" type="curve"/>
+      <point x="1015" y="999" type="line"/>
+      <point x="1085" y="1038"/>
+      <point x="1165" y="1060"/>
+      <point x="1252" y="1060" type="curve" smooth="yes"/>
+      <point x="1533" y="1060"/>
+      <point x="1750" y="832"/>
+      <point x="1750" y="520" type="curve" smooth="yes"/>
+      <point x="1750" y="208"/>
+      <point x="1533" y="-20"/>
+      <point x="1252" y="-20" type="curve" smooth="yes"/>
+      <point x="1070" y="-20"/>
+      <point x="916" y="75"/>
+      <point x="829" y="227" type="curve"/>
+      <point x="967" y="339" type="line"/>
+      <point x="1017" y="219"/>
+      <point x="1119" y="140"/>
+    </contour>
+    <contour>
+      <point x="598" y="140" type="curve" smooth="yes"/>
+      <point x="734" y="140"/>
+      <point x="838" y="221"/>
+      <point x="886" y="348" type="curve"/>
+      <point x="1021" y="226" type="line"/>
+      <point x="934" y="75"/>
+      <point x="779" y="-20"/>
+      <point x="598" y="-20" type="curve" smooth="yes"/>
+      <point x="317" y="-20"/>
+      <point x="100" y="208"/>
+      <point x="100" y="520" type="curve" smooth="yes"/>
+      <point x="100" y="832"/>
+      <point x="317" y="1060"/>
+      <point x="598" y="1060" type="curve" smooth="yes"/>
+      <point x="685" y="1060"/>
+      <point x="765" y="1038"/>
+      <point x="835" y="999" type="curve"/>
+      <point x="753" y="858" type="line"/>
+      <point x="708" y="885"/>
+      <point x="656" y="900"/>
+      <point x="598" y="900" type="curve" smooth="yes"/>
+      <point x="407" y="900"/>
+      <point x="280" y="740"/>
+      <point x="280" y="520" type="curve" smooth="yes"/>
+      <point x="280" y="300"/>
+      <point x="407" y="140"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/features.fea
+++ b/sources/Giphurs-Thin.ufo/features.fea
@@ -9278,8 +9278,8 @@ lookup mark_Mark_positioning {
 	<anchor 695 1716> mark @top_center;
   pos base [\uni0477 ] <anchor 525 0> mark @bottom_center
 	<anchor 565 1376> mark @top_center;
-  pos base [\uni047C ] <anchor 849 0> mark @bottom_center
-	<anchor 849 2112> mark @top_center;
+  pos base [\uni047C ] <anchor 1069 0> mark @bottom_center
+	<anchor 1069 2112> mark @top_center;
   pos base [\uni047D ] <anchor 866 0> mark @bottom_center
 	<anchor 866 1772> mark @top_center;
   pos base [\uni04C1 \uni04DC ] <anchor 909 0> mark @bottom_cedilla

--- a/sources/Giphurs-Thin.ufo/features.fea
+++ b/sources/Giphurs-Thin.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -8948,7 +8948,7 @@ lookup mark_Mark_positioning {
 	<anchor 411 0> mark @bottom_center
 	<anchor 435 0> mark @bottom_right
 	<anchor 410 -20> mark @bottom_cedilla;
-  pos base [\uni019C \uniA7B6 ] <anchor 849 1380> mark @top_center
+  pos base [\uni019C ] <anchor 849 1380> mark @top_center
 	<anchor 849 0> mark @bottom_center;
   pos base [\uni019D ] <anchor 768 1380> mark @top_center;
   pos base [\uni019F ] <anchor 757 1380> mark @top_center
@@ -9884,6 +9884,8 @@ lookup mark_Mark_positioning {
   pos base [\uni2C6D ] <anchor 722 -90> mark @bottom_ypogegrammeni
 	<anchor 722 1380> mark @top_center
 	<anchor 722 0> mark @bottom_center;
+  pos base [\uniA7B6 ] <anchor 1069 0> mark @bottom_center
+	<anchor 1069 1380> mark @top_center;
   pos base [\uniA7B7 ] <anchor 866 0> mark @bottom_center
 	<anchor 866 1040> mark @top_center;
   pos base [\a.sc \alpha.sc \uni0430.sc ] <anchor 1019 -20> mark @bottom_cedilla

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -1,4 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
     <key>familyName</key>
@@ -31,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/28 11:12:55</string>
+    <string>2025/04/28 14:56:46</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>
@@ -56,7 +57,7 @@
       <integer>0</integer>
     </array>
     <key>openTypeOS2Type</key>
-    <array />
+    <array/>
     <key>openTypeOS2TypoAscender</key>
     <integer>2048</integer>
     <key>openTypeOS2TypoDescender</key>
@@ -165,5 +166,5 @@
         <real>0</real>
       </dict>
     </array>
-  <key>openTypeOS2Selection</key><array><integer>7</integer></array></dict>
+  </dict>
 </plist>

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 17:20:41</string>
+    <string>2025/04/28 11:12:55</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version='1.0' encoding='UTF-8'?>
 <plist version="1.0">
   <dict>
     <key>familyName</key>
@@ -32,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/28 14:56:46</string>
+    <string>2025/04/28 15:02:51</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>
@@ -57,7 +56,7 @@
       <integer>0</integer>
     </array>
     <key>openTypeOS2Type</key>
-    <array/>
+    <array />
     <key>openTypeOS2TypoAscender</key>
     <integer>2048</integer>
     <key>openTypeOS2TypoDescender</key>
@@ -166,5 +165,5 @@
         <real>0</real>
       </dict>
     </array>
-  </dict>
+  <key>openTypeOS2Selection</key><array><integer>7</integer></array></dict>
 </plist>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni0460.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni0460.glif
@@ -1,42 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0460" format="2">
-  <advance width="1698"/>
+  <advance width="1902"/>
   <unicode hex="0460"/>
   <outline>
     <contour>
-      <point x="872" y="1480" type="line"/>
-      <point x="826" y="1480" type="line"/>
-      <point x="826" y="468" type="line" smooth="yes"/>
-      <point x="826" y="249"/>
-      <point x="746" y="32"/>
-      <point x="526" y="32" type="curve" smooth="yes"/>
-      <point x="276" y="32"/>
-      <point x="226" y="249"/>
-      <point x="226" y="468" type="curve" smooth="yes"/>
-      <point x="226" y="1480" type="line"/>
-      <point x="180" y="1480" type="line"/>
-      <point x="180" y="468" type="line" smooth="yes"/>
-      <point x="180" y="148"/>
-      <point x="288" y="-10"/>
-      <point x="516" y="-10" type="curve" smooth="yes"/>
-      <point x="688" y="-10"/>
-      <point x="803" y="79"/>
-      <point x="849" y="260" type="curve"/>
-      <point x="895" y="79"/>
-      <point x="1010" y="-10"/>
-      <point x="1182" y="-10" type="curve" smooth="yes"/>
-      <point x="1410" y="-10"/>
-      <point x="1518" y="148"/>
-      <point x="1518" y="468" type="curve" smooth="yes"/>
-      <point x="1518" y="1480" type="line"/>
-      <point x="1472" y="1480" type="line"/>
-      <point x="1472" y="468" type="line" smooth="yes"/>
-      <point x="1472" y="249"/>
-      <point x="1422" y="32"/>
-      <point x="1172" y="32" type="curve" smooth="yes"/>
-      <point x="952" y="32"/>
-      <point x="872" y="249"/>
-      <point x="872" y="468" type="curve" smooth="yes"/>
+      <point x="1359" y="0" type="curve"/>
+      <point x="1333" y="0" type="line"/>
+      <point x="1333" y="0"/>
+      <point x="930" y="680"/>
+      <point x="930" y="1480" type="curve"/>
+      <point x="979" y="1480" type="line"/>
+      <point x="979" y="740"/>
+      <point x="1346" y="80"/>
+      <point x="1346" y="80" type="curve"/>
+      <point x="1346" y="80"/>
+      <point x="1713" y="740"/>
+      <point x="1713" y="1480" type="curve"/>
+      <point x="1762" y="1480" type="line"/>
+      <point x="1762" y="680"/>
+      <point x="1359" y="0"/>
+    </contour>
+    <contour>
+      <point x="576" y="0" type="line"/>
+      <point x="543" y="0" type="line"/>
+      <point x="543" y="0"/>
+      <point x="140" y="680"/>
+      <point x="140" y="1480" type="curve"/>
+      <point x="189" y="1480" type="line"/>
+      <point x="189" y="740"/>
+      <point x="556" y="80"/>
+      <point x="556" y="80" type="curve"/>
+      <point x="955" y="1126" type="line"/>
+      <point x="1004" y="1126" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni0461.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni0461.glif
@@ -1,42 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0461" format="2">
-  <advance width="1732"/>
+  <advance width="1556"/>
   <unicode hex="0461"/>
   <outline>
     <contour>
-      <point x="888" y="1040" type="line"/>
-      <point x="844" y="1040" type="line"/>
-      <point x="844" y="468" type="line" smooth="yes"/>
-      <point x="844" y="249"/>
-      <point x="774" y="30"/>
-      <point x="534" y="30" type="curve" smooth="yes"/>
-      <point x="294" y="30"/>
-      <point x="224" y="249"/>
-      <point x="224" y="468" type="curve" smooth="yes"/>
-      <point x="224" y="1040" type="line"/>
-      <point x="180" y="1040" type="line"/>
-      <point x="180" y="468" type="line" smooth="yes"/>
-      <point x="180" y="138"/>
-      <point x="324" y="-10"/>
-      <point x="534" y="-10" type="curve" smooth="yes"/>
-      <point x="696" y="-10"/>
-      <point x="818" y="77"/>
-      <point x="866" y="268" type="curve"/>
-      <point x="914" y="77"/>
-      <point x="1036" y="-10"/>
-      <point x="1198" y="-10" type="curve" smooth="yes"/>
-      <point x="1408" y="-10"/>
-      <point x="1552" y="138"/>
-      <point x="1552" y="468" type="curve" smooth="yes"/>
-      <point x="1552" y="1040" type="line"/>
-      <point x="1508" y="1040" type="line"/>
-      <point x="1508" y="468" type="line" smooth="yes"/>
-      <point x="1508" y="249"/>
-      <point x="1438" y="30"/>
-      <point x="1198" y="30" type="curve" smooth="yes"/>
-      <point x="958" y="30"/>
-      <point x="888" y="249"/>
-      <point x="888" y="468" type="curve" smooth="yes"/>
+      <point x="802" y="1040" type="line"/>
+      <point x="802" y="520"/>
+      <point x="1085" y="89"/>
+      <point x="1085" y="89" type="curve"/>
+      <point x="1085" y="89"/>
+      <point x="1368" y="520"/>
+      <point x="1368" y="1040" type="curve"/>
+      <point x="1416" y="1040" type="line"/>
+      <point x="1416" y="500"/>
+      <point x="1094" y="0"/>
+      <point x="1094" y="0" type="curve"/>
+      <point x="1076" y="0" type="line"/>
+      <point x="1076" y="0"/>
+      <point x="754" y="500"/>
+      <point x="754" y="1040" type="curve"/>
+    </contour>
+    <contour>
+      <point x="188" y="1040" type="line"/>
+      <point x="188" y="520"/>
+      <point x="471" y="89"/>
+      <point x="471" y="89" type="curve"/>
+      <point x="772" y="810" type="line"/>
+      <point x="818" y="810" type="line"/>
+      <point x="486" y="0" type="line"/>
+      <point x="462" y="0" type="line"/>
+      <point x="462" y="0"/>
+      <point x="140" y="500"/>
+      <point x="140" y="1040" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni047C_.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni047C_.glif
@@ -2,11 +2,11 @@
 <glyph name="uni047C" format="2">
   <advance width="2138"/>
   <unicode hex="047C"/>
-  <anchor x="849" y="0" name="bottom_center"/>
-  <anchor x="849" y="2112" name="top_center"/>
+  <anchor x="1069" y="0" name="bottom_center"/>
+  <anchor x="1069" y="2112" name="top_center"/>
   <outline>
     <component base="uniA7B6"/>
-    <component base="uni0486" xOffset="207" yOffset="340"/>
-    <component base="uni0487" xOffset="207" yOffset="736"/>
+    <component base="uni0486" xOffset="427" yOffset="340"/>
+    <component base="uni0487" xOffset="427" yOffset="736"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni047C_.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni047C_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047C" format="2">
-  <advance width="1698"/>
+  <advance width="2138"/>
   <unicode hex="047C"/>
   <anchor x="849" y="0" name="bottom_center"/>
   <anchor x="849" y="2112" name="top_center"/>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni047D_.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni047D_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047D" format="2">
-  <advance width="1732"/>
+  <advance width="1728"/>
   <unicode hex="047D"/>
   <anchor x="866" y="0" name="bottom_center"/>
   <anchor x="866" y="1772" name="top_center"/>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni047E_.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni047E_.glif
@@ -1,66 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047E" format="2">
-  <advance width="1698"/>
+  <advance width="1902"/>
   <unicode hex="047E"/>
   <outline>
     <contour>
-      <point x="493" y="1842" type="line"/>
-      <point x="493" y="1878" type="line"/>
-      <point x="1205" y="1878" type="line"/>
-      <point x="1205" y="1842" type="line"/>
+      <point x="1359" y="0" type="curve"/>
+      <point x="1333" y="0" type="line"/>
+      <point x="1333" y="0"/>
+      <point x="930" y="680"/>
+      <point x="930" y="1480" type="curve"/>
+      <point x="979" y="1480" type="line"/>
+      <point x="979" y="740"/>
+      <point x="1346" y="80"/>
+      <point x="1346" y="80" type="curve"/>
+      <point x="1346" y="80"/>
+      <point x="1713" y="740"/>
+      <point x="1713" y="1480" type="curve"/>
+      <point x="1762" y="1480" type="line"/>
+      <point x="1762" y="680"/>
+      <point x="1359" y="0"/>
     </contour>
     <contour>
-      <point x="457" y="1626" type="line"/>
-      <point x="457" y="1878" type="line"/>
-      <point x="493" y="1878" type="line"/>
-      <point x="493" y="1626" type="line"/>
+      <point x="576" y="0" type="line"/>
+      <point x="543" y="0" type="line"/>
+      <point x="543" y="0"/>
+      <point x="140" y="680"/>
+      <point x="140" y="1480" type="curve"/>
+      <point x="189" y="1480" type="line"/>
+      <point x="189" y="740"/>
+      <point x="556" y="80"/>
+      <point x="556" y="80" type="curve"/>
+      <point x="955" y="1126" type="line"/>
+      <point x="1004" y="1126" type="line"/>
     </contour>
     <contour>
-      <point x="1205" y="1626" type="line"/>
-      <point x="1205" y="1878" type="line"/>
-      <point x="1241" y="1878" type="line"/>
-      <point x="1241" y="1626" type="line"/>
+      <point x="580" y="1842" type="line"/>
+      <point x="600" y="1878" type="line"/>
+      <point x="1312" y="1878" type="line"/>
+      <point x="1332" y="1842" type="line"/>
     </contour>
     <contour>
-      <point x="831" y="1626" type="line"/>
-      <point x="831" y="1878" type="line"/>
-      <point x="867" y="1878" type="line"/>
-      <point x="867" y="1626" type="line"/>
+      <point x="564" y="1626" type="line"/>
+      <point x="564" y="1878" type="line"/>
+      <point x="600" y="1878" type="line"/>
+      <point x="600" y="1626" type="line"/>
     </contour>
     <contour>
-      <point x="872" y="1480" type="line"/>
-      <point x="826" y="1480" type="line"/>
-      <point x="826" y="468" type="line" smooth="yes"/>
-      <point x="826" y="249"/>
-      <point x="746" y="32"/>
-      <point x="526" y="32" type="curve" smooth="yes"/>
-      <point x="276" y="32"/>
-      <point x="226" y="249"/>
-      <point x="226" y="468" type="curve" smooth="yes"/>
-      <point x="226" y="1480" type="line"/>
-      <point x="180" y="1480" type="line"/>
-      <point x="180" y="468" type="line" smooth="yes"/>
-      <point x="180" y="148"/>
-      <point x="288" y="-10"/>
-      <point x="516" y="-10" type="curve" smooth="yes"/>
-      <point x="688" y="-10"/>
-      <point x="803" y="79"/>
-      <point x="849" y="260" type="curve"/>
-      <point x="895" y="79"/>
-      <point x="1010" y="-10"/>
-      <point x="1182" y="-10" type="curve" smooth="yes"/>
-      <point x="1410" y="-10"/>
-      <point x="1518" y="148"/>
-      <point x="1518" y="468" type="curve" smooth="yes"/>
-      <point x="1518" y="1480" type="line"/>
-      <point x="1472" y="1480" type="line"/>
-      <point x="1472" y="468" type="line" smooth="yes"/>
-      <point x="1472" y="249"/>
-      <point x="1422" y="32"/>
-      <point x="1172" y="32" type="curve" smooth="yes"/>
-      <point x="952" y="32"/>
-      <point x="872" y="249"/>
-      <point x="872" y="468" type="curve" smooth="yes"/>
+      <point x="1312" y="1626" type="line"/>
+      <point x="1312" y="1878" type="line"/>
+      <point x="1348" y="1878" type="line"/>
+      <point x="1348" y="1626" type="line"/>
+    </contour>
+    <contour>
+      <point x="938" y="1626" type="line"/>
+      <point x="938" y="1878" type="line"/>
+      <point x="974" y="1878" type="line"/>
+      <point x="974" y="1626" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni047F_.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni047F_.glif
@@ -1,66 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047F" format="2">
-  <advance width="1732"/>
+  <advance width="1556"/>
   <unicode hex="047F"/>
   <outline>
     <contour>
-      <point x="510" y="1402" type="line"/>
-      <point x="510" y="1438" type="line"/>
-      <point x="1222" y="1438" type="line"/>
-      <point x="1222" y="1402" type="line"/>
+      <point x="802" y="1040" type="line"/>
+      <point x="802" y="520"/>
+      <point x="1085" y="89"/>
+      <point x="1085" y="89" type="curve"/>
+      <point x="1085" y="89"/>
+      <point x="1368" y="520"/>
+      <point x="1368" y="1040" type="curve"/>
+      <point x="1416" y="1040" type="line"/>
+      <point x="1416" y="500"/>
+      <point x="1094" y="0"/>
+      <point x="1094" y="0" type="curve"/>
+      <point x="1076" y="0" type="line"/>
+      <point x="1076" y="0"/>
+      <point x="754" y="500"/>
+      <point x="754" y="1040" type="curve"/>
     </contour>
     <contour>
-      <point x="474" y="1186" type="line"/>
-      <point x="474" y="1438" type="line"/>
-      <point x="510" y="1438" type="line"/>
-      <point x="510" y="1186" type="line"/>
+      <point x="188" y="1040" type="line"/>
+      <point x="188" y="520"/>
+      <point x="471" y="89"/>
+      <point x="471" y="89" type="curve"/>
+      <point x="772" y="810" type="line"/>
+      <point x="818" y="810" type="line"/>
+      <point x="486" y="0" type="line"/>
+      <point x="462" y="0" type="line"/>
+      <point x="462" y="0"/>
+      <point x="140" y="500"/>
+      <point x="140" y="1040" type="curve"/>
     </contour>
     <contour>
-      <point x="1222" y="1186" type="line"/>
-      <point x="1222" y="1438" type="line"/>
-      <point x="1258" y="1438" type="line"/>
-      <point x="1258" y="1186" type="line"/>
+      <point x="404" y="1444" type="line"/>
+      <point x="424" y="1480" type="line"/>
+      <point x="1136" y="1480" type="line"/>
+      <point x="1156" y="1444" type="line"/>
     </contour>
     <contour>
-      <point x="848" y="1186" type="line"/>
-      <point x="848" y="1418" type="line"/>
-      <point x="884" y="1418" type="line"/>
-      <point x="884" y="1186" type="line"/>
+      <point x="388" y="1228" type="line"/>
+      <point x="388" y="1480" type="line"/>
+      <point x="424" y="1480" type="line"/>
+      <point x="424" y="1228" type="line"/>
     </contour>
     <contour>
-      <point x="888" y="1040" type="line"/>
-      <point x="844" y="1040" type="line"/>
-      <point x="844" y="468" type="line" smooth="yes"/>
-      <point x="844" y="249"/>
-      <point x="774" y="30"/>
-      <point x="534" y="30" type="curve" smooth="yes"/>
-      <point x="294" y="30"/>
-      <point x="224" y="249"/>
-      <point x="224" y="468" type="curve" smooth="yes"/>
-      <point x="224" y="1040" type="line"/>
-      <point x="180" y="1040" type="line"/>
-      <point x="180" y="468" type="line" smooth="yes"/>
-      <point x="180" y="138"/>
-      <point x="324" y="-10"/>
-      <point x="534" y="-10" type="curve" smooth="yes"/>
-      <point x="696" y="-10"/>
-      <point x="818" y="77"/>
-      <point x="866" y="268" type="curve"/>
-      <point x="914" y="77"/>
-      <point x="1036" y="-10"/>
-      <point x="1198" y="-10" type="curve" smooth="yes"/>
-      <point x="1408" y="-10"/>
-      <point x="1552" y="138"/>
-      <point x="1552" y="468" type="curve" smooth="yes"/>
-      <point x="1552" y="1040" type="line"/>
-      <point x="1508" y="1040" type="line"/>
-      <point x="1508" y="468" type="line" smooth="yes"/>
-      <point x="1508" y="249"/>
-      <point x="1438" y="30"/>
-      <point x="1198" y="30" type="curve" smooth="yes"/>
-      <point x="958" y="30"/>
-      <point x="888" y="249"/>
-      <point x="888" y="468" type="curve" smooth="yes"/>
+      <point x="1136" y="1228" type="line"/>
+      <point x="1136" y="1480" type="line"/>
+      <point x="1172" y="1480" type="line"/>
+      <point x="1172" y="1228" type="line"/>
+    </contour>
+    <contour>
+      <point x="762" y="1228" type="line"/>
+      <point x="762" y="1460" type="line"/>
+      <point x="798" y="1460" type="line"/>
+      <point x="798" y="1228" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uniA_7B_6.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uniA_7B_6.glif
@@ -2,8 +2,8 @@
 <glyph name="uniA7B6" format="2">
   <advance width="2138"/>
   <unicode hex="A7B6"/>
-  <anchor x="849" y="0" name="bottom_center"/>
-  <anchor x="849" y="1380" name="top_center"/>
+  <anchor x="1069" y="0" name="bottom_center"/>
+  <anchor x="1069" y="1380" name="top_center"/>
   <outline>
     <contour>
       <point x="1046" y="540" type="line"/>

--- a/sources/Giphurs-Thin.ufo/glyphs/uniA_7B_6.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uniA_7B_6.glif
@@ -1,56 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B6" format="2">
-  <advance width="1698"/>
+  <advance width="2138"/>
   <unicode hex="A7B6"/>
   <anchor x="849" y="0" name="bottom_center"/>
   <anchor x="849" y="1380" name="top_center"/>
   <outline>
     <contour>
-      <point x="526" y="1490" type="line"/>
-      <point x="288" y="1490"/>
-      <point x="180" y="1332"/>
-      <point x="180" y="1012" type="curve" smooth="yes"/>
-      <point x="180" y="468" type="line" smooth="yes"/>
-      <point x="180" y="148"/>
-      <point x="288" y="-10"/>
-      <point x="516" y="-10" type="curve" smooth="yes"/>
-      <point x="688" y="-10"/>
-      <point x="803" y="79"/>
-      <point x="849" y="260" type="curve"/>
-      <point x="895" y="79"/>
-      <point x="1010" y="-10"/>
-      <point x="1182" y="-10" type="curve" smooth="yes"/>
-      <point x="1410" y="-10"/>
-      <point x="1518" y="148"/>
-      <point x="1518" y="468" type="curve" smooth="yes"/>
-      <point x="1518" y="1012" type="line" smooth="yes"/>
-      <point x="1518" y="1332"/>
-      <point x="1410" y="1490"/>
-      <point x="1172" y="1490" type="curve"/>
-      <point x="1172" y="1448" type="line"/>
-      <point x="1422" y="1448"/>
-      <point x="1472" y="1231"/>
-      <point x="1472" y="1012" type="curve" smooth="yes"/>
-      <point x="1472" y="468" type="line" smooth="yes"/>
-      <point x="1472" y="249"/>
-      <point x="1422" y="32"/>
-      <point x="1172" y="32" type="curve" smooth="yes"/>
-      <point x="952" y="32"/>
-      <point x="872" y="249"/>
-      <point x="872" y="468" type="curve" smooth="yes"/>
-      <point x="872" y="1012" type="line"/>
-      <point x="826" y="1012" type="line"/>
-      <point x="826" y="468" type="line" smooth="yes"/>
-      <point x="826" y="249"/>
-      <point x="746" y="32"/>
-      <point x="526" y="32" type="curve" smooth="yes"/>
-      <point x="276" y="32"/>
-      <point x="226" y="249"/>
-      <point x="226" y="468" type="curve" smooth="yes"/>
-      <point x="226" y="1012" type="line" smooth="yes"/>
-      <point x="226" y="1231"/>
-      <point x="276" y="1448"/>
-      <point x="526" y="1448" type="curve"/>
+      <point x="1046" y="540" type="line"/>
+      <point x="1092" y="540" type="line"/>
+      <point x="1092" y="138" type="line"/>
+      <point x="1046" y="138" type="line"/>
+    </contour>
+    <contour>
+      <point x="1416" y="32" type="curve" smooth="yes"/>
+      <point x="1676" y="32"/>
+      <point x="1952" y="265"/>
+      <point x="1952" y="740" type="curve" smooth="yes"/>
+      <point x="1952" y="1215"/>
+      <point x="1676" y="1448"/>
+      <point x="1416" y="1448" type="curve" smooth="yes"/>
+      <point x="1339" y="1448"/>
+      <point x="1260" y="1426"/>
+      <point x="1188" y="1386" type="curve"/>
+      <point x="1164" y="1427" type="line"/>
+      <point x="1238" y="1468"/>
+      <point x="1323" y="1490"/>
+      <point x="1416" y="1490" type="curve" smooth="yes"/>
+      <point x="1764" y="1490"/>
+      <point x="1998" y="1179"/>
+      <point x="1998" y="740" type="curve" smooth="yes"/>
+      <point x="1998" y="301"/>
+      <point x="1764" y="-10"/>
+      <point x="1416" y="-10" type="curve" smooth="yes"/>
+      <point x="1264" y="-10"/>
+      <point x="1134" y="49"/>
+      <point x="1036" y="152" type="curve"/>
+      <point x="1073" y="183" type="line"/>
+      <point x="1171" y="82"/>
+      <point x="1295" y="32"/>
+    </contour>
+    <contour>
+      <point x="722" y="32" type="curve" smooth="yes"/>
+      <point x="843" y="32"/>
+      <point x="967" y="83"/>
+      <point x="1065" y="184" type="curve"/>
+      <point x="1100" y="150" type="line"/>
+      <point x="1002" y="48"/>
+      <point x="873" y="-10"/>
+      <point x="722" y="-10" type="curve" smooth="yes"/>
+      <point x="374" y="-10"/>
+      <point x="140" y="301"/>
+      <point x="140" y="740" type="curve" smooth="yes"/>
+      <point x="140" y="1179"/>
+      <point x="374" y="1490"/>
+      <point x="722" y="1490" type="curve" smooth="yes"/>
+      <point x="815" y="1490"/>
+      <point x="900" y="1468"/>
+      <point x="974" y="1427" type="curve"/>
+      <point x="950" y="1386" type="line"/>
+      <point x="878" y="1426"/>
+      <point x="799" y="1448"/>
+      <point x="722" y="1448" type="curve" smooth="yes"/>
+      <point x="462" y="1448"/>
+      <point x="186" y="1215"/>
+      <point x="186" y="740" type="curve" smooth="yes"/>
+      <point x="186" y="265"/>
+      <point x="462" y="32"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uniA_7B_7.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uniA_7B_7.glif
@@ -1,56 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B7" format="2">
-  <advance width="1732"/>
+  <advance width="1728"/>
   <unicode hex="A7B7"/>
   <anchor x="866" y="0" name="bottom_center"/>
   <anchor x="866" y="1040" name="top_center"/>
   <outline>
     <contour>
-      <point x="534" y="1050" type="line"/>
-      <point x="324" y="1050"/>
-      <point x="180" y="902"/>
-      <point x="180" y="572" type="curve" smooth="yes"/>
-      <point x="180" y="468" type="line" smooth="yes"/>
-      <point x="180" y="138"/>
-      <point x="324" y="-10"/>
-      <point x="534" y="-10" type="curve" smooth="yes"/>
-      <point x="696" y="-10"/>
-      <point x="818" y="77"/>
-      <point x="866" y="268" type="curve"/>
-      <point x="914" y="77"/>
-      <point x="1036" y="-10"/>
-      <point x="1198" y="-10" type="curve" smooth="yes"/>
-      <point x="1408" y="-10"/>
-      <point x="1552" y="138"/>
-      <point x="1552" y="468" type="curve" smooth="yes"/>
-      <point x="1552" y="572" type="line" smooth="yes"/>
-      <point x="1552" y="902"/>
-      <point x="1408" y="1050"/>
-      <point x="1198" y="1050" type="curve"/>
-      <point x="1198" y="1010" type="line"/>
-      <point x="1438" y="1010"/>
-      <point x="1508" y="791"/>
-      <point x="1508" y="572" type="curve" smooth="yes"/>
-      <point x="1508" y="468" type="line" smooth="yes"/>
-      <point x="1508" y="249"/>
-      <point x="1438" y="30"/>
-      <point x="1198" y="30" type="curve" smooth="yes"/>
-      <point x="958" y="30"/>
-      <point x="888" y="249"/>
-      <point x="888" y="468" type="curve" smooth="yes"/>
-      <point x="888" y="680" type="line"/>
-      <point x="844" y="680" type="line"/>
-      <point x="844" y="468" type="line" smooth="yes"/>
-      <point x="844" y="249"/>
-      <point x="774" y="30"/>
-      <point x="534" y="30" type="curve" smooth="yes"/>
-      <point x="294" y="30"/>
-      <point x="224" y="249"/>
-      <point x="224" y="468" type="curve" smooth="yes"/>
-      <point x="224" y="572" type="line" smooth="yes"/>
-      <point x="224" y="791"/>
-      <point x="294" y="1010"/>
-      <point x="534" y="1010" type="curve"/>
+      <point x="842" y="540" type="line"/>
+      <point x="886" y="540" type="line"/>
+      <point x="886" y="138" type="line"/>
+      <point x="842" y="138" type="line"/>
+    </contour>
+    <contour>
+      <point x="1150" y="30" type="curve" smooth="yes"/>
+      <point x="1318" y="30"/>
+      <point x="1543" y="184"/>
+      <point x="1543" y="520" type="curve" smooth="yes"/>
+      <point x="1543" y="856"/>
+      <point x="1318" y="1010"/>
+      <point x="1150" y="1010" type="curve" smooth="yes"/>
+      <point x="1095" y="1010"/>
+      <point x="1034" y="994"/>
+      <point x="977" y="960" type="curve"/>
+      <point x="954" y="999" type="line"/>
+      <point x="1012" y="1032"/>
+      <point x="1079" y="1050"/>
+      <point x="1150" y="1050" type="curve" smooth="yes"/>
+      <point x="1397" y="1050"/>
+      <point x="1588" y="832"/>
+      <point x="1588" y="520" type="curve" smooth="yes"/>
+      <point x="1588" y="208"/>
+      <point x="1397" y="-10"/>
+      <point x="1150" y="-10" type="curve" smooth="yes"/>
+      <point x="1025" y="-10"/>
+      <point x="914" y="46"/>
+      <point x="835" y="142" type="curve"/>
+      <point x="866" y="177" type="line"/>
+      <point x="946" y="78"/>
+      <point x="1057" y="30"/>
+    </contour>
+    <contour>
+      <point x="578" y="30" type="curve" smooth="yes"/>
+      <point x="671" y="30"/>
+      <point x="782" y="77"/>
+      <point x="862" y="177" type="curve"/>
+      <point x="892" y="141" type="line"/>
+      <point x="813" y="46"/>
+      <point x="703" y="-10"/>
+      <point x="578" y="-10" type="curve" smooth="yes"/>
+      <point x="331" y="-10"/>
+      <point x="140" y="208"/>
+      <point x="140" y="520" type="curve" smooth="yes"/>
+      <point x="140" y="832"/>
+      <point x="331" y="1050"/>
+      <point x="578" y="1050" type="curve" smooth="yes"/>
+      <point x="649" y="1050"/>
+      <point x="716" y="1032"/>
+      <point x="774" y="999" type="curve"/>
+      <point x="751" y="960" type="line"/>
+      <point x="694" y="994"/>
+      <point x="633" y="1010"/>
+      <point x="578" y="1010" type="curve" smooth="yes"/>
+      <point x="410" y="1010"/>
+      <point x="185" y="856"/>
+      <point x="185" y="520" type="curve" smooth="yes"/>
+      <point x="185" y="184"/>
+      <point x="410" y="30"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0308  by \idieresis;
     sub \i \uni0307  by \idieresis;
+    sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -9002,7 +9002,7 @@ lookup mark_Mark_positioning {
 	<anchor 281 0> mark @bottom_center
 	<anchor 305 0> mark @bottom_right
 	<anchor 276 -20> mark @bottom_cedilla;
-  pos base [\uni019C \uniA7B6 ] <anchor 962 1380> mark @top_center
+  pos base [\uni019C ] <anchor 962 1380> mark @top_center
 	<anchor 719 0> mark @bottom_center;
   pos base [\uni019D ] <anchor 881 1380> mark @top_center;
   pos base [\uni019F ] <anchor 870 1380> mark @top_center
@@ -9964,6 +9964,8 @@ lookup mark_Mark_positioning {
   pos base [\uni2C6D ] <anchor 576 -90> mark @bottom_ypogegrammeni
 	<anchor 835 1380> mark @top_center
 	<anchor 592 0> mark @bottom_center;
+  pos base [\uniA7B6 ] <anchor 939 0> mark @bottom_center
+	<anchor 1182 1380> mark @top_center;
   pos base [\uniA7B7 ] <anchor 736 0> mark @bottom_center
 	<anchor 919 1040> mark @top_center;
   pos base [\a.sc \alphatonos.sc \alpha.sc \uni0430.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc \uni1F70.sc \uni1F71.sc ] <anchor 885 -20> mark @bottom_cedilla

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -9330,8 +9330,8 @@ lookup mark_Mark_positioning {
 	<anchor 868 1716> mark @top_center;
   pos base [\uni0477 ] <anchor 395 0> mark @bottom_center
 	<anchor 678 1376> mark @top_center;
-  pos base [\uni047C ] <anchor 719 0> mark @bottom_center
-	<anchor 1092 2112> mark @top_center;
+  pos base [\uni047C ] <anchor 939 0> mark @bottom_center
+	<anchor 1312 2112> mark @top_center;
   pos base [\uni047D ] <anchor 736 0> mark @bottom_center
 	<anchor 1049 1772> mark @top_center;
   pos base [\uni04C1 ] <anchor 779 0> mark @bottom_cedilla

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -4484,8 +4484,8 @@ lookup ccmp_latn {
     sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0302  by \icircumflex;
-    sub \i \uni0307  by \idieresis;
     sub \i \uni0308  by \idieresis;
+    sub \i \uni0307  by \idieresis;
     sub \n \tildecomb  by \ntilde;
     sub \o \gravecomb  by \ograve;
     sub \o \acutecomb  by \oacute;
@@ -4544,8 +4544,8 @@ lookup ccmp_latn {
     sub \i \uni0306  by \ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4634,13 +4634,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5595,8 +5595,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -1,4 +1,5 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
     <key>familyName</key>
@@ -31,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/28 14:15:44</string>
+    <string>2025/04/28 14:57:39</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>
@@ -56,7 +57,7 @@
       <integer>0</integer>
     </array>
     <key>openTypeOS2Type</key>
-    <array />
+    <array/>
     <key>openTypeOS2TypoAscender</key>
     <integer>2048</integer>
     <key>openTypeOS2TypoDescender</key>
@@ -165,5 +166,5 @@
         <real>0</real>
       </dict>
     </array>
-  <key>openTypeOS2Selection</key><array><integer>7</integer></array></dict>
+  </dict>
 </plist>

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<?xml version='1.0' encoding='UTF-8'?>
 <plist version="1.0">
   <dict>
     <key>familyName</key>
@@ -32,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/28 14:57:39</string>
+    <string>2025/04/28 15:02:44</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>
@@ -57,7 +56,7 @@
       <integer>0</integer>
     </array>
     <key>openTypeOS2Type</key>
-    <array/>
+    <array />
     <key>openTypeOS2TypoAscender</key>
     <integer>2048</integer>
     <key>openTypeOS2TypoDescender</key>
@@ -166,5 +165,5 @@
         <real>0</real>
       </dict>
     </array>
-  </dict>
+  <key>openTypeOS2Selection</key><array><integer>7</integer></array></dict>
 </plist>

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2025/04/27 17:23:46</string>
+    <string>2025/04/28 14:15:44</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni0460.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni0460.glif
@@ -1,51 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0460" format="2">
-  <advance width="1698"/>
+  <advance width="1902"/>
   <unicode hex="0460"/>
   <outline>
     <contour>
-      <point x="1003" y="1480" type="line"/>
-      <point x="957" y="1480" type="line"/>
-      <point x="779" y="468" type="line" smooth="yes"/>
-      <point x="740" y="249"/>
-      <point x="622" y="32"/>
-      <point x="402" y="32" type="curve" smooth="yes"/>
-      <point x="217" y="32"/>
-      <point x="162" y="151"/>
-      <point x="162" y="302" type="curve" smooth="yes"/>
-      <point x="162" y="355"/>
-      <point x="169" y="411"/>
-      <point x="179" y="468" type="curve" smooth="yes"/>
-      <point x="357" y="1480" type="line"/>
-      <point x="311" y="1480" type="line"/>
-      <point x="133" y="468" type="line" smooth="yes"/>
-      <point x="122" y="402"/>
-      <point x="116" y="343"/>
-      <point x="116" y="291" type="curve" smooth="yes"/>
-      <point x="116" y="89"/>
-      <point x="203" y="-10"/>
-      <point x="384" y="-10" type="curve" smooth="yes"/>
-      <point x="556" y="-10"/>
-      <point x="687" y="79"/>
-      <point x="765" y="260" type="curve"/>
-      <point x="779" y="79"/>
-      <point x="878" y="-10"/>
-      <point x="1050" y="-10" type="curve" smooth="yes"/>
-      <point x="1278" y="-10"/>
-      <point x="1415" y="148"/>
-      <point x="1471" y="468" type="curve" smooth="yes"/>
-      <point x="1649" y="1480" type="line"/>
-      <point x="1603" y="1480" type="line"/>
-      <point x="1425" y="468" type="line" smooth="yes"/>
-      <point x="1386" y="249"/>
-      <point x="1298" y="32"/>
-      <point x="1048" y="32" type="curve" smooth="yes"/>
-      <point x="875" y="32"/>
-      <point x="812" y="166"/>
-      <point x="812" y="330" type="curve" smooth="yes"/>
-      <point x="812" y="374"/>
-      <point x="817" y="421"/>
-      <point x="825" y="468" type="curve" smooth="yes"/>
+      <point x="1229" y="0" type="curve"/>
+      <point x="1203" y="0" type="line"/>
+      <point x="1203" y="0"/>
+      <point x="1021.57" y="435.8"/>
+      <point x="1021.57" y="1020.09" type="curve" smooth="yes"/>
+      <point x="1021.57" y="1165.66"/>
+      <point x="1032.83" y="1320.44"/>
+      <point x="1060.96" y="1480" type="curve"/>
+      <point x="1109.96" y="1480" type="line"/>
+      <point x="1083.01" y="1327.16"/>
+      <point x="1072.32" y="1177.72"/>
+      <point x="1072.32" y="1036.82" type="curve" smooth="yes"/>
+      <point x="1072.32" y="495.515"/>
+      <point x="1230.11" y="80"/>
+      <point x="1230.11" y="80" type="curve"/>
+      <point x="1230.11" y="80"/>
+      <point x="1713.48" y="740"/>
+      <point x="1843.96" y="1480" type="curve"/>
+      <point x="1892.96" y="1480" type="line"/>
+      <point x="1751.9" y="680"/>
+      <point x="1229" y="0"/>
+    </contour>
+    <contour>
+      <point x="446" y="0" type="line"/>
+      <point x="413" y="0" type="line"/>
+      <point x="413" y="0"/>
+      <point x="231.568" y="435.8"/>
+      <point x="231.568" y="1020.09" type="curve" smooth="yes"/>
+      <point x="231.568" y="1165.66"/>
+      <point x="242.829" y="1320.44"/>
+      <point x="270.964" y="1480" type="curve"/>
+      <point x="319.964" y="1480" type="line"/>
+      <point x="293.013" y="1327.16"/>
+      <point x="282.321" y="1177.72"/>
+      <point x="282.321" y="1036.82" type="curve" smooth="yes"/>
+      <point x="282.321" y="495.515"/>
+      <point x="440.106" y="80"/>
+      <point x="440.106" y="80" type="curve"/>
+      <point x="1023.54" y="1126" type="line"/>
+      <point x="1072.54" y="1126" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni0461.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni0461.glif
@@ -1,51 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni0461" format="2">
-  <advance width="1732"/>
+  <advance width="1556"/>
   <unicode hex="0461"/>
   <outline>
     <contour>
-      <point x="941" y="1040" type="line"/>
-      <point x="897" y="1040" type="line"/>
-      <point x="797" y="468" type="line" smooth="yes"/>
-      <point x="758" y="249"/>
-      <point x="649" y="30"/>
-      <point x="409" y="30" type="curve" smooth="yes"/>
-      <point x="224" y="30"/>
-      <point x="163" y="161"/>
-      <point x="163" y="321" type="curve" smooth="yes"/>
-      <point x="163" y="368"/>
-      <point x="168" y="418"/>
-      <point x="177" y="468" type="curve" smooth="yes"/>
-      <point x="277" y="1040" type="line"/>
-      <point x="233" y="1040" type="line"/>
-      <point x="133" y="468" type="line" smooth="yes"/>
-      <point x="123" y="411"/>
-      <point x="118" y="359"/>
-      <point x="118" y="313" type="curve" smooth="yes"/>
-      <point x="118" y="91"/>
-      <point x="228" y="-10"/>
-      <point x="402" y="-10" type="curve" smooth="yes"/>
-      <point x="564" y="-10"/>
-      <point x="701" y="77"/>
-      <point x="783" y="268" type="curve"/>
-      <point x="797" y="77"/>
-      <point x="904" y="-10"/>
-      <point x="1066" y="-10" type="curve" smooth="yes"/>
-      <point x="1276" y="-10"/>
-      <point x="1447" y="138"/>
-      <point x="1505" y="468" type="curve" smooth="yes"/>
-      <point x="1605" y="1040" type="line"/>
-      <point x="1561" y="1040" type="line"/>
-      <point x="1461" y="468" type="line" smooth="yes"/>
-      <point x="1422" y="249"/>
-      <point x="1313" y="30"/>
-      <point x="1073" y="30" type="curve" smooth="yes"/>
-      <point x="888" y="30"/>
-      <point x="827" y="161"/>
-      <point x="827" y="321" type="curve" smooth="yes"/>
-      <point x="827" y="368"/>
-      <point x="832" y="418"/>
-      <point x="841" y="468" type="curve" smooth="yes"/>
+      <point x="855.38" y="1040" type="line"/>
+      <point x="838.755" y="945.717"/>
+      <point x="831.95" y="854.36"/>
+      <point x="831.95" y="767.967" type="curve" smooth="yes"/>
+      <point x="831.95" y="377.877"/>
+      <point x="970.693" y="89"/>
+      <point x="970.693" y="89" type="curve"/>
+      <point x="970.693" y="89"/>
+      <point x="1329.69" y="520"/>
+      <point x="1421.38" y="1040" type="curve"/>
+      <point x="1469.38" y="1040" type="line"/>
+      <point x="1374.16" y="500"/>
+      <point x="964" y="0"/>
+      <point x="964" y="0" type="curve"/>
+      <point x="946" y="0" type="line"/>
+      <point x="946" y="0"/>
+      <point x="784.582" y="345.15"/>
+      <point x="784.582" y="771.626" type="curve" smooth="yes"/>
+      <point x="784.582" y="858.455"/>
+      <point x="791.273" y="948.655"/>
+      <point x="807.38" y="1040" type="curve"/>
+    </contour>
+    <contour>
+      <point x="241.38" y="1040" type="line"/>
+      <point x="224.755" y="945.717"/>
+      <point x="217.95" y="854.36"/>
+      <point x="217.95" y="767.967" type="curve" smooth="yes"/>
+      <point x="217.95" y="377.877"/>
+      <point x="356.693" y="89"/>
+      <point x="356.693" y="89" type="curve"/>
+      <point x="784.825" y="810" type="line"/>
+      <point x="830.825" y="810" type="line"/>
+      <point x="356" y="0" type="line"/>
+      <point x="332" y="0" type="line"/>
+      <point x="332" y="0"/>
+      <point x="170.582" y="345.15"/>
+      <point x="170.582" y="771.626" type="curve" smooth="yes"/>
+      <point x="170.582" y="858.455"/>
+      <point x="177.273" y="948.655"/>
+      <point x="193.38" y="1040" type="curve"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni047C_.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni047C_.glif
@@ -2,11 +2,11 @@
 <glyph name="uni047C" format="2">
   <advance width="2138"/>
   <unicode hex="047C"/>
-  <anchor x="719" y="0" name="bottom_center"/>
-  <anchor x="1092" y="2112" name="top_center"/>
+  <anchor x="939" y="0" name="bottom_center"/>
+  <anchor x="1312" y="2112" name="top_center"/>
   <outline>
     <component base="uniA7B6"/>
-    <component base="uni0486" xOffset="137" yOffset="340"/>
-    <component base="uni0487" xOffset="337" yOffset="736"/>
+    <component base="uni0486" xOffset="357" yOffset="340"/>
+    <component base="uni0487" xOffset="557" yOffset="736"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni047C_.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni047C_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047C" format="2">
-  <advance width="1698"/>
+  <advance width="2138"/>
   <unicode hex="047C"/>
   <anchor x="719" y="0" name="bottom_center"/>
   <anchor x="1092" y="2112" name="top_center"/>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni047D_.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni047D_.glif
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047D" format="2">
-  <advance width="1732"/>
+  <advance width="1728"/>
   <unicode hex="047D"/>
   <anchor x="736" y="0" name="bottom_center"/>
   <anchor x="1049" y="1772" name="top_center"/>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni047E_.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni047E_.glif
@@ -1,75 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047E" format="2">
-  <advance width="1698"/>
+  <advance width="1902"/>
   <unicode hex="047E"/>
   <outline>
     <contour>
-      <point x="668" y="1842" type="line"/>
-      <point x="694" y="1878" type="line"/>
-      <point x="1406" y="1878" type="line"/>
-      <point x="1420" y="1842" type="line"/>
+      <point x="1229" y="0" type="curve"/>
+      <point x="1203" y="0" type="line"/>
+      <point x="1203" y="0"/>
+      <point x="1022" y="436"/>
+      <point x="1022" y="1020" type="curve" smooth="yes"/>
+      <point x="1022" y="1166"/>
+      <point x="1033" y="1320"/>
+      <point x="1061" y="1480" type="curve"/>
+      <point x="1110" y="1480" type="line"/>
+      <point x="1083" y="1327"/>
+      <point x="1072" y="1178"/>
+      <point x="1072" y="1037" type="curve" smooth="yes"/>
+      <point x="1072" y="496"/>
+      <point x="1230" y="80"/>
+      <point x="1230" y="80" type="curve"/>
+      <point x="1230" y="80"/>
+      <point x="1714" y="740"/>
+      <point x="1844" y="1480" type="curve"/>
+      <point x="1893" y="1480" type="line"/>
+      <point x="1752" y="680"/>
+      <point x="1229" y="0"/>
     </contour>
     <contour>
-      <point x="614" y="1626" type="line"/>
-      <point x="658" y="1878" type="line"/>
-      <point x="694" y="1878" type="line"/>
-      <point x="650" y="1626" type="line"/>
+      <point x="446" y="0" type="line"/>
+      <point x="413" y="0" type="line"/>
+      <point x="413" y="0"/>
+      <point x="232" y="436"/>
+      <point x="232" y="1020" type="curve" smooth="yes"/>
+      <point x="232" y="1166"/>
+      <point x="243" y="1320"/>
+      <point x="271" y="1480" type="curve"/>
+      <point x="320" y="1480" type="line"/>
+      <point x="293" y="1327"/>
+      <point x="282" y="1178"/>
+      <point x="282" y="1037" type="curve" smooth="yes"/>
+      <point x="282" y="496"/>
+      <point x="440" y="80"/>
+      <point x="440" y="80" type="curve"/>
+      <point x="1024" y="1126" type="line"/>
+      <point x="1073" y="1126" type="line"/>
     </contour>
     <contour>
-      <point x="1362" y="1626" type="line"/>
-      <point x="1406" y="1878" type="line"/>
-      <point x="1442" y="1878" type="line"/>
-      <point x="1398" y="1626" type="line"/>
+      <point x="775" y="1842" type="line"/>
+      <point x="801" y="1878" type="line"/>
+      <point x="1513" y="1878" type="line"/>
+      <point x="1527" y="1842" type="line"/>
     </contour>
     <contour>
-      <point x="988" y="1626" type="line"/>
-      <point x="1032" y="1878" type="line"/>
-      <point x="1068" y="1878" type="line"/>
-      <point x="1024" y="1626" type="line"/>
+      <point x="721" y="1626" type="line"/>
+      <point x="765" y="1878" type="line"/>
+      <point x="801" y="1878" type="line"/>
+      <point x="757" y="1626" type="line"/>
     </contour>
     <contour>
-      <point x="1003" y="1480" type="line"/>
-      <point x="957" y="1480" type="line"/>
-      <point x="779" y="468" type="line" smooth="yes"/>
-      <point x="740" y="249"/>
-      <point x="622" y="32"/>
-      <point x="402" y="32" type="curve" smooth="yes"/>
-      <point x="217" y="32"/>
-      <point x="162" y="151"/>
-      <point x="162" y="302" type="curve" smooth="yes"/>
-      <point x="162" y="355"/>
-      <point x="169" y="411"/>
-      <point x="179" y="468" type="curve" smooth="yes"/>
-      <point x="357" y="1480" type="line"/>
-      <point x="311" y="1480" type="line"/>
-      <point x="133" y="468" type="line" smooth="yes"/>
-      <point x="122" y="402"/>
-      <point x="116" y="343"/>
-      <point x="116" y="291" type="curve" smooth="yes"/>
-      <point x="116" y="89"/>
-      <point x="203" y="-10"/>
-      <point x="384" y="-10" type="curve" smooth="yes"/>
-      <point x="556" y="-10"/>
-      <point x="687" y="79"/>
-      <point x="765" y="260" type="curve"/>
-      <point x="779" y="79"/>
-      <point x="878" y="-10"/>
-      <point x="1050" y="-10" type="curve" smooth="yes"/>
-      <point x="1278" y="-10"/>
-      <point x="1415" y="148"/>
-      <point x="1471" y="468" type="curve" smooth="yes"/>
-      <point x="1649" y="1480" type="line"/>
-      <point x="1603" y="1480" type="line"/>
-      <point x="1425" y="468" type="line" smooth="yes"/>
-      <point x="1386" y="249"/>
-      <point x="1298" y="32"/>
-      <point x="1048" y="32" type="curve" smooth="yes"/>
-      <point x="875" y="32"/>
-      <point x="812" y="166"/>
-      <point x="812" y="330" type="curve" smooth="yes"/>
-      <point x="812" y="374"/>
-      <point x="817" y="421"/>
-      <point x="825" y="468" type="curve" smooth="yes"/>
+      <point x="1469" y="1626" type="line"/>
+      <point x="1513" y="1878" type="line"/>
+      <point x="1549" y="1878" type="line"/>
+      <point x="1505" y="1626" type="line"/>
+    </contour>
+    <contour>
+      <point x="1095" y="1626" type="line"/>
+      <point x="1139" y="1878" type="line"/>
+      <point x="1175" y="1878" type="line"/>
+      <point x="1131" y="1626" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni047F_.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni047F_.glif
@@ -1,75 +1,73 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni047F" format="2">
-  <advance width="1732"/>
+  <advance width="1556"/>
   <unicode hex="047F"/>
   <outline>
     <contour>
-      <point x="607" y="1402" type="line"/>
-      <point x="634" y="1438" type="line"/>
-      <point x="1346" y="1438" type="line"/>
-      <point x="1359" y="1402" type="line"/>
+      <point x="855" y="1040" type="line"/>
+      <point x="838" y="946"/>
+      <point x="832" y="854"/>
+      <point x="832" y="768" type="curve" smooth="yes"/>
+      <point x="832" y="378"/>
+      <point x="971" y="89"/>
+      <point x="971" y="89" type="curve"/>
+      <point x="971" y="89"/>
+      <point x="1329" y="520"/>
+      <point x="1421" y="1040" type="curve"/>
+      <point x="1469" y="1040" type="line"/>
+      <point x="1374" y="500"/>
+      <point x="964" y="0"/>
+      <point x="964" y="0" type="curve"/>
+      <point x="946" y="0" type="line"/>
+      <point x="946" y="0"/>
+      <point x="785" y="346"/>
+      <point x="785" y="772" type="curve" smooth="yes"/>
+      <point x="785" y="859"/>
+      <point x="791" y="949"/>
+      <point x="807" y="1040" type="curve"/>
     </contour>
     <contour>
-      <point x="553" y="1186" type="line"/>
-      <point x="598" y="1438" type="line"/>
-      <point x="634" y="1438" type="line"/>
-      <point x="589" y="1186" type="line"/>
+      <point x="241" y="1040" type="line"/>
+      <point x="224" y="946"/>
+      <point x="218" y="854"/>
+      <point x="218" y="768" type="curve" smooth="yes"/>
+      <point x="218" y="378"/>
+      <point x="357" y="89"/>
+      <point x="357" y="89" type="curve"/>
+      <point x="785" y="810" type="line"/>
+      <point x="831" y="810" type="line"/>
+      <point x="356" y="0" type="line"/>
+      <point x="332" y="0" type="line"/>
+      <point x="332" y="0"/>
+      <point x="171" y="346"/>
+      <point x="171" y="772" type="curve" smooth="yes"/>
+      <point x="171" y="859"/>
+      <point x="177" y="949"/>
+      <point x="193" y="1040" type="curve"/>
     </contour>
     <contour>
-      <point x="1301" y="1186" type="line"/>
-      <point x="1346" y="1438" type="line"/>
-      <point x="1382" y="1438" type="line"/>
-      <point x="1337" y="1186" type="line"/>
+      <point x="529" y="1444" type="line"/>
+      <point x="555" y="1480" type="line"/>
+      <point x="1267" y="1480" type="line"/>
+      <point x="1281" y="1444" type="line"/>
     </contour>
     <contour>
-      <point x="927" y="1186" type="line"/>
-      <point x="968" y="1418" type="line"/>
-      <point x="1004" y="1418" type="line"/>
-      <point x="963" y="1186" type="line"/>
+      <point x="475" y="1228" type="line"/>
+      <point x="519" y="1480" type="line"/>
+      <point x="555" y="1480" type="line"/>
+      <point x="511" y="1228" type="line"/>
     </contour>
     <contour>
-      <point x="941" y="1040" type="line"/>
-      <point x="897" y="1040" type="line"/>
-      <point x="797" y="468" type="line" smooth="yes"/>
-      <point x="758" y="249"/>
-      <point x="649" y="30"/>
-      <point x="409" y="30" type="curve" smooth="yes"/>
-      <point x="224" y="30"/>
-      <point x="163" y="161"/>
-      <point x="163" y="321" type="curve" smooth="yes"/>
-      <point x="163" y="368"/>
-      <point x="168" y="418"/>
-      <point x="177" y="468" type="curve" smooth="yes"/>
-      <point x="277" y="1040" type="line"/>
-      <point x="233" y="1040" type="line"/>
-      <point x="133" y="468" type="line" smooth="yes"/>
-      <point x="123" y="411"/>
-      <point x="118" y="359"/>
-      <point x="118" y="313" type="curve" smooth="yes"/>
-      <point x="118" y="91"/>
-      <point x="228" y="-10"/>
-      <point x="402" y="-10" type="curve" smooth="yes"/>
-      <point x="564" y="-10"/>
-      <point x="701" y="77"/>
-      <point x="783" y="268" type="curve"/>
-      <point x="797" y="77"/>
-      <point x="904" y="-10"/>
-      <point x="1066" y="-10" type="curve" smooth="yes"/>
-      <point x="1276" y="-10"/>
-      <point x="1447" y="138"/>
-      <point x="1505" y="468" type="curve" smooth="yes"/>
-      <point x="1605" y="1040" type="line"/>
-      <point x="1561" y="1040" type="line"/>
-      <point x="1461" y="468" type="line" smooth="yes"/>
-      <point x="1422" y="249"/>
-      <point x="1313" y="30"/>
-      <point x="1073" y="30" type="curve" smooth="yes"/>
-      <point x="888" y="30"/>
-      <point x="827" y="161"/>
-      <point x="827" y="321" type="curve" smooth="yes"/>
-      <point x="827" y="368"/>
-      <point x="832" y="418"/>
-      <point x="841" y="468" type="curve" smooth="yes"/>
+      <point x="1223" y="1228" type="line"/>
+      <point x="1267" y="1480" type="line"/>
+      <point x="1303" y="1480" type="line"/>
+      <point x="1259" y="1228" type="line"/>
+    </contour>
+    <contour>
+      <point x="849" y="1228" type="line"/>
+      <point x="889" y="1460" type="line"/>
+      <point x="925" y="1460" type="line"/>
+      <point x="885" y="1228" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uniA_7B_6.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uniA_7B_6.glif
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B6" format="2">
-  <advance width="1698"/>
+  <advance width="2138"/>
   <unicode hex="A7B6"/>
   <anchor x="719" y="0" name="bottom_center"/>
   <anchor x="962" y="1380" name="top_center"/>
   <outline>
     <contour>
-      <point x="659" y="1490" type="line"/>
-      <point x="421" y="1490"/>
-      <point x="284" y="1332"/>
-      <point x="228" y="1012" type="curve" smooth="yes"/>
-      <point x="133" y="468" type="line" smooth="yes"/>
-      <point x="121" y="402"/>
-      <point x="115" y="344"/>
-      <point x="115" y="292" type="curve" smooth="yes"/>
-      <point x="115" y="90"/>
-      <point x="203" y="-10"/>
-      <point x="384" y="-10" type="curve" smooth="yes"/>
-      <point x="556" y="-10"/>
-      <point x="687" y="79"/>
-      <point x="765" y="260" type="curve"/>
-      <point x="779" y="79"/>
-      <point x="878" y="-10"/>
-      <point x="1050" y="-10" type="curve" smooth="yes"/>
-      <point x="1278" y="-10"/>
-      <point x="1415" y="148"/>
-      <point x="1471" y="468" type="curve" smooth="yes"/>
-      <point x="1566" y="1012" type="line" smooth="yes"/>
-      <point x="1577" y="1077"/>
-      <point x="1584" y="1135"/>
-      <point x="1584" y="1187" type="curve" smooth="yes"/>
-      <point x="1584" y="1390"/>
-      <point x="1495" y="1490"/>
-      <point x="1305" y="1490" type="curve"/>
-      <point x="1297" y="1448" type="line"/>
-      <point x="1482" y="1448"/>
-      <point x="1537" y="1329"/>
-      <point x="1537" y="1178" type="curve" smooth="yes"/>
-      <point x="1537" y="1125"/>
-      <point x="1530" y="1069"/>
-      <point x="1520" y="1012" type="curve" smooth="yes"/>
-      <point x="1425" y="468" type="line" smooth="yes"/>
-      <point x="1386" y="249"/>
-      <point x="1298" y="32"/>
-      <point x="1048" y="32" type="curve" smooth="yes"/>
-      <point x="875" y="32"/>
-      <point x="812" y="167"/>
-      <point x="812" y="331" type="curve" smooth="yes"/>
-      <point x="812" y="375"/>
-      <point x="817" y="421"/>
-      <point x="825" y="468" type="curve" smooth="yes"/>
-      <point x="920" y="1012" type="line"/>
-      <point x="874" y="1012" type="line"/>
-      <point x="779" y="468" type="line" smooth="yes"/>
-      <point x="740" y="249"/>
-      <point x="622" y="32"/>
-      <point x="402" y="32" type="curve" smooth="yes"/>
-      <point x="217" y="32"/>
-      <point x="162" y="151"/>
-      <point x="162" y="302" type="curve" smooth="yes"/>
-      <point x="162" y="355"/>
-      <point x="169" y="411"/>
-      <point x="179" y="468" type="curve" smooth="yes"/>
-      <point x="274" y="1012" type="line" smooth="yes"/>
-      <point x="313" y="1231"/>
-      <point x="401" y="1448"/>
-      <point x="651" y="1448" type="curve"/>
+      <point x="1011" y="540" type="line"/>
+      <point x="1057" y="540" type="line"/>
+      <point x="986" y="138" type="line"/>
+      <point x="940" y="138" type="line"/>
+    </contour>
+    <contour>
+      <point x="2016" y="934" type="curve" smooth="yes"/>
+      <point x="2016" y="485"/>
+      <point x="1732" y="-10"/>
+      <point x="1284" y="-10" type="curve" smooth="yes"/>
+      <point x="1132" y="-10"/>
+      <point x="1013" y="49"/>
+      <point x="933" y="152" type="curve"/>
+      <point x="975" y="183" type="line"/>
+      <point x="1055" y="82"/>
+      <point x="1171" y="32"/>
+      <point x="1292" y="32" type="curve" smooth="yes"/>
+      <point x="1664" y="32"/>
+      <point x="1970" y="457"/>
+      <point x="1970" y="926" type="curve" smooth="yes"/>
+      <point x="1970" y="1276"/>
+      <point x="1764" y="1448"/>
+      <point x="1541" y="1448" type="curve" smooth="yes"/>
+      <point x="1464" y="1448"/>
+      <point x="1381" y="1426"/>
+      <point x="1302" y="1386" type="curve"/>
+      <point x="1286" y="1427" type="line"/>
+      <point x="1367" y="1468"/>
+      <point x="1456" y="1490"/>
+      <point x="1549" y="1490" type="curve" smooth="yes"/>
+      <point x="1843" y="1490"/>
+      <point x="2016" y="1268"/>
+    </contour>
+    <contour>
+      <point x="847" y="1448" type="curve" smooth="yes"/>
+      <point x="475" y="1448"/>
+      <point x="169" y="1023"/>
+      <point x="169" y="554" type="curve" smooth="yes"/>
+      <point x="169" y="204"/>
+      <point x="375" y="32"/>
+      <point x="598" y="32" type="curve" smooth="yes"/>
+      <point x="719" y="32"/>
+      <point x="851" y="83"/>
+      <point x="967" y="184" type="curve"/>
+      <point x="996" y="150" type="line"/>
+      <point x="880" y="48"/>
+      <point x="741" y="-10"/>
+      <point x="590" y="-10" type="curve" smooth="yes"/>
+      <point x="296" y="-10"/>
+      <point x="123" y="212"/>
+      <point x="123" y="546" type="curve" smooth="yes"/>
+      <point x="123" y="995"/>
+      <point x="407" y="1490"/>
+      <point x="855" y="1490" type="curve" smooth="yes"/>
+      <point x="948" y="1490"/>
+      <point x="1029" y="1468"/>
+      <point x="1096" y="1427" type="curve"/>
+      <point x="1064" y="1386" type="line"/>
+      <point x="999" y="1426"/>
+      <point x="924" y="1448"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uniA_7B_6.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uniA_7B_6.glif
@@ -2,8 +2,8 @@
 <glyph name="uniA7B6" format="2">
   <advance width="2138"/>
   <unicode hex="A7B6"/>
-  <anchor x="719" y="0" name="bottom_center"/>
-  <anchor x="962" y="1380" name="top_center"/>
+  <anchor x="939" y="0" name="bottom_center"/>
+  <anchor x="1182" y="1380" name="top_center"/>
   <outline>
     <contour>
       <point x="1011" y="540" type="line"/>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uniA_7B_7.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uniA_7B_7.glif
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uniA7B7" format="2">
-  <advance width="1732"/>
+  <advance width="1728"/>
   <unicode hex="A7B7"/>
   <anchor x="736" y="0" name="bottom_center"/>
   <anchor x="919" y="1040" name="top_center"/>
   <outline>
     <contour>
-      <point x="589" y="1050" type="line"/>
-      <point x="379" y="1050"/>
-      <point x="209" y="902"/>
-      <point x="151" y="572" type="curve" smooth="yes"/>
-      <point x="133" y="468" type="line" smooth="yes"/>
-      <point x="123" y="411"/>
-      <point x="118" y="359"/>
-      <point x="118" y="313" type="curve" smooth="yes"/>
-      <point x="118" y="91"/>
-      <point x="228" y="-10"/>
-      <point x="402" y="-10" type="curve" smooth="yes"/>
-      <point x="564" y="-10"/>
-      <point x="701" y="77"/>
-      <point x="783" y="268" type="curve"/>
-      <point x="797" y="77"/>
-      <point x="904" y="-10"/>
-      <point x="1066" y="-10" type="curve" smooth="yes"/>
-      <point x="1276" y="-10"/>
-      <point x="1447" y="138"/>
-      <point x="1505" y="468" type="curve" smooth="yes"/>
-      <point x="1523" y="572" type="line" smooth="yes"/>
-      <point x="1533" y="629"/>
-      <point x="1538" y="681"/>
-      <point x="1538" y="727" type="curve" smooth="yes"/>
-      <point x="1538" y="949"/>
-      <point x="1427" y="1050"/>
-      <point x="1253" y="1050" type="curve"/>
-      <point x="1246" y="1010" type="line"/>
-      <point x="1432" y="1010"/>
-      <point x="1493" y="879"/>
-      <point x="1493" y="718" type="curve" smooth="yes"/>
-      <point x="1493" y="671"/>
-      <point x="1488" y="621"/>
-      <point x="1479" y="572" type="curve" smooth="yes"/>
-      <point x="1461" y="468" type="line" smooth="yes"/>
-      <point x="1422" y="249"/>
-      <point x="1313" y="30"/>
-      <point x="1073" y="30" type="curve" smooth="yes"/>
-      <point x="887" y="30"/>
-      <point x="827" y="161"/>
-      <point x="827" y="322" type="curve" smooth="yes"/>
-      <point x="827" y="369"/>
-      <point x="832" y="419"/>
-      <point x="841" y="468" type="curve" smooth="yes"/>
-      <point x="878" y="680" type="line"/>
-      <point x="834" y="680" type="line"/>
-      <point x="797" y="468" type="line" smooth="yes"/>
-      <point x="758" y="249"/>
-      <point x="649" y="30"/>
-      <point x="409" y="30" type="curve" smooth="yes"/>
-      <point x="223" y="30"/>
-      <point x="163" y="161"/>
-      <point x="163" y="322" type="curve" smooth="yes"/>
-      <point x="163" y="369"/>
-      <point x="168" y="419"/>
-      <point x="177" y="468" type="curve" smooth="yes"/>
-      <point x="195" y="572" type="line" smooth="yes"/>
-      <point x="234" y="791"/>
-      <point x="342" y="1010"/>
-      <point x="582" y="1010" type="curve"/>
+      <point x="807" y="540" type="line"/>
+      <point x="851" y="540" type="line"/>
+      <point x="780" y="138" type="line"/>
+      <point x="736" y="138" type="line"/>
+    </contour>
+    <contour>
+      <point x="1561" y="643" type="curve" smooth="yes"/>
+      <point x="1561" y="311"/>
+      <point x="1324" y="-10"/>
+      <point x="1018" y="-10" type="curve" smooth="yes"/>
+      <point x="893" y="-10"/>
+      <point x="792" y="46"/>
+      <point x="730" y="142" type="curve"/>
+      <point x="767" y="177" type="line"/>
+      <point x="830" y="78"/>
+      <point x="932" y="30"/>
+      <point x="1025" y="30" type="curve" smooth="yes"/>
+      <point x="1260" y="30"/>
+      <point x="1515" y="291"/>
+      <point x="1515" y="636" type="curve" smooth="yes"/>
+      <point x="1515" y="891"/>
+      <point x="1345" y="1010"/>
+      <point x="1198" y="1010" type="curve" smooth="yes"/>
+      <point x="1143" y="1010"/>
+      <point x="1079" y="994"/>
+      <point x="1016" y="960" type="curve"/>
+      <point x="1000" y="999" type="line"/>
+      <point x="1064" y="1032"/>
+      <point x="1134" y="1050"/>
+      <point x="1205" y="1050" type="curve" smooth="yes"/>
+      <point x="1418" y="1050"/>
+      <point x="1561" y="888"/>
+    </contour>
+    <contour>
+      <point x="626" y="1010" type="curve" smooth="yes"/>
+      <point x="391" y="1010"/>
+      <point x="136" y="749"/>
+      <point x="136" y="404" type="curve" smooth="yes"/>
+      <point x="136" y="149"/>
+      <point x="306" y="30"/>
+      <point x="453" y="30" type="curve" smooth="yes"/>
+      <point x="546" y="30"/>
+      <point x="665" y="77"/>
+      <point x="763" y="177" type="curve"/>
+      <point x="787" y="141" type="line"/>
+      <point x="691" y="46"/>
+      <point x="571" y="-10"/>
+      <point x="446" y="-10" type="curve" smooth="yes"/>
+      <point x="233" y="-10"/>
+      <point x="90" y="152"/>
+      <point x="90" y="397" type="curve" smooth="yes"/>
+      <point x="90" y="729"/>
+      <point x="327" y="1050"/>
+      <point x="633" y="1050" type="curve" smooth="yes"/>
+      <point x="704" y="1050"/>
+      <point x="768" y="1032"/>
+      <point x="820" y="999" type="curve"/>
+      <point x="790" y="960" type="line"/>
+      <point x="739" y="994"/>
+      <point x="681" y="1010"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a3bebd4c-23ed-418e-b3aa-6348315554f1)

Decided to use what's seems to be mostly used according to my search, and these design seems to better fit the rest of the font imo. I'll use these new design for uniA64C and uniA64D.

![image](https://github.com/user-attachments/assets/ec94443c-6153-4027-bf5c-89ec626ee0e5)
