### PR TITLE
Fix interpolation errors on cv28

### DIFF
--- a/sources/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlack.ufo/features.fea
@@ -5898,29 +5898,6 @@ lookup calt_Contextual_Alternates {
 	\threeeighths \fiveeighths \seveneighths \uni215F \uni2189 ] ;
 } calt_Contextual_Alternates;
 
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
-
 feature locl {
 
  script cyrl;
@@ -6007,6 +5984,29 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
+
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
 
 feature ss09 {
   featureNames {

--- a/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/05/01 21:59:32</string>
+    <string>2026/05/01 22:16:31</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni02A_B_.cv28.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni02A_B_.cv28.glif
@@ -9,8 +9,8 @@
       <point x="70" y="1480" type="line"/>
     </contour>
     <contour>
-      <point x="430" y="1040" type="line"/>
-      <point x="430" y="720" type="line"/>
+      <point x="310" y="1040" type="line"/>
+      <point x="310" y="720" type="line"/>
       <point x="908" y="720" type="line"/>
       <point x="1322" y="752" type="line"/>
       <point x="1322" y="1040" type="line"/>

--- a/sources/Giphurs-Thin.ufo/features.fea
+++ b/sources/Giphurs-Thin.ufo/features.fea
@@ -5898,29 +5898,6 @@ lookup calt_Contextual_Alternates {
 	\threeeighths \fiveeighths \seveneighths \uni215F \uni2189 ] ;
 } calt_Contextual_Alternates;
 
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
-
 feature locl {
 
  script cyrl;
@@ -6007,6 +5984,29 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
+
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
 
 feature ss09 {
   featureNames {

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/05/01 21:59:08</string>
+    <string>2026/05/01 22:15:33</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni02A_B_.cv28.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni02A_B_.cv28.glif
@@ -3,14 +3,14 @@
   <advance width="1057"/>
   <outline>
     <contour>
+      <point x="180" y="0" type="line"/>
       <point x="225" y="0" type="line"/>
       <point x="225" y="1480" type="line"/>
       <point x="180" y="1480" type="line"/>
-      <point x="180" y="0" type="line"/>
     </contour>
     <contour>
-      <point x="225" y="1040" type="line"/>
-      <point x="225" y="1000" type="line"/>
+      <point x="205" y="1040" type="line"/>
+      <point x="205" y="1000" type="line"/>
       <point x="848" y="1000" type="line"/>
       <point x="877" y="1008" type="line"/>
       <point x="877" y="1040" type="line"/>

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -5898,29 +5898,6 @@ lookup calt_Contextual_Alternates {
 	\threeeighths \fiveeighths \seveneighths \uni215F \uni2189 ] ;
 } calt_Contextual_Alternates;
 
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
-
 feature locl {
 
  script cyrl;
@@ -6007,6 +5984,29 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
+
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
 
 feature ss09 {
   featureNames {

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -31,7 +31,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/05/01 21:58:57</string>
+    <string>2026/05/01 22:18:19</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni02A_B_.cv28.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni02A_B_.cv28.glif
@@ -3,14 +3,14 @@
   <advance width="1057"/>
   <outline>
     <contour>
+      <point x="50" y="0" type="line"/>
       <point x="95" y="0" type="line"/>
       <point x="356" y="1480" type="line"/>
       <point x="311" y="1480" type="line"/>
-      <point x="50" y="0" type="line"/>
     </contour>
     <contour>
-      <point x="278" y="1040" type="line"/>
-      <point x="271" y="1000" type="line"/>
+      <point x="258" y="1040" type="line"/>
+      <point x="251" y="1000" type="line"/>
       <point x="894" y="1000" type="line"/>
       <point x="925" y="1008" type="line"/>
       <point x="930" y="1040" type="line"/>


### PR DESCRIPTION
Noticed after making #101. Small issue from #95.

<img width="1185" height="606" alt="image" src="https://github.com/user-attachments/assets/7389acbf-6fa0-495b-8e8a-bbee95c2d962" />

This has been fixed here.