### PR TITLE
Add alternative capital Q with horizontal bar as cv29.

### DIFF
--- a/scripts/composed_glyphs.csv
+++ b/scripts/composed_glyphs.csv
@@ -1357,6 +1357,8 @@ uni1E37.cv28,,3,A,1,1,l.cv28,dotbelowcomb,,
 uni1E39.cv28,,3,A,1,1,l.cv28,dotbelowcomb,uni0304,
 uni1E3B.cv28,,3,A,1,1,l.cv28,uni0331,,
 uni1E3D.cv28,,3,A,1,1,l.cv28,uni032D,,
+uni051A.cv29,,3,C,1,1,Q.cv29
+uni051B.sc.cv29,,3,C,1,1,q.sc.cv29
 copyright,,3,C,1,0,uni24B8,,,
 registered,,3,C,1,0,uni24C7,,,
 mu,,3,C,1,0,uni03BC,,,

--- a/sources/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlack.ufo/features.fea
@@ -2261,6 +2261,16 @@ lookup cv28_Alternative_small_letter_l {
     sub \uni24A7 by \uni24A7.cv28 ;
 } cv28_Alternative_small_letter_l;
 
+lookup cv29_Alternative_letter_Q {
+  lookupflag 0;
+    sub \Q by \Q.cv29 ;
+    sub \uni051A by \uni051A.cv29 ;
+    sub \uni213A by \uni213A.cv29 ;
+    sub \uni24C6 by \uni24C6.cv29 ;
+    sub \q.sc by \q.sc.cv29 ;
+    sub \uni051B.sc by \uni051B.sc.cv29 ;
+} cv29_Alternative_letter_Q;
+
 lookup ss01_Alternative_digits_set_A {
   lookupflag 0;
     sub \eight by \eight.cv08 ;
@@ -4564,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \i \acutecomb  by \iacute;
     sub \uni0456 \acutecomb  by \iacute;
+    sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4621,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4709,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5641,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6775,6 +6785,29 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
+
 feature locl {
 
  script cyrl;
@@ -6861,29 +6894,6 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
-
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
 
 feature ss09 {
   featureNames {
@@ -7743,6 +7753,29 @@ feature cv28 {
       lookup cv28_Alternative_small_letter_l;
 } cv28;
 
+feature cv29 {
+
+ script DFLT;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script copt;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script cyrl;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script grek;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script latn;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+} cv29;
+
 feature ss01 {
   featureNames {
     name 3 1 0x409 "Alternative numbers set 1";
@@ -8264,7 +8297,7 @@ feature calt {
 
 lookup kern_Horizontal_kerning {
   lookupflag 0;
-    @kc88_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
+    @kc89_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
 	\Aogonek \Aring \Aringacute \Atilde \Delta \Lambda \backslash \uni01CD 
 	\uni01DE \uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
@@ -8273,12 +8306,12 @@ lookup kern_Horizontal_kerning {
 	\uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F88 \uni1F89 \uni1F8A \uni1F8B 
 	\uni1F8C \uni1F8D \uni1F8E \uni1F8F \uni1FB8 \uni1FB9 \uni1FBA \uni1FBB 
 	\uni1FBC \uni212B \uniA656 ];
-    @kc88_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
+    @kc89_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
 	\uni0412 \uni0417 \uni0432.loclBGR \uni0498 \uni04DE \uni1E02 \uni1E04 
 	\uni1E06 \uni1E9E \uniA7B4 \uniA7B5 ];
-    @kc88_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
+    @kc89_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
 	\uni03FE \uni0421 \uni0464 \uni0480 \uni04AA \uni1E08 \uni2103 \uni216D ];
-    @kc88_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
+    @kc89_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
 	\Gcommaaccent.cv21 \Gdotaccent.cv21 \O \Oacute \Obreve \Ocircumflex 
 	\Odieresis \Ograve \Ohungarumlaut \Omacron \Omicron \Omicrontonos 
 	\Oslash \Oslashacute \Otilde \Theta \uni0189 \uni018A \uni018F 
@@ -8291,46 +8324,46 @@ lookup kern_Horizontal_kerning {
 	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
 	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
 	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
-    @kc88_first_5 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
+    @kc89_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
+	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
+	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
+	\uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA 
+	\uni1FFB \uni1FFC \uni20B2 \uni20B2.ss05 ];
+    @kc89_first_6 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
 	\uni0422 \uni0490 \uni0492 \uni04A4 \uni04AC \uni1E6A \uni1E6C \uni1E6E 
 	\uni1E70 ];
-    @kc88_first_6 = [\Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
-	\uni01E4 \uni03A9 \uni051A \uni1E20 \uni1F68 \uni1F69 \uni1F6A \uni1F6B 
-	\uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 \uni1FA9 \uni1FAA \uni1FAB 
-	\uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA \uni1FFB \uni1FFC \uni20B2 
-	\uni20B2.ss05 ];
-    @kc88_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+    @kc89_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2165 \uni2166 \uni2167 \uni216A \uni216B 
 	\uniA7AE ];
-    @kc88_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
+    @kc89_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc88_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
+    @kc89_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
 	\uniA7AD ];
-    @kc88_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
-    @kc88_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
-    @kc88_first_12 = [\Psi \uni0470 ];
-    @kc88_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
+    @kc89_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
+    @kc89_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
+    @kc89_first_12 = [\Psi \uni0470 ];
+    @kc89_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc88_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
+    @kc89_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
 	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
 	\uni2107 ];
-    @kc88_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
+    @kc89_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
-    @kc88_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
+    @kc89_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
 	\uni2163 \uni2164 \uni2C6F \universal ];
-    @kc88_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_first_19 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
+    @kc89_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_first_19 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
 	\atilde \uni01DF \uni01E1 \uni0201 \uni0203 \uni0227 \uni0430 \uni04D1 
 	\uni04D3 \uni1E01 \uni1EA1 \uni1EA3 \uni1EA5 \uni1EA7 \uni1EA9 \uni1EAB 
 	\uni1EAD \uni1EAF \uni1EB1 \uni1EB3 \uni1EB5 \uni1EB7 \uniA657 ];
-    @kc88_first_20 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 
+    @kc89_first_20 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 
 	\agrave.cv23 \amacron.cv23 \aogonek.cv23 \aring.cv23 
 	\aringacute.cv23 \atilde.cv23 \u \u.cv25 \uacute \uacute.cv25 \ubreve 
 	\ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
@@ -8351,7 +8384,7 @@ lookup kern_Horizontal_kerning {
 	\uni1EE7 \uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 
 	\uni1EED \uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 
 	\uogonek \uogonek.cv25 \uring \uring.cv25 \utilde \utilde.cv25 ];
-    @kc88_first_21 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
+    @kc89_first_21 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
 	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
 	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
 	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
@@ -8364,7 +8397,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
 	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
 	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
-    @kc88_first_22 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_first_22 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8418,7 +8451,7 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_first_23 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
+    @kc89_first_23 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
 	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
@@ -8431,28 +8464,28 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
-    @kc88_first_24 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
+    @kc89_first_24 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
 	\uni1FB7 \uni2C65 ];
-    @kc88_first_25 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_first_25 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_first_26 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
+    @kc89_first_26 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
 	\uni0253 \uni029A \uni03F1 \uni03F8 \uni0440 \uni0444 \uni1E03 \uni1E05 
 	\uni1E07 \uni1E55 \uni1E57 \uni20AF \uni2114 \uniA64D ];
-    @kc88_first_27 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
+    @kc89_first_27 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
 	\uni1E05.sc \uni1E07.sc \uniA7B5.sc ];
-    @kc88_first_28 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
+    @kc89_first_28 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
 	\uni0188 \uni023C \uni0255 \uni0297 \uni03F2 \uni03F5 \uni0441 \uni0454 
 	\uni0465 \uni04AB \uni1E09 \uni217D ];
-    @kc88_first_29 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
+    @kc89_first_29 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
 	\uni037C.sc \uni03F2.sc \uni0441.sc \uni0454.sc \uni0465.sc 
 	\uni0481.sc \uni1E09.sc ];
-    @kc88_first_30 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+    @kc89_first_30 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8508,14 +8541,14 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_first_31 = [\chi ];
-    @kc88_first_32 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
+    @kc89_first_31 = [\chi ];
+    @kc89_first_32 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
 	\uni0436.sc \uni0445.sc \uni0497.sc \uni049B.sc \uni049D.sc 
 	\uni049F.sc \uni04A1.sc \uni04B3.sc \uni04C2.sc \uni04DD.sc 
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc88_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
+    @kc89_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
 	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
 	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
@@ -8527,7 +8560,7 @@ lookup kern_Horizontal_kerning {
 	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
 	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
 	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
-    @kc88_first_34 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_first_34 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8537,7 +8570,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2175.sc 
 	\uni2176.sc \uni2177.sc \uni217A.sc \uni217B.sc ];
-    @kc88_first_35 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
+    @kc89_first_35 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
 	\eight.cv18.numr \eight.cv18.numr.pnum \eight.cv18.numr.tnum 
 	\eight.numr \eight.numr.pnum \eight.numr.tnum \five.cv05.numr 
 	\five.cv05.numr.pnum \five.cv05.numr.tnum \five.cv15.numr 
@@ -8575,146 +8608,146 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.numr.tnum \zero.numr \zero.numr.pnum 
 	\zero.numr.tnum \zero.zero.numr \zero.zero.numr.pnum 
 	\zero.zero.numr.tnum ];
-    @kc88_first_36 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
+    @kc89_first_36 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
 	\uni1F26 \uni1F27 \uni1F74 \uni1F75 \uni1F90 \uni1F91 \uni1F92 \uni1F93 
 	\uni1F94 \uni1F95 \uni1F96 \uni1F97 \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 
 	\uni1FC7 ];
-    @kc88_first_37 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_first_37 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0437 \uni0455 
 	\uni0479 \uni0499 \uni04DF \uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
-    @kc88_first_38 = [\eth \uni1EFC \uni1EFD ];
-    @kc88_first_39 = [\fraction ];
-    @kc88_first_40 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc88_first_41 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \uni0260.sc \uni051B.sc \uni1F60.sc \uni1F61.sc 
-	\uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc 
-	\uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc \uni1FA1.sc 
-	\uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc 
-	\uni1FF7.sc ];
-    @kc88_first_42 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc89_first_38 = [\eth \uni1EFC \uni1EFD ];
+    @kc89_first_39 = [\fraction ];
+    @kc89_first_40 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
+    @kc89_first_41 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
+	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
+	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
+	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
+    @kc89_first_42 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc88_first_43 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_first_43 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc88_first_44 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc89_first_44 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc88_first_45 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc89_first_45 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc88_first_46 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc89_first_46 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc88_first_47 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
+    @kc89_first_47 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
 	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc88_first_48 = [\lambda \uni019B ];
-    @kc88_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc88_first_50 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc89_first_48 = [\lambda \uni019B ];
+    @kc89_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc89_first_50 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc88_first_51 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc88_first_52 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc88_first_53 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc89_first_51 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc89_first_52 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc89_first_53 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc88_first_54 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc88_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc88_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc89_first_54 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc89_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc89_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc88_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc88_first_59 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+    @kc89_first_59 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
 	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_first_60 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+    @kc89_first_60 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
 	\uni1E71 ];
-    @kc88_first_61 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
-    @kc88_first_62 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc88_first_63 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc88_first_64 = [\uni0196 \uni01AA ];
-    @kc88_first_65 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_first_61 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
+    @kc89_first_62 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
+    @kc89_first_63 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc89_first_64 = [\uni0196 \uni01AA ];
+    @kc89_first_65 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
 	\ygrave ];
-    @kc88_first_66 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_first_66 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_first_67 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
+    @kc89_first_67 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
 	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
 	\zdotaccent ];
-    @kc88_first_68 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
+    @kc89_first_68 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
-    @kc88_first_69 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
+    @kc89_first_69 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
 	\uni052D \uni052F ];
-    @kc88_first_70 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
+    @kc89_first_70 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
 	\uni04B7.sc \uni04C6.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
 	\uni0525.sc \uni052F.sc ];
-    @kc88_first_71 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
-    @kc88_first_72 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
-    @kc88_first_73 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_first_71 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
+    @kc89_first_72 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
+    @kc89_first_73 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
+    @kc89_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
 	\Aring \Aringacute \Atilde \Delta \Lambda \slash \uni01CD \uni01DE 
 	\uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
 	\uni1EA0 \uni1EA2 \uni1EA4 \uni1EA6 \uni1EA8 \uni1EAA \uni1EAC \uni1EAE 
 	\uni1EB0 \uni1EB2 \uni1EB4 \uni1EB6 \uni1FB8 \uni1FB9 \uni1FBC \uni212B ];
-    @kc88_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
-    @kc88_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
+    @kc89_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
+    @kc89_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
 	\Gbreve \Gbreve.cv21 \Gcaron \Gcaron.cv21 \Gcircumflex 
 	\Gcircumflex.cv21 \Gcommaaccent \Gcommaaccent.cv21 \Gdotaccent 
 	\Gdotaccent.cv21 \O \OE \Oacute \Obreve \Ocircumflex \Odieresis \Ograve 
 	\Ohorn \Ohungarumlaut \Omacron \Omicron \Omicrontonos \Oslash 
-	\Oslashacute \Otilde \Q \Theta \colonmonetary \emptyset \uni0187 
-	\uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
+	\Oslashacute \Otilde \Q \Q.cv29 \Theta \colonmonetary \emptyset 
+	\uni0187 \uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
 	\uni01E4.cv21 \uni01EA \uni01EC \uni01F4 \uni01F4.cv21 \uni020C 
 	\uni020E \uni022A \uni022C \uni022E \uni0230 \uni023B \uni024A \uni0298 
 	\uni03D8 \uni03F4 \uni03FE \uni0404 \uni041E \uni0421 \uni0472 \uni047A 
 	\uni0480 \uni04AA \uni04BC \uni04BE \uni04D8 \uni04DA \uni04E6 \uni04E8 
-	\uni04EA \uni050C \uni051A \uni1E08 \uni1E20 \uni1E20.cv21 \uni1E4C 
-	\uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE \uni1ED0 \uni1ED2 \uni1ED4 
-	\uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE \uni1EE0 \uni1EE2 \uni20A2 
-	\uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE \uni216D \uni2180 \uni2182 
-	\uni2185 ];
-    @kc88_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
-    @kc88_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+	\uni04EA \uni050C \uni051A \uni051A.cv29 \uni1E08 \uni1E20 
+	\uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE 
+	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
+	\uni1EE0 \uni1EE2 \uni20A2 \uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE 
+	\uni216D \uni2180 \uni2182 \uni2185 ];
+    @kc89_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
+    @kc89_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
-    @kc88_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc88_second_7 = [\Omega \uni03A9 \uni1FFC ];
-    @kc88_second_8 = [\Phi \uni0424 ];
-    @kc88_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc88_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
+    @kc89_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
+    @kc89_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc89_second_8 = [\Phi \uni0424 ];
+    @kc89_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
+    @kc89_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
 	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc88_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
+    @kc89_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
 	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc88_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
+    @kc89_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
 	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
-    @kc88_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
+    @kc89_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
 	\uni2166 \uni2167 \uni2C6F \universal ];
-    @kc88_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
+    @kc89_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
 	\uni04FE \uni1E8A \uni1E8C \uni2169 \uni216A \uni216B ];
-    @kc88_second_17 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
+    @kc89_second_17 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
 	\atilde \uni01DF \uni01E1 \uni0201 \uni0203 \uni0227 \uni0430 \uni04D1 
 	\uni04D3 \uni1E01 \uni1EA1 \uni1EA3 \uni1EA5 \uni1EA7 \uni1EA9 \uni1EAB 
 	\uni1EAD \uni1EAF \uni1EB1 \uni1EB3 \uni1EB5 \uni1EB7 ];
-    @kc88_second_18 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 \ae.cv23 
+    @kc89_second_18 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 \ae.cv23 
 	\aeacute.cv23 \agrave.cv23 \alpha \alphatonos \amacron.cv23 
 	\aogonek.cv23 \aring.cv23 \aringacute.cv23 \atilde.cv23 \d \dcaron 
 	\dcroat \dong \eth \g.cv24 \gbreve.cv24 \gcaron.cv24 \gcircumflex.cv24 
@@ -8731,7 +8764,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 
 	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 
 	\uni1FB4 \uni1FB6 \uni1FB7 \uni217E \uniA64D \uniA7C8 ];
-    @kc88_second_19 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
+    @kc89_second_19 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
 	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
 	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
 	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
@@ -8744,7 +8777,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
 	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
 	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
-    @kc88_second_20 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_second_20 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8798,16 +8831,16 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_second_21 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
-    @kc88_second_22 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_second_21 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
+    @kc89_second_22 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_second_23 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
+    @kc89_second_23 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
 	\uniA7B4 \uniA7B5 ];
-    @kc88_second_24 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
+    @kc89_second_24 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
@@ -8821,25 +8854,26 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
-    @kc88_second_25 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
+    @kc89_second_25 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
 	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
 	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc 
-	\uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc 
-	\uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc 
-	\uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc 
-	\uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc 
-	\uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc 
-	\uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc 
-	\uni050D.sc \uni051B.sc \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
-	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
-	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc ];
-    @kc88_second_26 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+	\q.sc \q.sc.cv29 \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc 
+	\uni01E5.sc \uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc 
+	\uni020F.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc 
+	\uni023C.sc \uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc 
+	\uni037C.sc \uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc 
+	\uni0444.loclBGR.sc \uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc 
+	\uni04AB.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni050D.sc \uni051B.sc \uni051B.sc.cv29 \uni1E09.sc 
+	\uni1E21.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc 
+	\uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc 
+	\uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc 
+	\uni217D.sc ];
+    @kc89_second_26 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8895,11 +8929,11 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_second_27 = [\chi \gamma \uni04AF \uni04B1 ];
-    @kc88_second_28 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
+    @kc89_second_27 = [\chi \gamma \uni04AF \uni04B1 ];
+    @kc89_second_28 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
 	\uni04DD.sc \uni04FD.sc \uni04FF.sc \uni1E8B.sc \uni1E8D.sc 
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
-    @kc88_second_29 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_second_29 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8909,7 +8943,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
 	\uni2178.sc ];
-    @kc88_second_30 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
+    @kc89_second_30 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
 	\five.cv05.dnom.pnum \five.cv05.dnom.tnum \five.cv15.dnom 
@@ -8945,12 +8979,12 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.dnom.tnum \zero.cv20.zero.dnom 
 	\zero.cv20.zero.dnom.tnum \zero.dnom \zero.dnom.tnum 
 	\zero.zero.dnom \zero.zero.dnom.tnum ];
-    @kc88_second_31 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_second_31 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0437 \uni0455 
 	\uni0479 \uni0499 \uni04DF \uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
-    @kc88_second_32 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
+    @kc89_second_32 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
 	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
 	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
 	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
@@ -8974,1731 +9008,1732 @@ lookup kern_Horizontal_kerning {
 	\uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 \upsilon 
 	\upsilondieresistonos \upsilontonos \uring \uring.cv25 \utilde 
 	\utilde.cv25 ];
-    @kc88_second_33 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
+    @kc89_second_33 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
 	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc88_second_34 = [\fraction ];
-    @kc88_second_35 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \uni01E5 \uni1E21 ];
-    @kc88_second_36 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc88_second_37 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+    @kc89_second_34 = [\fraction ];
+    @kc89_second_35 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \uni01E5 \uni1E21 ];
+    @kc89_second_36 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc89_second_37 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc88_second_38 = [\lambda \uni019B ];
-    @kc88_second_39 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc89_second_38 = [\lambda \uni019B ];
+    @kc89_second_39 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc88_second_40 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+    @kc89_second_40 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
 	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
 	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
 	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
 	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc88_second_41 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_second_42 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
-    @kc88_second_43 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc89_second_41 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_second_42 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
+    @kc89_second_43 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc88_second_44 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_second_44 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc88_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc89_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_second_46 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_second_46 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
 	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
 	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc88_second_47 = [\theta \uni0478 \uniA64C ];
-    @kc88_second_48 = [\tonos2 ];
-    @kc88_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc88_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_second_47 = [\theta \uni0478 \uniA64C ];
+    @kc89_second_48 = [\tonos2 ];
+    @kc89_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc89_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc88_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_second_52 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
+    @kc89_second_52 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
 	\z \zacute \zcaron \zdotaccent ];
-    @kc88_second_53 = [\uni0237 ];
-    @kc88_second_54 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc88_second_55 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc88_second_56 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc88_second_57 = [\uni042F \uni0518 ];
-    @kc88_second_58 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
+    @kc89_second_53 = [\uni0237 ];
+    @kc89_second_54 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc89_second_55 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc89_second_56 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc89_second_57 = [\uni042F \uni0518 ];
+    @kc89_second_58 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
 	\uni052F ];
-    @kc88_second_59 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc89_second_59 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc88_second_60 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc89_second_60 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc88_second_61 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc88_second_62 = [\uni044F.sc \uni0519.sc ];
-    @kc88_second_63 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc89_second_61 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc89_second_62 = [\uni044F.sc \uni0519.sc ];
+    @kc89_second_63 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc88_second_64 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc88_second_65 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_second_64 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc89_second_65 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_66 = [\uni0500 \uni0502 ];
-    @kc88_second_67 = [\uni0501.sc \uni0503.sc ];
-    @kc88_second_68 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
+    @kc89_second_66 = [\uni0500 \uni0502 ];
+    @kc89_second_67 = [\uni0501.sc \uni0503.sc ];
+    @kc89_second_68 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
 	\zero.cv20.zero.dnom.pnum \zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc88_second_69 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
+    @kc89_second_69 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
 	\zero.cv20.zero.numr.pnum \zero.numr.pnum \zero.zero.numr.pnum ];
-    pos @kc88_first_1 @kc88_second_3 -70;
-    pos @kc88_first_1 @kc88_second_8 -70;
-    pos @kc88_first_1 @kc88_second_9 -140;
-    pos @kc88_first_1 @kc88_second_10 -35;
-    pos @kc88_first_1 @kc88_second_12 -280;
-    pos @kc88_first_1 @kc88_second_13 -280;
-    pos @kc88_first_1 @kc88_second_14 -280;
-    pos @kc88_first_1 @kc88_second_15 -210;
-    pos @kc88_first_1 @kc88_second_22 -70;
-    pos @kc88_first_1 @kc88_second_25 -35;
-    pos @kc88_first_1 @kc88_second_27 -50;
-    pos @kc88_first_1 @kc88_second_33 -70;
-    pos @kc88_first_1 @kc88_second_41 -35;
-    pos @kc88_first_1 @kc88_second_42 -140;
-    pos @kc88_first_1 @kc88_second_43 -105;
-    pos @kc88_first_1 @kc88_second_46 -210;
-    pos @kc88_first_1 @kc88_second_47 -35;
-    pos @kc88_first_1 @kc88_second_48 1;
-    pos @kc88_first_1 @kc88_second_50 -175;
-    pos @kc88_first_1 @kc88_second_51 -210;
-    pos @kc88_first_1 @kc88_second_61 -140;
-    pos @kc88_first_1 @kc88_second_63 -140;
-    pos @kc88_first_1 @kc88_second_64 -210;
-    pos @kc88_first_1 @kc88_second_65 -140;
-    pos @kc88_first_2 @kc88_second_9 -35;
-    pos @kc88_first_2 @kc88_second_12 -70;
-    pos @kc88_first_2 @kc88_second_13 -70;
-    pos @kc88_first_2 @kc88_second_14 -70;
-    pos @kc88_first_2 @kc88_second_15 -35;
-    pos @kc88_first_2 @kc88_second_16 -35;
-    pos @kc88_first_2 @kc88_second_42 -35;
-    pos @kc88_first_2 @kc88_second_48 1;
-    pos @kc88_first_3 @kc88_second_1 -35;
-    pos @kc88_first_3 @kc88_second_2 -70;
-    pos @kc88_first_3 @kc88_second_5 -35;
-    pos @kc88_first_3 @kc88_second_11 -35;
-    pos @kc88_first_3 @kc88_second_12 -35;
-    pos @kc88_first_3 @kc88_second_13 -70;
-    pos @kc88_first_3 @kc88_second_14 -35;
-    pos @kc88_first_3 @kc88_second_16 -70;
-    pos @kc88_first_3 @kc88_second_19 -35;
-    pos @kc88_first_3 @kc88_second_21 -70;
-    pos @kc88_first_3 @kc88_second_38 -35;
-    pos @kc88_first_3 @kc88_second_48 1;
-    pos @kc88_first_4 @kc88_second_1 -70;
-    pos @kc88_first_4 @kc88_second_2 -140;
-    pos @kc88_first_4 @kc88_second_4 70;
-    pos @kc88_first_4 @kc88_second_5 -70;
-    pos @kc88_first_4 @kc88_second_11 -105;
-    pos @kc88_first_4 @kc88_second_12 -140;
-    pos @kc88_first_4 @kc88_second_13 -140;
-    pos @kc88_first_4 @kc88_second_14 -105;
-    pos @kc88_first_4 @kc88_second_15 -35;
-    pos @kc88_first_4 @kc88_second_16 -140;
-    pos @kc88_first_4 @kc88_second_19 -70;
-    pos @kc88_first_4 @kc88_second_26 -70;
-    pos @kc88_first_4 @kc88_second_28 -70;
-    pos @kc88_first_4 @kc88_second_29 -35;
-    pos @kc88_first_4 @kc88_second_33 35;
-    pos @kc88_first_4 @kc88_second_35 -35;
-    pos @kc88_first_4 @kc88_second_37 -70;
-    pos @kc88_first_4 @kc88_second_38 -70;
-    pos @kc88_first_4 @kc88_second_46 -35;
-    pos @kc88_first_4 @kc88_second_48 1;
-    pos @kc88_first_4 @kc88_second_51 -70;
-    pos @kc88_first_4 @kc88_second_56 -70;
-    pos @kc88_first_4 @kc88_second_58 -70;
-    pos @kc88_first_4 @kc88_second_59 -70;
-    pos @kc88_first_4 @kc88_second_64 -35;
-    pos @kc88_first_5 @kc88_second_1 -280;
-    pos @kc88_first_5 @kc88_second_2 -350;
-    pos @kc88_first_5 @kc88_second_3 -140;
-    pos @kc88_first_5 @kc88_second_4 -70;
-    pos @kc88_first_5 @kc88_second_6 -350;
-    pos @kc88_first_5 @kc88_second_7 -140;
-    pos @kc88_first_5 @kc88_second_8 -210;
-    pos @kc88_first_5 @kc88_second_10 -70;
-    pos @kc88_first_5 @kc88_second_17 -240;
-    pos @kc88_first_5 @kc88_second_18 -240;
-    pos @kc88_first_5 @kc88_second_19 -280;
-    pos @kc88_first_5 @kc88_second_21 -350;
-    pos @kc88_first_5 @kc88_second_22 -280;
-    pos @kc88_first_5 @kc88_second_23 -240;
-    pos @kc88_first_5 @kc88_second_24 -240;
-    pos @kc88_first_5 @kc88_second_25 -210;
-    pos @kc88_first_5 @kc88_second_26 -350;
-    pos @kc88_first_5 @kc88_second_27 -140;
-    pos @kc88_first_5 @kc88_second_29 -140;
-    pos @kc88_first_5 @kc88_second_31 -240;
-    pos @kc88_first_5 @kc88_second_32 -240;
-    pos @kc88_first_5 @kc88_second_33 -175;
-    pos @kc88_first_5 @kc88_second_35 -240;
-    pos @kc88_first_5 @kc88_second_37 -350;
-    pos @kc88_first_5 @kc88_second_38 -105;
-    pos @kc88_first_5 @kc88_second_39 -240;
-    pos @kc88_first_5 @kc88_second_40 -210;
-    pos @kc88_first_5 @kc88_second_41 -240;
-    pos @kc88_first_5 @kc88_second_42 -240;
-    pos @kc88_first_5 @kc88_second_44 -240;
-    pos @kc88_first_5 @kc88_second_47 -140;
-    pos @kc88_first_5 @kc88_second_48 1;
-    pos @kc88_first_5 @kc88_second_49 -35;
-    pos @kc88_first_5 @kc88_second_50 -240;
-    pos @kc88_first_5 @kc88_second_52 -240;
-    pos @kc88_first_5 @kc88_second_53 -240;
-    pos @kc88_first_5 @kc88_second_54 -240;
-    pos @kc88_first_5 @kc88_second_55 -240;
-    pos @kc88_first_5 @kc88_second_56 -280;
-    pos @kc88_first_5 @kc88_second_57 -70;
-    pos @kc88_first_5 @kc88_second_58 -280;
-    pos @kc88_first_5 @kc88_second_59 -240;
-    pos @kc88_first_5 @kc88_second_60 -175;
-    pos @kc88_first_5 @kc88_second_61 -240;
-    pos @kc88_first_5 @kc88_second_62 -210;
-    pos @kc88_first_5 @kc88_second_63 -175;
-    pos @kc88_first_5 @kc88_second_66 -175;
-    pos @kc88_first_5 @kc88_second_67 -175;
-    pos @kc88_first_6 @kc88_second_48 1;
-    pos @kc88_first_7 @kc88_second_3 -70;
-    pos @kc88_first_7 @kc88_second_8 -105;
-    pos @kc88_first_7 @kc88_second_17 -35;
-    pos @kc88_first_7 @kc88_second_18 -70;
-    pos @kc88_first_7 @kc88_second_22 -105;
-    pos @kc88_first_7 @kc88_second_24 -105;
-    pos @kc88_first_7 @kc88_second_25 -70;
-    pos @kc88_first_7 @kc88_second_48 1;
-    pos @kc88_first_7 @kc88_second_49 -35;
-    pos @kc88_first_7 @kc88_second_50 -70;
-    pos @kc88_first_7 @kc88_second_54 -50;
-    pos @kc88_first_7 @kc88_second_63 -35;
-    pos @kc88_first_7 @kc88_second_66 -70;
-    pos @kc88_first_7 @kc88_second_67 -70;
-    pos @kc88_first_8 @kc88_second_3 -140;
-    pos @kc88_first_8 @kc88_second_4 -70;
-    pos @kc88_first_8 @kc88_second_6 -70;
-    pos @kc88_first_8 @kc88_second_8 -140;
-    pos @kc88_first_8 @kc88_second_10 -35;
-    pos @kc88_first_8 @kc88_second_17 -70;
-    pos @kc88_first_8 @kc88_second_18 -70;
-    pos @kc88_first_8 @kc88_second_22 -140;
-    pos @kc88_first_8 @kc88_second_24 -70;
-    pos @kc88_first_8 @kc88_second_25 -105;
-    pos @kc88_first_8 @kc88_second_27 -140;
-    pos @kc88_first_8 @kc88_second_31 -35;
-    pos @kc88_first_8 @kc88_second_33 -105;
-    pos @kc88_first_8 @kc88_second_37 -70;
-    pos @kc88_first_8 @kc88_second_39 -70;
-    pos @kc88_first_8 @kc88_second_41 -105;
-    pos @kc88_first_8 @kc88_second_42 -175;
-    pos @kc88_first_8 @kc88_second_43 -140;
-    pos @kc88_first_8 @kc88_second_44 -35;
-    pos @kc88_first_8 @kc88_second_46 -140;
-    pos @kc88_first_8 @kc88_second_47 -105;
-    pos @kc88_first_8 @kc88_second_48 1;
-    pos @kc88_first_8 @kc88_second_49 -70;
-    pos @kc88_first_8 @kc88_second_50 -140;
-    pos @kc88_first_8 @kc88_second_51 -70;
-    pos @kc88_first_8 @kc88_second_54 -35;
-    pos @kc88_first_8 @kc88_second_55 -35;
-    pos @kc88_first_8 @kc88_second_61 -210;
-    pos @kc88_first_8 @kc88_second_63 -105;
-    pos @kc88_first_8 @kc88_second_64 -70;
-    pos @kc88_first_8 @kc88_second_65 -35;
-    pos @kc88_first_8 @kc88_second_66 -70;
-    pos @kc88_first_8 @kc88_second_67 -35;
-    pos @kc88_first_9 @kc88_second_3 -140;
-    pos @kc88_first_9 @kc88_second_4 -70;
-    pos @kc88_first_9 @kc88_second_6 -70;
-    pos @kc88_first_9 @kc88_second_8 -210;
-    pos @kc88_first_9 @kc88_second_9 -420;
-    pos @kc88_first_9 @kc88_second_10 -70;
-    pos @kc88_first_9 @kc88_second_12 -350;
-    pos @kc88_first_9 @kc88_second_13 -420;
-    pos @kc88_first_9 @kc88_second_14 -350;
-    pos @kc88_first_9 @kc88_second_15 -280;
-    pos @kc88_first_9 @kc88_second_17 -70;
-    pos @kc88_first_9 @kc88_second_18 -70;
-    pos @kc88_first_9 @kc88_second_20 -210;
-    pos @kc88_first_9 @kc88_second_22 -210;
-    pos @kc88_first_9 @kc88_second_24 -70;
-    pos @kc88_first_9 @kc88_second_25 -140;
-    pos @kc88_first_9 @kc88_second_31 -50;
-    pos @kc88_first_9 @kc88_second_33 -140;
-    pos @kc88_first_9 @kc88_second_37 -70;
-    pos @kc88_first_9 @kc88_second_41 -105;
-    pos @kc88_first_9 @kc88_second_42 -280;
-    pos @kc88_first_9 @kc88_second_43 -350;
-    pos @kc88_first_9 @kc88_second_44 -50;
-    pos @kc88_first_9 @kc88_second_46 -350;
-    pos @kc88_first_9 @kc88_second_48 1;
-    pos @kc88_first_9 @kc88_second_49 -35;
-    pos @kc88_first_9 @kc88_second_50 -210;
-    pos @kc88_first_9 @kc88_second_51 -350;
-    pos @kc88_first_9 @kc88_second_54 -35;
-    pos @kc88_first_9 @kc88_second_55 -35;
-    pos @kc88_first_9 @kc88_second_61 -280;
-    pos @kc88_first_9 @kc88_second_63 -175;
-    pos @kc88_first_9 @kc88_second_64 -280;
-    pos @kc88_first_9 @kc88_second_65 -210;
-    pos @kc88_first_9 @kc88_second_66 -70;
-    pos @kc88_first_9 @kc88_second_67 -70;
-    pos @kc88_first_10 @kc88_second_1 -210;
-    pos @kc88_first_10 @kc88_second_2 -350;
-    pos @kc88_first_10 @kc88_second_5 -70;
-    pos @kc88_first_10 @kc88_second_6 -140;
-    pos @kc88_first_10 @kc88_second_11 -35;
-    pos @kc88_first_10 @kc88_second_12 -70;
-    pos @kc88_first_10 @kc88_second_13 -70;
-    pos @kc88_first_10 @kc88_second_14 -35;
-    pos @kc88_first_10 @kc88_second_16 -70;
-    pos @kc88_first_10 @kc88_second_17 -35;
-    pos @kc88_first_10 @kc88_second_18 -70;
-    pos @kc88_first_10 @kc88_second_19 -140;
-    pos @kc88_first_10 @kc88_second_21 -280;
-    pos @kc88_first_10 @kc88_second_24 -70;
-    pos @kc88_first_10 @kc88_second_26 -350;
-    pos @kc88_first_10 @kc88_second_31 -70;
-    pos @kc88_first_10 @kc88_second_34 -140;
-    pos @kc88_first_10 @kc88_second_35 -70;
-    pos @kc88_first_10 @kc88_second_37 -210;
-    pos @kc88_first_10 @kc88_second_38 -105;
-    pos @kc88_first_10 @kc88_second_41 -70;
-    pos @kc88_first_10 @kc88_second_48 1;
-    pos @kc88_first_10 @kc88_second_56 -210;
-    pos @kc88_first_10 @kc88_second_58 -210;
-    pos @kc88_first_10 @kc88_second_59 -210;
-    pos @kc88_first_10 @kc88_second_64 -70;
-    pos @kc88_first_10 @kc88_second_66 -70;
-    pos @kc88_first_10 @kc88_second_67 -105;
-    pos @kc88_first_11 @kc88_second_1 -70;
-    pos @kc88_first_11 @kc88_second_2 -140;
-    pos @kc88_first_11 @kc88_second_5 -105;
-    pos @kc88_first_11 @kc88_second_6 -35;
-    pos @kc88_first_11 @kc88_second_11 -70;
-    pos @kc88_first_11 @kc88_second_12 -210;
-    pos @kc88_first_11 @kc88_second_13 -175;
-    pos @kc88_first_11 @kc88_second_14 -105;
-    pos @kc88_first_11 @kc88_second_15 -70;
-    pos @kc88_first_11 @kc88_second_16 -140;
-    pos @kc88_first_11 @kc88_second_19 -70;
-    pos @kc88_first_11 @kc88_second_21 -140;
-    pos @kc88_first_11 @kc88_second_26 -70;
-    pos @kc88_first_11 @kc88_second_28 -70;
-    pos @kc88_first_11 @kc88_second_29 -70;
-    pos @kc88_first_11 @kc88_second_35 -35;
-    pos @kc88_first_11 @kc88_second_37 -35;
-    pos @kc88_first_11 @kc88_second_38 -140;
-    pos @kc88_first_11 @kc88_second_42 -70;
-    pos @kc88_first_11 @kc88_second_45 -35;
-    pos @kc88_first_11 @kc88_second_46 -35;
-    pos @kc88_first_11 @kc88_second_48 1;
-    pos @kc88_first_11 @kc88_second_51 -70;
-    pos @kc88_first_11 @kc88_second_56 -210;
-    pos @kc88_first_11 @kc88_second_58 -175;
-    pos @kc88_first_11 @kc88_second_59 -175;
-    pos @kc88_first_11 @kc88_second_60 -35;
-    pos @kc88_first_11 @kc88_second_64 -70;
-    pos @kc88_first_11 @kc88_second_65 -35;
-    pos @kc88_first_11 @kc88_second_66 -35;
-    pos @kc88_first_11 @kc88_second_67 -70;
-    pos @kc88_first_12 @kc88_second_1 -140;
-    pos @kc88_first_12 @kc88_second_2 -210;
-    pos @kc88_first_12 @kc88_second_6 -140;
-    pos @kc88_first_12 @kc88_second_17 -70;
-    pos @kc88_first_12 @kc88_second_18 -70;
-    pos @kc88_first_12 @kc88_second_19 -140;
-    pos @kc88_first_12 @kc88_second_21 -210;
-    pos @kc88_first_12 @kc88_second_24 -70;
-    pos @kc88_first_12 @kc88_second_26 -350;
-    pos @kc88_first_12 @kc88_second_31 -35;
-    pos @kc88_first_12 @kc88_second_34 -140;
-    pos @kc88_first_12 @kc88_second_35 -70;
-    pos @kc88_first_12 @kc88_second_37 -140;
-    pos @kc88_first_12 @kc88_second_38 -70;
-    pos @kc88_first_12 @kc88_second_41 -70;
-    pos @kc88_first_12 @kc88_second_48 1;
-    pos @kc88_first_12 @kc88_second_54 -35;
-    pos @kc88_first_12 @kc88_second_56 -210;
-    pos @kc88_first_12 @kc88_second_58 -210;
-    pos @kc88_first_12 @kc88_second_59 -210;
-    pos @kc88_first_12 @kc88_second_66 -70;
-    pos @kc88_first_12 @kc88_second_67 -105;
-    pos @kc88_first_13 @kc88_second_6 -70;
-    pos @kc88_first_13 @kc88_second_12 -70;
-    pos @kc88_first_13 @kc88_second_13 -105;
-    pos @kc88_first_13 @kc88_second_14 -35;
-    pos @kc88_first_13 @kc88_second_18 -35;
-    pos @kc88_first_13 @kc88_second_24 -35;
-    pos @kc88_first_13 @kc88_second_31 -35;
-    pos @kc88_first_13 @kc88_second_37 -70;
-    pos @kc88_first_13 @kc88_second_41 -70;
-    pos @kc88_first_13 @kc88_second_48 1;
-    pos @kc88_first_13 @kc88_second_66 -70;
-    pos @kc88_first_13 @kc88_second_67 -35;
-    pos @kc88_first_14 @kc88_second_2 -35;
-    pos @kc88_first_14 @kc88_second_11 -35;
-    pos @kc88_first_14 @kc88_second_12 -70;
-    pos @kc88_first_14 @kc88_second_13 -70;
-    pos @kc88_first_14 @kc88_second_14 -35;
-    pos @kc88_first_14 @kc88_second_16 -35;
-    pos @kc88_first_14 @kc88_second_21 -35;
-    pos @kc88_first_14 @kc88_second_27 -35;
-    pos @kc88_first_14 @kc88_second_35 -35;
-    pos @kc88_first_14 @kc88_second_42 -70;
-    pos @kc88_first_14 @kc88_second_48 1;
-    pos @kc88_first_14 @kc88_second_50 -70;
-    pos @kc88_first_14 @kc88_second_51 -35;
-    pos @kc88_first_14 @kc88_second_60 -35;
-    pos @kc88_first_14 @kc88_second_61 -35;
-    pos @kc88_first_14 @kc88_second_63 -35;
-    pos @kc88_first_14 @kc88_second_65 -35;
-    pos @kc88_first_15 @kc88_second_3 -70;
-    pos @kc88_first_15 @kc88_second_4 -70;
-    pos @kc88_first_15 @kc88_second_6 -35;
-    pos @kc88_first_15 @kc88_second_8 -70;
-    pos @kc88_first_15 @kc88_second_17 -70;
-    pos @kc88_first_15 @kc88_second_18 -70;
-    pos @kc88_first_15 @kc88_second_22 -140;
-    pos @kc88_first_15 @kc88_second_24 -70;
-    pos @kc88_first_15 @kc88_second_25 -70;
-    pos @kc88_first_15 @kc88_second_27 -70;
-    pos @kc88_first_15 @kc88_second_31 -35;
-    pos @kc88_first_15 @kc88_second_33 -35;
-    pos @kc88_first_15 @kc88_second_39 -35;
-    pos @kc88_first_15 @kc88_second_41 -70;
-    pos @kc88_first_15 @kc88_second_42 -142;
-    pos @kc88_first_15 @kc88_second_43 -35;
-    pos @kc88_first_15 @kc88_second_47 -35;
-    pos @kc88_first_15 @kc88_second_48 1;
-    pos @kc88_first_15 @kc88_second_49 -35;
-    pos @kc88_first_15 @kc88_second_50 -70;
-    pos @kc88_first_15 @kc88_second_54 -35;
-    pos @kc88_first_15 @kc88_second_55 -35;
-    pos @kc88_first_15 @kc88_second_61 -105;
-    pos @kc88_first_15 @kc88_second_63 -35;
-    pos @kc88_first_15 @kc88_second_66 -35;
-    pos @kc88_first_15 @kc88_second_67 -35;
-    pos @kc88_first_16 @kc88_second_1 -280;
-    pos @kc88_first_16 @kc88_second_2 -280;
-    pos @kc88_first_16 @kc88_second_3 -140;
-    pos @kc88_first_16 @kc88_second_4 -70;
-    pos @kc88_first_16 @kc88_second_6 -280;
-    pos @kc88_first_16 @kc88_second_7 -140;
-    pos @kc88_first_16 @kc88_second_8 -175;
-    pos @kc88_first_16 @kc88_second_10 -70;
-    pos @kc88_first_16 @kc88_second_17 -245;
-    pos @kc88_first_16 @kc88_second_18 -280;
-    pos @kc88_first_16 @kc88_second_19 -280;
-    pos @kc88_first_16 @kc88_second_21 -280;
-    pos @kc88_first_16 @kc88_second_22 -210;
-    pos @kc88_first_16 @kc88_second_23 -140;
-    pos @kc88_first_16 @kc88_second_24 -280;
-    pos @kc88_first_16 @kc88_second_25 -210;
-    pos @kc88_first_16 @kc88_second_26 -350;
-    pos @kc88_first_16 @kc88_second_27 -70;
-    pos @kc88_first_16 @kc88_second_29 -140;
-    pos @kc88_first_16 @kc88_second_31 -240;
-    pos @kc88_first_16 @kc88_second_32 -140;
-    pos @kc88_first_16 @kc88_second_33 -140;
-    pos @kc88_first_16 @kc88_second_34 -245;
-    pos @kc88_first_16 @kc88_second_35 -315;
-    pos @kc88_first_16 @kc88_second_37 -315;
-    pos @kc88_first_16 @kc88_second_38 -70;
-    pos @kc88_first_16 @kc88_second_39 -210;
-    pos @kc88_first_16 @kc88_second_40 -210;
-    pos @kc88_first_16 @kc88_second_41 -245;
-    pos @kc88_first_16 @kc88_second_42 -245;
-    pos @kc88_first_16 @kc88_second_43 -70;
-    pos @kc88_first_16 @kc88_second_45 -35;
-    pos @kc88_first_16 @kc88_second_46 -140;
-    pos @kc88_first_16 @kc88_second_47 -140;
-    pos @kc88_first_16 @kc88_second_48 1;
-    pos @kc88_first_16 @kc88_second_49 -70;
-    pos @kc88_first_16 @kc88_second_50 -140;
-    pos @kc88_first_16 @kc88_second_52 -140;
-    pos @kc88_first_16 @kc88_second_53 -140;
-    pos @kc88_first_16 @kc88_second_54 -240;
-    pos @kc88_first_16 @kc88_second_55 -140;
-    pos @kc88_first_16 @kc88_second_56 -280;
-    pos @kc88_first_16 @kc88_second_57 -105;
-    pos @kc88_first_16 @kc88_second_58 -315;
-    pos @kc88_first_16 @kc88_second_59 -280;
-    pos @kc88_first_16 @kc88_second_60 -140;
-    pos @kc88_first_16 @kc88_second_61 -210;
-    pos @kc88_first_16 @kc88_second_62 -210;
-    pos @kc88_first_16 @kc88_second_63 -105;
-    pos @kc88_first_16 @kc88_second_66 -315;
-    pos @kc88_first_16 @kc88_second_67 -350;
-    pos @kc88_first_17 @kc88_second_1 -280;
-    pos @kc88_first_17 @kc88_second_2 -280;
-    pos @kc88_first_17 @kc88_second_3 -105;
-    pos @kc88_first_17 @kc88_second_6 -210;
-    pos @kc88_first_17 @kc88_second_7 -105;
-    pos @kc88_first_17 @kc88_second_8 -105;
-    pos @kc88_first_17 @kc88_second_10 -35;
-    pos @kc88_first_17 @kc88_second_17 -105;
-    pos @kc88_first_17 @kc88_second_18 -175;
-    pos @kc88_first_17 @kc88_second_19 -280;
-    pos @kc88_first_17 @kc88_second_21 -280;
-    pos @kc88_first_17 @kc88_second_22 -70;
-    pos @kc88_first_17 @kc88_second_23 -105;
-    pos @kc88_first_17 @kc88_second_24 -140;
-    pos @kc88_first_17 @kc88_second_25 -140;
-    pos @kc88_first_17 @kc88_second_26 -210;
-    pos @kc88_first_17 @kc88_second_29 -70;
-    pos @kc88_first_17 @kc88_second_31 -140;
-    pos @kc88_first_17 @kc88_second_32 -105;
-    pos @kc88_first_17 @kc88_second_34 -210;
-    pos @kc88_first_17 @kc88_second_35 -175;
-    pos @kc88_first_17 @kc88_second_37 -245;
-    pos @kc88_first_17 @kc88_second_38 -70;
-    pos @kc88_first_17 @kc88_second_39 -140;
-    pos @kc88_first_17 @kc88_second_40 -140;
-    pos @kc88_first_17 @kc88_second_41 -140;
-    pos @kc88_first_17 @kc88_second_42 -105;
-    pos @kc88_first_17 @kc88_second_43 -35;
-    pos @kc88_first_17 @kc88_second_46 -35;
-    pos @kc88_first_17 @kc88_second_47 -70;
-    pos @kc88_first_17 @kc88_second_48 1;
-    pos @kc88_first_17 @kc88_second_49 -35;
-    pos @kc88_first_17 @kc88_second_50 -70;
-    pos @kc88_first_17 @kc88_second_52 -105;
-    pos @kc88_first_17 @kc88_second_53 -70;
-    pos @kc88_first_17 @kc88_second_54 -105;
-    pos @kc88_first_17 @kc88_second_55 -70;
-    pos @kc88_first_17 @kc88_second_56 -210;
-    pos @kc88_first_17 @kc88_second_57 -35;
-    pos @kc88_first_17 @kc88_second_58 -245;
-    pos @kc88_first_17 @kc88_second_59 -210;
-    pos @kc88_first_17 @kc88_second_60 -70;
-    pos @kc88_first_17 @kc88_second_61 -105;
-    pos @kc88_first_17 @kc88_second_62 -105;
-    pos @kc88_first_17 @kc88_second_63 -70;
-    pos @kc88_first_17 @kc88_second_66 -175;
-    pos @kc88_first_17 @kc88_second_67 -245;
-    pos @kc88_first_18 @kc88_second_1 -210;
-    pos @kc88_first_18 @kc88_second_2 -245;
-    pos @kc88_first_18 @kc88_second_3 -35;
-    pos @kc88_first_18 @kc88_second_6 -140;
-    pos @kc88_first_18 @kc88_second_7 -35;
-    pos @kc88_first_18 @kc88_second_8 -70;
-    pos @kc88_first_18 @kc88_second_17 -105;
-    pos @kc88_first_18 @kc88_second_18 -105;
-    pos @kc88_first_18 @kc88_second_19 -175;
-    pos @kc88_first_18 @kc88_second_21 -210;
-    pos @kc88_first_18 @kc88_second_22 -70;
-    pos @kc88_first_18 @kc88_second_24 -105;
-    pos @kc88_first_18 @kc88_second_25 -70;
-    pos @kc88_first_18 @kc88_second_26 -140;
-    pos @kc88_first_18 @kc88_second_29 -35;
-    pos @kc88_first_18 @kc88_second_34 -140;
-    pos @kc88_first_18 @kc88_second_35 -105;
-    pos @kc88_first_18 @kc88_second_37 -140;
-    pos @kc88_first_18 @kc88_second_39 -105;
-    pos @kc88_first_18 @kc88_second_40 -70;
-    pos @kc88_first_18 @kc88_second_41 -105;
-    pos @kc88_first_18 @kc88_second_42 -70;
-    pos @kc88_first_18 @kc88_second_44 -35;
-    pos @kc88_first_18 @kc88_second_48 1;
-    pos @kc88_first_18 @kc88_second_53 -35;
-    pos @kc88_first_18 @kc88_second_54 -70;
-    pos @kc88_first_18 @kc88_second_56 -140;
-    pos @kc88_first_18 @kc88_second_58 -175;
-    pos @kc88_first_18 @kc88_second_59 -140;
-    pos @kc88_first_18 @kc88_second_61 -70;
-    pos @kc88_first_18 @kc88_second_66 -105;
-    pos @kc88_first_18 @kc88_second_67 -140;
-    pos @kc88_first_19 @kc88_second_12 -280;
-    pos @kc88_first_19 @kc88_second_14 -175;
-    pos @kc88_first_19 @kc88_second_15 -140;
-    pos @kc88_first_19 @kc88_second_18 -35;
-    pos @kc88_first_19 @kc88_second_31 -35;
-    pos @kc88_first_19 @kc88_second_33 -50;
-    pos @kc88_first_19 @kc88_second_48 1;
-    pos @kc88_first_19 @kc88_second_50 -70;
-    pos @kc88_first_19 @kc88_second_51 -140;
-    pos @kc88_first_19 @kc88_second_61 -70;
-    pos @kc88_first_19 @kc88_second_63 -35;
-    pos @kc88_first_19 @kc88_second_64 -105;
-    pos @kc88_first_19 @kc88_second_65 -70;
-    pos @kc88_first_20 @kc88_second_12 -240;
-    pos @kc88_first_20 @kc88_second_13 -140;
-    pos @kc88_first_20 @kc88_second_14 -105;
-    pos @kc88_first_20 @kc88_second_15 -35;
-    pos @kc88_first_20 @kc88_second_48 1;
-    pos @kc88_first_21 @kc88_second_8 -35;
-    pos @kc88_first_21 @kc88_second_9 -140;
-    pos @kc88_first_21 @kc88_second_12 -280;
-    pos @kc88_first_21 @kc88_second_13 -280;
-    pos @kc88_first_21 @kc88_second_14 -280;
-    pos @kc88_first_21 @kc88_second_15 -175;
-    pos @kc88_first_21 @kc88_second_20 -140;
-    pos @kc88_first_21 @kc88_second_22 -70;
-    pos @kc88_first_21 @kc88_second_27 -70;
-    pos @kc88_first_21 @kc88_second_33 -50;
-    pos @kc88_first_21 @kc88_second_42 -140;
-    pos @kc88_first_21 @kc88_second_43 -105;
-    pos @kc88_first_21 @kc88_second_46 -210;
-    pos @kc88_first_21 @kc88_second_48 1;
-    pos @kc88_first_21 @kc88_second_49 -35;
-    pos @kc88_first_21 @kc88_second_50 -140;
-    pos @kc88_first_21 @kc88_second_51 -210;
-    pos @kc88_first_21 @kc88_second_55 -35;
-    pos @kc88_first_21 @kc88_second_61 -105;
-    pos @kc88_first_21 @kc88_second_63 -105;
-    pos @kc88_first_21 @kc88_second_64 -210;
-    pos @kc88_first_21 @kc88_second_65 -140;
-    pos @kc88_first_22 @kc88_second_1 -140;
-    pos @kc88_first_22 @kc88_second_2 -350;
-    pos @kc88_first_22 @kc88_second_19 -140;
-    pos @kc88_first_22 @kc88_second_21 -280;
-    pos @kc88_first_22 @kc88_second_41 -70;
-    pos @kc88_first_22 @kc88_second_48 1;
-    pos @kc88_first_22 @kc88_second_67 -210;
-    pos @kc88_first_23 @kc88_second_1 -35;
-    pos @kc88_first_23 @kc88_second_5 -105;
-    pos @kc88_first_23 @kc88_second_9 -70;
-    pos @kc88_first_23 @kc88_second_11 -70;
-    pos @kc88_first_23 @kc88_second_12 -240;
-    pos @kc88_first_23 @kc88_second_13 -280;
-    pos @kc88_first_23 @kc88_second_14 -140;
-    pos @kc88_first_23 @kc88_second_15 -105;
-    pos @kc88_first_23 @kc88_second_16 -70;
-    pos @kc88_first_23 @kc88_second_27 -35;
-    pos @kc88_first_23 @kc88_second_28 -70;
-    pos @kc88_first_23 @kc88_second_29 -105;
-    pos @kc88_first_23 @kc88_second_35 -35;
-    pos @kc88_first_23 @kc88_second_38 -70;
-    pos @kc88_first_23 @kc88_second_42 -70;
-    pos @kc88_first_23 @kc88_second_43 -35;
-    pos @kc88_first_23 @kc88_second_45 -35;
-    pos @kc88_first_23 @kc88_second_46 -140;
-    pos @kc88_first_23 @kc88_second_48 1;
-    pos @kc88_first_23 @kc88_second_50 -70;
-    pos @kc88_first_23 @kc88_second_51 -175;
-    pos @kc88_first_23 @kc88_second_52 -35;
-    pos @kc88_first_23 @kc88_second_60 -105;
-    pos @kc88_first_23 @kc88_second_61 -35;
-    pos @kc88_first_23 @kc88_second_63 -50;
-    pos @kc88_first_23 @kc88_second_64 -105;
-    pos @kc88_first_23 @kc88_second_65 -70;
-    pos @kc88_first_24 @kc88_second_6 -35;
-    pos @kc88_first_24 @kc88_second_12 -240;
-    pos @kc88_first_24 @kc88_second_13 -175;
-    pos @kc88_first_24 @kc88_second_14 -70;
-    pos @kc88_first_24 @kc88_second_15 -70;
-    pos @kc88_first_24 @kc88_second_18 -70;
-    pos @kc88_first_24 @kc88_second_24 -70;
-    pos @kc88_first_24 @kc88_second_25 -35;
-    pos @kc88_first_24 @kc88_second_37 -35;
-    pos @kc88_first_24 @kc88_second_42 -35;
-    pos @kc88_first_24 @kc88_second_43 -35;
-    pos @kc88_first_24 @kc88_second_46 -70;
-    pos @kc88_first_24 @kc88_second_47 -35;
-    pos @kc88_first_24 @kc88_second_48 1;
-    pos @kc88_first_24 @kc88_second_51 -35;
-    pos @kc88_first_24 @kc88_second_61 -35;
-    pos @kc88_first_24 @kc88_second_65 -35;
-    pos @kc88_first_24 @kc88_second_66 -35;
-    pos @kc88_first_24 @kc88_second_67 -35;
-    pos @kc88_first_25 @kc88_second_1 -70;
-    pos @kc88_first_25 @kc88_second_2 -140;
-    pos @kc88_first_25 @kc88_second_5 -105;
-    pos @kc88_first_25 @kc88_second_11 -70;
-    pos @kc88_first_25 @kc88_second_12 -280;
-    pos @kc88_first_25 @kc88_second_13 -210;
-    pos @kc88_first_25 @kc88_second_14 -70;
-    pos @kc88_first_25 @kc88_second_15 -70;
-    pos @kc88_first_25 @kc88_second_16 -140;
-    pos @kc88_first_25 @kc88_second_21 -70;
-    pos @kc88_first_25 @kc88_second_28 -70;
-    pos @kc88_first_25 @kc88_second_29 -70;
-    pos @kc88_first_25 @kc88_second_34 -70;
-    pos @kc88_first_25 @kc88_second_38 -70;
-    pos @kc88_first_25 @kc88_second_45 -35;
-    pos @kc88_first_25 @kc88_second_46 -140;
-    pos @kc88_first_25 @kc88_second_48 1;
-    pos @kc88_first_25 @kc88_second_51 -140;
-    pos @kc88_first_25 @kc88_second_52 -35;
-    pos @kc88_first_25 @kc88_second_56 -140;
-    pos @kc88_first_25 @kc88_second_58 -70;
-    pos @kc88_first_25 @kc88_second_59 -105;
-    pos @kc88_first_25 @kc88_second_60 -70;
-    pos @kc88_first_25 @kc88_second_64 -70;
-    pos @kc88_first_25 @kc88_second_65 -35;
-    pos @kc88_first_26 @kc88_second_5 -70;
-    pos @kc88_first_26 @kc88_second_9 -70;
-    pos @kc88_first_26 @kc88_second_12 -240;
-    pos @kc88_first_26 @kc88_second_13 -280;
-    pos @kc88_first_26 @kc88_second_14 -175;
-    pos @kc88_first_26 @kc88_second_15 -105;
-    pos @kc88_first_26 @kc88_second_16 -70;
-    pos @kc88_first_26 @kc88_second_27 -35;
-    pos @kc88_first_26 @kc88_second_28 -70;
-    pos @kc88_first_26 @kc88_second_29 -70;
-    pos @kc88_first_26 @kc88_second_38 -70;
-    pos @kc88_first_26 @kc88_second_42 -70;
-    pos @kc88_first_26 @kc88_second_43 -35;
-    pos @kc88_first_26 @kc88_second_46 -140;
-    pos @kc88_first_26 @kc88_second_48 1;
-    pos @kc88_first_26 @kc88_second_50 -70;
-    pos @kc88_first_26 @kc88_second_51 -140;
-    pos @kc88_first_26 @kc88_second_52 -35;
-    pos @kc88_first_26 @kc88_second_56 -50;
-    pos @kc88_first_26 @kc88_second_57 -35;
-    pos @kc88_first_26 @kc88_second_58 -50;
-    pos @kc88_first_26 @kc88_second_59 -50;
-    pos @kc88_first_26 @kc88_second_60 -105;
-    pos @kc88_first_26 @kc88_second_61 -50;
-    pos @kc88_first_26 @kc88_second_63 -35;
-    pos @kc88_first_26 @kc88_second_64 -105;
-    pos @kc88_first_26 @kc88_second_65 -70;
-    pos @kc88_first_27 @kc88_second_9 -35;
-    pos @kc88_first_27 @kc88_second_12 -140;
-    pos @kc88_first_27 @kc88_second_28 -70;
-    pos @kc88_first_27 @kc88_second_42 -35;
-    pos @kc88_first_27 @kc88_second_46 -70;
-    pos @kc88_first_27 @kc88_second_48 1;
-    pos @kc88_first_27 @kc88_second_51 -70;
-    pos @kc88_first_27 @kc88_second_64 -70;
-    pos @kc88_first_27 @kc88_second_65 -35;
-    pos @kc88_first_28 @kc88_second_5 -50;
-    pos @kc88_first_28 @kc88_second_9 -35;
-    pos @kc88_first_28 @kc88_second_11 -35;
-    pos @kc88_first_28 @kc88_second_12 -240;
-    pos @kc88_first_28 @kc88_second_13 -240;
-    pos @kc88_first_28 @kc88_second_14 -105;
-    pos @kc88_first_28 @kc88_second_15 -70;
-    pos @kc88_first_28 @kc88_second_16 -35;
-    pos @kc88_first_28 @kc88_second_28 -35;
-    pos @kc88_first_28 @kc88_second_29 -35;
-    pos @kc88_first_28 @kc88_second_35 -35;
-    pos @kc88_first_28 @kc88_second_38 -35;
-    pos @kc88_first_28 @kc88_second_42 -50;
-    pos @kc88_first_28 @kc88_second_43 -35;
-    pos @kc88_first_28 @kc88_second_46 -100;
-    pos @kc88_first_28 @kc88_second_48 1;
-    pos @kc88_first_28 @kc88_second_50 -35;
-    pos @kc88_first_28 @kc88_second_51 -140;
-    pos @kc88_first_28 @kc88_second_60 -35;
-    pos @kc88_first_28 @kc88_second_64 -70;
-    pos @kc88_first_28 @kc88_second_65 -35;
-    pos @kc88_first_29 @kc88_second_48 1;
-    pos @kc88_first_30 @kc88_second_8 -70;
-    pos @kc88_first_30 @kc88_second_9 -210;
-    pos @kc88_first_30 @kc88_second_12 -350;
-    pos @kc88_first_30 @kc88_second_13 -350;
-    pos @kc88_first_30 @kc88_second_14 -210;
-    pos @kc88_first_30 @kc88_second_15 -175;
-    pos @kc88_first_30 @kc88_second_27 -70;
-    pos @kc88_first_30 @kc88_second_41 -35;
-    pos @kc88_first_30 @kc88_second_42 -210;
-    pos @kc88_first_30 @kc88_second_43 -210;
-    pos @kc88_first_30 @kc88_second_46 -210;
-    pos @kc88_first_30 @kc88_second_48 1;
-    pos @kc88_first_30 @kc88_second_50 -140;
-    pos @kc88_first_30 @kc88_second_51 -280;
-    pos @kc88_first_30 @kc88_second_61 -210;
-    pos @kc88_first_30 @kc88_second_63 -105;
-    pos @kc88_first_30 @kc88_second_64 -175;
-    pos @kc88_first_30 @kc88_second_65 -140;
-    pos @kc88_first_31 @kc88_second_1 -175;
-    pos @kc88_first_31 @kc88_second_2 -175;
-    pos @kc88_first_31 @kc88_second_5 -70;
-    pos @kc88_first_31 @kc88_second_6 -105;
-    pos @kc88_first_31 @kc88_second_10 -35;
-    pos @kc88_first_31 @kc88_second_11 -105;
-    pos @kc88_first_31 @kc88_second_12 -175;
-    pos @kc88_first_31 @kc88_second_13 -140;
-    pos @kc88_first_31 @kc88_second_14 -70;
-    pos @kc88_first_31 @kc88_second_15 -35;
-    pos @kc88_first_31 @kc88_second_16 -140;
-    pos @kc88_first_31 @kc88_second_17 -70;
-    pos @kc88_first_31 @kc88_second_18 -70;
-    pos @kc88_first_31 @kc88_second_19 -140;
-    pos @kc88_first_31 @kc88_second_21 -175;
-    pos @kc88_first_31 @kc88_second_24 -70;
-    pos @kc88_first_31 @kc88_second_31 -105;
-    pos @kc88_first_31 @kc88_second_36 165;
-    pos @kc88_first_31 @kc88_second_37 -105;
-    pos @kc88_first_31 @kc88_second_38 -175;
-    pos @kc88_first_31 @kc88_second_39 -35;
-    pos @kc88_first_31 @kc88_second_41 -70;
-    pos @kc88_first_31 @kc88_second_48 1;
-    pos @kc88_first_31 @kc88_second_53 165;
-    pos @kc88_first_31 @kc88_second_54 -35;
-    pos @kc88_first_31 @kc88_second_66 -70;
-    pos @kc88_first_31 @kc88_second_67 -105;
-    pos @kc88_first_32 @kc88_second_3 -70;
-    pos @kc88_first_32 @kc88_second_4 -35;
-    pos @kc88_first_32 @kc88_second_6 -70;
-    pos @kc88_first_32 @kc88_second_8 -105;
-    pos @kc88_first_32 @kc88_second_17 -35;
-    pos @kc88_first_32 @kc88_second_18 -70;
-    pos @kc88_first_32 @kc88_second_22 -70;
-    pos @kc88_first_32 @kc88_second_24 -70;
-    pos @kc88_first_32 @kc88_second_25 -140;
-    pos @kc88_first_32 @kc88_second_31 -35;
-    pos @kc88_first_32 @kc88_second_37 -70;
-    pos @kc88_first_32 @kc88_second_39 -35;
-    pos @kc88_first_32 @kc88_second_41 -140;
-    pos @kc88_first_32 @kc88_second_42 -70;
-    pos @kc88_first_32 @kc88_second_48 1;
-    pos @kc88_first_32 @kc88_second_54 -35;
-    pos @kc88_first_32 @kc88_second_55 -35;
-    pos @kc88_first_32 @kc88_second_61 -140;
-    pos @kc88_first_32 @kc88_second_66 -70;
-    pos @kc88_first_32 @kc88_second_67 -70;
-    pos @kc88_first_33 @kc88_second_1 -35;
-    pos @kc88_first_33 @kc88_second_2 -105;
-    pos @kc88_first_33 @kc88_second_3 -70;
-    pos @kc88_first_33 @kc88_second_4 70;
-    pos @kc88_first_33 @kc88_second_5 -70;
-    pos @kc88_first_33 @kc88_second_11 -35;
-    pos @kc88_first_33 @kc88_second_12 -240;
-    pos @kc88_first_33 @kc88_second_13 -175;
-    pos @kc88_first_33 @kc88_second_14 -105;
-    pos @kc88_first_33 @kc88_second_15 -70;
-    pos @kc88_first_33 @kc88_second_16 -70;
-    pos @kc88_first_33 @kc88_second_19 -70;
-    pos @kc88_first_33 @kc88_second_26 -35;
-    pos @kc88_first_33 @kc88_second_29 -70;
-    pos @kc88_first_33 @kc88_second_35 -35;
-    pos @kc88_first_33 @kc88_second_38 -35;
-    pos @kc88_first_33 @kc88_second_42 -35;
-    pos @kc88_first_33 @kc88_second_43 -35;
-    pos @kc88_first_33 @kc88_second_45 -35;
-    pos @kc88_first_33 @kc88_second_46 -140;
-    pos @kc88_first_33 @kc88_second_48 1;
-    pos @kc88_first_33 @kc88_second_50 -50;
-    pos @kc88_first_33 @kc88_second_51 -140;
-    pos @kc88_first_33 @kc88_second_52 -35;
-    pos @kc88_first_33 @kc88_second_56 -70;
-    pos @kc88_first_33 @kc88_second_58 -70;
-    pos @kc88_first_33 @kc88_second_59 -70;
-    pos @kc88_first_33 @kc88_second_64 -70;
-    pos @kc88_first_33 @kc88_second_65 -35;
-    pos @kc88_first_34 @kc88_second_3 -35;
-    pos @kc88_first_34 @kc88_second_4 -70;
-    pos @kc88_first_34 @kc88_second_6 -70;
-    pos @kc88_first_34 @kc88_second_8 -70;
-    pos @kc88_first_34 @kc88_second_12 -140;
-    pos @kc88_first_34 @kc88_second_13 -105;
-    pos @kc88_first_34 @kc88_second_14 -70;
-    pos @kc88_first_34 @kc88_second_15 -35;
-    pos @kc88_first_34 @kc88_second_18 -70;
-    pos @kc88_first_34 @kc88_second_22 -70;
-    pos @kc88_first_34 @kc88_second_24 -105;
-    pos @kc88_first_34 @kc88_second_25 -70;
-    pos @kc88_first_34 @kc88_second_31 -35;
-    pos @kc88_first_34 @kc88_second_37 -70;
-    pos @kc88_first_34 @kc88_second_39 -70;
-    pos @kc88_first_34 @kc88_second_41 -105;
-    pos @kc88_first_34 @kc88_second_42 -70;
-    pos @kc88_first_34 @kc88_second_47 -70;
-    pos @kc88_first_34 @kc88_second_48 1;
-    pos @kc88_first_34 @kc88_second_54 -35;
-    pos @kc88_first_34 @kc88_second_55 -35;
-    pos @kc88_first_34 @kc88_second_66 -70;
-    pos @kc88_first_34 @kc88_second_67 -70;
-    pos @kc88_first_35 @kc88_second_34 -315;
-    pos @kc88_first_35 @kc88_second_48 1;
-    pos @kc88_first_36 @kc88_second_9 -70;
-    pos @kc88_first_36 @kc88_second_12 -240;
-    pos @kc88_first_36 @kc88_second_13 -210;
-    pos @kc88_first_36 @kc88_second_14 -140;
-    pos @kc88_first_36 @kc88_second_15 -105;
-    pos @kc88_first_36 @kc88_second_36 70;
-    pos @kc88_first_36 @kc88_second_42 -70;
-    pos @kc88_first_36 @kc88_second_43 -35;
-    pos @kc88_first_36 @kc88_second_46 -140;
-    pos @kc88_first_36 @kc88_second_48 1;
-    pos @kc88_first_36 @kc88_second_50 -50;
-    pos @kc88_first_36 @kc88_second_51 -140;
-    pos @kc88_first_36 @kc88_second_53 165;
-    pos @kc88_first_36 @kc88_second_61 -35;
-    pos @kc88_first_36 @kc88_second_63 -35;
-    pos @kc88_first_36 @kc88_second_64 -70;
-    pos @kc88_first_36 @kc88_second_65 -70;
-    pos @kc88_first_37 @kc88_second_9 -35;
-    pos @kc88_first_37 @kc88_second_12 -240;
-    pos @kc88_first_37 @kc88_second_13 -240;
-    pos @kc88_first_37 @kc88_second_14 -140;
-    pos @kc88_first_37 @kc88_second_15 -105;
-    pos @kc88_first_37 @kc88_second_16 -35;
-    pos @kc88_first_37 @kc88_second_28 -35;
-    pos @kc88_first_37 @kc88_second_29 -35;
-    pos @kc88_first_37 @kc88_second_42 -70;
-    pos @kc88_first_37 @kc88_second_43 -35;
-    pos @kc88_first_37 @kc88_second_46 -70;
-    pos @kc88_first_37 @kc88_second_48 1;
-    pos @kc88_first_37 @kc88_second_50 -35;
-    pos @kc88_first_37 @kc88_second_51 -70;
-    pos @kc88_first_37 @kc88_second_63 -35;
-    pos @kc88_first_37 @kc88_second_64 -70;
-    pos @kc88_first_37 @kc88_second_65 -70;
-    pos @kc88_first_38 @kc88_second_5 -70;
-    pos @kc88_first_38 @kc88_second_9 -70;
-    pos @kc88_first_38 @kc88_second_12 -140;
-    pos @kc88_first_38 @kc88_second_13 -210;
-    pos @kc88_first_38 @kc88_second_14 -140;
-    pos @kc88_first_38 @kc88_second_15 -105;
-    pos @kc88_first_38 @kc88_second_16 -70;
-    pos @kc88_first_38 @kc88_second_28 -70;
-    pos @kc88_first_38 @kc88_second_29 -70;
-    pos @kc88_first_38 @kc88_second_38 -50;
-    pos @kc88_first_38 @kc88_second_42 -50;
-    pos @kc88_first_38 @kc88_second_43 -35;
-    pos @kc88_first_38 @kc88_second_48 1;
-    pos @kc88_first_38 @kc88_second_50 -35;
-    pos @kc88_first_38 @kc88_second_51 -140;
-    pos @kc88_first_38 @kc88_second_60 -35;
-    pos @kc88_first_38 @kc88_second_64 -70;
-    pos @kc88_first_38 @kc88_second_65 -35;
-    pos @kc88_first_39 @kc88_second_1 -210;
-    pos @kc88_first_39 @kc88_second_2 -280;
-    pos @kc88_first_39 @kc88_second_6 -280;
-    pos @kc88_first_39 @kc88_second_8 -70;
-    pos @kc88_first_39 @kc88_second_17 -140;
-    pos @kc88_first_39 @kc88_second_18 -140;
-    pos @kc88_first_39 @kc88_second_19 -245;
-    pos @kc88_first_39 @kc88_second_21 -350;
-    pos @kc88_first_39 @kc88_second_22 -140;
-    pos @kc88_first_39 @kc88_second_24 -140;
-    pos @kc88_first_39 @kc88_second_25 -70;
-    pos @kc88_first_39 @kc88_second_26 -280;
-    pos @kc88_first_39 @kc88_second_30 -315;
-    pos @kc88_first_39 @kc88_second_31 -140;
-    pos @kc88_first_39 @kc88_second_34 -385;
-    pos @kc88_first_39 @kc88_second_35 -140;
-    pos @kc88_first_39 @kc88_second_37 -210;
-    pos @kc88_first_39 @kc88_second_38 -70;
-    pos @kc88_first_39 @kc88_second_39 -140;
-    pos @kc88_first_39 @kc88_second_40 -140;
-    pos @kc88_first_39 @kc88_second_41 -140;
-    pos @kc88_first_39 @kc88_second_42 -70;
-    pos @kc88_first_39 @kc88_second_44 -70;
-    pos @kc88_first_39 @kc88_second_48 1;
-    pos @kc88_first_39 @kc88_second_54 -140;
-    pos @kc88_first_39 @kc88_second_55 -70;
-    pos @kc88_first_39 @kc88_second_56 -140;
-    pos @kc88_first_39 @kc88_second_58 -245;
-    pos @kc88_first_39 @kc88_second_59 -210;
-    pos @kc88_first_39 @kc88_second_60 -70;
-    pos @kc88_first_39 @kc88_second_61 -70;
-    pos @kc88_first_39 @kc88_second_62 -70;
-    pos @kc88_first_39 @kc88_second_63 -70;
-    pos @kc88_first_39 @kc88_second_66 -245;
-    pos @kc88_first_39 @kc88_second_67 -280;
-    pos @kc88_first_39 @kc88_second_68 -315;
-    pos @kc88_first_40 @kc88_second_6 -35;
-    pos @kc88_first_40 @kc88_second_12 -240;
-    pos @kc88_first_40 @kc88_second_13 -140;
-    pos @kc88_first_40 @kc88_second_14 -35;
-    pos @kc88_first_40 @kc88_second_15 -35;
-    pos @kc88_first_40 @kc88_second_37 -35;
-    pos @kc88_first_40 @kc88_second_48 1;
-    pos @kc88_first_40 @kc88_second_53 105;
-    pos @kc88_first_40 @kc88_second_66 -35;
-    pos @kc88_first_40 @kc88_second_67 -35;
-    pos @kc88_first_41 @kc88_second_12 -210;
-    pos @kc88_first_41 @kc88_second_13 -175;
-    pos @kc88_first_41 @kc88_second_14 -105;
-    pos @kc88_first_41 @kc88_second_15 -70;
-    pos @kc88_first_41 @kc88_second_46 -70;
-    pos @kc88_first_41 @kc88_second_48 1;
-    pos @kc88_first_41 @kc88_second_51 -105;
-    pos @kc88_first_41 @kc88_second_64 -70;
-    pos @kc88_first_42 @kc88_second_1 -140;
-    pos @kc88_first_42 @kc88_second_2 -175;
-    pos @kc88_first_42 @kc88_second_5 -105;
-    pos @kc88_first_42 @kc88_second_6 -70;
-    pos @kc88_first_42 @kc88_second_11 -70;
-    pos @kc88_first_42 @kc88_second_12 -175;
-    pos @kc88_first_42 @kc88_second_13 -105;
-    pos @kc88_first_42 @kc88_second_14 -70;
-    pos @kc88_first_42 @kc88_second_15 -35;
-    pos @kc88_first_42 @kc88_second_16 -105;
-    pos @kc88_first_42 @kc88_second_17 -35;
-    pos @kc88_first_42 @kc88_second_18 -50;
-    pos @kc88_first_42 @kc88_second_19 -140;
-    pos @kc88_first_42 @kc88_second_21 -175;
-    pos @kc88_first_42 @kc88_second_24 -50;
-    pos @kc88_first_42 @kc88_second_26 -105;
-    pos @kc88_first_42 @kc88_second_31 -35;
-    pos @kc88_first_42 @kc88_second_34 -70;
-    pos @kc88_first_42 @kc88_second_35 -50;
-    pos @kc88_first_42 @kc88_second_37 -70;
-    pos @kc88_first_42 @kc88_second_38 -140;
-    pos @kc88_first_42 @kc88_second_39 -35;
-    pos @kc88_first_42 @kc88_second_41 -50;
-    pos @kc88_first_42 @kc88_second_48 1;
-    pos @kc88_first_42 @kc88_second_54 -35;
-    pos @kc88_first_42 @kc88_second_56 -105;
-    pos @kc88_first_42 @kc88_second_58 -105;
-    pos @kc88_first_42 @kc88_second_59 -105;
-    pos @kc88_first_42 @kc88_second_66 -50;
-    pos @kc88_first_42 @kc88_second_67 -70;
-    pos @kc88_first_43 @kc88_second_1 -210;
-    pos @kc88_first_43 @kc88_second_2 -280;
-    pos @kc88_first_43 @kc88_second_3 -70;
-    pos @kc88_first_43 @kc88_second_6 -280;
-    pos @kc88_first_43 @kc88_second_8 -35;
-    pos @kc88_first_43 @kc88_second_11 -70;
-    pos @kc88_first_43 @kc88_second_13 -140;
-    pos @kc88_first_43 @kc88_second_14 -35;
-    pos @kc88_first_43 @kc88_second_15 -35;
-    pos @kc88_first_43 @kc88_second_16 -140;
-    pos @kc88_first_43 @kc88_second_17 -105;
-    pos @kc88_first_43 @kc88_second_18 -140;
-    pos @kc88_first_43 @kc88_second_19 -210;
-    pos @kc88_first_43 @kc88_second_21 -280;
-    pos @kc88_first_43 @kc88_second_22 -140;
-    pos @kc88_first_43 @kc88_second_24 -140;
-    pos @kc88_first_43 @kc88_second_25 -140;
-    pos @kc88_first_43 @kc88_second_26 -210;
-    pos @kc88_first_43 @kc88_second_34 -140;
-    pos @kc88_first_43 @kc88_second_35 -140;
-    pos @kc88_first_43 @kc88_second_37 -280;
-    pos @kc88_first_43 @kc88_second_38 -140;
-    pos @kc88_first_43 @kc88_second_39 -70;
-    pos @kc88_first_43 @kc88_second_40 -140;
-    pos @kc88_first_43 @kc88_second_41 -175;
-    pos @kc88_first_43 @kc88_second_47 -70;
-    pos @kc88_first_43 @kc88_second_48 1;
-    pos @kc88_first_43 @kc88_second_56 -210;
-    pos @kc88_first_43 @kc88_second_58 -210;
-    pos @kc88_first_43 @kc88_second_59 -175;
-    pos @kc88_first_43 @kc88_second_62 -70;
-    pos @kc88_first_43 @kc88_second_66 -175;
-    pos @kc88_first_43 @kc88_second_67 -175;
-    pos @kc88_first_44 @kc88_second_9 -70;
-    pos @kc88_first_44 @kc88_second_12 -240;
-    pos @kc88_first_44 @kc88_second_13 -210;
-    pos @kc88_first_44 @kc88_second_14 -140;
-    pos @kc88_first_44 @kc88_second_15 -105;
-    pos @kc88_first_44 @kc88_second_42 -70;
-    pos @kc88_first_44 @kc88_second_43 -35;
-    pos @kc88_first_44 @kc88_second_46 -140;
-    pos @kc88_first_44 @kc88_second_48 1;
-    pos @kc88_first_44 @kc88_second_50 -50;
-    pos @kc88_first_44 @kc88_second_51 -140;
-    pos @kc88_first_44 @kc88_second_61 -35;
-    pos @kc88_first_44 @kc88_second_63 -35;
-    pos @kc88_first_44 @kc88_second_64 -70;
-    pos @kc88_first_44 @kc88_second_65 -70;
-    pos @kc88_first_45 @kc88_second_8 -35;
-    pos @kc88_first_45 @kc88_second_9 -70;
-    pos @kc88_first_45 @kc88_second_12 -240;
-    pos @kc88_first_45 @kc88_second_13 -210;
-    pos @kc88_first_45 @kc88_second_14 -70;
-    pos @kc88_first_45 @kc88_second_15 -105;
-    pos @kc88_first_45 @kc88_second_18 -35;
-    pos @kc88_first_45 @kc88_second_24 -35;
-    pos @kc88_first_45 @kc88_second_41 -70;
-    pos @kc88_first_45 @kc88_second_42 -105;
-    pos @kc88_first_45 @kc88_second_43 -70;
-    pos @kc88_first_45 @kc88_second_46 -70;
-    pos @kc88_first_45 @kc88_second_47 -35;
-    pos @kc88_first_45 @kc88_second_48 1;
-    pos @kc88_first_45 @kc88_second_50 -70;
-    pos @kc88_first_45 @kc88_second_51 -70;
-    pos @kc88_first_45 @kc88_second_61 -70;
-    pos @kc88_first_45 @kc88_second_63 -50;
-    pos @kc88_first_45 @kc88_second_65 -70;
-    pos @kc88_first_45 @kc88_second_66 -35;
-    pos @kc88_first_45 @kc88_second_67 -35;
-    pos @kc88_first_46 @kc88_second_6 -70;
-    pos @kc88_first_46 @kc88_second_8 -35;
-    pos @kc88_first_46 @kc88_second_12 -175;
-    pos @kc88_first_46 @kc88_second_13 -140;
-    pos @kc88_first_46 @kc88_second_14 -70;
-    pos @kc88_first_46 @kc88_second_15 -35;
-    pos @kc88_first_46 @kc88_second_17 -70;
-    pos @kc88_first_46 @kc88_second_18 -105;
-    pos @kc88_first_46 @kc88_second_22 -70;
-    pos @kc88_first_46 @kc88_second_24 -105;
-    pos @kc88_first_46 @kc88_second_31 -35;
-    pos @kc88_first_46 @kc88_second_37 -70;
-    pos @kc88_first_46 @kc88_second_39 -35;
-    pos @kc88_first_46 @kc88_second_41 -105;
-    pos @kc88_first_46 @kc88_second_48 1;
-    pos @kc88_first_46 @kc88_second_54 -35;
-    pos @kc88_first_46 @kc88_second_66 -70;
-    pos @kc88_first_46 @kc88_second_67 -70;
-    pos @kc88_first_47 @kc88_second_3 -140;
-    pos @kc88_first_47 @kc88_second_4 -70;
-    pos @kc88_first_47 @kc88_second_6 -70;
-    pos @kc88_first_47 @kc88_second_8 -210;
-    pos @kc88_first_47 @kc88_second_9 -420;
-    pos @kc88_first_47 @kc88_second_12 -350;
-    pos @kc88_first_47 @kc88_second_13 -420;
-    pos @kc88_first_47 @kc88_second_14 -350;
-    pos @kc88_first_47 @kc88_second_15 -280;
-    pos @kc88_first_47 @kc88_second_17 -70;
-    pos @kc88_first_47 @kc88_second_18 -70;
-    pos @kc88_first_47 @kc88_second_20 -210;
-    pos @kc88_first_47 @kc88_second_22 -210;
-    pos @kc88_first_47 @kc88_second_24 -70;
-    pos @kc88_first_47 @kc88_second_25 -140;
-    pos @kc88_first_47 @kc88_second_31 -35;
-    pos @kc88_first_47 @kc88_second_33 -140;
-    pos @kc88_first_47 @kc88_second_37 -70;
-    pos @kc88_first_47 @kc88_second_39 -70;
-    pos @kc88_first_47 @kc88_second_41 -210;
-    pos @kc88_first_47 @kc88_second_42 -280;
-    pos @kc88_first_47 @kc88_second_43 -420;
-    pos @kc88_first_47 @kc88_second_46 -350;
-    pos @kc88_first_47 @kc88_second_48 1;
-    pos @kc88_first_47 @kc88_second_49 -35;
-    pos @kc88_first_47 @kc88_second_50 -210;
-    pos @kc88_first_47 @kc88_second_51 -350;
-    pos @kc88_first_47 @kc88_second_54 -35;
-    pos @kc88_first_47 @kc88_second_55 -35;
-    pos @kc88_first_47 @kc88_second_61 -280;
-    pos @kc88_first_47 @kc88_second_63 -175;
-    pos @kc88_first_47 @kc88_second_64 -280;
-    pos @kc88_first_47 @kc88_second_65 -210;
-    pos @kc88_first_47 @kc88_second_66 -70;
-    pos @kc88_first_48 @kc88_second_3 -140;
-    pos @kc88_first_48 @kc88_second_4 -105;
-    pos @kc88_first_48 @kc88_second_6 -70;
-    pos @kc88_first_48 @kc88_second_8 -210;
-    pos @kc88_first_48 @kc88_second_9 -280;
-    pos @kc88_first_48 @kc88_second_12 -350;
-    pos @kc88_first_48 @kc88_second_13 -385;
-    pos @kc88_first_48 @kc88_second_14 -350;
-    pos @kc88_first_48 @kc88_second_15 -280;
-    pos @kc88_first_48 @kc88_second_18 -105;
-    pos @kc88_first_48 @kc88_second_20 -210;
-    pos @kc88_first_48 @kc88_second_22 -140;
-    pos @kc88_first_48 @kc88_second_24 -105;
-    pos @kc88_first_48 @kc88_second_25 -140;
-    pos @kc88_first_48 @kc88_second_31 -70;
-    pos @kc88_first_48 @kc88_second_33 -175;
-    pos @kc88_first_48 @kc88_second_37 -70;
-    pos @kc88_first_48 @kc88_second_39 -35;
-    pos @kc88_first_48 @kc88_second_41 -175;
-    pos @kc88_first_48 @kc88_second_42 -280;
-    pos @kc88_first_48 @kc88_second_43 -280;
-    pos @kc88_first_48 @kc88_second_46 -280;
-    pos @kc88_first_48 @kc88_second_47 -140;
-    pos @kc88_first_48 @kc88_second_48 1;
-    pos @kc88_first_48 @kc88_second_49 -70;
-    pos @kc88_first_48 @kc88_second_50 -280;
-    pos @kc88_first_48 @kc88_second_51 -350;
-    pos @kc88_first_48 @kc88_second_54 -35;
-    pos @kc88_first_48 @kc88_second_55 -70;
-    pos @kc88_first_48 @kc88_second_61 -245;
-    pos @kc88_first_48 @kc88_second_63 -245;
-    pos @kc88_first_48 @kc88_second_64 -280;
-    pos @kc88_first_48 @kc88_second_65 -210;
-    pos @kc88_first_48 @kc88_second_66 -70;
-    pos @kc88_first_48 @kc88_second_67 -70;
-    pos @kc88_first_49 @kc88_second_3 -70;
-    pos @kc88_first_49 @kc88_second_4 -105;
-    pos @kc88_first_49 @kc88_second_6 -210;
-    pos @kc88_first_49 @kc88_second_7 -70;
-    pos @kc88_first_49 @kc88_second_8 -175;
-    pos @kc88_first_49 @kc88_second_17 -210;
-    pos @kc88_first_49 @kc88_second_18 -210;
-    pos @kc88_first_49 @kc88_second_22 -140;
-    pos @kc88_first_49 @kc88_second_23 -210;
-    pos @kc88_first_49 @kc88_second_24 -210;
-    pos @kc88_first_49 @kc88_second_25 -210;
-    pos @kc88_first_49 @kc88_second_26 -140;
-    pos @kc88_first_49 @kc88_second_27 -140;
-    pos @kc88_first_49 @kc88_second_29 -140;
-    pos @kc88_first_49 @kc88_second_31 -210;
-    pos @kc88_first_49 @kc88_second_32 -210;
-    pos @kc88_first_49 @kc88_second_33 -140;
-    pos @kc88_first_49 @kc88_second_35 -210;
-    pos @kc88_first_49 @kc88_second_37 -210;
-    pos @kc88_first_49 @kc88_second_38 -70;
-    pos @kc88_first_49 @kc88_second_39 -175;
-    pos @kc88_first_49 @kc88_second_40 -210;
-    pos @kc88_first_49 @kc88_second_41 -175;
-    pos @kc88_first_49 @kc88_second_42 -210;
-    pos @kc88_first_49 @kc88_second_43 -105;
-    pos @kc88_first_49 @kc88_second_46 -70;
-    pos @kc88_first_49 @kc88_second_47 -105;
-    pos @kc88_first_49 @kc88_second_48 1;
-    pos @kc88_first_49 @kc88_second_49 -35;
-    pos @kc88_first_49 @kc88_second_50 -210;
-    pos @kc88_first_49 @kc88_second_53 -210;
-    pos @kc88_first_49 @kc88_second_54 -210;
-    pos @kc88_first_49 @kc88_second_55 -175;
-    pos @kc88_first_49 @kc88_second_56 -175;
-    pos @kc88_first_49 @kc88_second_58 -210;
-    pos @kc88_first_49 @kc88_second_59 -210;
-    pos @kc88_first_49 @kc88_second_60 -140;
-    pos @kc88_first_49 @kc88_second_61 -210;
-    pos @kc88_first_49 @kc88_second_62 -175;
-    pos @kc88_first_49 @kc88_second_63 -175;
-    pos @kc88_first_49 @kc88_second_66 -210;
-    pos @kc88_first_49 @kc88_second_67 -210;
-    pos @kc88_first_50 @kc88_second_5 -70;
-    pos @kc88_first_50 @kc88_second_11 -35;
-    pos @kc88_first_50 @kc88_second_12 -240;
-    pos @kc88_first_50 @kc88_second_13 -70;
-    pos @kc88_first_50 @kc88_second_14 -140;
-    pos @kc88_first_50 @kc88_second_15 -105;
-    pos @kc88_first_50 @kc88_second_16 -70;
-    pos @kc88_first_50 @kc88_second_28 -70;
-    pos @kc88_first_50 @kc88_second_29 -70;
-    pos @kc88_first_50 @kc88_second_38 -35;
-    pos @kc88_first_50 @kc88_second_42 -70;
-    pos @kc88_first_50 @kc88_second_45 -35;
-    pos @kc88_first_50 @kc88_second_46 -70;
-    pos @kc88_first_50 @kc88_second_48 1;
-    pos @kc88_first_50 @kc88_second_50 -35;
-    pos @kc88_first_50 @kc88_second_51 -140;
-    pos @kc88_first_50 @kc88_second_54 1;
-    pos @kc88_first_50 @kc88_second_60 -35;
-    pos @kc88_first_50 @kc88_second_63 -35;
-    pos @kc88_first_50 @kc88_second_64 -105;
-    pos @kc88_first_50 @kc88_second_65 -70;
-    pos @kc88_first_51 @kc88_second_68 -70;
-    pos @kc88_first_52 @kc88_second_34 -315;
-    pos @kc88_first_52 @kc88_second_69 -70;
-    pos @kc88_first_53 @kc88_second_1 -105;
-    pos @kc88_first_53 @kc88_second_2 -210;
-    pos @kc88_first_53 @kc88_second_6 -140;
-    pos @kc88_first_53 @kc88_second_11 -70;
-    pos @kc88_first_53 @kc88_second_12 -210;
-    pos @kc88_first_53 @kc88_second_13 -210;
-    pos @kc88_first_53 @kc88_second_14 -105;
-    pos @kc88_first_53 @kc88_second_15 -70;
-    pos @kc88_first_53 @kc88_second_16 -140;
-    pos @kc88_first_53 @kc88_second_17 -35;
-    pos @kc88_first_53 @kc88_second_18 -35;
-    pos @kc88_first_53 @kc88_second_19 -105;
-    pos @kc88_first_53 @kc88_second_24 -35;
-    pos @kc88_first_53 @kc88_second_26 -210;
-    pos @kc88_first_53 @kc88_second_28 -70;
-    pos @kc88_first_53 @kc88_second_29 -70;
-    pos @kc88_first_53 @kc88_second_31 -35;
-    pos @kc88_first_53 @kc88_second_35 -70;
-    pos @kc88_first_53 @kc88_second_37 -210;
-    pos @kc88_first_53 @kc88_second_38 -140;
-    pos @kc88_first_53 @kc88_second_45 -35;
-    pos @kc88_first_53 @kc88_second_46 -70;
-    pos @kc88_first_53 @kc88_second_48 1;
-    pos @kc88_first_53 @kc88_second_50 -35;
-    pos @kc88_first_53 @kc88_second_51 -105;
-    pos @kc88_first_53 @kc88_second_56 -210;
-    pos @kc88_first_53 @kc88_second_58 -175;
-    pos @kc88_first_53 @kc88_second_59 -140;
-    pos @kc88_first_53 @kc88_second_64 -35;
-    pos @kc88_first_53 @kc88_second_65 -35;
-    pos @kc88_first_53 @kc88_second_66 -35;
-    pos @kc88_first_53 @kc88_second_67 -70;
-    pos @kc88_first_54 @kc88_second_1 -35;
-    pos @kc88_first_54 @kc88_second_2 -70;
-    pos @kc88_first_54 @kc88_second_5 -105;
-    pos @kc88_first_54 @kc88_second_6 -35;
-    pos @kc88_first_54 @kc88_second_9 -70;
-    pos @kc88_first_54 @kc88_second_11 -70;
-    pos @kc88_first_54 @kc88_second_12 -240;
-    pos @kc88_first_54 @kc88_second_13 -245;
-    pos @kc88_first_54 @kc88_second_14 -140;
-    pos @kc88_first_54 @kc88_second_15 -105;
-    pos @kc88_first_54 @kc88_second_16 -105;
-    pos @kc88_first_54 @kc88_second_19 -35;
-    pos @kc88_first_54 @kc88_second_20 -70;
-    pos @kc88_first_54 @kc88_second_21 -70;
-    pos @kc88_first_54 @kc88_second_26 -35;
-    pos @kc88_first_54 @kc88_second_27 -70;
-    pos @kc88_first_54 @kc88_second_28 -140;
-    pos @kc88_first_54 @kc88_second_29 -105;
-    pos @kc88_first_54 @kc88_second_35 -35;
-    pos @kc88_first_54 @kc88_second_37 -35;
-    pos @kc88_first_54 @kc88_second_38 -140;
-    pos @kc88_first_54 @kc88_second_42 -105;
-    pos @kc88_first_54 @kc88_second_43 -70;
-    pos @kc88_first_54 @kc88_second_45 -105;
-    pos @kc88_first_54 @kc88_second_46 -175;
-    pos @kc88_first_54 @kc88_second_48 1;
-    pos @kc88_first_54 @kc88_second_50 -70;
-    pos @kc88_first_54 @kc88_second_51 -140;
-    pos @kc88_first_54 @kc88_second_52 -70;
-    pos @kc88_first_54 @kc88_second_56 -210;
-    pos @kc88_first_54 @kc88_second_57 -70;
-    pos @kc88_first_54 @kc88_second_58 -175;
-    pos @kc88_first_54 @kc88_second_59 -175;
-    pos @kc88_first_54 @kc88_second_60 -105;
-    pos @kc88_first_54 @kc88_second_63 -50;
-    pos @kc88_first_54 @kc88_second_64 -105;
-    pos @kc88_first_54 @kc88_second_65 -70;
-    pos @kc88_first_54 @kc88_second_67 -35;
-    pos @kc88_first_55 @kc88_second_1 -105;
-    pos @kc88_first_55 @kc88_second_2 -210;
-    pos @kc88_first_55 @kc88_second_5 -70;
-    pos @kc88_first_55 @kc88_second_6 -105;
-    pos @kc88_first_55 @kc88_second_13 -70;
-    pos @kc88_first_55 @kc88_second_14 -35;
-    pos @kc88_first_55 @kc88_second_16 -140;
-    pos @kc88_first_55 @kc88_second_17 -70;
-    pos @kc88_first_55 @kc88_second_18 -35;
-    pos @kc88_first_55 @kc88_second_19 -105;
-    pos @kc88_first_55 @kc88_second_21 -210;
-    pos @kc88_first_55 @kc88_second_24 -35;
-    pos @kc88_first_55 @kc88_second_26 -210;
-    pos @kc88_first_55 @kc88_second_31 -35;
-    pos @kc88_first_55 @kc88_second_34 -105;
-    pos @kc88_first_55 @kc88_second_35 -35;
-    pos @kc88_first_55 @kc88_second_37 -105;
-    pos @kc88_first_55 @kc88_second_38 -140;
-    pos @kc88_first_55 @kc88_second_41 -70;
-    pos @kc88_first_55 @kc88_second_48 1;
-    pos @kc88_first_55 @kc88_second_54 -35;
-    pos @kc88_first_55 @kc88_second_56 -245;
-    pos @kc88_first_55 @kc88_second_58 -210;
-    pos @kc88_first_55 @kc88_second_59 -210;
-    pos @kc88_first_55 @kc88_second_66 -70;
-    pos @kc88_first_55 @kc88_second_67 -105;
-    pos @kc88_first_56 @kc88_second_12 -240;
-    pos @kc88_first_56 @kc88_second_13 -140;
-    pos @kc88_first_56 @kc88_second_14 -105;
-    pos @kc88_first_56 @kc88_second_15 -35;
-    pos @kc88_first_56 @kc88_second_36 165;
-    pos @kc88_first_56 @kc88_second_48 1;
-    pos @kc88_first_56 @kc88_second_53 165;
-    pos @kc88_first_57 @kc88_second_1 -140;
-    pos @kc88_first_57 @kc88_second_2 -210;
-    pos @kc88_first_57 @kc88_second_6 -140;
-    pos @kc88_first_57 @kc88_second_12 -175;
-    pos @kc88_first_57 @kc88_second_13 -140;
-    pos @kc88_first_57 @kc88_second_16 -140;
-    pos @kc88_first_57 @kc88_second_19 -140;
-    pos @kc88_first_57 @kc88_second_21 -210;
-    pos @kc88_first_57 @kc88_second_26 -210;
-    pos @kc88_first_57 @kc88_second_34 -140;
-    pos @kc88_first_57 @kc88_second_35 -50;
-    pos @kc88_first_57 @kc88_second_37 -140;
-    pos @kc88_first_57 @kc88_second_38 -210;
-    pos @kc88_first_57 @kc88_second_39 -35;
-    pos @kc88_first_57 @kc88_second_48 1;
-    pos @kc88_first_57 @kc88_second_56 -210;
-    pos @kc88_first_57 @kc88_second_58 -175;
-    pos @kc88_first_57 @kc88_second_59 -175;
-    pos @kc88_first_57 @kc88_second_66 -105;
-    pos @kc88_first_57 @kc88_second_67 -210;
-    pos @kc88_first_58 @kc88_second_12 -240;
-    pos @kc88_first_58 @kc88_second_13 -175;
-    pos @kc88_first_58 @kc88_second_14 -70;
-    pos @kc88_first_58 @kc88_second_15 -35;
-    pos @kc88_first_58 @kc88_second_21 -35;
-    pos @kc88_first_58 @kc88_second_28 -35;
-    pos @kc88_first_58 @kc88_second_42 -35;
-    pos @kc88_first_58 @kc88_second_43 -35;
-    pos @kc88_first_58 @kc88_second_46 -70;
-    pos @kc88_first_58 @kc88_second_48 1;
-    pos @kc88_first_58 @kc88_second_50 -35;
-    pos @kc88_first_58 @kc88_second_51 -70;
-    pos @kc88_first_58 @kc88_second_61 -35;
-    pos @kc88_first_58 @kc88_second_63 -35;
-    pos @kc88_first_58 @kc88_second_64 -70;
-    pos @kc88_first_58 @kc88_second_65 -35;
-    pos @kc88_first_59 @kc88_second_13 -35;
-    pos @kc88_first_59 @kc88_second_18 -70;
-    pos @kc88_first_59 @kc88_second_61 -35;
-    pos @kc88_first_59 @kc88_second_67 -35;
-    pos @kc88_first_60 @kc88_second_12 -175;
-    pos @kc88_first_60 @kc88_second_13 -140;
-    pos @kc88_first_60 @kc88_second_14 -35;
-    pos @kc88_first_60 @kc88_second_48 1;
-    pos @kc88_first_61 @kc88_second_1 -140;
-    pos @kc88_first_61 @kc88_second_2 -280;
-    pos @kc88_first_61 @kc88_second_5 -140;
-    pos @kc88_first_61 @kc88_second_6 -280;
-    pos @kc88_first_61 @kc88_second_8 -70;
-    pos @kc88_first_61 @kc88_second_10 -70;
-    pos @kc88_first_61 @kc88_second_11 -175;
-    pos @kc88_first_61 @kc88_second_12 -240;
-    pos @kc88_first_61 @kc88_second_13 -140;
-    pos @kc88_first_61 @kc88_second_14 -105;
-    pos @kc88_first_61 @kc88_second_15 -70;
-    pos @kc88_first_61 @kc88_second_16 -175;
-    pos @kc88_first_61 @kc88_second_17 -70;
-    pos @kc88_first_61 @kc88_second_18 -70;
-    pos @kc88_first_61 @kc88_second_19 -140;
-    pos @kc88_first_61 @kc88_second_21 -280;
-    pos @kc88_first_61 @kc88_second_24 -70;
-    pos @kc88_first_61 @kc88_second_25 -70;
-    pos @kc88_first_61 @kc88_second_26 -210;
-    pos @kc88_first_61 @kc88_second_28 -70;
-    pos @kc88_first_61 @kc88_second_29 -70;
-    pos @kc88_first_61 @kc88_second_31 -70;
-    pos @kc88_first_61 @kc88_second_34 -70;
-    pos @kc88_first_61 @kc88_second_35 -70;
-    pos @kc88_first_61 @kc88_second_37 -315;
-    pos @kc88_first_61 @kc88_second_38 -140;
-    pos @kc88_first_61 @kc88_second_39 -70;
-    pos @kc88_first_61 @kc88_second_41 -105;
-    pos @kc88_first_61 @kc88_second_48 1;
-    pos @kc88_first_61 @kc88_second_51 -35;
-    pos @kc88_first_61 @kc88_second_54 -50;
-    pos @kc88_first_61 @kc88_second_56 -210;
-    pos @kc88_first_61 @kc88_second_58 -210;
-    pos @kc88_first_61 @kc88_second_59 -175;
-    pos @kc88_first_61 @kc88_second_62 -35;
-    pos @kc88_first_61 @kc88_second_64 -70;
-    pos @kc88_first_61 @kc88_second_65 -35;
-    pos @kc88_first_61 @kc88_second_66 -140;
-    pos @kc88_first_61 @kc88_second_67 -210;
-    pos @kc88_first_62 @kc88_second_1 -35;
-    pos @kc88_first_62 @kc88_second_2 -70;
-    pos @kc88_first_62 @kc88_second_5 -70;
-    pos @kc88_first_62 @kc88_second_11 -35;
-    pos @kc88_first_62 @kc88_second_12 -140;
-    pos @kc88_first_62 @kc88_second_13 -140;
-    pos @kc88_first_62 @kc88_second_14 -70;
-    pos @kc88_first_62 @kc88_second_15 -35;
-    pos @kc88_first_62 @kc88_second_16 -105;
-    pos @kc88_first_62 @kc88_second_28 -35;
-    pos @kc88_first_62 @kc88_second_29 -70;
-    pos @kc88_first_62 @kc88_second_35 -35;
-    pos @kc88_first_62 @kc88_second_38 -70;
-    pos @kc88_first_62 @kc88_second_46 -70;
-    pos @kc88_first_62 @kc88_second_48 1;
-    pos @kc88_first_62 @kc88_second_56 -175;
-    pos @kc88_first_62 @kc88_second_58 -140;
-    pos @kc88_first_62 @kc88_second_59 -140;
-    pos @kc88_first_62 @kc88_second_64 -35;
-    pos @kc88_first_63 @kc88_second_5 -70;
-    pos @kc88_first_63 @kc88_second_9 -70;
-    pos @kc88_first_63 @kc88_second_11 -35;
-    pos @kc88_first_63 @kc88_second_12 -350;
-    pos @kc88_first_63 @kc88_second_13 -315;
-    pos @kc88_first_63 @kc88_second_14 -175;
-    pos @kc88_first_63 @kc88_second_15 -140;
-    pos @kc88_first_63 @kc88_second_16 -70;
-    pos @kc88_first_63 @kc88_second_20 -70;
-    pos @kc88_first_63 @kc88_second_29 -70;
-    pos @kc88_first_63 @kc88_second_33 -50;
-    pos @kc88_first_63 @kc88_second_42 -140;
-    pos @kc88_first_63 @kc88_second_43 -50;
-    pos @kc88_first_63 @kc88_second_45 -35;
-    pos @kc88_first_63 @kc88_second_46 -175;
-    pos @kc88_first_63 @kc88_second_48 1;
-    pos @kc88_first_63 @kc88_second_50 -70;
-    pos @kc88_first_63 @kc88_second_51 -175;
-    pos @kc88_first_63 @kc88_second_57 -70;
-    pos @kc88_first_63 @kc88_second_61 -70;
-    pos @kc88_first_63 @kc88_second_63 -50;
-    pos @kc88_first_63 @kc88_second_64 -140;
-    pos @kc88_first_63 @kc88_second_65 -105;
-    pos @kc88_first_64 @kc88_second_4 -105;
-    pos @kc88_first_64 @kc88_second_6 -35;
-    pos @kc88_first_64 @kc88_second_8 1;
-    pos @kc88_first_64 @kc88_second_9 -245;
-    pos @kc88_first_64 @kc88_second_12 -210;
-    pos @kc88_first_64 @kc88_second_13 -210;
-    pos @kc88_first_64 @kc88_second_14 -210;
-    pos @kc88_first_64 @kc88_second_15 -175;
-    pos @kc88_first_64 @kc88_second_17 -70;
-    pos @kc88_first_64 @kc88_second_18 -105;
-    pos @kc88_first_64 @kc88_second_20 -180;
-    pos @kc88_first_64 @kc88_second_22 -140;
-    pos @kc88_first_64 @kc88_second_24 -105;
-    pos @kc88_first_64 @kc88_second_27 -140;
-    pos @kc88_first_64 @kc88_second_31 -105;
-    pos @kc88_first_64 @kc88_second_33 -140;
-    pos @kc88_first_64 @kc88_second_37 -35;
-    pos @kc88_first_64 @kc88_second_39 -35;
-    pos @kc88_first_64 @kc88_second_41 -175;
-    pos @kc88_first_64 @kc88_second_42 -142;
-    pos @kc88_first_64 @kc88_second_43 -245;
-    pos @kc88_first_64 @kc88_second_46 -210;
-    pos @kc88_first_64 @kc88_second_47 -105;
-    pos @kc88_first_64 @kc88_second_48 1;
-    pos @kc88_first_64 @kc88_second_49 -35;
-    pos @kc88_first_64 @kc88_second_50 -210;
-    pos @kc88_first_64 @kc88_second_51 -210;
-    pos @kc88_first_64 @kc88_second_54 -35;
-    pos @kc88_first_64 @kc88_second_61 -280;
-    pos @kc88_first_64 @kc88_second_63 -175;
-    pos @kc88_first_64 @kc88_second_64 -140;
-    pos @kc88_first_64 @kc88_second_65 -140;
-    pos @kc88_first_64 @kc88_second_66 -70;
-    pos @kc88_first_64 @kc88_second_67 -70;
-    pos @kc88_first_65 @kc88_second_1 -175;
-    pos @kc88_first_65 @kc88_second_2 -175;
-    pos @kc88_first_65 @kc88_second_5 -70;
-    pos @kc88_first_65 @kc88_second_6 -105;
-    pos @kc88_first_65 @kc88_second_11 -105;
-    pos @kc88_first_65 @kc88_second_12 -175;
-    pos @kc88_first_65 @kc88_second_13 -140;
-    pos @kc88_first_65 @kc88_second_14 -70;
-    pos @kc88_first_65 @kc88_second_15 -35;
-    pos @kc88_first_65 @kc88_second_16 -140;
-    pos @kc88_first_65 @kc88_second_17 -70;
-    pos @kc88_first_65 @kc88_second_18 -70;
-    pos @kc88_first_65 @kc88_second_19 -140;
-    pos @kc88_first_65 @kc88_second_21 -175;
-    pos @kc88_first_65 @kc88_second_24 -70;
-    pos @kc88_first_65 @kc88_second_31 -35;
-    pos @kc88_first_65 @kc88_second_35 -70;
-    pos @kc88_first_65 @kc88_second_37 -105;
-    pos @kc88_first_65 @kc88_second_38 -175;
-    pos @kc88_first_65 @kc88_second_39 -35;
-    pos @kc88_first_65 @kc88_second_41 -70;
-    pos @kc88_first_65 @kc88_second_48 1;
-    pos @kc88_first_65 @kc88_second_54 -35;
-    pos @kc88_first_65 @kc88_second_56 -140;
-    pos @kc88_first_65 @kc88_second_58 -140;
-    pos @kc88_first_65 @kc88_second_59 -140;
-    pos @kc88_first_65 @kc88_second_66 -70;
-    pos @kc88_first_65 @kc88_second_67 -105;
-    pos @kc88_first_66 @kc88_second_1 -210;
-    pos @kc88_first_66 @kc88_second_2 -210;
-    pos @kc88_first_66 @kc88_second_3 -70;
-    pos @kc88_first_66 @kc88_second_4 -35;
-    pos @kc88_first_66 @kc88_second_6 -210;
-    pos @kc88_first_66 @kc88_second_7 -70;
-    pos @kc88_first_66 @kc88_second_8 -70;
-    pos @kc88_first_66 @kc88_second_16 -70;
-    pos @kc88_first_66 @kc88_second_17 -140;
-    pos @kc88_first_66 @kc88_second_18 -175;
-    pos @kc88_first_66 @kc88_second_19 -210;
-    pos @kc88_first_66 @kc88_second_21 -210;
-    pos @kc88_first_66 @kc88_second_22 -140;
-    pos @kc88_first_66 @kc88_second_23 -35;
-    pos @kc88_first_66 @kc88_second_24 -175;
-    pos @kc88_first_66 @kc88_second_25 -140;
-    pos @kc88_first_66 @kc88_second_26 -280;
-    pos @kc88_first_66 @kc88_second_31 -35;
-    pos @kc88_first_66 @kc88_second_32 -35;
-    pos @kc88_first_66 @kc88_second_34 -210;
-    pos @kc88_first_66 @kc88_second_35 -175;
-    pos @kc88_first_66 @kc88_second_37 -245;
-    pos @kc88_first_66 @kc88_second_38 -140;
-    pos @kc88_first_66 @kc88_second_39 -140;
-    pos @kc88_first_66 @kc88_second_40 -140;
-    pos @kc88_first_66 @kc88_second_41 -140;
-    pos @kc88_first_66 @kc88_second_42 -35;
-    pos @kc88_first_66 @kc88_second_47 -35;
-    pos @kc88_first_66 @kc88_second_48 1;
-    pos @kc88_first_66 @kc88_second_52 -35;
-    pos @kc88_first_66 @kc88_second_54 -140;
-    pos @kc88_first_66 @kc88_second_55 -70;
-    pos @kc88_first_66 @kc88_second_56 -210;
-    pos @kc88_first_66 @kc88_second_58 -210;
-    pos @kc88_first_66 @kc88_second_59 -210;
-    pos @kc88_first_66 @kc88_second_61 -35;
-    pos @kc88_first_66 @kc88_second_66 -175;
-    pos @kc88_first_66 @kc88_second_67 -245;
-    pos @kc88_first_67 @kc88_second_6 -35;
-    pos @kc88_first_67 @kc88_second_12 -240;
-    pos @kc88_first_67 @kc88_second_13 -140;
-    pos @kc88_first_67 @kc88_second_14 -70;
-    pos @kc88_first_67 @kc88_second_15 -35;
-    pos @kc88_first_67 @kc88_second_18 -35;
-    pos @kc88_first_67 @kc88_second_22 -35;
-    pos @kc88_first_67 @kc88_second_24 -35;
-    pos @kc88_first_67 @kc88_second_37 -70;
-    pos @kc88_first_67 @kc88_second_41 -70;
-    pos @kc88_first_67 @kc88_second_42 -50;
-    pos @kc88_first_67 @kc88_second_48 1;
-    pos @kc88_first_67 @kc88_second_51 -35;
-    pos @kc88_first_67 @kc88_second_66 -35;
-    pos @kc88_first_67 @kc88_second_67 -35;
-    pos @kc88_first_68 @kc88_second_3 -100;
-    pos @kc88_first_68 @kc88_second_4 -50;
-    pos @kc88_first_68 @kc88_second_6 -50;
-    pos @kc88_first_68 @kc88_second_8 -70;
-    pos @kc88_first_68 @kc88_second_9 -140;
-    pos @kc88_first_68 @kc88_second_10 -50;
-    pos @kc88_first_68 @kc88_second_12 -140;
-    pos @kc88_first_68 @kc88_second_13 -100;
-    pos @kc88_first_68 @kc88_second_14 -70;
-    pos @kc88_first_68 @kc88_second_15 -50;
-    pos @kc88_first_68 @kc88_second_18 -50;
-    pos @kc88_first_68 @kc88_second_20 -70;
-    pos @kc88_first_68 @kc88_second_22 -70;
-    pos @kc88_first_68 @kc88_second_24 -50;
-    pos @kc88_first_68 @kc88_second_25 -70;
-    pos @kc88_first_68 @kc88_second_31 -35;
-    pos @kc88_first_68 @kc88_second_33 -70;
-    pos @kc88_first_68 @kc88_second_36 105;
-    pos @kc88_first_68 @kc88_second_37 -35;
-    pos @kc88_first_68 @kc88_second_41 -70;
-    pos @kc88_first_68 @kc88_second_42 -140;
-    pos @kc88_first_68 @kc88_second_43 -140;
-    pos @kc88_first_68 @kc88_second_46 -140;
-    pos @kc88_first_68 @kc88_second_47 -35;
-    pos @kc88_first_68 @kc88_second_48 1;
-    pos @kc88_first_68 @kc88_second_50 -70;
-    pos @kc88_first_68 @kc88_second_51 -100;
-    pos @kc88_first_68 @kc88_second_53 105;
-    pos @kc88_first_68 @kc88_second_61 -140;
-    pos @kc88_first_68 @kc88_second_63 -70;
-    pos @kc88_first_68 @kc88_second_64 -70;
-    pos @kc88_first_68 @kc88_second_65 -50;
-    pos @kc88_first_68 @kc88_second_66 -35;
-    pos @kc88_first_68 @kc88_second_67 -35;
-    pos @kc88_first_69 @kc88_second_3 -70;
-    pos @kc88_first_69 @kc88_second_4 -50;
-    pos @kc88_first_69 @kc88_second_6 -50;
-    pos @kc88_first_69 @kc88_second_8 -70;
-    pos @kc88_first_69 @kc88_second_9 -140;
-    pos @kc88_first_69 @kc88_second_10 -50;
-    pos @kc88_first_69 @kc88_second_12 -240;
-    pos @kc88_first_69 @kc88_second_13 -240;
-    pos @kc88_first_69 @kc88_second_14 -175;
-    pos @kc88_first_69 @kc88_second_15 -140;
-    pos @kc88_first_69 @kc88_second_18 -50;
-    pos @kc88_first_69 @kc88_second_20 -70;
-    pos @kc88_first_69 @kc88_second_22 -70;
-    pos @kc88_first_69 @kc88_second_24 -50;
-    pos @kc88_first_69 @kc88_second_25 -70;
-    pos @kc88_first_69 @kc88_second_31 -35;
-    pos @kc88_first_69 @kc88_second_33 -70;
-    pos @kc88_first_69 @kc88_second_36 105;
-    pos @kc88_first_69 @kc88_second_37 -35;
-    pos @kc88_first_69 @kc88_second_41 -70;
-    pos @kc88_first_69 @kc88_second_42 -140;
-    pos @kc88_first_69 @kc88_second_43 -140;
-    pos @kc88_first_69 @kc88_second_46 -140;
-    pos @kc88_first_69 @kc88_second_47 -35;
-    pos @kc88_first_69 @kc88_second_48 1;
-    pos @kc88_first_69 @kc88_second_50 -70;
-    pos @kc88_first_69 @kc88_second_51 -140;
-    pos @kc88_first_69 @kc88_second_53 105;
-    pos @kc88_first_69 @kc88_second_61 -140;
-    pos @kc88_first_69 @kc88_second_63 -70;
-    pos @kc88_first_69 @kc88_second_64 -105;
-    pos @kc88_first_69 @kc88_second_65 -70;
-    pos @kc88_first_69 @kc88_second_66 -35;
-    pos @kc88_first_69 @kc88_second_67 -35;
-    pos @kc88_first_70 @kc88_second_3 -70;
-    pos @kc88_first_70 @kc88_second_4 -50;
-    pos @kc88_first_70 @kc88_second_6 -50;
-    pos @kc88_first_70 @kc88_second_8 -70;
-    pos @kc88_first_70 @kc88_second_9 -140;
-    pos @kc88_first_70 @kc88_second_10 -50;
-    pos @kc88_first_70 @kc88_second_12 -140;
-    pos @kc88_first_70 @kc88_second_13 -140;
-    pos @kc88_first_70 @kc88_second_14 -105;
-    pos @kc88_first_70 @kc88_second_15 -70;
-    pos @kc88_first_70 @kc88_second_18 -50;
-    pos @kc88_first_70 @kc88_second_20 -70;
-    pos @kc88_first_70 @kc88_second_22 -70;
-    pos @kc88_first_70 @kc88_second_24 -50;
-    pos @kc88_first_70 @kc88_second_25 -100;
-    pos @kc88_first_70 @kc88_second_31 -35;
-    pos @kc88_first_70 @kc88_second_33 -70;
-    pos @kc88_first_70 @kc88_second_36 105;
-    pos @kc88_first_70 @kc88_second_37 -35;
-    pos @kc88_first_70 @kc88_second_41 -70;
-    pos @kc88_first_70 @kc88_second_42 -140;
-    pos @kc88_first_70 @kc88_second_43 -140;
-    pos @kc88_first_70 @kc88_second_46 -140;
-    pos @kc88_first_70 @kc88_second_47 -35;
-    pos @kc88_first_70 @kc88_second_48 1;
-    pos @kc88_first_70 @kc88_second_50 -70;
-    pos @kc88_first_70 @kc88_second_51 -140;
-    pos @kc88_first_70 @kc88_second_53 105;
-    pos @kc88_first_70 @kc88_second_61 -140;
-    pos @kc88_first_70 @kc88_second_63 -70;
-    pos @kc88_first_70 @kc88_second_64 -70;
-    pos @kc88_first_70 @kc88_second_65 -50;
-    pos @kc88_first_70 @kc88_second_66 -35;
-    pos @kc88_first_70 @kc88_second_67 -35;
-    pos @kc88_first_71 @kc88_second_1 -210;
-    pos @kc88_first_71 @kc88_second_2 -210;
-    pos @kc88_first_71 @kc88_second_3 -35;
-    pos @kc88_first_71 @kc88_second_6 -140;
-    pos @kc88_first_71 @kc88_second_8 -70;
-    pos @kc88_first_71 @kc88_second_10 -35;
-    pos @kc88_first_71 @kc88_second_17 -70;
-    pos @kc88_first_71 @kc88_second_18 -105;
-    pos @kc88_first_71 @kc88_second_19 -210;
-    pos @kc88_first_71 @kc88_second_21 -210;
-    pos @kc88_first_71 @kc88_second_22 -70;
-    pos @kc88_first_71 @kc88_second_24 -105;
-    pos @kc88_first_71 @kc88_second_25 -105;
-    pos @kc88_first_71 @kc88_second_26 -175;
-    pos @kc88_first_71 @kc88_second_31 -105;
-    pos @kc88_first_71 @kc88_second_34 -210;
-    pos @kc88_first_71 @kc88_second_35 -105;
-    pos @kc88_first_71 @kc88_second_37 -175;
-    pos @kc88_first_71 @kc88_second_38 -140;
-    pos @kc88_first_71 @kc88_second_39 -70;
-    pos @kc88_first_71 @kc88_second_40 -105;
-    pos @kc88_first_71 @kc88_second_41 -105;
-    pos @kc88_first_71 @kc88_second_42 -70;
-    pos @kc88_first_71 @kc88_second_47 -35;
-    pos @kc88_first_71 @kc88_second_48 1;
-    pos @kc88_first_71 @kc88_second_53 -35;
-    pos @kc88_first_71 @kc88_second_54 -70;
-    pos @kc88_first_71 @kc88_second_55 -70;
-    pos @kc88_first_71 @kc88_second_56 -175;
-    pos @kc88_first_71 @kc88_second_58 -175;
-    pos @kc88_first_71 @kc88_second_59 -175;
-    pos @kc88_first_71 @kc88_second_61 -35;
-    pos @kc88_first_71 @kc88_second_62 -35;
-    pos @kc88_first_71 @kc88_second_66 -140;
-    pos @kc88_first_71 @kc88_second_67 -175;
-    pos @kc88_first_72 @kc88_second_5 -70;
-    pos @kc88_first_72 @kc88_second_8 -70;
-    pos @kc88_first_72 @kc88_second_9 -105;
-    pos @kc88_first_72 @kc88_second_11 -35;
-    pos @kc88_first_72 @kc88_second_12 -350;
-    pos @kc88_first_72 @kc88_second_13 -350;
-    pos @kc88_first_72 @kc88_second_14 -245;
-    pos @kc88_first_72 @kc88_second_15 -210;
-    pos @kc88_first_72 @kc88_second_16 -70;
-    pos @kc88_first_72 @kc88_second_20 -210;
-    pos @kc88_first_72 @kc88_second_25 -35;
-    pos @kc88_first_72 @kc88_second_28 -35;
-    pos @kc88_first_72 @kc88_second_29 -70;
-    pos @kc88_first_72 @kc88_second_33 -70;
-    pos @kc88_first_72 @kc88_second_41 -35;
-    pos @kc88_first_72 @kc88_second_42 -245;
-    pos @kc88_first_72 @kc88_second_43 -70;
-    pos @kc88_first_72 @kc88_second_45 -35;
-    pos @kc88_first_72 @kc88_second_46 -240;
-    pos @kc88_first_72 @kc88_second_48 1;
-    pos @kc88_first_72 @kc88_second_50 -105;
-    pos @kc88_first_72 @kc88_second_51 -280;
-    pos @kc88_first_72 @kc88_second_52 -35;
-    pos @kc88_first_72 @kc88_second_57 -35;
-    pos @kc88_first_72 @kc88_second_60 -70;
-    pos @kc88_first_72 @kc88_second_61 -105;
-    pos @kc88_first_72 @kc88_second_62 -35;
-    pos @kc88_first_72 @kc88_second_63 -70;
-    pos @kc88_first_72 @kc88_second_64 -175;
-    pos @kc88_first_72 @kc88_second_65 -140;
-    pos @kc88_first_73 @kc88_second_1 -140;
-    pos @kc88_first_73 @kc88_second_2 -140;
-    pos @kc88_first_73 @kc88_second_6 -140;
-    pos @kc88_first_73 @kc88_second_8 -35;
-    pos @kc88_first_73 @kc88_second_10 -35;
-    pos @kc88_first_73 @kc88_second_17 -35;
-    pos @kc88_first_73 @kc88_second_18 -70;
-    pos @kc88_first_73 @kc88_second_19 -140;
-    pos @kc88_first_73 @kc88_second_21 -140;
-    pos @kc88_first_73 @kc88_second_22 -35;
-    pos @kc88_first_73 @kc88_second_24 -70;
-    pos @kc88_first_73 @kc88_second_25 -70;
-    pos @kc88_first_73 @kc88_second_26 -140;
-    pos @kc88_first_73 @kc88_second_31 -70;
-    pos @kc88_first_73 @kc88_second_35 -70;
-    pos @kc88_first_73 @kc88_second_37 -175;
-    pos @kc88_first_73 @kc88_second_38 -105;
-    pos @kc88_first_73 @kc88_second_39 -70;
-    pos @kc88_first_73 @kc88_second_40 -70;
-    pos @kc88_first_73 @kc88_second_41 -70;
-    pos @kc88_first_73 @kc88_second_42 -35;
-    pos @kc88_first_73 @kc88_second_48 1;
-    pos @kc88_first_73 @kc88_second_53 -35;
-    pos @kc88_first_73 @kc88_second_54 -35;
-    pos @kc88_first_73 @kc88_second_56 -140;
-    pos @kc88_first_73 @kc88_second_58 -140;
-    pos @kc88_first_73 @kc88_second_59 -140;
-    pos @kc88_first_73 @kc88_second_66 -105;
-    pos @kc88_first_73 @kc88_second_67 -105;
+    pos @kc89_first_1 @kc89_second_3 -70;
+    pos @kc89_first_1 @kc89_second_8 -70;
+    pos @kc89_first_1 @kc89_second_9 -140;
+    pos @kc89_first_1 @kc89_second_10 -35;
+    pos @kc89_first_1 @kc89_second_12 -280;
+    pos @kc89_first_1 @kc89_second_13 -280;
+    pos @kc89_first_1 @kc89_second_14 -280;
+    pos @kc89_first_1 @kc89_second_15 -210;
+    pos @kc89_first_1 @kc89_second_22 -70;
+    pos @kc89_first_1 @kc89_second_25 -35;
+    pos @kc89_first_1 @kc89_second_27 -50;
+    pos @kc89_first_1 @kc89_second_33 -70;
+    pos @kc89_first_1 @kc89_second_41 -35;
+    pos @kc89_first_1 @kc89_second_42 -140;
+    pos @kc89_first_1 @kc89_second_43 -105;
+    pos @kc89_first_1 @kc89_second_46 -210;
+    pos @kc89_first_1 @kc89_second_47 -35;
+    pos @kc89_first_1 @kc89_second_48 1;
+    pos @kc89_first_1 @kc89_second_50 -175;
+    pos @kc89_first_1 @kc89_second_51 -210;
+    pos @kc89_first_1 @kc89_second_61 -140;
+    pos @kc89_first_1 @kc89_second_63 -140;
+    pos @kc89_first_1 @kc89_second_64 -210;
+    pos @kc89_first_1 @kc89_second_65 -140;
+    pos @kc89_first_2 @kc89_second_9 -35;
+    pos @kc89_first_2 @kc89_second_12 -70;
+    pos @kc89_first_2 @kc89_second_13 -70;
+    pos @kc89_first_2 @kc89_second_14 -70;
+    pos @kc89_first_2 @kc89_second_15 -35;
+    pos @kc89_first_2 @kc89_second_16 -35;
+    pos @kc89_first_2 @kc89_second_42 -35;
+    pos @kc89_first_2 @kc89_second_48 1;
+    pos @kc89_first_3 @kc89_second_1 -35;
+    pos @kc89_first_3 @kc89_second_2 -70;
+    pos @kc89_first_3 @kc89_second_5 -35;
+    pos @kc89_first_3 @kc89_second_11 -35;
+    pos @kc89_first_3 @kc89_second_12 -35;
+    pos @kc89_first_3 @kc89_second_13 -70;
+    pos @kc89_first_3 @kc89_second_14 -35;
+    pos @kc89_first_3 @kc89_second_16 -70;
+    pos @kc89_first_3 @kc89_second_19 -35;
+    pos @kc89_first_3 @kc89_second_21 -70;
+    pos @kc89_first_3 @kc89_second_38 -35;
+    pos @kc89_first_3 @kc89_second_48 1;
+    pos @kc89_first_4 @kc89_second_1 -70;
+    pos @kc89_first_4 @kc89_second_2 -140;
+    pos @kc89_first_4 @kc89_second_4 70;
+    pos @kc89_first_4 @kc89_second_5 -70;
+    pos @kc89_first_4 @kc89_second_11 -105;
+    pos @kc89_first_4 @kc89_second_12 -140;
+    pos @kc89_first_4 @kc89_second_13 -140;
+    pos @kc89_first_4 @kc89_second_14 -105;
+    pos @kc89_first_4 @kc89_second_15 -35;
+    pos @kc89_first_4 @kc89_second_16 -140;
+    pos @kc89_first_4 @kc89_second_19 -70;
+    pos @kc89_first_4 @kc89_second_26 -70;
+    pos @kc89_first_4 @kc89_second_28 -70;
+    pos @kc89_first_4 @kc89_second_29 -35;
+    pos @kc89_first_4 @kc89_second_33 35;
+    pos @kc89_first_4 @kc89_second_35 -35;
+    pos @kc89_first_4 @kc89_second_37 -70;
+    pos @kc89_first_4 @kc89_second_38 -70;
+    pos @kc89_first_4 @kc89_second_46 -35;
+    pos @kc89_first_4 @kc89_second_48 1;
+    pos @kc89_first_4 @kc89_second_51 -70;
+    pos @kc89_first_4 @kc89_second_56 -70;
+    pos @kc89_first_4 @kc89_second_58 -70;
+    pos @kc89_first_4 @kc89_second_59 -70;
+    pos @kc89_first_4 @kc89_second_64 -35;
+    pos @kc89_first_5 @kc89_second_12 -70;
+    pos @kc89_first_5 @kc89_second_48 1;
+    pos @kc89_first_6 @kc89_second_1 -280;
+    pos @kc89_first_6 @kc89_second_2 -350;
+    pos @kc89_first_6 @kc89_second_3 -140;
+    pos @kc89_first_6 @kc89_second_4 -70;
+    pos @kc89_first_6 @kc89_second_6 -350;
+    pos @kc89_first_6 @kc89_second_7 -140;
+    pos @kc89_first_6 @kc89_second_8 -210;
+    pos @kc89_first_6 @kc89_second_10 -70;
+    pos @kc89_first_6 @kc89_second_17 -240;
+    pos @kc89_first_6 @kc89_second_18 -240;
+    pos @kc89_first_6 @kc89_second_19 -280;
+    pos @kc89_first_6 @kc89_second_21 -350;
+    pos @kc89_first_6 @kc89_second_22 -280;
+    pos @kc89_first_6 @kc89_second_23 -240;
+    pos @kc89_first_6 @kc89_second_24 -240;
+    pos @kc89_first_6 @kc89_second_25 -210;
+    pos @kc89_first_6 @kc89_second_26 -350;
+    pos @kc89_first_6 @kc89_second_27 -140;
+    pos @kc89_first_6 @kc89_second_29 -140;
+    pos @kc89_first_6 @kc89_second_31 -240;
+    pos @kc89_first_6 @kc89_second_32 -240;
+    pos @kc89_first_6 @kc89_second_33 -175;
+    pos @kc89_first_6 @kc89_second_35 -240;
+    pos @kc89_first_6 @kc89_second_37 -350;
+    pos @kc89_first_6 @kc89_second_38 -105;
+    pos @kc89_first_6 @kc89_second_39 -240;
+    pos @kc89_first_6 @kc89_second_40 -210;
+    pos @kc89_first_6 @kc89_second_41 -240;
+    pos @kc89_first_6 @kc89_second_42 -240;
+    pos @kc89_first_6 @kc89_second_44 -240;
+    pos @kc89_first_6 @kc89_second_47 -140;
+    pos @kc89_first_6 @kc89_second_48 1;
+    pos @kc89_first_6 @kc89_second_49 -35;
+    pos @kc89_first_6 @kc89_second_50 -240;
+    pos @kc89_first_6 @kc89_second_52 -240;
+    pos @kc89_first_6 @kc89_second_53 -240;
+    pos @kc89_first_6 @kc89_second_54 -240;
+    pos @kc89_first_6 @kc89_second_55 -240;
+    pos @kc89_first_6 @kc89_second_56 -280;
+    pos @kc89_first_6 @kc89_second_57 -70;
+    pos @kc89_first_6 @kc89_second_58 -280;
+    pos @kc89_first_6 @kc89_second_59 -240;
+    pos @kc89_first_6 @kc89_second_60 -175;
+    pos @kc89_first_6 @kc89_second_61 -240;
+    pos @kc89_first_6 @kc89_second_62 -210;
+    pos @kc89_first_6 @kc89_second_63 -175;
+    pos @kc89_first_6 @kc89_second_66 -175;
+    pos @kc89_first_6 @kc89_second_67 -175;
+    pos @kc89_first_7 @kc89_second_3 -70;
+    pos @kc89_first_7 @kc89_second_8 -105;
+    pos @kc89_first_7 @kc89_second_17 -35;
+    pos @kc89_first_7 @kc89_second_18 -70;
+    pos @kc89_first_7 @kc89_second_22 -105;
+    pos @kc89_first_7 @kc89_second_24 -105;
+    pos @kc89_first_7 @kc89_second_25 -70;
+    pos @kc89_first_7 @kc89_second_48 1;
+    pos @kc89_first_7 @kc89_second_49 -35;
+    pos @kc89_first_7 @kc89_second_50 -70;
+    pos @kc89_first_7 @kc89_second_54 -50;
+    pos @kc89_first_7 @kc89_second_63 -35;
+    pos @kc89_first_7 @kc89_second_66 -70;
+    pos @kc89_first_7 @kc89_second_67 -70;
+    pos @kc89_first_8 @kc89_second_3 -140;
+    pos @kc89_first_8 @kc89_second_4 -70;
+    pos @kc89_first_8 @kc89_second_6 -70;
+    pos @kc89_first_8 @kc89_second_8 -140;
+    pos @kc89_first_8 @kc89_second_10 -35;
+    pos @kc89_first_8 @kc89_second_17 -70;
+    pos @kc89_first_8 @kc89_second_18 -70;
+    pos @kc89_first_8 @kc89_second_22 -140;
+    pos @kc89_first_8 @kc89_second_24 -70;
+    pos @kc89_first_8 @kc89_second_25 -105;
+    pos @kc89_first_8 @kc89_second_27 -140;
+    pos @kc89_first_8 @kc89_second_31 -35;
+    pos @kc89_first_8 @kc89_second_33 -105;
+    pos @kc89_first_8 @kc89_second_37 -70;
+    pos @kc89_first_8 @kc89_second_39 -70;
+    pos @kc89_first_8 @kc89_second_41 -105;
+    pos @kc89_first_8 @kc89_second_42 -175;
+    pos @kc89_first_8 @kc89_second_43 -140;
+    pos @kc89_first_8 @kc89_second_44 -35;
+    pos @kc89_first_8 @kc89_second_46 -140;
+    pos @kc89_first_8 @kc89_second_47 -105;
+    pos @kc89_first_8 @kc89_second_48 1;
+    pos @kc89_first_8 @kc89_second_49 -70;
+    pos @kc89_first_8 @kc89_second_50 -140;
+    pos @kc89_first_8 @kc89_second_51 -70;
+    pos @kc89_first_8 @kc89_second_54 -35;
+    pos @kc89_first_8 @kc89_second_55 -35;
+    pos @kc89_first_8 @kc89_second_61 -210;
+    pos @kc89_first_8 @kc89_second_63 -105;
+    pos @kc89_first_8 @kc89_second_64 -70;
+    pos @kc89_first_8 @kc89_second_65 -35;
+    pos @kc89_first_8 @kc89_second_66 -70;
+    pos @kc89_first_8 @kc89_second_67 -35;
+    pos @kc89_first_9 @kc89_second_3 -140;
+    pos @kc89_first_9 @kc89_second_4 -70;
+    pos @kc89_first_9 @kc89_second_6 -70;
+    pos @kc89_first_9 @kc89_second_8 -210;
+    pos @kc89_first_9 @kc89_second_9 -420;
+    pos @kc89_first_9 @kc89_second_10 -70;
+    pos @kc89_first_9 @kc89_second_12 -350;
+    pos @kc89_first_9 @kc89_second_13 -420;
+    pos @kc89_first_9 @kc89_second_14 -350;
+    pos @kc89_first_9 @kc89_second_15 -280;
+    pos @kc89_first_9 @kc89_second_17 -70;
+    pos @kc89_first_9 @kc89_second_18 -70;
+    pos @kc89_first_9 @kc89_second_20 -210;
+    pos @kc89_first_9 @kc89_second_22 -210;
+    pos @kc89_first_9 @kc89_second_24 -70;
+    pos @kc89_first_9 @kc89_second_25 -140;
+    pos @kc89_first_9 @kc89_second_31 -50;
+    pos @kc89_first_9 @kc89_second_33 -140;
+    pos @kc89_first_9 @kc89_second_37 -70;
+    pos @kc89_first_9 @kc89_second_41 -105;
+    pos @kc89_first_9 @kc89_second_42 -280;
+    pos @kc89_first_9 @kc89_second_43 -350;
+    pos @kc89_first_9 @kc89_second_44 -50;
+    pos @kc89_first_9 @kc89_second_46 -350;
+    pos @kc89_first_9 @kc89_second_48 1;
+    pos @kc89_first_9 @kc89_second_49 -35;
+    pos @kc89_first_9 @kc89_second_50 -210;
+    pos @kc89_first_9 @kc89_second_51 -350;
+    pos @kc89_first_9 @kc89_second_54 -35;
+    pos @kc89_first_9 @kc89_second_55 -35;
+    pos @kc89_first_9 @kc89_second_61 -280;
+    pos @kc89_first_9 @kc89_second_63 -175;
+    pos @kc89_first_9 @kc89_second_64 -280;
+    pos @kc89_first_9 @kc89_second_65 -210;
+    pos @kc89_first_9 @kc89_second_66 -70;
+    pos @kc89_first_9 @kc89_second_67 -70;
+    pos @kc89_first_10 @kc89_second_1 -210;
+    pos @kc89_first_10 @kc89_second_2 -350;
+    pos @kc89_first_10 @kc89_second_5 -70;
+    pos @kc89_first_10 @kc89_second_6 -140;
+    pos @kc89_first_10 @kc89_second_11 -35;
+    pos @kc89_first_10 @kc89_second_12 -70;
+    pos @kc89_first_10 @kc89_second_13 -70;
+    pos @kc89_first_10 @kc89_second_14 -35;
+    pos @kc89_first_10 @kc89_second_16 -70;
+    pos @kc89_first_10 @kc89_second_17 -35;
+    pos @kc89_first_10 @kc89_second_18 -70;
+    pos @kc89_first_10 @kc89_second_19 -140;
+    pos @kc89_first_10 @kc89_second_21 -280;
+    pos @kc89_first_10 @kc89_second_24 -70;
+    pos @kc89_first_10 @kc89_second_26 -350;
+    pos @kc89_first_10 @kc89_second_31 -70;
+    pos @kc89_first_10 @kc89_second_34 -140;
+    pos @kc89_first_10 @kc89_second_35 -70;
+    pos @kc89_first_10 @kc89_second_37 -210;
+    pos @kc89_first_10 @kc89_second_38 -105;
+    pos @kc89_first_10 @kc89_second_41 -70;
+    pos @kc89_first_10 @kc89_second_48 1;
+    pos @kc89_first_10 @kc89_second_56 -210;
+    pos @kc89_first_10 @kc89_second_58 -210;
+    pos @kc89_first_10 @kc89_second_59 -210;
+    pos @kc89_first_10 @kc89_second_64 -70;
+    pos @kc89_first_10 @kc89_second_66 -70;
+    pos @kc89_first_10 @kc89_second_67 -105;
+    pos @kc89_first_11 @kc89_second_1 -70;
+    pos @kc89_first_11 @kc89_second_2 -140;
+    pos @kc89_first_11 @kc89_second_5 -105;
+    pos @kc89_first_11 @kc89_second_6 -35;
+    pos @kc89_first_11 @kc89_second_11 -70;
+    pos @kc89_first_11 @kc89_second_12 -210;
+    pos @kc89_first_11 @kc89_second_13 -175;
+    pos @kc89_first_11 @kc89_second_14 -105;
+    pos @kc89_first_11 @kc89_second_15 -70;
+    pos @kc89_first_11 @kc89_second_16 -140;
+    pos @kc89_first_11 @kc89_second_19 -70;
+    pos @kc89_first_11 @kc89_second_21 -140;
+    pos @kc89_first_11 @kc89_second_26 -70;
+    pos @kc89_first_11 @kc89_second_28 -70;
+    pos @kc89_first_11 @kc89_second_29 -70;
+    pos @kc89_first_11 @kc89_second_35 -35;
+    pos @kc89_first_11 @kc89_second_37 -35;
+    pos @kc89_first_11 @kc89_second_38 -140;
+    pos @kc89_first_11 @kc89_second_42 -70;
+    pos @kc89_first_11 @kc89_second_45 -35;
+    pos @kc89_first_11 @kc89_second_46 -35;
+    pos @kc89_first_11 @kc89_second_48 1;
+    pos @kc89_first_11 @kc89_second_51 -70;
+    pos @kc89_first_11 @kc89_second_56 -210;
+    pos @kc89_first_11 @kc89_second_58 -175;
+    pos @kc89_first_11 @kc89_second_59 -175;
+    pos @kc89_first_11 @kc89_second_60 -35;
+    pos @kc89_first_11 @kc89_second_64 -70;
+    pos @kc89_first_11 @kc89_second_65 -35;
+    pos @kc89_first_11 @kc89_second_66 -35;
+    pos @kc89_first_11 @kc89_second_67 -70;
+    pos @kc89_first_12 @kc89_second_1 -140;
+    pos @kc89_first_12 @kc89_second_2 -210;
+    pos @kc89_first_12 @kc89_second_6 -140;
+    pos @kc89_first_12 @kc89_second_17 -70;
+    pos @kc89_first_12 @kc89_second_18 -70;
+    pos @kc89_first_12 @kc89_second_19 -140;
+    pos @kc89_first_12 @kc89_second_21 -210;
+    pos @kc89_first_12 @kc89_second_24 -70;
+    pos @kc89_first_12 @kc89_second_26 -350;
+    pos @kc89_first_12 @kc89_second_31 -35;
+    pos @kc89_first_12 @kc89_second_34 -140;
+    pos @kc89_first_12 @kc89_second_35 -70;
+    pos @kc89_first_12 @kc89_second_37 -140;
+    pos @kc89_first_12 @kc89_second_38 -70;
+    pos @kc89_first_12 @kc89_second_41 -70;
+    pos @kc89_first_12 @kc89_second_48 1;
+    pos @kc89_first_12 @kc89_second_54 -35;
+    pos @kc89_first_12 @kc89_second_56 -210;
+    pos @kc89_first_12 @kc89_second_58 -210;
+    pos @kc89_first_12 @kc89_second_59 -210;
+    pos @kc89_first_12 @kc89_second_66 -70;
+    pos @kc89_first_12 @kc89_second_67 -105;
+    pos @kc89_first_13 @kc89_second_6 -70;
+    pos @kc89_first_13 @kc89_second_12 -70;
+    pos @kc89_first_13 @kc89_second_13 -105;
+    pos @kc89_first_13 @kc89_second_14 -35;
+    pos @kc89_first_13 @kc89_second_18 -35;
+    pos @kc89_first_13 @kc89_second_24 -35;
+    pos @kc89_first_13 @kc89_second_31 -35;
+    pos @kc89_first_13 @kc89_second_37 -70;
+    pos @kc89_first_13 @kc89_second_41 -70;
+    pos @kc89_first_13 @kc89_second_48 1;
+    pos @kc89_first_13 @kc89_second_66 -70;
+    pos @kc89_first_13 @kc89_second_67 -35;
+    pos @kc89_first_14 @kc89_second_2 -35;
+    pos @kc89_first_14 @kc89_second_11 -35;
+    pos @kc89_first_14 @kc89_second_12 -70;
+    pos @kc89_first_14 @kc89_second_13 -70;
+    pos @kc89_first_14 @kc89_second_14 -35;
+    pos @kc89_first_14 @kc89_second_16 -35;
+    pos @kc89_first_14 @kc89_second_21 -35;
+    pos @kc89_first_14 @kc89_second_27 -35;
+    pos @kc89_first_14 @kc89_second_35 -35;
+    pos @kc89_first_14 @kc89_second_42 -70;
+    pos @kc89_first_14 @kc89_second_48 1;
+    pos @kc89_first_14 @kc89_second_50 -70;
+    pos @kc89_first_14 @kc89_second_51 -35;
+    pos @kc89_first_14 @kc89_second_60 -35;
+    pos @kc89_first_14 @kc89_second_61 -35;
+    pos @kc89_first_14 @kc89_second_63 -35;
+    pos @kc89_first_14 @kc89_second_65 -35;
+    pos @kc89_first_15 @kc89_second_3 -70;
+    pos @kc89_first_15 @kc89_second_4 -70;
+    pos @kc89_first_15 @kc89_second_6 -35;
+    pos @kc89_first_15 @kc89_second_8 -70;
+    pos @kc89_first_15 @kc89_second_17 -70;
+    pos @kc89_first_15 @kc89_second_18 -70;
+    pos @kc89_first_15 @kc89_second_22 -140;
+    pos @kc89_first_15 @kc89_second_24 -70;
+    pos @kc89_first_15 @kc89_second_25 -70;
+    pos @kc89_first_15 @kc89_second_27 -70;
+    pos @kc89_first_15 @kc89_second_31 -35;
+    pos @kc89_first_15 @kc89_second_33 -35;
+    pos @kc89_first_15 @kc89_second_39 -35;
+    pos @kc89_first_15 @kc89_second_41 -70;
+    pos @kc89_first_15 @kc89_second_42 -142;
+    pos @kc89_first_15 @kc89_second_43 -35;
+    pos @kc89_first_15 @kc89_second_47 -35;
+    pos @kc89_first_15 @kc89_second_48 1;
+    pos @kc89_first_15 @kc89_second_49 -35;
+    pos @kc89_first_15 @kc89_second_50 -70;
+    pos @kc89_first_15 @kc89_second_54 -35;
+    pos @kc89_first_15 @kc89_second_55 -35;
+    pos @kc89_first_15 @kc89_second_61 -105;
+    pos @kc89_first_15 @kc89_second_63 -35;
+    pos @kc89_first_15 @kc89_second_66 -35;
+    pos @kc89_first_15 @kc89_second_67 -35;
+    pos @kc89_first_16 @kc89_second_1 -280;
+    pos @kc89_first_16 @kc89_second_2 -280;
+    pos @kc89_first_16 @kc89_second_3 -140;
+    pos @kc89_first_16 @kc89_second_4 -70;
+    pos @kc89_first_16 @kc89_second_6 -280;
+    pos @kc89_first_16 @kc89_second_7 -140;
+    pos @kc89_first_16 @kc89_second_8 -175;
+    pos @kc89_first_16 @kc89_second_10 -70;
+    pos @kc89_first_16 @kc89_second_17 -245;
+    pos @kc89_first_16 @kc89_second_18 -280;
+    pos @kc89_first_16 @kc89_second_19 -280;
+    pos @kc89_first_16 @kc89_second_21 -280;
+    pos @kc89_first_16 @kc89_second_22 -210;
+    pos @kc89_first_16 @kc89_second_23 -140;
+    pos @kc89_first_16 @kc89_second_24 -280;
+    pos @kc89_first_16 @kc89_second_25 -210;
+    pos @kc89_first_16 @kc89_second_26 -350;
+    pos @kc89_first_16 @kc89_second_27 -70;
+    pos @kc89_first_16 @kc89_second_29 -140;
+    pos @kc89_first_16 @kc89_second_31 -240;
+    pos @kc89_first_16 @kc89_second_32 -140;
+    pos @kc89_first_16 @kc89_second_33 -140;
+    pos @kc89_first_16 @kc89_second_34 -245;
+    pos @kc89_first_16 @kc89_second_35 -315;
+    pos @kc89_first_16 @kc89_second_37 -315;
+    pos @kc89_first_16 @kc89_second_38 -70;
+    pos @kc89_first_16 @kc89_second_39 -210;
+    pos @kc89_first_16 @kc89_second_40 -210;
+    pos @kc89_first_16 @kc89_second_41 -245;
+    pos @kc89_first_16 @kc89_second_42 -245;
+    pos @kc89_first_16 @kc89_second_43 -70;
+    pos @kc89_first_16 @kc89_second_45 -35;
+    pos @kc89_first_16 @kc89_second_46 -140;
+    pos @kc89_first_16 @kc89_second_47 -140;
+    pos @kc89_first_16 @kc89_second_48 1;
+    pos @kc89_first_16 @kc89_second_49 -70;
+    pos @kc89_first_16 @kc89_second_50 -140;
+    pos @kc89_first_16 @kc89_second_52 -140;
+    pos @kc89_first_16 @kc89_second_53 -140;
+    pos @kc89_first_16 @kc89_second_54 -240;
+    pos @kc89_first_16 @kc89_second_55 -140;
+    pos @kc89_first_16 @kc89_second_56 -280;
+    pos @kc89_first_16 @kc89_second_57 -105;
+    pos @kc89_first_16 @kc89_second_58 -315;
+    pos @kc89_first_16 @kc89_second_59 -280;
+    pos @kc89_first_16 @kc89_second_60 -140;
+    pos @kc89_first_16 @kc89_second_61 -210;
+    pos @kc89_first_16 @kc89_second_62 -210;
+    pos @kc89_first_16 @kc89_second_63 -105;
+    pos @kc89_first_16 @kc89_second_66 -315;
+    pos @kc89_first_16 @kc89_second_67 -350;
+    pos @kc89_first_17 @kc89_second_1 -280;
+    pos @kc89_first_17 @kc89_second_2 -280;
+    pos @kc89_first_17 @kc89_second_3 -105;
+    pos @kc89_first_17 @kc89_second_6 -210;
+    pos @kc89_first_17 @kc89_second_7 -105;
+    pos @kc89_first_17 @kc89_second_8 -105;
+    pos @kc89_first_17 @kc89_second_10 -35;
+    pos @kc89_first_17 @kc89_second_17 -105;
+    pos @kc89_first_17 @kc89_second_18 -175;
+    pos @kc89_first_17 @kc89_second_19 -280;
+    pos @kc89_first_17 @kc89_second_21 -280;
+    pos @kc89_first_17 @kc89_second_22 -70;
+    pos @kc89_first_17 @kc89_second_23 -105;
+    pos @kc89_first_17 @kc89_second_24 -140;
+    pos @kc89_first_17 @kc89_second_25 -140;
+    pos @kc89_first_17 @kc89_second_26 -210;
+    pos @kc89_first_17 @kc89_second_29 -70;
+    pos @kc89_first_17 @kc89_second_31 -140;
+    pos @kc89_first_17 @kc89_second_32 -105;
+    pos @kc89_first_17 @kc89_second_34 -210;
+    pos @kc89_first_17 @kc89_second_35 -175;
+    pos @kc89_first_17 @kc89_second_37 -245;
+    pos @kc89_first_17 @kc89_second_38 -70;
+    pos @kc89_first_17 @kc89_second_39 -140;
+    pos @kc89_first_17 @kc89_second_40 -140;
+    pos @kc89_first_17 @kc89_second_41 -140;
+    pos @kc89_first_17 @kc89_second_42 -105;
+    pos @kc89_first_17 @kc89_second_43 -35;
+    pos @kc89_first_17 @kc89_second_46 -35;
+    pos @kc89_first_17 @kc89_second_47 -70;
+    pos @kc89_first_17 @kc89_second_48 1;
+    pos @kc89_first_17 @kc89_second_49 -35;
+    pos @kc89_first_17 @kc89_second_50 -70;
+    pos @kc89_first_17 @kc89_second_52 -105;
+    pos @kc89_first_17 @kc89_second_53 -70;
+    pos @kc89_first_17 @kc89_second_54 -105;
+    pos @kc89_first_17 @kc89_second_55 -70;
+    pos @kc89_first_17 @kc89_second_56 -210;
+    pos @kc89_first_17 @kc89_second_57 -35;
+    pos @kc89_first_17 @kc89_second_58 -245;
+    pos @kc89_first_17 @kc89_second_59 -210;
+    pos @kc89_first_17 @kc89_second_60 -70;
+    pos @kc89_first_17 @kc89_second_61 -105;
+    pos @kc89_first_17 @kc89_second_62 -105;
+    pos @kc89_first_17 @kc89_second_63 -70;
+    pos @kc89_first_17 @kc89_second_66 -175;
+    pos @kc89_first_17 @kc89_second_67 -245;
+    pos @kc89_first_18 @kc89_second_1 -210;
+    pos @kc89_first_18 @kc89_second_2 -245;
+    pos @kc89_first_18 @kc89_second_3 -35;
+    pos @kc89_first_18 @kc89_second_6 -140;
+    pos @kc89_first_18 @kc89_second_7 -35;
+    pos @kc89_first_18 @kc89_second_8 -70;
+    pos @kc89_first_18 @kc89_second_17 -105;
+    pos @kc89_first_18 @kc89_second_18 -105;
+    pos @kc89_first_18 @kc89_second_19 -175;
+    pos @kc89_first_18 @kc89_second_21 -210;
+    pos @kc89_first_18 @kc89_second_22 -70;
+    pos @kc89_first_18 @kc89_second_24 -105;
+    pos @kc89_first_18 @kc89_second_25 -70;
+    pos @kc89_first_18 @kc89_second_26 -140;
+    pos @kc89_first_18 @kc89_second_29 -35;
+    pos @kc89_first_18 @kc89_second_34 -140;
+    pos @kc89_first_18 @kc89_second_35 -105;
+    pos @kc89_first_18 @kc89_second_37 -140;
+    pos @kc89_first_18 @kc89_second_39 -105;
+    pos @kc89_first_18 @kc89_second_40 -70;
+    pos @kc89_first_18 @kc89_second_41 -105;
+    pos @kc89_first_18 @kc89_second_42 -70;
+    pos @kc89_first_18 @kc89_second_44 -35;
+    pos @kc89_first_18 @kc89_second_48 1;
+    pos @kc89_first_18 @kc89_second_53 -35;
+    pos @kc89_first_18 @kc89_second_54 -70;
+    pos @kc89_first_18 @kc89_second_56 -140;
+    pos @kc89_first_18 @kc89_second_58 -175;
+    pos @kc89_first_18 @kc89_second_59 -140;
+    pos @kc89_first_18 @kc89_second_61 -70;
+    pos @kc89_first_18 @kc89_second_66 -105;
+    pos @kc89_first_18 @kc89_second_67 -140;
+    pos @kc89_first_19 @kc89_second_12 -280;
+    pos @kc89_first_19 @kc89_second_14 -175;
+    pos @kc89_first_19 @kc89_second_15 -140;
+    pos @kc89_first_19 @kc89_second_18 -35;
+    pos @kc89_first_19 @kc89_second_31 -35;
+    pos @kc89_first_19 @kc89_second_33 -50;
+    pos @kc89_first_19 @kc89_second_48 1;
+    pos @kc89_first_19 @kc89_second_50 -70;
+    pos @kc89_first_19 @kc89_second_51 -140;
+    pos @kc89_first_19 @kc89_second_61 -70;
+    pos @kc89_first_19 @kc89_second_63 -35;
+    pos @kc89_first_19 @kc89_second_64 -105;
+    pos @kc89_first_19 @kc89_second_65 -70;
+    pos @kc89_first_20 @kc89_second_12 -240;
+    pos @kc89_first_20 @kc89_second_13 -140;
+    pos @kc89_first_20 @kc89_second_14 -105;
+    pos @kc89_first_20 @kc89_second_15 -35;
+    pos @kc89_first_20 @kc89_second_48 1;
+    pos @kc89_first_21 @kc89_second_8 -35;
+    pos @kc89_first_21 @kc89_second_9 -140;
+    pos @kc89_first_21 @kc89_second_12 -280;
+    pos @kc89_first_21 @kc89_second_13 -280;
+    pos @kc89_first_21 @kc89_second_14 -280;
+    pos @kc89_first_21 @kc89_second_15 -175;
+    pos @kc89_first_21 @kc89_second_20 -140;
+    pos @kc89_first_21 @kc89_second_22 -70;
+    pos @kc89_first_21 @kc89_second_27 -70;
+    pos @kc89_first_21 @kc89_second_33 -50;
+    pos @kc89_first_21 @kc89_second_42 -140;
+    pos @kc89_first_21 @kc89_second_43 -105;
+    pos @kc89_first_21 @kc89_second_46 -210;
+    pos @kc89_first_21 @kc89_second_48 1;
+    pos @kc89_first_21 @kc89_second_49 -35;
+    pos @kc89_first_21 @kc89_second_50 -140;
+    pos @kc89_first_21 @kc89_second_51 -210;
+    pos @kc89_first_21 @kc89_second_55 -35;
+    pos @kc89_first_21 @kc89_second_61 -105;
+    pos @kc89_first_21 @kc89_second_63 -105;
+    pos @kc89_first_21 @kc89_second_64 -210;
+    pos @kc89_first_21 @kc89_second_65 -140;
+    pos @kc89_first_22 @kc89_second_1 -140;
+    pos @kc89_first_22 @kc89_second_2 -350;
+    pos @kc89_first_22 @kc89_second_19 -140;
+    pos @kc89_first_22 @kc89_second_21 -280;
+    pos @kc89_first_22 @kc89_second_41 -70;
+    pos @kc89_first_22 @kc89_second_48 1;
+    pos @kc89_first_22 @kc89_second_67 -210;
+    pos @kc89_first_23 @kc89_second_1 -35;
+    pos @kc89_first_23 @kc89_second_5 -105;
+    pos @kc89_first_23 @kc89_second_9 -70;
+    pos @kc89_first_23 @kc89_second_11 -70;
+    pos @kc89_first_23 @kc89_second_12 -240;
+    pos @kc89_first_23 @kc89_second_13 -280;
+    pos @kc89_first_23 @kc89_second_14 -140;
+    pos @kc89_first_23 @kc89_second_15 -105;
+    pos @kc89_first_23 @kc89_second_16 -70;
+    pos @kc89_first_23 @kc89_second_27 -35;
+    pos @kc89_first_23 @kc89_second_28 -70;
+    pos @kc89_first_23 @kc89_second_29 -105;
+    pos @kc89_first_23 @kc89_second_35 -35;
+    pos @kc89_first_23 @kc89_second_38 -70;
+    pos @kc89_first_23 @kc89_second_42 -70;
+    pos @kc89_first_23 @kc89_second_43 -35;
+    pos @kc89_first_23 @kc89_second_45 -35;
+    pos @kc89_first_23 @kc89_second_46 -140;
+    pos @kc89_first_23 @kc89_second_48 1;
+    pos @kc89_first_23 @kc89_second_50 -70;
+    pos @kc89_first_23 @kc89_second_51 -175;
+    pos @kc89_first_23 @kc89_second_52 -35;
+    pos @kc89_first_23 @kc89_second_60 -105;
+    pos @kc89_first_23 @kc89_second_61 -35;
+    pos @kc89_first_23 @kc89_second_63 -50;
+    pos @kc89_first_23 @kc89_second_64 -105;
+    pos @kc89_first_23 @kc89_second_65 -70;
+    pos @kc89_first_24 @kc89_second_6 -35;
+    pos @kc89_first_24 @kc89_second_12 -240;
+    pos @kc89_first_24 @kc89_second_13 -175;
+    pos @kc89_first_24 @kc89_second_14 -70;
+    pos @kc89_first_24 @kc89_second_15 -70;
+    pos @kc89_first_24 @kc89_second_18 -70;
+    pos @kc89_first_24 @kc89_second_24 -70;
+    pos @kc89_first_24 @kc89_second_25 -35;
+    pos @kc89_first_24 @kc89_second_37 -35;
+    pos @kc89_first_24 @kc89_second_42 -35;
+    pos @kc89_first_24 @kc89_second_43 -35;
+    pos @kc89_first_24 @kc89_second_46 -70;
+    pos @kc89_first_24 @kc89_second_47 -35;
+    pos @kc89_first_24 @kc89_second_48 1;
+    pos @kc89_first_24 @kc89_second_51 -35;
+    pos @kc89_first_24 @kc89_second_61 -35;
+    pos @kc89_first_24 @kc89_second_65 -35;
+    pos @kc89_first_24 @kc89_second_66 -35;
+    pos @kc89_first_24 @kc89_second_67 -35;
+    pos @kc89_first_25 @kc89_second_1 -70;
+    pos @kc89_first_25 @kc89_second_2 -140;
+    pos @kc89_first_25 @kc89_second_5 -105;
+    pos @kc89_first_25 @kc89_second_11 -70;
+    pos @kc89_first_25 @kc89_second_12 -280;
+    pos @kc89_first_25 @kc89_second_13 -210;
+    pos @kc89_first_25 @kc89_second_14 -70;
+    pos @kc89_first_25 @kc89_second_15 -70;
+    pos @kc89_first_25 @kc89_second_16 -140;
+    pos @kc89_first_25 @kc89_second_21 -70;
+    pos @kc89_first_25 @kc89_second_28 -70;
+    pos @kc89_first_25 @kc89_second_29 -70;
+    pos @kc89_first_25 @kc89_second_34 -70;
+    pos @kc89_first_25 @kc89_second_38 -70;
+    pos @kc89_first_25 @kc89_second_45 -35;
+    pos @kc89_first_25 @kc89_second_46 -140;
+    pos @kc89_first_25 @kc89_second_48 1;
+    pos @kc89_first_25 @kc89_second_51 -140;
+    pos @kc89_first_25 @kc89_second_52 -35;
+    pos @kc89_first_25 @kc89_second_56 -140;
+    pos @kc89_first_25 @kc89_second_58 -70;
+    pos @kc89_first_25 @kc89_second_59 -105;
+    pos @kc89_first_25 @kc89_second_60 -70;
+    pos @kc89_first_25 @kc89_second_64 -70;
+    pos @kc89_first_25 @kc89_second_65 -35;
+    pos @kc89_first_26 @kc89_second_5 -70;
+    pos @kc89_first_26 @kc89_second_9 -70;
+    pos @kc89_first_26 @kc89_second_12 -240;
+    pos @kc89_first_26 @kc89_second_13 -280;
+    pos @kc89_first_26 @kc89_second_14 -175;
+    pos @kc89_first_26 @kc89_second_15 -105;
+    pos @kc89_first_26 @kc89_second_16 -70;
+    pos @kc89_first_26 @kc89_second_27 -35;
+    pos @kc89_first_26 @kc89_second_28 -70;
+    pos @kc89_first_26 @kc89_second_29 -70;
+    pos @kc89_first_26 @kc89_second_38 -70;
+    pos @kc89_first_26 @kc89_second_42 -70;
+    pos @kc89_first_26 @kc89_second_43 -35;
+    pos @kc89_first_26 @kc89_second_46 -140;
+    pos @kc89_first_26 @kc89_second_48 1;
+    pos @kc89_first_26 @kc89_second_50 -70;
+    pos @kc89_first_26 @kc89_second_51 -140;
+    pos @kc89_first_26 @kc89_second_52 -35;
+    pos @kc89_first_26 @kc89_second_56 -50;
+    pos @kc89_first_26 @kc89_second_57 -35;
+    pos @kc89_first_26 @kc89_second_58 -50;
+    pos @kc89_first_26 @kc89_second_59 -50;
+    pos @kc89_first_26 @kc89_second_60 -105;
+    pos @kc89_first_26 @kc89_second_61 -50;
+    pos @kc89_first_26 @kc89_second_63 -35;
+    pos @kc89_first_26 @kc89_second_64 -105;
+    pos @kc89_first_26 @kc89_second_65 -70;
+    pos @kc89_first_27 @kc89_second_9 -35;
+    pos @kc89_first_27 @kc89_second_12 -140;
+    pos @kc89_first_27 @kc89_second_28 -70;
+    pos @kc89_first_27 @kc89_second_42 -35;
+    pos @kc89_first_27 @kc89_second_46 -70;
+    pos @kc89_first_27 @kc89_second_48 1;
+    pos @kc89_first_27 @kc89_second_51 -70;
+    pos @kc89_first_27 @kc89_second_64 -70;
+    pos @kc89_first_27 @kc89_second_65 -35;
+    pos @kc89_first_28 @kc89_second_5 -50;
+    pos @kc89_first_28 @kc89_second_9 -35;
+    pos @kc89_first_28 @kc89_second_11 -35;
+    pos @kc89_first_28 @kc89_second_12 -240;
+    pos @kc89_first_28 @kc89_second_13 -240;
+    pos @kc89_first_28 @kc89_second_14 -105;
+    pos @kc89_first_28 @kc89_second_15 -70;
+    pos @kc89_first_28 @kc89_second_16 -35;
+    pos @kc89_first_28 @kc89_second_28 -35;
+    pos @kc89_first_28 @kc89_second_29 -35;
+    pos @kc89_first_28 @kc89_second_35 -35;
+    pos @kc89_first_28 @kc89_second_38 -35;
+    pos @kc89_first_28 @kc89_second_42 -50;
+    pos @kc89_first_28 @kc89_second_43 -35;
+    pos @kc89_first_28 @kc89_second_46 -100;
+    pos @kc89_first_28 @kc89_second_48 1;
+    pos @kc89_first_28 @kc89_second_50 -35;
+    pos @kc89_first_28 @kc89_second_51 -140;
+    pos @kc89_first_28 @kc89_second_60 -35;
+    pos @kc89_first_28 @kc89_second_64 -70;
+    pos @kc89_first_28 @kc89_second_65 -35;
+    pos @kc89_first_29 @kc89_second_48 1;
+    pos @kc89_first_30 @kc89_second_8 -70;
+    pos @kc89_first_30 @kc89_second_9 -210;
+    pos @kc89_first_30 @kc89_second_12 -350;
+    pos @kc89_first_30 @kc89_second_13 -350;
+    pos @kc89_first_30 @kc89_second_14 -210;
+    pos @kc89_first_30 @kc89_second_15 -175;
+    pos @kc89_first_30 @kc89_second_27 -70;
+    pos @kc89_first_30 @kc89_second_41 -35;
+    pos @kc89_first_30 @kc89_second_42 -210;
+    pos @kc89_first_30 @kc89_second_43 -210;
+    pos @kc89_first_30 @kc89_second_46 -210;
+    pos @kc89_first_30 @kc89_second_48 1;
+    pos @kc89_first_30 @kc89_second_50 -140;
+    pos @kc89_first_30 @kc89_second_51 -280;
+    pos @kc89_first_30 @kc89_second_61 -210;
+    pos @kc89_first_30 @kc89_second_63 -105;
+    pos @kc89_first_30 @kc89_second_64 -175;
+    pos @kc89_first_30 @kc89_second_65 -140;
+    pos @kc89_first_31 @kc89_second_1 -175;
+    pos @kc89_first_31 @kc89_second_2 -175;
+    pos @kc89_first_31 @kc89_second_5 -70;
+    pos @kc89_first_31 @kc89_second_6 -105;
+    pos @kc89_first_31 @kc89_second_10 -35;
+    pos @kc89_first_31 @kc89_second_11 -105;
+    pos @kc89_first_31 @kc89_second_12 -175;
+    pos @kc89_first_31 @kc89_second_13 -140;
+    pos @kc89_first_31 @kc89_second_14 -70;
+    pos @kc89_first_31 @kc89_second_15 -35;
+    pos @kc89_first_31 @kc89_second_16 -140;
+    pos @kc89_first_31 @kc89_second_17 -70;
+    pos @kc89_first_31 @kc89_second_18 -70;
+    pos @kc89_first_31 @kc89_second_19 -140;
+    pos @kc89_first_31 @kc89_second_21 -175;
+    pos @kc89_first_31 @kc89_second_24 -70;
+    pos @kc89_first_31 @kc89_second_31 -105;
+    pos @kc89_first_31 @kc89_second_36 165;
+    pos @kc89_first_31 @kc89_second_37 -105;
+    pos @kc89_first_31 @kc89_second_38 -175;
+    pos @kc89_first_31 @kc89_second_39 -35;
+    pos @kc89_first_31 @kc89_second_41 -70;
+    pos @kc89_first_31 @kc89_second_48 1;
+    pos @kc89_first_31 @kc89_second_53 165;
+    pos @kc89_first_31 @kc89_second_54 -35;
+    pos @kc89_first_31 @kc89_second_66 -70;
+    pos @kc89_first_31 @kc89_second_67 -105;
+    pos @kc89_first_32 @kc89_second_3 -70;
+    pos @kc89_first_32 @kc89_second_4 -35;
+    pos @kc89_first_32 @kc89_second_6 -70;
+    pos @kc89_first_32 @kc89_second_8 -105;
+    pos @kc89_first_32 @kc89_second_17 -35;
+    pos @kc89_first_32 @kc89_second_18 -70;
+    pos @kc89_first_32 @kc89_second_22 -70;
+    pos @kc89_first_32 @kc89_second_24 -70;
+    pos @kc89_first_32 @kc89_second_25 -140;
+    pos @kc89_first_32 @kc89_second_31 -35;
+    pos @kc89_first_32 @kc89_second_37 -70;
+    pos @kc89_first_32 @kc89_second_39 -35;
+    pos @kc89_first_32 @kc89_second_41 -140;
+    pos @kc89_first_32 @kc89_second_42 -70;
+    pos @kc89_first_32 @kc89_second_48 1;
+    pos @kc89_first_32 @kc89_second_54 -35;
+    pos @kc89_first_32 @kc89_second_55 -35;
+    pos @kc89_first_32 @kc89_second_61 -140;
+    pos @kc89_first_32 @kc89_second_66 -70;
+    pos @kc89_first_32 @kc89_second_67 -70;
+    pos @kc89_first_33 @kc89_second_1 -35;
+    pos @kc89_first_33 @kc89_second_2 -105;
+    pos @kc89_first_33 @kc89_second_3 -70;
+    pos @kc89_first_33 @kc89_second_4 70;
+    pos @kc89_first_33 @kc89_second_5 -70;
+    pos @kc89_first_33 @kc89_second_11 -35;
+    pos @kc89_first_33 @kc89_second_12 -240;
+    pos @kc89_first_33 @kc89_second_13 -175;
+    pos @kc89_first_33 @kc89_second_14 -105;
+    pos @kc89_first_33 @kc89_second_15 -70;
+    pos @kc89_first_33 @kc89_second_16 -70;
+    pos @kc89_first_33 @kc89_second_19 -70;
+    pos @kc89_first_33 @kc89_second_26 -35;
+    pos @kc89_first_33 @kc89_second_29 -70;
+    pos @kc89_first_33 @kc89_second_35 -35;
+    pos @kc89_first_33 @kc89_second_38 -35;
+    pos @kc89_first_33 @kc89_second_42 -35;
+    pos @kc89_first_33 @kc89_second_43 -35;
+    pos @kc89_first_33 @kc89_second_45 -35;
+    pos @kc89_first_33 @kc89_second_46 -140;
+    pos @kc89_first_33 @kc89_second_48 1;
+    pos @kc89_first_33 @kc89_second_50 -50;
+    pos @kc89_first_33 @kc89_second_51 -140;
+    pos @kc89_first_33 @kc89_second_52 -35;
+    pos @kc89_first_33 @kc89_second_56 -70;
+    pos @kc89_first_33 @kc89_second_58 -70;
+    pos @kc89_first_33 @kc89_second_59 -70;
+    pos @kc89_first_33 @kc89_second_64 -70;
+    pos @kc89_first_33 @kc89_second_65 -35;
+    pos @kc89_first_34 @kc89_second_3 -35;
+    pos @kc89_first_34 @kc89_second_4 -70;
+    pos @kc89_first_34 @kc89_second_6 -70;
+    pos @kc89_first_34 @kc89_second_8 -70;
+    pos @kc89_first_34 @kc89_second_12 -140;
+    pos @kc89_first_34 @kc89_second_13 -105;
+    pos @kc89_first_34 @kc89_second_14 -70;
+    pos @kc89_first_34 @kc89_second_15 -35;
+    pos @kc89_first_34 @kc89_second_18 -70;
+    pos @kc89_first_34 @kc89_second_22 -70;
+    pos @kc89_first_34 @kc89_second_24 -105;
+    pos @kc89_first_34 @kc89_second_25 -70;
+    pos @kc89_first_34 @kc89_second_31 -35;
+    pos @kc89_first_34 @kc89_second_37 -70;
+    pos @kc89_first_34 @kc89_second_39 -70;
+    pos @kc89_first_34 @kc89_second_41 -105;
+    pos @kc89_first_34 @kc89_second_42 -70;
+    pos @kc89_first_34 @kc89_second_47 -70;
+    pos @kc89_first_34 @kc89_second_48 1;
+    pos @kc89_first_34 @kc89_second_54 -35;
+    pos @kc89_first_34 @kc89_second_55 -35;
+    pos @kc89_first_34 @kc89_second_66 -70;
+    pos @kc89_first_34 @kc89_second_67 -70;
+    pos @kc89_first_35 @kc89_second_34 -315;
+    pos @kc89_first_35 @kc89_second_48 1;
+    pos @kc89_first_36 @kc89_second_9 -70;
+    pos @kc89_first_36 @kc89_second_12 -240;
+    pos @kc89_first_36 @kc89_second_13 -210;
+    pos @kc89_first_36 @kc89_second_14 -140;
+    pos @kc89_first_36 @kc89_second_15 -105;
+    pos @kc89_first_36 @kc89_second_36 70;
+    pos @kc89_first_36 @kc89_second_42 -70;
+    pos @kc89_first_36 @kc89_second_43 -35;
+    pos @kc89_first_36 @kc89_second_46 -140;
+    pos @kc89_first_36 @kc89_second_48 1;
+    pos @kc89_first_36 @kc89_second_50 -50;
+    pos @kc89_first_36 @kc89_second_51 -140;
+    pos @kc89_first_36 @kc89_second_53 165;
+    pos @kc89_first_36 @kc89_second_61 -35;
+    pos @kc89_first_36 @kc89_second_63 -35;
+    pos @kc89_first_36 @kc89_second_64 -70;
+    pos @kc89_first_36 @kc89_second_65 -70;
+    pos @kc89_first_37 @kc89_second_9 -35;
+    pos @kc89_first_37 @kc89_second_12 -240;
+    pos @kc89_first_37 @kc89_second_13 -240;
+    pos @kc89_first_37 @kc89_second_14 -140;
+    pos @kc89_first_37 @kc89_second_15 -105;
+    pos @kc89_first_37 @kc89_second_16 -35;
+    pos @kc89_first_37 @kc89_second_28 -35;
+    pos @kc89_first_37 @kc89_second_29 -35;
+    pos @kc89_first_37 @kc89_second_42 -70;
+    pos @kc89_first_37 @kc89_second_43 -35;
+    pos @kc89_first_37 @kc89_second_46 -70;
+    pos @kc89_first_37 @kc89_second_48 1;
+    pos @kc89_first_37 @kc89_second_50 -35;
+    pos @kc89_first_37 @kc89_second_51 -70;
+    pos @kc89_first_37 @kc89_second_63 -35;
+    pos @kc89_first_37 @kc89_second_64 -70;
+    pos @kc89_first_37 @kc89_second_65 -70;
+    pos @kc89_first_38 @kc89_second_5 -70;
+    pos @kc89_first_38 @kc89_second_9 -70;
+    pos @kc89_first_38 @kc89_second_12 -140;
+    pos @kc89_first_38 @kc89_second_13 -210;
+    pos @kc89_first_38 @kc89_second_14 -140;
+    pos @kc89_first_38 @kc89_second_15 -105;
+    pos @kc89_first_38 @kc89_second_16 -70;
+    pos @kc89_first_38 @kc89_second_28 -70;
+    pos @kc89_first_38 @kc89_second_29 -70;
+    pos @kc89_first_38 @kc89_second_38 -50;
+    pos @kc89_first_38 @kc89_second_42 -50;
+    pos @kc89_first_38 @kc89_second_43 -35;
+    pos @kc89_first_38 @kc89_second_48 1;
+    pos @kc89_first_38 @kc89_second_50 -35;
+    pos @kc89_first_38 @kc89_second_51 -140;
+    pos @kc89_first_38 @kc89_second_60 -35;
+    pos @kc89_first_38 @kc89_second_64 -70;
+    pos @kc89_first_38 @kc89_second_65 -35;
+    pos @kc89_first_39 @kc89_second_1 -210;
+    pos @kc89_first_39 @kc89_second_2 -280;
+    pos @kc89_first_39 @kc89_second_6 -280;
+    pos @kc89_first_39 @kc89_second_8 -70;
+    pos @kc89_first_39 @kc89_second_17 -140;
+    pos @kc89_first_39 @kc89_second_18 -140;
+    pos @kc89_first_39 @kc89_second_19 -245;
+    pos @kc89_first_39 @kc89_second_21 -350;
+    pos @kc89_first_39 @kc89_second_22 -140;
+    pos @kc89_first_39 @kc89_second_24 -140;
+    pos @kc89_first_39 @kc89_second_25 -70;
+    pos @kc89_first_39 @kc89_second_26 -280;
+    pos @kc89_first_39 @kc89_second_30 -315;
+    pos @kc89_first_39 @kc89_second_31 -140;
+    pos @kc89_first_39 @kc89_second_34 -385;
+    pos @kc89_first_39 @kc89_second_35 -140;
+    pos @kc89_first_39 @kc89_second_37 -210;
+    pos @kc89_first_39 @kc89_second_38 -70;
+    pos @kc89_first_39 @kc89_second_39 -140;
+    pos @kc89_first_39 @kc89_second_40 -140;
+    pos @kc89_first_39 @kc89_second_41 -140;
+    pos @kc89_first_39 @kc89_second_42 -70;
+    pos @kc89_first_39 @kc89_second_44 -70;
+    pos @kc89_first_39 @kc89_second_48 1;
+    pos @kc89_first_39 @kc89_second_54 -140;
+    pos @kc89_first_39 @kc89_second_55 -70;
+    pos @kc89_first_39 @kc89_second_56 -140;
+    pos @kc89_first_39 @kc89_second_58 -245;
+    pos @kc89_first_39 @kc89_second_59 -210;
+    pos @kc89_first_39 @kc89_second_60 -70;
+    pos @kc89_first_39 @kc89_second_61 -70;
+    pos @kc89_first_39 @kc89_second_62 -70;
+    pos @kc89_first_39 @kc89_second_63 -70;
+    pos @kc89_first_39 @kc89_second_66 -245;
+    pos @kc89_first_39 @kc89_second_67 -280;
+    pos @kc89_first_39 @kc89_second_68 -315;
+    pos @kc89_first_40 @kc89_second_6 -35;
+    pos @kc89_first_40 @kc89_second_12 -240;
+    pos @kc89_first_40 @kc89_second_13 -140;
+    pos @kc89_first_40 @kc89_second_14 -35;
+    pos @kc89_first_40 @kc89_second_15 -35;
+    pos @kc89_first_40 @kc89_second_37 -35;
+    pos @kc89_first_40 @kc89_second_48 1;
+    pos @kc89_first_40 @kc89_second_53 105;
+    pos @kc89_first_40 @kc89_second_66 -35;
+    pos @kc89_first_40 @kc89_second_67 -35;
+    pos @kc89_first_41 @kc89_second_12 -210;
+    pos @kc89_first_41 @kc89_second_13 -175;
+    pos @kc89_first_41 @kc89_second_14 -105;
+    pos @kc89_first_41 @kc89_second_15 -70;
+    pos @kc89_first_41 @kc89_second_46 -70;
+    pos @kc89_first_41 @kc89_second_48 1;
+    pos @kc89_first_41 @kc89_second_51 -105;
+    pos @kc89_first_41 @kc89_second_64 -70;
+    pos @kc89_first_42 @kc89_second_1 -140;
+    pos @kc89_first_42 @kc89_second_2 -175;
+    pos @kc89_first_42 @kc89_second_5 -105;
+    pos @kc89_first_42 @kc89_second_6 -70;
+    pos @kc89_first_42 @kc89_second_11 -70;
+    pos @kc89_first_42 @kc89_second_12 -175;
+    pos @kc89_first_42 @kc89_second_13 -105;
+    pos @kc89_first_42 @kc89_second_14 -70;
+    pos @kc89_first_42 @kc89_second_15 -35;
+    pos @kc89_first_42 @kc89_second_16 -105;
+    pos @kc89_first_42 @kc89_second_17 -35;
+    pos @kc89_first_42 @kc89_second_18 -50;
+    pos @kc89_first_42 @kc89_second_19 -140;
+    pos @kc89_first_42 @kc89_second_21 -175;
+    pos @kc89_first_42 @kc89_second_24 -50;
+    pos @kc89_first_42 @kc89_second_26 -105;
+    pos @kc89_first_42 @kc89_second_31 -35;
+    pos @kc89_first_42 @kc89_second_34 -70;
+    pos @kc89_first_42 @kc89_second_35 -50;
+    pos @kc89_first_42 @kc89_second_37 -70;
+    pos @kc89_first_42 @kc89_second_38 -140;
+    pos @kc89_first_42 @kc89_second_39 -35;
+    pos @kc89_first_42 @kc89_second_41 -50;
+    pos @kc89_first_42 @kc89_second_48 1;
+    pos @kc89_first_42 @kc89_second_54 -35;
+    pos @kc89_first_42 @kc89_second_56 -105;
+    pos @kc89_first_42 @kc89_second_58 -105;
+    pos @kc89_first_42 @kc89_second_59 -105;
+    pos @kc89_first_42 @kc89_second_66 -50;
+    pos @kc89_first_42 @kc89_second_67 -70;
+    pos @kc89_first_43 @kc89_second_1 -210;
+    pos @kc89_first_43 @kc89_second_2 -280;
+    pos @kc89_first_43 @kc89_second_3 -70;
+    pos @kc89_first_43 @kc89_second_6 -280;
+    pos @kc89_first_43 @kc89_second_8 -35;
+    pos @kc89_first_43 @kc89_second_11 -70;
+    pos @kc89_first_43 @kc89_second_13 -140;
+    pos @kc89_first_43 @kc89_second_14 -35;
+    pos @kc89_first_43 @kc89_second_15 -35;
+    pos @kc89_first_43 @kc89_second_16 -140;
+    pos @kc89_first_43 @kc89_second_17 -105;
+    pos @kc89_first_43 @kc89_second_18 -140;
+    pos @kc89_first_43 @kc89_second_19 -210;
+    pos @kc89_first_43 @kc89_second_21 -280;
+    pos @kc89_first_43 @kc89_second_22 -140;
+    pos @kc89_first_43 @kc89_second_24 -140;
+    pos @kc89_first_43 @kc89_second_25 -140;
+    pos @kc89_first_43 @kc89_second_26 -210;
+    pos @kc89_first_43 @kc89_second_34 -140;
+    pos @kc89_first_43 @kc89_second_35 -140;
+    pos @kc89_first_43 @kc89_second_37 -280;
+    pos @kc89_first_43 @kc89_second_38 -140;
+    pos @kc89_first_43 @kc89_second_39 -70;
+    pos @kc89_first_43 @kc89_second_40 -140;
+    pos @kc89_first_43 @kc89_second_41 -175;
+    pos @kc89_first_43 @kc89_second_47 -70;
+    pos @kc89_first_43 @kc89_second_48 1;
+    pos @kc89_first_43 @kc89_second_56 -210;
+    pos @kc89_first_43 @kc89_second_58 -210;
+    pos @kc89_first_43 @kc89_second_59 -175;
+    pos @kc89_first_43 @kc89_second_62 -70;
+    pos @kc89_first_43 @kc89_second_66 -175;
+    pos @kc89_first_43 @kc89_second_67 -175;
+    pos @kc89_first_44 @kc89_second_9 -70;
+    pos @kc89_first_44 @kc89_second_12 -240;
+    pos @kc89_first_44 @kc89_second_13 -210;
+    pos @kc89_first_44 @kc89_second_14 -140;
+    pos @kc89_first_44 @kc89_second_15 -105;
+    pos @kc89_first_44 @kc89_second_42 -70;
+    pos @kc89_first_44 @kc89_second_43 -35;
+    pos @kc89_first_44 @kc89_second_46 -140;
+    pos @kc89_first_44 @kc89_second_48 1;
+    pos @kc89_first_44 @kc89_second_50 -50;
+    pos @kc89_first_44 @kc89_second_51 -140;
+    pos @kc89_first_44 @kc89_second_61 -35;
+    pos @kc89_first_44 @kc89_second_63 -35;
+    pos @kc89_first_44 @kc89_second_64 -70;
+    pos @kc89_first_44 @kc89_second_65 -70;
+    pos @kc89_first_45 @kc89_second_8 -35;
+    pos @kc89_first_45 @kc89_second_9 -70;
+    pos @kc89_first_45 @kc89_second_12 -240;
+    pos @kc89_first_45 @kc89_second_13 -210;
+    pos @kc89_first_45 @kc89_second_14 -70;
+    pos @kc89_first_45 @kc89_second_15 -105;
+    pos @kc89_first_45 @kc89_second_18 -35;
+    pos @kc89_first_45 @kc89_second_24 -35;
+    pos @kc89_first_45 @kc89_second_41 -70;
+    pos @kc89_first_45 @kc89_second_42 -105;
+    pos @kc89_first_45 @kc89_second_43 -70;
+    pos @kc89_first_45 @kc89_second_46 -70;
+    pos @kc89_first_45 @kc89_second_47 -35;
+    pos @kc89_first_45 @kc89_second_48 1;
+    pos @kc89_first_45 @kc89_second_50 -70;
+    pos @kc89_first_45 @kc89_second_51 -70;
+    pos @kc89_first_45 @kc89_second_61 -70;
+    pos @kc89_first_45 @kc89_second_63 -50;
+    pos @kc89_first_45 @kc89_second_65 -70;
+    pos @kc89_first_45 @kc89_second_66 -35;
+    pos @kc89_first_45 @kc89_second_67 -35;
+    pos @kc89_first_46 @kc89_second_6 -70;
+    pos @kc89_first_46 @kc89_second_8 -35;
+    pos @kc89_first_46 @kc89_second_12 -175;
+    pos @kc89_first_46 @kc89_second_13 -140;
+    pos @kc89_first_46 @kc89_second_14 -70;
+    pos @kc89_first_46 @kc89_second_15 -35;
+    pos @kc89_first_46 @kc89_second_17 -70;
+    pos @kc89_first_46 @kc89_second_18 -105;
+    pos @kc89_first_46 @kc89_second_22 -70;
+    pos @kc89_first_46 @kc89_second_24 -105;
+    pos @kc89_first_46 @kc89_second_31 -35;
+    pos @kc89_first_46 @kc89_second_37 -70;
+    pos @kc89_first_46 @kc89_second_39 -35;
+    pos @kc89_first_46 @kc89_second_41 -105;
+    pos @kc89_first_46 @kc89_second_48 1;
+    pos @kc89_first_46 @kc89_second_54 -35;
+    pos @kc89_first_46 @kc89_second_66 -70;
+    pos @kc89_first_46 @kc89_second_67 -70;
+    pos @kc89_first_47 @kc89_second_3 -140;
+    pos @kc89_first_47 @kc89_second_4 -70;
+    pos @kc89_first_47 @kc89_second_6 -70;
+    pos @kc89_first_47 @kc89_second_8 -210;
+    pos @kc89_first_47 @kc89_second_9 -420;
+    pos @kc89_first_47 @kc89_second_12 -350;
+    pos @kc89_first_47 @kc89_second_13 -420;
+    pos @kc89_first_47 @kc89_second_14 -350;
+    pos @kc89_first_47 @kc89_second_15 -280;
+    pos @kc89_first_47 @kc89_second_17 -70;
+    pos @kc89_first_47 @kc89_second_18 -70;
+    pos @kc89_first_47 @kc89_second_20 -210;
+    pos @kc89_first_47 @kc89_second_22 -210;
+    pos @kc89_first_47 @kc89_second_24 -70;
+    pos @kc89_first_47 @kc89_second_25 -140;
+    pos @kc89_first_47 @kc89_second_31 -35;
+    pos @kc89_first_47 @kc89_second_33 -140;
+    pos @kc89_first_47 @kc89_second_37 -70;
+    pos @kc89_first_47 @kc89_second_39 -70;
+    pos @kc89_first_47 @kc89_second_41 -210;
+    pos @kc89_first_47 @kc89_second_42 -280;
+    pos @kc89_first_47 @kc89_second_43 -420;
+    pos @kc89_first_47 @kc89_second_46 -350;
+    pos @kc89_first_47 @kc89_second_48 1;
+    pos @kc89_first_47 @kc89_second_49 -35;
+    pos @kc89_first_47 @kc89_second_50 -210;
+    pos @kc89_first_47 @kc89_second_51 -350;
+    pos @kc89_first_47 @kc89_second_54 -35;
+    pos @kc89_first_47 @kc89_second_55 -35;
+    pos @kc89_first_47 @kc89_second_61 -280;
+    pos @kc89_first_47 @kc89_second_63 -175;
+    pos @kc89_first_47 @kc89_second_64 -280;
+    pos @kc89_first_47 @kc89_second_65 -210;
+    pos @kc89_first_47 @kc89_second_66 -70;
+    pos @kc89_first_48 @kc89_second_3 -140;
+    pos @kc89_first_48 @kc89_second_4 -105;
+    pos @kc89_first_48 @kc89_second_6 -70;
+    pos @kc89_first_48 @kc89_second_8 -210;
+    pos @kc89_first_48 @kc89_second_9 -280;
+    pos @kc89_first_48 @kc89_second_12 -350;
+    pos @kc89_first_48 @kc89_second_13 -385;
+    pos @kc89_first_48 @kc89_second_14 -350;
+    pos @kc89_first_48 @kc89_second_15 -280;
+    pos @kc89_first_48 @kc89_second_18 -105;
+    pos @kc89_first_48 @kc89_second_20 -210;
+    pos @kc89_first_48 @kc89_second_22 -140;
+    pos @kc89_first_48 @kc89_second_24 -105;
+    pos @kc89_first_48 @kc89_second_25 -140;
+    pos @kc89_first_48 @kc89_second_31 -70;
+    pos @kc89_first_48 @kc89_second_33 -175;
+    pos @kc89_first_48 @kc89_second_37 -70;
+    pos @kc89_first_48 @kc89_second_39 -35;
+    pos @kc89_first_48 @kc89_second_41 -175;
+    pos @kc89_first_48 @kc89_second_42 -280;
+    pos @kc89_first_48 @kc89_second_43 -280;
+    pos @kc89_first_48 @kc89_second_46 -280;
+    pos @kc89_first_48 @kc89_second_47 -140;
+    pos @kc89_first_48 @kc89_second_48 1;
+    pos @kc89_first_48 @kc89_second_49 -70;
+    pos @kc89_first_48 @kc89_second_50 -280;
+    pos @kc89_first_48 @kc89_second_51 -350;
+    pos @kc89_first_48 @kc89_second_54 -35;
+    pos @kc89_first_48 @kc89_second_55 -70;
+    pos @kc89_first_48 @kc89_second_61 -245;
+    pos @kc89_first_48 @kc89_second_63 -245;
+    pos @kc89_first_48 @kc89_second_64 -280;
+    pos @kc89_first_48 @kc89_second_65 -210;
+    pos @kc89_first_48 @kc89_second_66 -70;
+    pos @kc89_first_48 @kc89_second_67 -70;
+    pos @kc89_first_49 @kc89_second_3 -70;
+    pos @kc89_first_49 @kc89_second_4 -105;
+    pos @kc89_first_49 @kc89_second_6 -210;
+    pos @kc89_first_49 @kc89_second_7 -70;
+    pos @kc89_first_49 @kc89_second_8 -175;
+    pos @kc89_first_49 @kc89_second_17 -210;
+    pos @kc89_first_49 @kc89_second_18 -210;
+    pos @kc89_first_49 @kc89_second_22 -140;
+    pos @kc89_first_49 @kc89_second_23 -210;
+    pos @kc89_first_49 @kc89_second_24 -210;
+    pos @kc89_first_49 @kc89_second_25 -210;
+    pos @kc89_first_49 @kc89_second_26 -140;
+    pos @kc89_first_49 @kc89_second_27 -140;
+    pos @kc89_first_49 @kc89_second_29 -140;
+    pos @kc89_first_49 @kc89_second_31 -210;
+    pos @kc89_first_49 @kc89_second_32 -210;
+    pos @kc89_first_49 @kc89_second_33 -140;
+    pos @kc89_first_49 @kc89_second_35 -210;
+    pos @kc89_first_49 @kc89_second_37 -210;
+    pos @kc89_first_49 @kc89_second_38 -70;
+    pos @kc89_first_49 @kc89_second_39 -175;
+    pos @kc89_first_49 @kc89_second_40 -210;
+    pos @kc89_first_49 @kc89_second_41 -175;
+    pos @kc89_first_49 @kc89_second_42 -210;
+    pos @kc89_first_49 @kc89_second_43 -105;
+    pos @kc89_first_49 @kc89_second_46 -70;
+    pos @kc89_first_49 @kc89_second_47 -105;
+    pos @kc89_first_49 @kc89_second_48 1;
+    pos @kc89_first_49 @kc89_second_49 -35;
+    pos @kc89_first_49 @kc89_second_50 -210;
+    pos @kc89_first_49 @kc89_second_53 -210;
+    pos @kc89_first_49 @kc89_second_54 -210;
+    pos @kc89_first_49 @kc89_second_55 -175;
+    pos @kc89_first_49 @kc89_second_56 -175;
+    pos @kc89_first_49 @kc89_second_58 -210;
+    pos @kc89_first_49 @kc89_second_59 -210;
+    pos @kc89_first_49 @kc89_second_60 -140;
+    pos @kc89_first_49 @kc89_second_61 -210;
+    pos @kc89_first_49 @kc89_second_62 -175;
+    pos @kc89_first_49 @kc89_second_63 -175;
+    pos @kc89_first_49 @kc89_second_66 -210;
+    pos @kc89_first_49 @kc89_second_67 -210;
+    pos @kc89_first_50 @kc89_second_5 -70;
+    pos @kc89_first_50 @kc89_second_11 -35;
+    pos @kc89_first_50 @kc89_second_12 -240;
+    pos @kc89_first_50 @kc89_second_13 -70;
+    pos @kc89_first_50 @kc89_second_14 -140;
+    pos @kc89_first_50 @kc89_second_15 -105;
+    pos @kc89_first_50 @kc89_second_16 -70;
+    pos @kc89_first_50 @kc89_second_28 -70;
+    pos @kc89_first_50 @kc89_second_29 -70;
+    pos @kc89_first_50 @kc89_second_38 -35;
+    pos @kc89_first_50 @kc89_second_42 -70;
+    pos @kc89_first_50 @kc89_second_45 -35;
+    pos @kc89_first_50 @kc89_second_46 -70;
+    pos @kc89_first_50 @kc89_second_48 1;
+    pos @kc89_first_50 @kc89_second_50 -35;
+    pos @kc89_first_50 @kc89_second_51 -140;
+    pos @kc89_first_50 @kc89_second_54 1;
+    pos @kc89_first_50 @kc89_second_60 -35;
+    pos @kc89_first_50 @kc89_second_63 -35;
+    pos @kc89_first_50 @kc89_second_64 -105;
+    pos @kc89_first_50 @kc89_second_65 -70;
+    pos @kc89_first_51 @kc89_second_68 -70;
+    pos @kc89_first_52 @kc89_second_34 -315;
+    pos @kc89_first_52 @kc89_second_69 -70;
+    pos @kc89_first_53 @kc89_second_1 -105;
+    pos @kc89_first_53 @kc89_second_2 -210;
+    pos @kc89_first_53 @kc89_second_6 -140;
+    pos @kc89_first_53 @kc89_second_11 -70;
+    pos @kc89_first_53 @kc89_second_12 -210;
+    pos @kc89_first_53 @kc89_second_13 -210;
+    pos @kc89_first_53 @kc89_second_14 -105;
+    pos @kc89_first_53 @kc89_second_15 -70;
+    pos @kc89_first_53 @kc89_second_16 -140;
+    pos @kc89_first_53 @kc89_second_17 -35;
+    pos @kc89_first_53 @kc89_second_18 -35;
+    pos @kc89_first_53 @kc89_second_19 -105;
+    pos @kc89_first_53 @kc89_second_24 -35;
+    pos @kc89_first_53 @kc89_second_26 -210;
+    pos @kc89_first_53 @kc89_second_28 -70;
+    pos @kc89_first_53 @kc89_second_29 -70;
+    pos @kc89_first_53 @kc89_second_31 -35;
+    pos @kc89_first_53 @kc89_second_35 -70;
+    pos @kc89_first_53 @kc89_second_37 -210;
+    pos @kc89_first_53 @kc89_second_38 -140;
+    pos @kc89_first_53 @kc89_second_45 -35;
+    pos @kc89_first_53 @kc89_second_46 -70;
+    pos @kc89_first_53 @kc89_second_48 1;
+    pos @kc89_first_53 @kc89_second_50 -35;
+    pos @kc89_first_53 @kc89_second_51 -105;
+    pos @kc89_first_53 @kc89_second_56 -210;
+    pos @kc89_first_53 @kc89_second_58 -175;
+    pos @kc89_first_53 @kc89_second_59 -140;
+    pos @kc89_first_53 @kc89_second_64 -35;
+    pos @kc89_first_53 @kc89_second_65 -35;
+    pos @kc89_first_53 @kc89_second_66 -35;
+    pos @kc89_first_53 @kc89_second_67 -70;
+    pos @kc89_first_54 @kc89_second_1 -35;
+    pos @kc89_first_54 @kc89_second_2 -70;
+    pos @kc89_first_54 @kc89_second_5 -105;
+    pos @kc89_first_54 @kc89_second_6 -35;
+    pos @kc89_first_54 @kc89_second_9 -70;
+    pos @kc89_first_54 @kc89_second_11 -70;
+    pos @kc89_first_54 @kc89_second_12 -240;
+    pos @kc89_first_54 @kc89_second_13 -245;
+    pos @kc89_first_54 @kc89_second_14 -140;
+    pos @kc89_first_54 @kc89_second_15 -105;
+    pos @kc89_first_54 @kc89_second_16 -105;
+    pos @kc89_first_54 @kc89_second_19 -35;
+    pos @kc89_first_54 @kc89_second_20 -70;
+    pos @kc89_first_54 @kc89_second_21 -70;
+    pos @kc89_first_54 @kc89_second_26 -35;
+    pos @kc89_first_54 @kc89_second_27 -70;
+    pos @kc89_first_54 @kc89_second_28 -140;
+    pos @kc89_first_54 @kc89_second_29 -105;
+    pos @kc89_first_54 @kc89_second_35 -35;
+    pos @kc89_first_54 @kc89_second_37 -35;
+    pos @kc89_first_54 @kc89_second_38 -140;
+    pos @kc89_first_54 @kc89_second_42 -105;
+    pos @kc89_first_54 @kc89_second_43 -70;
+    pos @kc89_first_54 @kc89_second_45 -105;
+    pos @kc89_first_54 @kc89_second_46 -175;
+    pos @kc89_first_54 @kc89_second_48 1;
+    pos @kc89_first_54 @kc89_second_50 -70;
+    pos @kc89_first_54 @kc89_second_51 -140;
+    pos @kc89_first_54 @kc89_second_52 -70;
+    pos @kc89_first_54 @kc89_second_56 -210;
+    pos @kc89_first_54 @kc89_second_57 -70;
+    pos @kc89_first_54 @kc89_second_58 -175;
+    pos @kc89_first_54 @kc89_second_59 -175;
+    pos @kc89_first_54 @kc89_second_60 -105;
+    pos @kc89_first_54 @kc89_second_63 -50;
+    pos @kc89_first_54 @kc89_second_64 -105;
+    pos @kc89_first_54 @kc89_second_65 -70;
+    pos @kc89_first_54 @kc89_second_67 -35;
+    pos @kc89_first_55 @kc89_second_1 -105;
+    pos @kc89_first_55 @kc89_second_2 -210;
+    pos @kc89_first_55 @kc89_second_5 -70;
+    pos @kc89_first_55 @kc89_second_6 -105;
+    pos @kc89_first_55 @kc89_second_13 -70;
+    pos @kc89_first_55 @kc89_second_14 -35;
+    pos @kc89_first_55 @kc89_second_16 -140;
+    pos @kc89_first_55 @kc89_second_17 -70;
+    pos @kc89_first_55 @kc89_second_18 -35;
+    pos @kc89_first_55 @kc89_second_19 -105;
+    pos @kc89_first_55 @kc89_second_21 -210;
+    pos @kc89_first_55 @kc89_second_24 -35;
+    pos @kc89_first_55 @kc89_second_26 -210;
+    pos @kc89_first_55 @kc89_second_31 -35;
+    pos @kc89_first_55 @kc89_second_34 -105;
+    pos @kc89_first_55 @kc89_second_35 -35;
+    pos @kc89_first_55 @kc89_second_37 -105;
+    pos @kc89_first_55 @kc89_second_38 -140;
+    pos @kc89_first_55 @kc89_second_41 -70;
+    pos @kc89_first_55 @kc89_second_48 1;
+    pos @kc89_first_55 @kc89_second_54 -35;
+    pos @kc89_first_55 @kc89_second_56 -245;
+    pos @kc89_first_55 @kc89_second_58 -210;
+    pos @kc89_first_55 @kc89_second_59 -210;
+    pos @kc89_first_55 @kc89_second_66 -70;
+    pos @kc89_first_55 @kc89_second_67 -105;
+    pos @kc89_first_56 @kc89_second_12 -240;
+    pos @kc89_first_56 @kc89_second_13 -140;
+    pos @kc89_first_56 @kc89_second_14 -105;
+    pos @kc89_first_56 @kc89_second_15 -35;
+    pos @kc89_first_56 @kc89_second_36 165;
+    pos @kc89_first_56 @kc89_second_48 1;
+    pos @kc89_first_56 @kc89_second_53 165;
+    pos @kc89_first_57 @kc89_second_1 -140;
+    pos @kc89_first_57 @kc89_second_2 -210;
+    pos @kc89_first_57 @kc89_second_6 -140;
+    pos @kc89_first_57 @kc89_second_12 -175;
+    pos @kc89_first_57 @kc89_second_13 -140;
+    pos @kc89_first_57 @kc89_second_16 -140;
+    pos @kc89_first_57 @kc89_second_19 -140;
+    pos @kc89_first_57 @kc89_second_21 -210;
+    pos @kc89_first_57 @kc89_second_26 -210;
+    pos @kc89_first_57 @kc89_second_34 -140;
+    pos @kc89_first_57 @kc89_second_35 -50;
+    pos @kc89_first_57 @kc89_second_37 -140;
+    pos @kc89_first_57 @kc89_second_38 -210;
+    pos @kc89_first_57 @kc89_second_39 -35;
+    pos @kc89_first_57 @kc89_second_48 1;
+    pos @kc89_first_57 @kc89_second_56 -210;
+    pos @kc89_first_57 @kc89_second_58 -175;
+    pos @kc89_first_57 @kc89_second_59 -175;
+    pos @kc89_first_57 @kc89_second_66 -105;
+    pos @kc89_first_57 @kc89_second_67 -210;
+    pos @kc89_first_58 @kc89_second_12 -240;
+    pos @kc89_first_58 @kc89_second_13 -175;
+    pos @kc89_first_58 @kc89_second_14 -70;
+    pos @kc89_first_58 @kc89_second_15 -35;
+    pos @kc89_first_58 @kc89_second_21 -35;
+    pos @kc89_first_58 @kc89_second_28 -35;
+    pos @kc89_first_58 @kc89_second_42 -35;
+    pos @kc89_first_58 @kc89_second_43 -35;
+    pos @kc89_first_58 @kc89_second_46 -70;
+    pos @kc89_first_58 @kc89_second_48 1;
+    pos @kc89_first_58 @kc89_second_50 -35;
+    pos @kc89_first_58 @kc89_second_51 -70;
+    pos @kc89_first_58 @kc89_second_61 -35;
+    pos @kc89_first_58 @kc89_second_63 -35;
+    pos @kc89_first_58 @kc89_second_64 -70;
+    pos @kc89_first_58 @kc89_second_65 -35;
+    pos @kc89_first_59 @kc89_second_13 -35;
+    pos @kc89_first_59 @kc89_second_18 -70;
+    pos @kc89_first_59 @kc89_second_61 -35;
+    pos @kc89_first_59 @kc89_second_67 -35;
+    pos @kc89_first_60 @kc89_second_12 -175;
+    pos @kc89_first_60 @kc89_second_13 -140;
+    pos @kc89_first_60 @kc89_second_14 -35;
+    pos @kc89_first_60 @kc89_second_48 1;
+    pos @kc89_first_61 @kc89_second_1 -140;
+    pos @kc89_first_61 @kc89_second_2 -280;
+    pos @kc89_first_61 @kc89_second_5 -140;
+    pos @kc89_first_61 @kc89_second_6 -280;
+    pos @kc89_first_61 @kc89_second_8 -70;
+    pos @kc89_first_61 @kc89_second_10 -70;
+    pos @kc89_first_61 @kc89_second_11 -175;
+    pos @kc89_first_61 @kc89_second_12 -240;
+    pos @kc89_first_61 @kc89_second_13 -140;
+    pos @kc89_first_61 @kc89_second_14 -105;
+    pos @kc89_first_61 @kc89_second_15 -70;
+    pos @kc89_first_61 @kc89_second_16 -175;
+    pos @kc89_first_61 @kc89_second_17 -70;
+    pos @kc89_first_61 @kc89_second_18 -70;
+    pos @kc89_first_61 @kc89_second_19 -140;
+    pos @kc89_first_61 @kc89_second_21 -280;
+    pos @kc89_first_61 @kc89_second_24 -70;
+    pos @kc89_first_61 @kc89_second_25 -70;
+    pos @kc89_first_61 @kc89_second_26 -210;
+    pos @kc89_first_61 @kc89_second_28 -70;
+    pos @kc89_first_61 @kc89_second_29 -70;
+    pos @kc89_first_61 @kc89_second_31 -70;
+    pos @kc89_first_61 @kc89_second_34 -70;
+    pos @kc89_first_61 @kc89_second_35 -70;
+    pos @kc89_first_61 @kc89_second_37 -315;
+    pos @kc89_first_61 @kc89_second_38 -140;
+    pos @kc89_first_61 @kc89_second_39 -70;
+    pos @kc89_first_61 @kc89_second_41 -105;
+    pos @kc89_first_61 @kc89_second_48 1;
+    pos @kc89_first_61 @kc89_second_51 -35;
+    pos @kc89_first_61 @kc89_second_54 -50;
+    pos @kc89_first_61 @kc89_second_56 -210;
+    pos @kc89_first_61 @kc89_second_58 -210;
+    pos @kc89_first_61 @kc89_second_59 -175;
+    pos @kc89_first_61 @kc89_second_62 -35;
+    pos @kc89_first_61 @kc89_second_64 -70;
+    pos @kc89_first_61 @kc89_second_65 -35;
+    pos @kc89_first_61 @kc89_second_66 -140;
+    pos @kc89_first_61 @kc89_second_67 -210;
+    pos @kc89_first_62 @kc89_second_1 -35;
+    pos @kc89_first_62 @kc89_second_2 -70;
+    pos @kc89_first_62 @kc89_second_5 -70;
+    pos @kc89_first_62 @kc89_second_11 -35;
+    pos @kc89_first_62 @kc89_second_12 -140;
+    pos @kc89_first_62 @kc89_second_13 -140;
+    pos @kc89_first_62 @kc89_second_14 -70;
+    pos @kc89_first_62 @kc89_second_15 -35;
+    pos @kc89_first_62 @kc89_second_16 -105;
+    pos @kc89_first_62 @kc89_second_28 -35;
+    pos @kc89_first_62 @kc89_second_29 -70;
+    pos @kc89_first_62 @kc89_second_35 -35;
+    pos @kc89_first_62 @kc89_second_38 -70;
+    pos @kc89_first_62 @kc89_second_46 -70;
+    pos @kc89_first_62 @kc89_second_48 1;
+    pos @kc89_first_62 @kc89_second_56 -175;
+    pos @kc89_first_62 @kc89_second_58 -140;
+    pos @kc89_first_62 @kc89_second_59 -140;
+    pos @kc89_first_62 @kc89_second_64 -35;
+    pos @kc89_first_63 @kc89_second_5 -70;
+    pos @kc89_first_63 @kc89_second_9 -70;
+    pos @kc89_first_63 @kc89_second_11 -35;
+    pos @kc89_first_63 @kc89_second_12 -350;
+    pos @kc89_first_63 @kc89_second_13 -315;
+    pos @kc89_first_63 @kc89_second_14 -175;
+    pos @kc89_first_63 @kc89_second_15 -140;
+    pos @kc89_first_63 @kc89_second_16 -70;
+    pos @kc89_first_63 @kc89_second_20 -70;
+    pos @kc89_first_63 @kc89_second_29 -70;
+    pos @kc89_first_63 @kc89_second_33 -50;
+    pos @kc89_first_63 @kc89_second_42 -140;
+    pos @kc89_first_63 @kc89_second_43 -50;
+    pos @kc89_first_63 @kc89_second_45 -35;
+    pos @kc89_first_63 @kc89_second_46 -175;
+    pos @kc89_first_63 @kc89_second_48 1;
+    pos @kc89_first_63 @kc89_second_50 -70;
+    pos @kc89_first_63 @kc89_second_51 -175;
+    pos @kc89_first_63 @kc89_second_57 -70;
+    pos @kc89_first_63 @kc89_second_61 -70;
+    pos @kc89_first_63 @kc89_second_63 -50;
+    pos @kc89_first_63 @kc89_second_64 -140;
+    pos @kc89_first_63 @kc89_second_65 -105;
+    pos @kc89_first_64 @kc89_second_4 -105;
+    pos @kc89_first_64 @kc89_second_6 -35;
+    pos @kc89_first_64 @kc89_second_8 1;
+    pos @kc89_first_64 @kc89_second_9 -245;
+    pos @kc89_first_64 @kc89_second_12 -210;
+    pos @kc89_first_64 @kc89_second_13 -210;
+    pos @kc89_first_64 @kc89_second_14 -210;
+    pos @kc89_first_64 @kc89_second_15 -175;
+    pos @kc89_first_64 @kc89_second_17 -70;
+    pos @kc89_first_64 @kc89_second_18 -105;
+    pos @kc89_first_64 @kc89_second_20 -180;
+    pos @kc89_first_64 @kc89_second_22 -140;
+    pos @kc89_first_64 @kc89_second_24 -105;
+    pos @kc89_first_64 @kc89_second_27 -140;
+    pos @kc89_first_64 @kc89_second_31 -105;
+    pos @kc89_first_64 @kc89_second_33 -140;
+    pos @kc89_first_64 @kc89_second_37 -35;
+    pos @kc89_first_64 @kc89_second_39 -35;
+    pos @kc89_first_64 @kc89_second_41 -175;
+    pos @kc89_first_64 @kc89_second_42 -142;
+    pos @kc89_first_64 @kc89_second_43 -245;
+    pos @kc89_first_64 @kc89_second_46 -210;
+    pos @kc89_first_64 @kc89_second_47 -105;
+    pos @kc89_first_64 @kc89_second_48 1;
+    pos @kc89_first_64 @kc89_second_49 -35;
+    pos @kc89_first_64 @kc89_second_50 -210;
+    pos @kc89_first_64 @kc89_second_51 -210;
+    pos @kc89_first_64 @kc89_second_54 -35;
+    pos @kc89_first_64 @kc89_second_61 -280;
+    pos @kc89_first_64 @kc89_second_63 -175;
+    pos @kc89_first_64 @kc89_second_64 -140;
+    pos @kc89_first_64 @kc89_second_65 -140;
+    pos @kc89_first_64 @kc89_second_66 -70;
+    pos @kc89_first_64 @kc89_second_67 -70;
+    pos @kc89_first_65 @kc89_second_1 -175;
+    pos @kc89_first_65 @kc89_second_2 -175;
+    pos @kc89_first_65 @kc89_second_5 -70;
+    pos @kc89_first_65 @kc89_second_6 -105;
+    pos @kc89_first_65 @kc89_second_11 -105;
+    pos @kc89_first_65 @kc89_second_12 -175;
+    pos @kc89_first_65 @kc89_second_13 -140;
+    pos @kc89_first_65 @kc89_second_14 -70;
+    pos @kc89_first_65 @kc89_second_15 -35;
+    pos @kc89_first_65 @kc89_second_16 -140;
+    pos @kc89_first_65 @kc89_second_17 -70;
+    pos @kc89_first_65 @kc89_second_18 -70;
+    pos @kc89_first_65 @kc89_second_19 -140;
+    pos @kc89_first_65 @kc89_second_21 -175;
+    pos @kc89_first_65 @kc89_second_24 -70;
+    pos @kc89_first_65 @kc89_second_31 -35;
+    pos @kc89_first_65 @kc89_second_35 -70;
+    pos @kc89_first_65 @kc89_second_37 -105;
+    pos @kc89_first_65 @kc89_second_38 -175;
+    pos @kc89_first_65 @kc89_second_39 -35;
+    pos @kc89_first_65 @kc89_second_41 -70;
+    pos @kc89_first_65 @kc89_second_48 1;
+    pos @kc89_first_65 @kc89_second_54 -35;
+    pos @kc89_first_65 @kc89_second_56 -140;
+    pos @kc89_first_65 @kc89_second_58 -140;
+    pos @kc89_first_65 @kc89_second_59 -140;
+    pos @kc89_first_65 @kc89_second_66 -70;
+    pos @kc89_first_65 @kc89_second_67 -105;
+    pos @kc89_first_66 @kc89_second_1 -210;
+    pos @kc89_first_66 @kc89_second_2 -210;
+    pos @kc89_first_66 @kc89_second_3 -70;
+    pos @kc89_first_66 @kc89_second_4 -35;
+    pos @kc89_first_66 @kc89_second_6 -210;
+    pos @kc89_first_66 @kc89_second_7 -70;
+    pos @kc89_first_66 @kc89_second_8 -70;
+    pos @kc89_first_66 @kc89_second_16 -70;
+    pos @kc89_first_66 @kc89_second_17 -140;
+    pos @kc89_first_66 @kc89_second_18 -175;
+    pos @kc89_first_66 @kc89_second_19 -210;
+    pos @kc89_first_66 @kc89_second_21 -210;
+    pos @kc89_first_66 @kc89_second_22 -140;
+    pos @kc89_first_66 @kc89_second_23 -35;
+    pos @kc89_first_66 @kc89_second_24 -175;
+    pos @kc89_first_66 @kc89_second_25 -140;
+    pos @kc89_first_66 @kc89_second_26 -280;
+    pos @kc89_first_66 @kc89_second_31 -35;
+    pos @kc89_first_66 @kc89_second_32 -35;
+    pos @kc89_first_66 @kc89_second_34 -210;
+    pos @kc89_first_66 @kc89_second_35 -175;
+    pos @kc89_first_66 @kc89_second_37 -245;
+    pos @kc89_first_66 @kc89_second_38 -140;
+    pos @kc89_first_66 @kc89_second_39 -140;
+    pos @kc89_first_66 @kc89_second_40 -140;
+    pos @kc89_first_66 @kc89_second_41 -140;
+    pos @kc89_first_66 @kc89_second_42 -35;
+    pos @kc89_first_66 @kc89_second_47 -35;
+    pos @kc89_first_66 @kc89_second_48 1;
+    pos @kc89_first_66 @kc89_second_52 -35;
+    pos @kc89_first_66 @kc89_second_54 -140;
+    pos @kc89_first_66 @kc89_second_55 -70;
+    pos @kc89_first_66 @kc89_second_56 -210;
+    pos @kc89_first_66 @kc89_second_58 -210;
+    pos @kc89_first_66 @kc89_second_59 -210;
+    pos @kc89_first_66 @kc89_second_61 -35;
+    pos @kc89_first_66 @kc89_second_66 -175;
+    pos @kc89_first_66 @kc89_second_67 -245;
+    pos @kc89_first_67 @kc89_second_6 -35;
+    pos @kc89_first_67 @kc89_second_12 -240;
+    pos @kc89_first_67 @kc89_second_13 -140;
+    pos @kc89_first_67 @kc89_second_14 -70;
+    pos @kc89_first_67 @kc89_second_15 -35;
+    pos @kc89_first_67 @kc89_second_18 -35;
+    pos @kc89_first_67 @kc89_second_22 -35;
+    pos @kc89_first_67 @kc89_second_24 -35;
+    pos @kc89_first_67 @kc89_second_37 -70;
+    pos @kc89_first_67 @kc89_second_41 -70;
+    pos @kc89_first_67 @kc89_second_42 -50;
+    pos @kc89_first_67 @kc89_second_48 1;
+    pos @kc89_first_67 @kc89_second_51 -35;
+    pos @kc89_first_67 @kc89_second_66 -35;
+    pos @kc89_first_67 @kc89_second_67 -35;
+    pos @kc89_first_68 @kc89_second_3 -100;
+    pos @kc89_first_68 @kc89_second_4 -50;
+    pos @kc89_first_68 @kc89_second_6 -50;
+    pos @kc89_first_68 @kc89_second_8 -70;
+    pos @kc89_first_68 @kc89_second_9 -140;
+    pos @kc89_first_68 @kc89_second_10 -50;
+    pos @kc89_first_68 @kc89_second_12 -140;
+    pos @kc89_first_68 @kc89_second_13 -100;
+    pos @kc89_first_68 @kc89_second_14 -70;
+    pos @kc89_first_68 @kc89_second_15 -50;
+    pos @kc89_first_68 @kc89_second_18 -50;
+    pos @kc89_first_68 @kc89_second_20 -70;
+    pos @kc89_first_68 @kc89_second_22 -70;
+    pos @kc89_first_68 @kc89_second_24 -50;
+    pos @kc89_first_68 @kc89_second_25 -70;
+    pos @kc89_first_68 @kc89_second_31 -35;
+    pos @kc89_first_68 @kc89_second_33 -70;
+    pos @kc89_first_68 @kc89_second_36 105;
+    pos @kc89_first_68 @kc89_second_37 -35;
+    pos @kc89_first_68 @kc89_second_41 -70;
+    pos @kc89_first_68 @kc89_second_42 -140;
+    pos @kc89_first_68 @kc89_second_43 -140;
+    pos @kc89_first_68 @kc89_second_46 -140;
+    pos @kc89_first_68 @kc89_second_47 -35;
+    pos @kc89_first_68 @kc89_second_48 1;
+    pos @kc89_first_68 @kc89_second_50 -70;
+    pos @kc89_first_68 @kc89_second_51 -100;
+    pos @kc89_first_68 @kc89_second_53 105;
+    pos @kc89_first_68 @kc89_second_61 -140;
+    pos @kc89_first_68 @kc89_second_63 -70;
+    pos @kc89_first_68 @kc89_second_64 -70;
+    pos @kc89_first_68 @kc89_second_65 -50;
+    pos @kc89_first_68 @kc89_second_66 -35;
+    pos @kc89_first_68 @kc89_second_67 -35;
+    pos @kc89_first_69 @kc89_second_3 -70;
+    pos @kc89_first_69 @kc89_second_4 -50;
+    pos @kc89_first_69 @kc89_second_6 -50;
+    pos @kc89_first_69 @kc89_second_8 -70;
+    pos @kc89_first_69 @kc89_second_9 -140;
+    pos @kc89_first_69 @kc89_second_10 -50;
+    pos @kc89_first_69 @kc89_second_12 -240;
+    pos @kc89_first_69 @kc89_second_13 -240;
+    pos @kc89_first_69 @kc89_second_14 -175;
+    pos @kc89_first_69 @kc89_second_15 -140;
+    pos @kc89_first_69 @kc89_second_18 -50;
+    pos @kc89_first_69 @kc89_second_20 -70;
+    pos @kc89_first_69 @kc89_second_22 -70;
+    pos @kc89_first_69 @kc89_second_24 -50;
+    pos @kc89_first_69 @kc89_second_25 -70;
+    pos @kc89_first_69 @kc89_second_31 -35;
+    pos @kc89_first_69 @kc89_second_33 -70;
+    pos @kc89_first_69 @kc89_second_36 105;
+    pos @kc89_first_69 @kc89_second_37 -35;
+    pos @kc89_first_69 @kc89_second_41 -70;
+    pos @kc89_first_69 @kc89_second_42 -140;
+    pos @kc89_first_69 @kc89_second_43 -140;
+    pos @kc89_first_69 @kc89_second_46 -140;
+    pos @kc89_first_69 @kc89_second_47 -35;
+    pos @kc89_first_69 @kc89_second_48 1;
+    pos @kc89_first_69 @kc89_second_50 -70;
+    pos @kc89_first_69 @kc89_second_51 -140;
+    pos @kc89_first_69 @kc89_second_53 105;
+    pos @kc89_first_69 @kc89_second_61 -140;
+    pos @kc89_first_69 @kc89_second_63 -70;
+    pos @kc89_first_69 @kc89_second_64 -105;
+    pos @kc89_first_69 @kc89_second_65 -70;
+    pos @kc89_first_69 @kc89_second_66 -35;
+    pos @kc89_first_69 @kc89_second_67 -35;
+    pos @kc89_first_70 @kc89_second_3 -70;
+    pos @kc89_first_70 @kc89_second_4 -50;
+    pos @kc89_first_70 @kc89_second_6 -50;
+    pos @kc89_first_70 @kc89_second_8 -70;
+    pos @kc89_first_70 @kc89_second_9 -140;
+    pos @kc89_first_70 @kc89_second_10 -50;
+    pos @kc89_first_70 @kc89_second_12 -140;
+    pos @kc89_first_70 @kc89_second_13 -140;
+    pos @kc89_first_70 @kc89_second_14 -105;
+    pos @kc89_first_70 @kc89_second_15 -70;
+    pos @kc89_first_70 @kc89_second_18 -50;
+    pos @kc89_first_70 @kc89_second_20 -70;
+    pos @kc89_first_70 @kc89_second_22 -70;
+    pos @kc89_first_70 @kc89_second_24 -50;
+    pos @kc89_first_70 @kc89_second_25 -100;
+    pos @kc89_first_70 @kc89_second_31 -35;
+    pos @kc89_first_70 @kc89_second_33 -70;
+    pos @kc89_first_70 @kc89_second_36 105;
+    pos @kc89_first_70 @kc89_second_37 -35;
+    pos @kc89_first_70 @kc89_second_41 -70;
+    pos @kc89_first_70 @kc89_second_42 -140;
+    pos @kc89_first_70 @kc89_second_43 -140;
+    pos @kc89_first_70 @kc89_second_46 -140;
+    pos @kc89_first_70 @kc89_second_47 -35;
+    pos @kc89_first_70 @kc89_second_48 1;
+    pos @kc89_first_70 @kc89_second_50 -70;
+    pos @kc89_first_70 @kc89_second_51 -140;
+    pos @kc89_first_70 @kc89_second_53 105;
+    pos @kc89_first_70 @kc89_second_61 -140;
+    pos @kc89_first_70 @kc89_second_63 -70;
+    pos @kc89_first_70 @kc89_second_64 -70;
+    pos @kc89_first_70 @kc89_second_65 -50;
+    pos @kc89_first_70 @kc89_second_66 -35;
+    pos @kc89_first_70 @kc89_second_67 -35;
+    pos @kc89_first_71 @kc89_second_1 -210;
+    pos @kc89_first_71 @kc89_second_2 -210;
+    pos @kc89_first_71 @kc89_second_3 -35;
+    pos @kc89_first_71 @kc89_second_6 -140;
+    pos @kc89_first_71 @kc89_second_8 -70;
+    pos @kc89_first_71 @kc89_second_10 -35;
+    pos @kc89_first_71 @kc89_second_17 -70;
+    pos @kc89_first_71 @kc89_second_18 -105;
+    pos @kc89_first_71 @kc89_second_19 -210;
+    pos @kc89_first_71 @kc89_second_21 -210;
+    pos @kc89_first_71 @kc89_second_22 -70;
+    pos @kc89_first_71 @kc89_second_24 -105;
+    pos @kc89_first_71 @kc89_second_25 -105;
+    pos @kc89_first_71 @kc89_second_26 -175;
+    pos @kc89_first_71 @kc89_second_31 -105;
+    pos @kc89_first_71 @kc89_second_34 -210;
+    pos @kc89_first_71 @kc89_second_35 -105;
+    pos @kc89_first_71 @kc89_second_37 -175;
+    pos @kc89_first_71 @kc89_second_38 -140;
+    pos @kc89_first_71 @kc89_second_39 -70;
+    pos @kc89_first_71 @kc89_second_40 -105;
+    pos @kc89_first_71 @kc89_second_41 -105;
+    pos @kc89_first_71 @kc89_second_42 -70;
+    pos @kc89_first_71 @kc89_second_47 -35;
+    pos @kc89_first_71 @kc89_second_48 1;
+    pos @kc89_first_71 @kc89_second_53 -35;
+    pos @kc89_first_71 @kc89_second_54 -70;
+    pos @kc89_first_71 @kc89_second_55 -70;
+    pos @kc89_first_71 @kc89_second_56 -175;
+    pos @kc89_first_71 @kc89_second_58 -175;
+    pos @kc89_first_71 @kc89_second_59 -175;
+    pos @kc89_first_71 @kc89_second_61 -35;
+    pos @kc89_first_71 @kc89_second_62 -35;
+    pos @kc89_first_71 @kc89_second_66 -140;
+    pos @kc89_first_71 @kc89_second_67 -175;
+    pos @kc89_first_72 @kc89_second_5 -70;
+    pos @kc89_first_72 @kc89_second_8 -70;
+    pos @kc89_first_72 @kc89_second_9 -105;
+    pos @kc89_first_72 @kc89_second_11 -35;
+    pos @kc89_first_72 @kc89_second_12 -350;
+    pos @kc89_first_72 @kc89_second_13 -350;
+    pos @kc89_first_72 @kc89_second_14 -245;
+    pos @kc89_first_72 @kc89_second_15 -210;
+    pos @kc89_first_72 @kc89_second_16 -70;
+    pos @kc89_first_72 @kc89_second_20 -210;
+    pos @kc89_first_72 @kc89_second_25 -35;
+    pos @kc89_first_72 @kc89_second_28 -35;
+    pos @kc89_first_72 @kc89_second_29 -70;
+    pos @kc89_first_72 @kc89_second_33 -70;
+    pos @kc89_first_72 @kc89_second_41 -35;
+    pos @kc89_first_72 @kc89_second_42 -245;
+    pos @kc89_first_72 @kc89_second_43 -70;
+    pos @kc89_first_72 @kc89_second_45 -35;
+    pos @kc89_first_72 @kc89_second_46 -240;
+    pos @kc89_first_72 @kc89_second_48 1;
+    pos @kc89_first_72 @kc89_second_50 -105;
+    pos @kc89_first_72 @kc89_second_51 -280;
+    pos @kc89_first_72 @kc89_second_52 -35;
+    pos @kc89_first_72 @kc89_second_57 -35;
+    pos @kc89_first_72 @kc89_second_60 -70;
+    pos @kc89_first_72 @kc89_second_61 -105;
+    pos @kc89_first_72 @kc89_second_62 -35;
+    pos @kc89_first_72 @kc89_second_63 -70;
+    pos @kc89_first_72 @kc89_second_64 -175;
+    pos @kc89_first_72 @kc89_second_65 -140;
+    pos @kc89_first_73 @kc89_second_1 -140;
+    pos @kc89_first_73 @kc89_second_2 -140;
+    pos @kc89_first_73 @kc89_second_6 -140;
+    pos @kc89_first_73 @kc89_second_8 -35;
+    pos @kc89_first_73 @kc89_second_10 -35;
+    pos @kc89_first_73 @kc89_second_17 -35;
+    pos @kc89_first_73 @kc89_second_18 -70;
+    pos @kc89_first_73 @kc89_second_19 -140;
+    pos @kc89_first_73 @kc89_second_21 -140;
+    pos @kc89_first_73 @kc89_second_22 -35;
+    pos @kc89_first_73 @kc89_second_24 -70;
+    pos @kc89_first_73 @kc89_second_25 -70;
+    pos @kc89_first_73 @kc89_second_26 -140;
+    pos @kc89_first_73 @kc89_second_31 -70;
+    pos @kc89_first_73 @kc89_second_35 -70;
+    pos @kc89_first_73 @kc89_second_37 -175;
+    pos @kc89_first_73 @kc89_second_38 -105;
+    pos @kc89_first_73 @kc89_second_39 -70;
+    pos @kc89_first_73 @kc89_second_40 -70;
+    pos @kc89_first_73 @kc89_second_41 -70;
+    pos @kc89_first_73 @kc89_second_42 -35;
+    pos @kc89_first_73 @kc89_second_48 1;
+    pos @kc89_first_73 @kc89_second_53 -35;
+    pos @kc89_first_73 @kc89_second_54 -35;
+    pos @kc89_first_73 @kc89_second_56 -140;
+    pos @kc89_first_73 @kc89_second_58 -140;
+    pos @kc89_first_73 @kc89_second_59 -140;
+    pos @kc89_first_73 @kc89_second_66 -105;
+    pos @kc89_first_73 @kc89_second_67 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -10828,7 +10863,7 @@ lookup mark_Mark_positioning {
   pos base [\C \uni0421 \uni216D ] <anchor 810 -20> mark @bottom_cedilla
 	<anchor 810 0> mark @bottom_center
 	<anchor 810 1380> mark @top_center;
-  pos base [\G \Q \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \G.cv21 ] <anchor 810 1380> mark @top_center
+  pos base [\G \Q \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \G.cv21 \Q.cv29 ] <anchor 810 1380> mark @top_center
 	<anchor 810 0> mark @bottom_center;
   pos base [\U ] <anchor 741 -20> mark @bottom_cedilla
 	<anchor 741 1380> mark @top_center
@@ -12396,7 +12431,7 @@ lookup mark_Mark_positioning {
 	<anchor 537 0> mark @bottom_center;
   pos base [\f.sc \gamma.sc \uni03DD.sc \uni0433.sc ] <anchor 537 1200> mark @top_center
 	<anchor 250 0> mark @bottom_center;
-  pos base [\g.sc \q.sc \x.sc \uni01E5.sc \theta.sc \chi.sc \uni0445.sc \uni0473.sc \uni04D9.sc \g.sc.cv21 ] <anchor 680 0> mark @bottom_center
+  pos base [\g.sc \q.sc \x.sc \uni01E5.sc \theta.sc \chi.sc \uni0445.sc \uni0473.sc \uni04D9.sc \g.sc.cv21 \q.sc.cv29 ] <anchor 680 0> mark @bottom_center
 	<anchor 680 1200> mark @top_center;
   pos base [\h.sc \eta.sc \uni043D.sc ] <anchor 645 -80> mark @bottom_ypogegrammeni
 	<anchor 250 -20> mark @bottom_cedilla
@@ -14353,7 +14388,8 @@ feature mkmk {
 	\lcaron.cv28 \ldot.cv28 \lslash.cv28 \uni019A.cv28 \uni01C9.cv28 
 	\uni0234.cv28 \uni026D.cv28 \uni026E.cv28 \uni02AA.cv28 \uni02AB.cv28 
 	\uni02E1.cv28 \uni1E37.cv28 \uni1E39.cv28 \uni1E3B.cv28 \uni1E3D.cv28 
-	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \dollar.ss05 
+	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \Q.cv29 \uni051A.cv29 
+	\uni213A.cv29 \uni24C6.cv29 \q.sc.cv29 \uni051B.sc.cv29 \dollar.ss05 
 	\cent.ss05 \sterling.ss05 \lira.ss05 \peseta.ss05 \uni20AA.ss05 \Euro.ss05 
 	\uni20B2.ss05 \one.ss06 \one.ss06.pnum \one.ss06.tnum \one.ss06.onum 
 	\one.ss06.onum.tnum \one.ss06.superior \one.ss06.superior.pnum 

--- a/sources/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlack.ufo/features.fea
@@ -4574,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \uni0456 \acutecomb  by \iacute;
     sub \i \acutecomb  by \iacute;
+    sub \uni0456 \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4631,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4719,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5651,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6785,29 +6785,6 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
-
 feature locl {
 
  script cyrl;
@@ -6894,6 +6871,29 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
+
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
 
 feature ss09 {
   featureNames {
@@ -13368,6 +13368,10 @@ lookup mark_Mark_positioning {
 	<anchor 250 -270> mark @bottom_center;
   pos base [\uni1E3D.cv28 ] <anchor 250 1380> mark @top_center
 	<anchor 250 -336> mark @bottom_center;
+  pos base [\uni051A.cv29 ] <anchor 810 1381> mark @top_center
+	<anchor 810 1> mark @bottom_center;
+  pos base [\uni051B.sc.cv29 ] <anchor 680 1> mark @bottom_center
+	<anchor 680 1201> mark @top_center;
   pos base [\dotlessuni0268 ] <anchor 402 -20> mark @bottom_cedilla
 	<anchor 402 1040> mark @top_center
 	<anchor 402 0> mark @bottom_center

--- a/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/28 21:04:51</string>
+    <string>2026/07/28 21:56:11</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/27 23:38:20</string>
+    <string>2026/07/28 21:04:51</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/Q_.cv29.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/Q_.cv29.glif
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.cv29" format="2">
+  <advance width="1725"/>
+  <anchor x="810" y="1380" name="top_center"/>
+  <anchor x="810" y="0" name="bottom_center"/>
+  <outline>
+    <contour>
+      <point x="1690" y="0" type="line"/>
+      <point x="810" y="0" type="line"/>
+      <point x="1120" y="336" type="line"/>
+      <point x="1690" y="336" type="line"/>
+    </contour>
+    <contour>
+      <point x="430" y="755" type="curve" smooth="yes"/>
+      <point x="430" y="505"/>
+      <point x="560" y="336"/>
+      <point x="810" y="336" type="curve" smooth="yes"/>
+      <point x="1060" y="336"/>
+      <point x="1190" y="505"/>
+      <point x="1190" y="755" type="curve" smooth="yes"/>
+      <point x="1190" y="1005"/>
+      <point x="1060" y="1174"/>
+      <point x="810" y="1174" type="curve" smooth="yes"/>
+      <point x="560" y="1174"/>
+      <point x="430" y="1005"/>
+    </contour>
+    <contour>
+      <point x="50" y="755" type="curve" smooth="yes"/>
+      <point x="50" y="1205"/>
+      <point x="350" y="1510"/>
+      <point x="810" y="1510" type="curve" smooth="yes"/>
+      <point x="1270" y="1510"/>
+      <point x="1570" y="1205"/>
+      <point x="1570" y="755" type="curve" smooth="yes"/>
+      <point x="1570" y="305"/>
+      <point x="1270" y="0"/>
+      <point x="810" y="0" type="curve" smooth="yes"/>
+      <point x="350" y="0"/>
+      <point x="50" y="305"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict/>
+  </lib>
+</glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/contents.plist
@@ -9106,6 +9106,18 @@
     <string>uni24A_7.cv28.glif</string>
     <key>uni24DB.cv28</key>
     <string>uni24D_B_.cv28.glif</string>
+    <key>Q.cv29</key>
+    <string>Q_.cv29.glif</string>
+    <key>uni051A.cv29</key>
+    <string>uni051A_.cv29.glif</string>
+    <key>uni213A.cv29</key>
+    <string>uni213A_.cv29.glif</string>
+    <key>uni24C6.cv29</key>
+    <string>uni24C_6.cv29.glif</string>
+    <key>q.sc.cv29</key>
+    <string>q.sc.cv29.glif</string>
+    <key>uni051B.sc.cv29</key>
+    <string>uni051B_.sc.cv29.glif</string>
     <key>dollar.ss05</key>
     <string>dollar.ss05.glif</string>
     <key>cent.ss05</key>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/q.sc.cv29.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/q.sc.cv29.glif
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="q.sc.cv29" format="2">
+  <advance width="1441"/>
+  <anchor x="680" y="0" name="bottom_center"/>
+  <anchor x="680" y="1200" name="top_center"/>
+  <outline>
+    <contour>
+      <point x="1406" y="0" type="line"/>
+      <point x="680" y="0" type="line"/>
+      <point x="1020" y="320" type="line"/>
+      <point x="1406" y="320" type="line"/>
+    </contour>
+    <contour>
+      <point x="680" y="320" type="curve" smooth="yes"/>
+      <point x="860" y="320"/>
+      <point x="950" y="435"/>
+      <point x="950" y="615" type="curve" smooth="yes"/>
+      <point x="950" y="795"/>
+      <point x="860" y="910"/>
+      <point x="680" y="910" type="curve" smooth="yes"/>
+      <point x="500" y="910"/>
+      <point x="410" y="795"/>
+      <point x="410" y="615" type="curve" smooth="yes"/>
+      <point x="410" y="435"/>
+      <point x="500" y="320"/>
+    </contour>
+    <contour>
+      <point x="680" y="1230" type="curve" smooth="yes"/>
+      <point x="1074" y="1230"/>
+      <point x="1310" y="978"/>
+      <point x="1310" y="615" type="curve" smooth="yes"/>
+      <point x="1310" y="252"/>
+      <point x="1074" y="0"/>
+      <point x="680" y="0" type="curve" smooth="yes"/>
+      <point x="286" y="0"/>
+      <point x="50" y="252"/>
+      <point x="50" y="615" type="curve" smooth="yes"/>
+      <point x="50" y="978"/>
+      <point x="286" y="1230"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni051A_.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051A.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1725"/>
+  <anchor x="810" y="1381" name="top_center"/>
+  <anchor x="810" y="1" name="bottom_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="Q.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni051A_.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051A.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051B.sc.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051B.sc.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1441"/>
+  <anchor x="680" y="1" name="bottom_center"/>
+  <anchor x="680" y="1201" name="top_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="q.sc.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni213A_.cv29.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni213A_.cv29.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni213A.cv29" format="2">
+  <advance width="1610"/>
+  <outline>
+    <contour>
+      <point x="1560" y="1620" type="line"/>
+      <point x="1560" y="740" type="line"/>
+      <point x="1224" y="1050" type="line"/>
+      <point x="1224" y="1620" type="line"/>
+    </contour>
+    <contour>
+      <point x="805" y="360" type="curve" smooth="yes"/>
+      <point x="1055" y="360"/>
+      <point x="1224" y="490"/>
+      <point x="1224" y="740" type="curve" smooth="yes"/>
+      <point x="1224" y="990"/>
+      <point x="1055" y="1120"/>
+      <point x="805" y="1120" type="curve" smooth="yes"/>
+      <point x="555" y="1120"/>
+      <point x="386" y="990"/>
+      <point x="386" y="740" type="curve" smooth="yes"/>
+      <point x="386" y="490"/>
+      <point x="555" y="360"/>
+    </contour>
+    <contour>
+      <point x="805" y="-20" type="curve" smooth="yes"/>
+      <point x="355" y="-20"/>
+      <point x="50" y="280"/>
+      <point x="50" y="740" type="curve" smooth="yes"/>
+      <point x="50" y="1200"/>
+      <point x="355" y="1500"/>
+      <point x="805" y="1500" type="curve" smooth="yes"/>
+      <point x="1255" y="1500"/>
+      <point x="1560" y="1200"/>
+      <point x="1560" y="740" type="curve" smooth="yes"/>
+      <point x="1560" y="280"/>
+      <point x="1255" y="-20"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlack.ufo/glyphs/uni24C_6.cv29.glif
+++ b/sources/Giphurs-ExtraBlack.ufo/glyphs/uni24C_6.cv29.glif
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni24C6.cv29" format="2">
+  <advance width="1720"/>
+  <outline>
+    <contour>
+      <point x="220" y="740" type="curve" smooth="yes"/>
+      <point x="220" y="380"/>
+      <point x="500" y="100"/>
+      <point x="860" y="100" type="curve" smooth="yes"/>
+      <point x="1220" y="100"/>
+      <point x="1500" y="380"/>
+      <point x="1500" y="740" type="curve" smooth="yes"/>
+      <point x="1500" y="1100"/>
+      <point x="1220" y="1380"/>
+      <point x="860" y="1380" type="curve" smooth="yes"/>
+      <point x="500" y="1380"/>
+      <point x="220" y="1100"/>
+    </contour>
+    <contour>
+      <point x="100" y="740" type="curve" smooth="yes"/>
+      <point x="100" y="1160"/>
+      <point x="440" y="1500"/>
+      <point x="860" y="1500" type="curve" smooth="yes"/>
+      <point x="1280" y="1500"/>
+      <point x="1620" y="1160"/>
+      <point x="1620" y="740" type="curve" smooth="yes"/>
+      <point x="1620" y="320"/>
+      <point x="1280" y="-20"/>
+      <point x="860" y="-20" type="curve" smooth="yes"/>
+      <point x="440" y="-20"/>
+      <point x="100" y="320"/>
+    </contour>
+    <contour>
+      <point x="846" y="1187" type="curve" smooth="yes"/>
+      <point x="1120" y="1187"/>
+      <point x="1300" y="1022"/>
+      <point x="1300" y="748" type="curve" smooth="yes"/>
+      <point x="1300" y="474"/>
+      <point x="1120" y="311"/>
+      <point x="846" y="311" type="curve" smooth="yes"/>
+      <point x="572" y="311"/>
+      <point x="392" y="474"/>
+      <point x="392" y="748" type="curve" smooth="yes"/>
+      <point x="392" y="1022"/>
+      <point x="572" y="1187"/>
+    </contour>
+    <contour>
+      <point x="846" y="947" type="curve" smooth="yes"/>
+      <point x="726" y="947"/>
+      <point x="663" y="869"/>
+      <point x="663" y="749" type="curve" smooth="yes"/>
+      <point x="663" y="629"/>
+      <point x="726" y="551"/>
+      <point x="846" y="551" type="curve" smooth="yes"/>
+      <point x="966" y="551"/>
+      <point x="1029" y="629"/>
+      <point x="1029" y="749" type="curve" smooth="yes"/>
+      <point x="1029" y="869"/>
+      <point x="966" y="947"/>
+    </contour>
+    <contour>
+      <point x="1372" y="311" type="line"/>
+      <point x="846" y="311" type="line"/>
+      <point x="1046" y="551" type="line"/>
+      <point x="1372" y="551" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
@@ -4574,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \uni0456 \acutecomb  by \iacute;
     sub \i \acutecomb  by \iacute;
+    sub \uni0456 \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4631,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4719,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5651,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6785,6 +6785,29 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
+
 feature locl {
 
  script cyrl;
@@ -6871,29 +6894,6 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
-
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
 
 feature ss09 {
   featureNames {
@@ -13207,6 +13207,10 @@ lookup mark_Mark_positioning {
 	<anchor 72 -270> mark @bottom_center;
   pos base [\uni1E3D.cv28 ] <anchor 363 1380> mark @top_center
 	<anchor 61 -336> mark @bottom_center;
+  pos base [\uni051A.cv29 ] <anchor 923 1381> mark @top_center
+	<anchor 680 1> mark @bottom_center;
+  pos base [\uni051B.sc.cv29 ] <anchor 550 1> mark @bottom_center
+	<anchor 762 1201> mark @top_center;
   pos base [\dotlessuni0268 ] <anchor 268 -20> mark @bottom_cedilla
 	<anchor 455 1040> mark @top_center
 	<anchor 272 0> mark @bottom_center

--- a/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
@@ -2261,6 +2261,16 @@ lookup cv28_Alternative_small_letter_l {
     sub \uni24A7 by \uni24A7.cv28 ;
 } cv28_Alternative_small_letter_l;
 
+lookup cv29_Alternative_letter_Q {
+  lookupflag 0;
+    sub \Q by \Q.cv29 ;
+    sub \uni051A by \uni051A.cv29 ;
+    sub \uni213A by \uni213A.cv29 ;
+    sub \uni24C6 by \uni24C6.cv29 ;
+    sub \q.sc by \q.sc.cv29 ;
+    sub \uni051B.sc by \uni051B.sc.cv29 ;
+} cv29_Alternative_letter_Q;
+
 lookup ss01_Alternative_digits_set_A {
   lookupflag 0;
     sub \eight by \eight.cv08 ;
@@ -4564,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \i \acutecomb  by \iacute;
     sub \uni0456 \acutecomb  by \iacute;
+    sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4621,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4709,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5641,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6775,29 +6785,6 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
-
 feature locl {
 
  script cyrl;
@@ -6884,6 +6871,29 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
+
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
 
 feature ss09 {
   featureNames {
@@ -7743,6 +7753,29 @@ feature cv28 {
       lookup cv28_Alternative_small_letter_l;
 } cv28;
 
+feature cv29 {
+
+ script DFLT;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script copt;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script cyrl;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script grek;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script latn;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+} cv29;
+
 feature ss01 {
   featureNames {
     name 3 1 0x409 "Alternative numbers set 1";
@@ -8264,7 +8297,7 @@ feature calt {
 
 lookup kern_Horizontal_kerning {
   lookupflag 0;
-    @kc88_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
+    @kc89_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
 	\Aogonek \Aring \Aringacute \Atilde \Delta \Lambda \backslash \uni01CD 
 	\uni01DE \uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
@@ -8273,12 +8306,12 @@ lookup kern_Horizontal_kerning {
 	\uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F88 \uni1F89 \uni1F8A \uni1F8B 
 	\uni1F8C \uni1F8D \uni1F8E \uni1F8F \uni1FB8 \uni1FB9 \uni1FBA \uni1FBB 
 	\uni1FBC \uni212B \uniA656 ];
-    @kc88_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
+    @kc89_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
 	\uni0412 \uni0417 \uni0432.loclBGR \uni0498 \uni04DE \uni1E02 \uni1E04 
 	\uni1E06 \uni1E9E \uniA7B4 \uniA7B5 ];
-    @kc88_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
+    @kc89_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
 	\uni03FE \uni0421 \uni0464 \uni0480 \uni04AA \uni1E08 \uni2103 \uni216D ];
-    @kc88_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
+    @kc89_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
 	\Gcommaaccent.cv21 \Gdotaccent.cv21 \O \Oacute \Obreve \Ocircumflex 
 	\Odieresis \Ograve \Ohungarumlaut \Omacron \Omicron \Omicrontonos 
 	\Oslash \Oslashacute \Otilde \Theta \uni0189 \uni018A \uni018F 
@@ -8291,42 +8324,42 @@ lookup kern_Horizontal_kerning {
 	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
 	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
 	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
-    @kc88_first_5 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
+    @kc89_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
+	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
+	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
+	\uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA 
+	\uni1FFB \uni1FFC \uni20B2 \uni20B2.ss05 ];
+    @kc89_first_6 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
 	\uni0422 \uni0490 \uni0492 \uni04A4 \uni04AC \uni1E6A \uni1E6C \uni1E6E 
 	\uni1E70 ];
-    @kc88_first_6 = [\Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
-	\uni01E4 \uni03A9 \uni051A \uni1E20 \uni1F68 \uni1F69 \uni1F6A \uni1F6B 
-	\uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 \uni1FA9 \uni1FAA \uni1FAB 
-	\uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA \uni1FFB \uni1FFC \uni20B2 
-	\uni20B2.ss05 ];
-    @kc88_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+    @kc89_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2165 \uni2166 \uni2167 \uni216A \uni216B 
 	\uniA7AE ];
-    @kc88_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
+    @kc89_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc88_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
+    @kc89_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
 	\uniA7AD ];
-    @kc88_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
-    @kc88_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
-    @kc88_first_12 = [\Psi \uni0470 ];
-    @kc88_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
+    @kc89_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
+    @kc89_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
+    @kc89_first_12 = [\Psi \uni0470 ];
+    @kc89_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc88_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
+    @kc89_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
 	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
 	\uni2107 ];
-    @kc88_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
+    @kc89_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
-    @kc88_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
+    @kc89_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
 	\uni2163 \uni2164 \universal ];
-    @kc88_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_first_19 = [\a \a.cv23 \aacute \aacute.cv23 \abreve \abreve.cv23 \acircumflex 
+    @kc89_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_first_19 = [\a \a.cv23 \aacute \aacute.cv23 \abreve \abreve.cv23 \acircumflex 
 	\acircumflex.cv23 \adieresis \adieresis.cv23 \agrave \agrave.cv23 
 	\amacron \amacron.cv23 \aogonek \aogonek.cv23 \aring \aring.cv23 
 	\aringacute.cv23 \atilde \atilde.cv23 \u \u.cv25 \uacute \uacute.cv25 
@@ -8350,7 +8383,7 @@ lookup kern_Horizontal_kerning {
 	\uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 \uni1EED 
 	\uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 \uniA657 
 	\uogonek \uogonek.cv25 \uring \uring.cv25 \utilde \utilde.cv25 ];
-    @kc88_first_20 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
+    @kc89_first_20 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
 	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
 	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
 	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
@@ -8363,7 +8396,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
 	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
 	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
-    @kc88_first_21 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_first_21 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8417,7 +8450,7 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_first_22 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
+    @kc89_first_22 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
 	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
@@ -8430,28 +8463,28 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
-    @kc88_first_23 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
+    @kc89_first_23 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
 	\uni1FB7 \uni2C65 ];
-    @kc88_first_24 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_first_24 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_first_25 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
+    @kc89_first_25 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
 	\uni0253 \uni029A \uni03F1 \uni03F8 \uni0440 \uni0444 \uni1E03 \uni1E05 
 	\uni1E07 \uni1E55 \uni1E57 \uni20AF \uni2114 ];
-    @kc88_first_26 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
+    @kc89_first_26 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
 	\uni1E05.sc \uni1E07.sc \uniA7B5.sc ];
-    @kc88_first_27 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
+    @kc89_first_27 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
 	\uni0188 \uni023C \uni0255 \uni0297 \uni03F2 \uni03F5 \uni0441 \uni0454 
 	\uni0465 \uni04AB \uni1E09 \uni217D ];
-    @kc88_first_28 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
+    @kc89_first_28 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
 	\uni037C.sc \uni03F2.sc \uni0441.sc \uni0454.sc \uni0465.sc 
 	\uni0481.sc \uni1E09.sc ];
-    @kc88_first_29 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+    @kc89_first_29 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8507,14 +8540,14 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_first_30 = [\chi ];
-    @kc88_first_31 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
+    @kc89_first_30 = [\chi ];
+    @kc89_first_31 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
 	\uni0436.sc \uni0445.sc \uni0497.sc \uni049B.sc \uni049D.sc 
 	\uni049F.sc \uni04A1.sc \uni04B3.sc \uni04C2.sc \uni04DD.sc 
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc88_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
+    @kc89_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
 	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
 	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
@@ -8526,7 +8559,7 @@ lookup kern_Horizontal_kerning {
 	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
 	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
 	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
-    @kc88_first_33 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_first_33 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8536,7 +8569,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2175.sc 
 	\uni2176.sc \uni2177.sc \uni217A.sc \uni217B.sc ];
-    @kc88_first_34 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
+    @kc89_first_34 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
 	\eight.cv18.numr \eight.cv18.numr.pnum \eight.cv18.numr.tnum 
 	\eight.numr \eight.numr.pnum \eight.numr.tnum \five.cv05.numr 
 	\five.cv05.numr.pnum \five.cv05.numr.tnum \five.cv15.numr 
@@ -8574,142 +8607,142 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.numr.tnum \zero.numr \zero.numr.pnum 
 	\zero.numr.tnum \zero.zero.numr \zero.zero.numr.pnum 
 	\zero.zero.numr.tnum ];
-    @kc88_first_35 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
+    @kc89_first_35 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
 	\uni1F26 \uni1F27 \uni1F74 \uni1F75 \uni1F90 \uni1F91 \uni1F92 \uni1F93 
 	\uni1F94 \uni1F95 \uni1F96 \uni1F97 \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 
 	\uni1FC7 ];
-    @kc88_first_36 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_first_36 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0433 \uni0437 
 	\uni0453 \uni0455 \uni0479 \uni0493 \uni0499 \uni04DF \uni04F7 \uni04FB 
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
-    @kc88_first_37 = [\eth \uni1EFC \uni1EFD ];
-    @kc88_first_38 = [\fraction ];
-    @kc88_first_39 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc88_first_40 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \uni0260.sc \uni051B.sc \uni1F60.sc \uni1F61.sc 
-	\uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc 
-	\uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc \uni1FA1.sc 
-	\uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc 
-	\uni1FF7.sc ];
-    @kc88_first_41 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc89_first_37 = [\eth \uni1EFC \uni1EFD ];
+    @kc89_first_38 = [\fraction ];
+    @kc89_first_39 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
+    @kc89_first_40 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
+	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
+	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
+	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
+    @kc89_first_41 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc88_first_42 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_first_42 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc88_first_43 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc89_first_43 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc88_first_44 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc89_first_44 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc88_first_45 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc89_first_45 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc88_first_46 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
+    @kc89_first_46 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
 	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc88_first_47 = [\lambda \uni019B ];
-    @kc88_first_48 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc88_first_49 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc89_first_47 = [\lambda \uni019B ];
+    @kc89_first_48 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc89_first_49 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc88_first_50 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc88_first_51 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc88_first_52 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc89_first_50 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc89_first_51 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc89_first_52 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc88_first_53 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_first_54 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc88_first_55 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc88_first_56 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc89_first_53 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_first_54 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc89_first_55 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc89_first_56 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc88_first_57 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_first_57 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc88_first_58 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+    @kc89_first_58 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
 	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_first_59 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+    @kc89_first_59 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
 	\uni1E71 ];
-    @kc88_first_60 = [\tau \uni0491 \uni04A5 ];
-    @kc88_first_61 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc88_first_62 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc88_first_63 = [\uni0196 \uni01AA ];
-    @kc88_first_64 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_first_60 = [\tau \uni0491 \uni04A5 ];
+    @kc89_first_61 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
+    @kc89_first_62 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc89_first_63 = [\uni0196 \uni01AA ];
+    @kc89_first_64 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
 	\ygrave ];
-    @kc88_first_65 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_first_65 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_first_66 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
+    @kc89_first_66 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
 	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
 	\zdotaccent ];
-    @kc88_first_67 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
+    @kc89_first_67 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
-    @kc88_first_68 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
+    @kc89_first_68 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
 	\uni052D \uni052F ];
-    @kc88_first_69 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
+    @kc89_first_69 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
 	\uni04B7.sc \uni04C6.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
 	\uni0525.sc \uni052F.sc ];
-    @kc88_first_70 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
-    @kc88_first_71 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
-    @kc88_first_72 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_first_70 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
+    @kc89_first_71 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
+    @kc89_first_72 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
+    @kc89_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
 	\Aring \Aringacute \Atilde \Delta \Lambda \slash \uni01CD \uni01DE 
 	\uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
 	\uni1EA0 \uni1EA2 \uni1EA4 \uni1EA6 \uni1EA8 \uni1EAA \uni1EAC \uni1EAE 
 	\uni1EB0 \uni1EB2 \uni1EB4 \uni1EB6 \uni1FB8 \uni1FB9 \uni1FBC \uni212B ];
-    @kc88_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
-    @kc88_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
+    @kc89_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
+    @kc89_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
 	\Gbreve \Gbreve.cv21 \Gcaron \Gcaron.cv21 \Gcircumflex 
 	\Gcircumflex.cv21 \Gcommaaccent \Gcommaaccent.cv21 \Gdotaccent 
 	\Gdotaccent.cv21 \O \OE \Oacute \Obreve \Ocircumflex \Odieresis \Ograve 
 	\Ohorn \Ohungarumlaut \Omacron \Omicron \Omicrontonos \Oslash 
-	\Oslashacute \Otilde \Q \Theta \colonmonetary \emptyset \uni0187 
-	\uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
+	\Oslashacute \Otilde \Q \Q.cv29 \Theta \colonmonetary \emptyset 
+	\uni0187 \uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
 	\uni01E4.cv21 \uni01EA \uni01EC \uni01F4 \uni01F4.cv21 \uni020C 
 	\uni020E \uni022A \uni022C \uni022E \uni0230 \uni023B \uni024A \uni0298 
 	\uni03D8 \uni03F4 \uni03FE \uni0404 \uni041E \uni0421 \uni0472 \uni047A 
 	\uni0480 \uni04AA \uni04BC \uni04BE \uni04D8 \uni04DA \uni04E6 \uni04E8 
-	\uni04EA \uni050C \uni051A \uni1E08 \uni1E20 \uni1E20.cv21 \uni1E4C 
-	\uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE \uni1ED0 \uni1ED2 \uni1ED4 
-	\uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE \uni1EE0 \uni1EE2 \uni20A2 
-	\uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE \uni216D \uni2180 \uni2182 
-	\uni2185 ];
-    @kc88_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
-    @kc88_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+	\uni04EA \uni050C \uni051A \uni051A.cv29 \uni1E08 \uni1E20 
+	\uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE 
+	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
+	\uni1EE0 \uni1EE2 \uni20A2 \uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE 
+	\uni216D \uni2180 \uni2182 \uni2185 ];
+    @kc89_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
+    @kc89_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
-    @kc88_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc88_second_7 = [\Omega \uni03A9 \uni1FFC ];
-    @kc88_second_8 = [\Phi \uni0424 ];
-    @kc88_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc88_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
+    @kc89_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
+    @kc89_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc89_second_8 = [\Phi \uni0424 ];
+    @kc89_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
+    @kc89_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
 	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc88_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
+    @kc89_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
 	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc88_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
+    @kc89_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
 	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
-    @kc88_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
+    @kc89_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
 	\uni2166 \uni2167 \universal ];
-    @kc88_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
+    @kc89_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
 	\uni04FE \uni1E8A \uni1E8C \uni2169 \uni216A \uni216B ];
-    @kc88_second_17 = [\a \a.cv23 \a.sc \aacute \aacute.cv23 \aacute.sc \abreve \abreve.cv23 \abreve.sc 
+    @kc89_second_17 = [\a \a.cv23 \a.sc \aacute \aacute.cv23 \aacute.sc \abreve \abreve.cv23 \abreve.sc 
 	\acircumflex \acircumflex.cv23 \acircumflex.sc \adieresis 
 	\adieresis.cv23 \adieresis.sc \ae.cv23 \aeacute.cv23 \agrave 
 	\agrave.cv23 \agrave.sc \alpha \alpha.sc \alphatonos \amacron 
@@ -8743,7 +8776,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F87 \uni1F87.sc \uni1FB0 \uni1FB0.sc \uni1FB1 \uni1FB1.sc 
 	\uni1FB2 \uni1FB2.sc \uni1FB3 \uni1FB3.sc \uni1FB4 \uni1FB4.sc 
 	\uni1FB6 \uni1FB6.sc \uni1FB7 \uni1FB7.sc \uni217E \uniA7C8 ];
-    @kc88_second_18 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_second_18 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8797,30 +8830,31 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_second_19 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
-    @kc88_second_20 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_second_19 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
+    @kc89_second_20 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_second_21 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
+    @kc89_second_21 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
 	\uniA7B4 \uniA7B5 ];
-    @kc88_second_22 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
+    @kc89_second_22 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni0188 \uni018D \uni01A3 \uni01D2 \uni01DD \uni01EB \uni020D 
-	\uni020F \uni022B \uni022D \uni022F \uni0231 \uni023C \uni0247 \uni0255 
-	\uni0258 \uni0259 \uni025A \uni0275 \uni0276 \uni029B \uni03D9 \uni03F2 
-	\uni03F5 \uni0435 \uni043E \uni0450 \uni0451 \uni0473 \uni047B \uni04A9 
-	\uni04AB \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni050D 
-	\uni1E09 \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
-    @kc88_second_23 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
+	\otilde \q.sc.cv29 \uni0188 \uni018D \uni01A3 \uni01D2 \uni01DD 
+	\uni01EB \uni020D \uni020F \uni022B \uni022D \uni022F \uni0231 \uni023C 
+	\uni0247 \uni0255 \uni0258 \uni0259 \uni025A \uni0275 \uni0276 \uni029B 
+	\uni03D9 \uni03F2 \uni03F5 \uni0435 \uni043E \uni0450 \uni0451 \uni0473 
+	\uni047B \uni04A9 \uni04AB \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 
+	\uni04EB \uni050D \uni051B.sc.cv29 \uni1E09 \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni20C0 \uni217D ];
+    @kc89_second_23 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
 	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
@@ -8838,7 +8872,7 @@ lookup kern_Horizontal_kerning {
 	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
 	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
 	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc ];
-    @kc88_second_24 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+    @kc89_second_24 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8894,11 +8928,11 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_second_25 = [\chi \gamma \uni04AF \uni04B1 ];
-    @kc88_second_26 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
+    @kc89_second_25 = [\chi \gamma \uni04AF \uni04B1 ];
+    @kc89_second_26 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
 	\uni04DD.sc \uni04FD.sc \uni04FF.sc \uni1E8B.sc \uni1E8D.sc 
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
-    @kc88_second_27 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_second_27 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8908,7 +8942,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
 	\uni2178.sc ];
-    @kc88_second_28 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
+    @kc89_second_28 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
 	\five.cv05.dnom.pnum \five.cv05.dnom.tnum \five.cv15.dnom 
@@ -8944,12 +8978,12 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.dnom.tnum \zero.cv20.zero.dnom 
 	\zero.cv20.zero.dnom.tnum \zero.dnom \zero.dnom.tnum 
 	\zero.zero.dnom \zero.zero.dnom.tnum ];
-    @kc88_second_29 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_second_29 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0433 \uni0437 
 	\uni0453 \uni0455 \uni0479 \uni0493 \uni0499 \uni04DF \uni04F7 \uni04FB 
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
-    @kc88_second_30 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
+    @kc89_second_30 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
 	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
 	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
 	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
@@ -8972,1624 +9006,1625 @@ lookup kern_Horizontal_kerning {
 	\uni1F7B \uni1FE6 \uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 
 	\upsilon \upsilondieresistonos \upsilontonos \uring \uring.cv25 
 	\utilde \utilde.cv25 ];
-    @kc88_second_31 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
+    @kc89_second_31 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
 	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc88_second_32 = [\fraction ];
-    @kc88_second_33 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc88_second_34 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+    @kc89_second_32 = [\fraction ];
+    @kc89_second_33 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc89_second_34 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc88_second_35 = [\lambda \uni019B ];
-    @kc88_second_36 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc89_second_35 = [\lambda \uni019B ];
+    @kc89_second_36 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc88_second_37 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+    @kc89_second_37 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
 	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
 	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
 	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
 	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc88_second_38 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_second_39 = [\pi \tau \uni044A \uni04B5 ];
-    @kc88_second_40 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc89_second_38 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_second_39 = [\pi \tau \uni044A \uni04B5 ];
+    @kc89_second_40 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc88_second_41 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_second_41 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc88_second_42 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc89_second_42 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_second_43 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_second_43 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
 	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
 	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc88_second_44 = [\theta \uni0478 \uniA64C ];
-    @kc88_second_45 = [\tonos2 ];
-    @kc88_second_46 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc88_second_47 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_second_44 = [\theta \uni0478 \uniA64C ];
+    @kc89_second_45 = [\tonos2 ];
+    @kc89_second_46 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc89_second_47 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc88_second_48 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_second_48 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_second_49 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
+    @kc89_second_49 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
 	\z \zacute \zcaron \zdotaccent ];
-    @kc88_second_50 = [\uni0237 ];
-    @kc88_second_51 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc88_second_52 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc88_second_53 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc88_second_54 = [\uni042F \uni0518 ];
-    @kc88_second_55 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc89_second_50 = [\uni0237 ];
+    @kc89_second_51 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc89_second_52 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc89_second_53 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc89_second_54 = [\uni042F \uni0518 ];
+    @kc89_second_55 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc88_second_56 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc89_second_56 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc88_second_57 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
-    @kc88_second_58 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc88_second_59 = [\uni044F.sc \uni0519.sc ];
-    @kc88_second_60 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc89_second_57 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
+    @kc89_second_58 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc89_second_59 = [\uni044F.sc \uni0519.sc ];
+    @kc89_second_60 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc88_second_61 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc88_second_62 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_second_61 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc89_second_62 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_63 = [\uni0500 \uni0502 ];
-    @kc88_second_64 = [\uni0501.sc \uni0503.sc ];
-    @kc88_second_65 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
+    @kc89_second_63 = [\uni0500 \uni0502 ];
+    @kc89_second_64 = [\uni0501.sc \uni0503.sc ];
+    @kc89_second_65 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
 	\zero.cv20.zero.dnom.pnum \zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc88_second_66 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
+    @kc89_second_66 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
 	\zero.cv20.zero.numr.pnum \zero.numr.pnum \zero.zero.numr.pnum ];
-    pos @kc88_first_1 @kc88_second_3 -70;
-    pos @kc88_first_1 @kc88_second_8 -70;
-    pos @kc88_first_1 @kc88_second_9 -140;
-    pos @kc88_first_1 @kc88_second_10 -35;
-    pos @kc88_first_1 @kc88_second_12 -280;
-    pos @kc88_first_1 @kc88_second_13 -280;
-    pos @kc88_first_1 @kc88_second_14 -280;
-    pos @kc88_first_1 @kc88_second_15 -210;
-    pos @kc88_first_1 @kc88_second_20 -70;
-    pos @kc88_first_1 @kc88_second_23 -35;
-    pos @kc88_first_1 @kc88_second_25 -50;
-    pos @kc88_first_1 @kc88_second_31 -70;
-    pos @kc88_first_1 @kc88_second_38 -35;
-    pos @kc88_first_1 @kc88_second_39 -140;
-    pos @kc88_first_1 @kc88_second_40 -105;
-    pos @kc88_first_1 @kc88_second_43 -210;
-    pos @kc88_first_1 @kc88_second_44 -35;
-    pos @kc88_first_1 @kc88_second_45 1;
-    pos @kc88_first_1 @kc88_second_47 -175;
-    pos @kc88_first_1 @kc88_second_48 -210;
-    pos @kc88_first_1 @kc88_second_58 -140;
-    pos @kc88_first_1 @kc88_second_60 -140;
-    pos @kc88_first_1 @kc88_second_61 -210;
-    pos @kc88_first_1 @kc88_second_62 -140;
-    pos @kc88_first_2 @kc88_second_9 -35;
-    pos @kc88_first_2 @kc88_second_12 -70;
-    pos @kc88_first_2 @kc88_second_13 -70;
-    pos @kc88_first_2 @kc88_second_14 -70;
-    pos @kc88_first_2 @kc88_second_15 -35;
-    pos @kc88_first_2 @kc88_second_16 -35;
-    pos @kc88_first_2 @kc88_second_39 -35;
-    pos @kc88_first_2 @kc88_second_45 1;
-    pos @kc88_first_3 @kc88_second_1 -35;
-    pos @kc88_first_3 @kc88_second_2 -70;
-    pos @kc88_first_3 @kc88_second_5 -35;
-    pos @kc88_first_3 @kc88_second_11 -35;
-    pos @kc88_first_3 @kc88_second_12 -35;
-    pos @kc88_first_3 @kc88_second_13 -70;
-    pos @kc88_first_3 @kc88_second_14 -35;
-    pos @kc88_first_3 @kc88_second_16 -70;
-    pos @kc88_first_3 @kc88_second_19 -70;
-    pos @kc88_first_3 @kc88_second_35 -35;
-    pos @kc88_first_3 @kc88_second_45 1;
-    pos @kc88_first_4 @kc88_second_1 -70;
-    pos @kc88_first_4 @kc88_second_2 -140;
-    pos @kc88_first_4 @kc88_second_4 70;
-    pos @kc88_first_4 @kc88_second_5 -70;
-    pos @kc88_first_4 @kc88_second_11 -105;
-    pos @kc88_first_4 @kc88_second_12 -140;
-    pos @kc88_first_4 @kc88_second_13 -140;
-    pos @kc88_first_4 @kc88_second_14 -105;
-    pos @kc88_first_4 @kc88_second_15 -35;
-    pos @kc88_first_4 @kc88_second_16 -140;
-    pos @kc88_first_4 @kc88_second_24 -70;
-    pos @kc88_first_4 @kc88_second_26 -70;
-    pos @kc88_first_4 @kc88_second_27 -35;
-    pos @kc88_first_4 @kc88_second_31 35;
-    pos @kc88_first_4 @kc88_second_34 -70;
-    pos @kc88_first_4 @kc88_second_35 -70;
-    pos @kc88_first_4 @kc88_second_43 -35;
-    pos @kc88_first_4 @kc88_second_45 1;
-    pos @kc88_first_4 @kc88_second_48 -70;
-    pos @kc88_first_4 @kc88_second_53 -70;
-    pos @kc88_first_4 @kc88_second_55 -70;
-    pos @kc88_first_4 @kc88_second_57 -70;
-    pos @kc88_first_4 @kc88_second_61 -35;
-    pos @kc88_first_5 @kc88_second_1 -280;
-    pos @kc88_first_5 @kc88_second_2 -350;
-    pos @kc88_first_5 @kc88_second_3 -140;
-    pos @kc88_first_5 @kc88_second_4 -70;
-    pos @kc88_first_5 @kc88_second_6 -350;
-    pos @kc88_first_5 @kc88_second_7 -140;
-    pos @kc88_first_5 @kc88_second_8 -210;
-    pos @kc88_first_5 @kc88_second_10 -70;
-    pos @kc88_first_5 @kc88_second_17 -240;
-    pos @kc88_first_5 @kc88_second_19 -350;
-    pos @kc88_first_5 @kc88_second_20 -280;
-    pos @kc88_first_5 @kc88_second_21 -240;
-    pos @kc88_first_5 @kc88_second_22 -240;
-    pos @kc88_first_5 @kc88_second_23 -210;
-    pos @kc88_first_5 @kc88_second_24 -350;
-    pos @kc88_first_5 @kc88_second_25 -140;
-    pos @kc88_first_5 @kc88_second_27 -140;
-    pos @kc88_first_5 @kc88_second_29 -240;
-    pos @kc88_first_5 @kc88_second_30 -240;
-    pos @kc88_first_5 @kc88_second_31 -175;
-    pos @kc88_first_5 @kc88_second_34 -350;
-    pos @kc88_first_5 @kc88_second_35 -105;
-    pos @kc88_first_5 @kc88_second_36 -240;
-    pos @kc88_first_5 @kc88_second_37 -210;
-    pos @kc88_first_5 @kc88_second_38 -240;
-    pos @kc88_first_5 @kc88_second_39 -240;
-    pos @kc88_first_5 @kc88_second_41 -240;
-    pos @kc88_first_5 @kc88_second_44 -140;
-    pos @kc88_first_5 @kc88_second_45 1;
-    pos @kc88_first_5 @kc88_second_46 -35;
-    pos @kc88_first_5 @kc88_second_47 -240;
-    pos @kc88_first_5 @kc88_second_49 -240;
-    pos @kc88_first_5 @kc88_second_50 -240;
-    pos @kc88_first_5 @kc88_second_51 -240;
-    pos @kc88_first_5 @kc88_second_52 -240;
-    pos @kc88_first_5 @kc88_second_53 -280;
-    pos @kc88_first_5 @kc88_second_54 -70;
-    pos @kc88_first_5 @kc88_second_55 -240;
-    pos @kc88_first_5 @kc88_second_56 -175;
-    pos @kc88_first_5 @kc88_second_57 -280;
-    pos @kc88_first_5 @kc88_second_58 -240;
-    pos @kc88_first_5 @kc88_second_59 -210;
-    pos @kc88_first_5 @kc88_second_60 -175;
-    pos @kc88_first_5 @kc88_second_63 -175;
-    pos @kc88_first_5 @kc88_second_64 -175;
-    pos @kc88_first_6 @kc88_second_45 1;
-    pos @kc88_first_7 @kc88_second_3 -70;
-    pos @kc88_first_7 @kc88_second_8 -105;
-    pos @kc88_first_7 @kc88_second_17 -35;
-    pos @kc88_first_7 @kc88_second_20 -105;
-    pos @kc88_first_7 @kc88_second_22 -105;
-    pos @kc88_first_7 @kc88_second_23 -70;
-    pos @kc88_first_7 @kc88_second_45 1;
-    pos @kc88_first_7 @kc88_second_46 -35;
-    pos @kc88_first_7 @kc88_second_47 -70;
-    pos @kc88_first_7 @kc88_second_51 -50;
-    pos @kc88_first_7 @kc88_second_60 -35;
-    pos @kc88_first_7 @kc88_second_63 -70;
-    pos @kc88_first_7 @kc88_second_64 -70;
-    pos @kc88_first_8 @kc88_second_3 -140;
-    pos @kc88_first_8 @kc88_second_4 -70;
-    pos @kc88_first_8 @kc88_second_6 -70;
-    pos @kc88_first_8 @kc88_second_8 -140;
-    pos @kc88_first_8 @kc88_second_10 -35;
-    pos @kc88_first_8 @kc88_second_17 -70;
-    pos @kc88_first_8 @kc88_second_20 -140;
-    pos @kc88_first_8 @kc88_second_22 -70;
-    pos @kc88_first_8 @kc88_second_23 -105;
-    pos @kc88_first_8 @kc88_second_25 -140;
-    pos @kc88_first_8 @kc88_second_29 -35;
-    pos @kc88_first_8 @kc88_second_31 -105;
-    pos @kc88_first_8 @kc88_second_34 -70;
-    pos @kc88_first_8 @kc88_second_36 -70;
-    pos @kc88_first_8 @kc88_second_38 -105;
-    pos @kc88_first_8 @kc88_second_39 -175;
-    pos @kc88_first_8 @kc88_second_40 -140;
-    pos @kc88_first_8 @kc88_second_41 -35;
-    pos @kc88_first_8 @kc88_second_43 -140;
-    pos @kc88_first_8 @kc88_second_44 -105;
-    pos @kc88_first_8 @kc88_second_45 1;
-    pos @kc88_first_8 @kc88_second_46 -70;
-    pos @kc88_first_8 @kc88_second_47 -140;
-    pos @kc88_first_8 @kc88_second_48 -70;
-    pos @kc88_first_8 @kc88_second_51 -35;
-    pos @kc88_first_8 @kc88_second_52 -35;
-    pos @kc88_first_8 @kc88_second_58 -210;
-    pos @kc88_first_8 @kc88_second_60 -105;
-    pos @kc88_first_8 @kc88_second_61 -70;
-    pos @kc88_first_8 @kc88_second_62 -35;
-    pos @kc88_first_8 @kc88_second_63 -70;
-    pos @kc88_first_8 @kc88_second_64 -35;
-    pos @kc88_first_9 @kc88_second_3 -140;
-    pos @kc88_first_9 @kc88_second_4 -70;
-    pos @kc88_first_9 @kc88_second_6 -70;
-    pos @kc88_first_9 @kc88_second_8 -210;
-    pos @kc88_first_9 @kc88_second_9 -420;
-    pos @kc88_first_9 @kc88_second_10 -70;
-    pos @kc88_first_9 @kc88_second_12 -350;
-    pos @kc88_first_9 @kc88_second_13 -420;
-    pos @kc88_first_9 @kc88_second_14 -350;
-    pos @kc88_first_9 @kc88_second_15 -280;
-    pos @kc88_first_9 @kc88_second_17 -70;
-    pos @kc88_first_9 @kc88_second_18 -210;
-    pos @kc88_first_9 @kc88_second_20 -210;
-    pos @kc88_first_9 @kc88_second_22 -70;
-    pos @kc88_first_9 @kc88_second_23 -140;
-    pos @kc88_first_9 @kc88_second_29 -50;
-    pos @kc88_first_9 @kc88_second_31 -140;
-    pos @kc88_first_9 @kc88_second_34 -70;
-    pos @kc88_first_9 @kc88_second_38 -105;
-    pos @kc88_first_9 @kc88_second_39 -280;
-    pos @kc88_first_9 @kc88_second_40 -350;
-    pos @kc88_first_9 @kc88_second_41 -50;
-    pos @kc88_first_9 @kc88_second_43 -350;
-    pos @kc88_first_9 @kc88_second_45 1;
-    pos @kc88_first_9 @kc88_second_46 -35;
-    pos @kc88_first_9 @kc88_second_47 -210;
-    pos @kc88_first_9 @kc88_second_48 -350;
-    pos @kc88_first_9 @kc88_second_51 -35;
-    pos @kc88_first_9 @kc88_second_52 -35;
-    pos @kc88_first_9 @kc88_second_58 -280;
-    pos @kc88_first_9 @kc88_second_60 -175;
-    pos @kc88_first_9 @kc88_second_61 -280;
-    pos @kc88_first_9 @kc88_second_62 -210;
-    pos @kc88_first_9 @kc88_second_63 -70;
-    pos @kc88_first_9 @kc88_second_64 -70;
-    pos @kc88_first_10 @kc88_second_1 -210;
-    pos @kc88_first_10 @kc88_second_2 -350;
-    pos @kc88_first_10 @kc88_second_5 -70;
-    pos @kc88_first_10 @kc88_second_6 -140;
-    pos @kc88_first_10 @kc88_second_11 -35;
-    pos @kc88_first_10 @kc88_second_12 -70;
-    pos @kc88_first_10 @kc88_second_13 -70;
-    pos @kc88_first_10 @kc88_second_14 -35;
-    pos @kc88_first_10 @kc88_second_16 -70;
-    pos @kc88_first_10 @kc88_second_17 -35;
-    pos @kc88_first_10 @kc88_second_19 -280;
-    pos @kc88_first_10 @kc88_second_22 -70;
-    pos @kc88_first_10 @kc88_second_24 -350;
-    pos @kc88_first_10 @kc88_second_29 -70;
-    pos @kc88_first_10 @kc88_second_32 -140;
-    pos @kc88_first_10 @kc88_second_34 -210;
-    pos @kc88_first_10 @kc88_second_35 -105;
-    pos @kc88_first_10 @kc88_second_38 -70;
-    pos @kc88_first_10 @kc88_second_45 1;
-    pos @kc88_first_10 @kc88_second_53 -210;
-    pos @kc88_first_10 @kc88_second_55 -210;
-    pos @kc88_first_10 @kc88_second_57 -210;
-    pos @kc88_first_10 @kc88_second_61 -70;
-    pos @kc88_first_10 @kc88_second_63 -70;
-    pos @kc88_first_10 @kc88_second_64 -105;
-    pos @kc88_first_11 @kc88_second_1 -70;
-    pos @kc88_first_11 @kc88_second_2 -140;
-    pos @kc88_first_11 @kc88_second_5 -105;
-    pos @kc88_first_11 @kc88_second_6 -35;
-    pos @kc88_first_11 @kc88_second_11 -70;
-    pos @kc88_first_11 @kc88_second_12 -210;
-    pos @kc88_first_11 @kc88_second_13 -175;
-    pos @kc88_first_11 @kc88_second_14 -105;
-    pos @kc88_first_11 @kc88_second_15 -70;
-    pos @kc88_first_11 @kc88_second_16 -140;
-    pos @kc88_first_11 @kc88_second_19 -140;
-    pos @kc88_first_11 @kc88_second_24 -70;
-    pos @kc88_first_11 @kc88_second_26 -70;
-    pos @kc88_first_11 @kc88_second_27 -70;
-    pos @kc88_first_11 @kc88_second_34 -35;
-    pos @kc88_first_11 @kc88_second_35 -140;
-    pos @kc88_first_11 @kc88_second_39 -70;
-    pos @kc88_first_11 @kc88_second_42 -35;
-    pos @kc88_first_11 @kc88_second_43 -35;
-    pos @kc88_first_11 @kc88_second_45 1;
-    pos @kc88_first_11 @kc88_second_48 -70;
-    pos @kc88_first_11 @kc88_second_53 -210;
-    pos @kc88_first_11 @kc88_second_55 -175;
-    pos @kc88_first_11 @kc88_second_56 -35;
-    pos @kc88_first_11 @kc88_second_57 -175;
-    pos @kc88_first_11 @kc88_second_61 -70;
-    pos @kc88_first_11 @kc88_second_62 -35;
-    pos @kc88_first_11 @kc88_second_63 -35;
-    pos @kc88_first_11 @kc88_second_64 -70;
-    pos @kc88_first_12 @kc88_second_1 -140;
-    pos @kc88_first_12 @kc88_second_2 -210;
-    pos @kc88_first_12 @kc88_second_6 -140;
-    pos @kc88_first_12 @kc88_second_17 -70;
-    pos @kc88_first_12 @kc88_second_19 -210;
-    pos @kc88_first_12 @kc88_second_22 -70;
-    pos @kc88_first_12 @kc88_second_24 -350;
-    pos @kc88_first_12 @kc88_second_29 -35;
-    pos @kc88_first_12 @kc88_second_32 -140;
-    pos @kc88_first_12 @kc88_second_34 -140;
-    pos @kc88_first_12 @kc88_second_35 -70;
-    pos @kc88_first_12 @kc88_second_38 -70;
-    pos @kc88_first_12 @kc88_second_45 1;
-    pos @kc88_first_12 @kc88_second_51 -35;
-    pos @kc88_first_12 @kc88_second_53 -210;
-    pos @kc88_first_12 @kc88_second_55 -210;
-    pos @kc88_first_12 @kc88_second_57 -210;
-    pos @kc88_first_12 @kc88_second_63 -70;
-    pos @kc88_first_12 @kc88_second_64 -105;
-    pos @kc88_first_13 @kc88_second_6 -70;
-    pos @kc88_first_13 @kc88_second_12 -70;
-    pos @kc88_first_13 @kc88_second_13 -105;
-    pos @kc88_first_13 @kc88_second_14 -35;
-    pos @kc88_first_13 @kc88_second_22 -35;
-    pos @kc88_first_13 @kc88_second_29 -35;
-    pos @kc88_first_13 @kc88_second_34 -70;
-    pos @kc88_first_13 @kc88_second_38 -70;
-    pos @kc88_first_13 @kc88_second_45 1;
-    pos @kc88_first_13 @kc88_second_63 -70;
-    pos @kc88_first_13 @kc88_second_64 -35;
-    pos @kc88_first_14 @kc88_second_2 -35;
-    pos @kc88_first_14 @kc88_second_11 -35;
-    pos @kc88_first_14 @kc88_second_12 -70;
-    pos @kc88_first_14 @kc88_second_13 -70;
-    pos @kc88_first_14 @kc88_second_14 -35;
-    pos @kc88_first_14 @kc88_second_16 -35;
-    pos @kc88_first_14 @kc88_second_19 -35;
-    pos @kc88_first_14 @kc88_second_25 -35;
-    pos @kc88_first_14 @kc88_second_39 -70;
-    pos @kc88_first_14 @kc88_second_45 1;
-    pos @kc88_first_14 @kc88_second_47 -70;
-    pos @kc88_first_14 @kc88_second_48 -35;
-    pos @kc88_first_14 @kc88_second_56 -35;
-    pos @kc88_first_14 @kc88_second_58 -35;
-    pos @kc88_first_14 @kc88_second_60 -35;
-    pos @kc88_first_14 @kc88_second_62 -35;
-    pos @kc88_first_15 @kc88_second_3 -70;
-    pos @kc88_first_15 @kc88_second_4 -70;
-    pos @kc88_first_15 @kc88_second_6 -35;
-    pos @kc88_first_15 @kc88_second_8 -70;
-    pos @kc88_first_15 @kc88_second_17 -70;
-    pos @kc88_first_15 @kc88_second_20 -140;
-    pos @kc88_first_15 @kc88_second_22 -70;
-    pos @kc88_first_15 @kc88_second_23 -70;
-    pos @kc88_first_15 @kc88_second_25 -70;
-    pos @kc88_first_15 @kc88_second_29 -35;
-    pos @kc88_first_15 @kc88_second_31 -35;
-    pos @kc88_first_15 @kc88_second_36 -35;
-    pos @kc88_first_15 @kc88_second_38 -70;
-    pos @kc88_first_15 @kc88_second_39 -142;
-    pos @kc88_first_15 @kc88_second_40 -35;
-    pos @kc88_first_15 @kc88_second_44 -35;
-    pos @kc88_first_15 @kc88_second_45 1;
-    pos @kc88_first_15 @kc88_second_46 -35;
-    pos @kc88_first_15 @kc88_second_47 -70;
-    pos @kc88_first_15 @kc88_second_51 -35;
-    pos @kc88_first_15 @kc88_second_52 -35;
-    pos @kc88_first_15 @kc88_second_58 -105;
-    pos @kc88_first_15 @kc88_second_60 -35;
-    pos @kc88_first_15 @kc88_second_63 -35;
-    pos @kc88_first_15 @kc88_second_64 -35;
-    pos @kc88_first_16 @kc88_second_1 -280;
-    pos @kc88_first_16 @kc88_second_2 -280;
-    pos @kc88_first_16 @kc88_second_3 -140;
-    pos @kc88_first_16 @kc88_second_4 -70;
-    pos @kc88_first_16 @kc88_second_6 -280;
-    pos @kc88_first_16 @kc88_second_7 -140;
-    pos @kc88_first_16 @kc88_second_8 -175;
-    pos @kc88_first_16 @kc88_second_10 -70;
-    pos @kc88_first_16 @kc88_second_17 -245;
-    pos @kc88_first_16 @kc88_second_19 -280;
-    pos @kc88_first_16 @kc88_second_20 -210;
-    pos @kc88_first_16 @kc88_second_21 -140;
-    pos @kc88_first_16 @kc88_second_22 -280;
-    pos @kc88_first_16 @kc88_second_23 -210;
-    pos @kc88_first_16 @kc88_second_24 -350;
-    pos @kc88_first_16 @kc88_second_25 -70;
-    pos @kc88_first_16 @kc88_second_27 -140;
-    pos @kc88_first_16 @kc88_second_29 -240;
-    pos @kc88_first_16 @kc88_second_30 -140;
-    pos @kc88_first_16 @kc88_second_31 -140;
-    pos @kc88_first_16 @kc88_second_32 -245;
-    pos @kc88_first_16 @kc88_second_34 -315;
-    pos @kc88_first_16 @kc88_second_35 -70;
-    pos @kc88_first_16 @kc88_second_36 -210;
-    pos @kc88_first_16 @kc88_second_37 -210;
-    pos @kc88_first_16 @kc88_second_38 -245;
-    pos @kc88_first_16 @kc88_second_39 -245;
-    pos @kc88_first_16 @kc88_second_40 -70;
-    pos @kc88_first_16 @kc88_second_42 -35;
-    pos @kc88_first_16 @kc88_second_43 -140;
-    pos @kc88_first_16 @kc88_second_44 -140;
-    pos @kc88_first_16 @kc88_second_45 1;
-    pos @kc88_first_16 @kc88_second_46 -70;
-    pos @kc88_first_16 @kc88_second_47 -140;
-    pos @kc88_first_16 @kc88_second_49 -140;
-    pos @kc88_first_16 @kc88_second_50 -140;
-    pos @kc88_first_16 @kc88_second_51 -240;
-    pos @kc88_first_16 @kc88_second_52 -140;
-    pos @kc88_first_16 @kc88_second_53 -280;
-    pos @kc88_first_16 @kc88_second_54 -105;
-    pos @kc88_first_16 @kc88_second_55 -280;
-    pos @kc88_first_16 @kc88_second_56 -140;
-    pos @kc88_first_16 @kc88_second_57 -315;
-    pos @kc88_first_16 @kc88_second_58 -210;
-    pos @kc88_first_16 @kc88_second_59 -210;
-    pos @kc88_first_16 @kc88_second_60 -105;
-    pos @kc88_first_16 @kc88_second_63 -315;
-    pos @kc88_first_16 @kc88_second_64 -350;
-    pos @kc88_first_17 @kc88_second_1 -280;
-    pos @kc88_first_17 @kc88_second_2 -280;
-    pos @kc88_first_17 @kc88_second_3 -105;
-    pos @kc88_first_17 @kc88_second_6 -210;
-    pos @kc88_first_17 @kc88_second_7 -105;
-    pos @kc88_first_17 @kc88_second_8 -105;
-    pos @kc88_first_17 @kc88_second_10 -35;
-    pos @kc88_first_17 @kc88_second_17 -105;
-    pos @kc88_first_17 @kc88_second_19 -280;
-    pos @kc88_first_17 @kc88_second_20 -70;
-    pos @kc88_first_17 @kc88_second_21 -105;
-    pos @kc88_first_17 @kc88_second_22 -140;
-    pos @kc88_first_17 @kc88_second_23 -140;
-    pos @kc88_first_17 @kc88_second_24 -210;
-    pos @kc88_first_17 @kc88_second_27 -70;
-    pos @kc88_first_17 @kc88_second_29 -140;
-    pos @kc88_first_17 @kc88_second_30 -105;
-    pos @kc88_first_17 @kc88_second_32 -210;
-    pos @kc88_first_17 @kc88_second_34 -245;
-    pos @kc88_first_17 @kc88_second_35 -70;
-    pos @kc88_first_17 @kc88_second_36 -140;
-    pos @kc88_first_17 @kc88_second_37 -140;
-    pos @kc88_first_17 @kc88_second_38 -140;
-    pos @kc88_first_17 @kc88_second_39 -105;
-    pos @kc88_first_17 @kc88_second_40 -35;
-    pos @kc88_first_17 @kc88_second_43 -35;
-    pos @kc88_first_17 @kc88_second_44 -70;
-    pos @kc88_first_17 @kc88_second_45 1;
-    pos @kc88_first_17 @kc88_second_46 -35;
-    pos @kc88_first_17 @kc88_second_47 -70;
-    pos @kc88_first_17 @kc88_second_49 -105;
-    pos @kc88_first_17 @kc88_second_50 -70;
-    pos @kc88_first_17 @kc88_second_51 -105;
-    pos @kc88_first_17 @kc88_second_52 -70;
-    pos @kc88_first_17 @kc88_second_53 -210;
-    pos @kc88_first_17 @kc88_second_54 -35;
-    pos @kc88_first_17 @kc88_second_55 -210;
-    pos @kc88_first_17 @kc88_second_56 -70;
-    pos @kc88_first_17 @kc88_second_57 -245;
-    pos @kc88_first_17 @kc88_second_58 -105;
-    pos @kc88_first_17 @kc88_second_59 -105;
-    pos @kc88_first_17 @kc88_second_60 -70;
-    pos @kc88_first_17 @kc88_second_63 -175;
-    pos @kc88_first_17 @kc88_second_64 -245;
-    pos @kc88_first_18 @kc88_second_1 -210;
-    pos @kc88_first_18 @kc88_second_2 -245;
-    pos @kc88_first_18 @kc88_second_3 -35;
-    pos @kc88_first_18 @kc88_second_6 -140;
-    pos @kc88_first_18 @kc88_second_7 -35;
-    pos @kc88_first_18 @kc88_second_8 -70;
-    pos @kc88_first_18 @kc88_second_17 -105;
-    pos @kc88_first_18 @kc88_second_19 -210;
-    pos @kc88_first_18 @kc88_second_20 -70;
-    pos @kc88_first_18 @kc88_second_22 -105;
-    pos @kc88_first_18 @kc88_second_23 -70;
-    pos @kc88_first_18 @kc88_second_24 -140;
-    pos @kc88_first_18 @kc88_second_27 -35;
-    pos @kc88_first_18 @kc88_second_32 -140;
-    pos @kc88_first_18 @kc88_second_34 -140;
-    pos @kc88_first_18 @kc88_second_36 -105;
-    pos @kc88_first_18 @kc88_second_37 -70;
-    pos @kc88_first_18 @kc88_second_38 -105;
-    pos @kc88_first_18 @kc88_second_39 -70;
-    pos @kc88_first_18 @kc88_second_41 -35;
-    pos @kc88_first_18 @kc88_second_45 1;
-    pos @kc88_first_18 @kc88_second_50 -35;
-    pos @kc88_first_18 @kc88_second_51 -70;
-    pos @kc88_first_18 @kc88_second_53 -140;
-    pos @kc88_first_18 @kc88_second_55 -140;
-    pos @kc88_first_18 @kc88_second_57 -175;
-    pos @kc88_first_18 @kc88_second_58 -70;
-    pos @kc88_first_18 @kc88_second_63 -105;
-    pos @kc88_first_18 @kc88_second_64 -140;
-    pos @kc88_first_19 @kc88_second_12 -280;
-    pos @kc88_first_19 @kc88_second_14 -175;
-    pos @kc88_first_19 @kc88_second_15 -140;
-    pos @kc88_first_19 @kc88_second_29 -35;
-    pos @kc88_first_19 @kc88_second_45 1;
-    pos @kc88_first_19 @kc88_second_47 -70;
-    pos @kc88_first_19 @kc88_second_48 -140;
-    pos @kc88_first_19 @kc88_second_58 -70;
-    pos @kc88_first_19 @kc88_second_60 -35;
-    pos @kc88_first_19 @kc88_second_61 -105;
-    pos @kc88_first_19 @kc88_second_62 -70;
-    pos @kc88_first_20 @kc88_second_8 -35;
-    pos @kc88_first_20 @kc88_second_9 -140;
-    pos @kc88_first_20 @kc88_second_12 -280;
-    pos @kc88_first_20 @kc88_second_13 -280;
-    pos @kc88_first_20 @kc88_second_14 -280;
-    pos @kc88_first_20 @kc88_second_15 -175;
-    pos @kc88_first_20 @kc88_second_18 -140;
-    pos @kc88_first_20 @kc88_second_20 -70;
-    pos @kc88_first_20 @kc88_second_25 -70;
-    pos @kc88_first_20 @kc88_second_31 -50;
-    pos @kc88_first_20 @kc88_second_39 -140;
-    pos @kc88_first_20 @kc88_second_40 -105;
-    pos @kc88_first_20 @kc88_second_43 -210;
-    pos @kc88_first_20 @kc88_second_45 1;
-    pos @kc88_first_20 @kc88_second_46 -35;
-    pos @kc88_first_20 @kc88_second_47 -140;
-    pos @kc88_first_20 @kc88_second_48 -210;
-    pos @kc88_first_20 @kc88_second_52 -35;
-    pos @kc88_first_20 @kc88_second_58 -105;
-    pos @kc88_first_20 @kc88_second_60 -105;
-    pos @kc88_first_20 @kc88_second_61 -210;
-    pos @kc88_first_20 @kc88_second_62 -140;
-    pos @kc88_first_21 @kc88_second_1 -140;
-    pos @kc88_first_21 @kc88_second_2 -350;
-    pos @kc88_first_21 @kc88_second_19 -280;
-    pos @kc88_first_21 @kc88_second_38 -70;
-    pos @kc88_first_21 @kc88_second_45 1;
-    pos @kc88_first_21 @kc88_second_64 -210;
-    pos @kc88_first_22 @kc88_second_1 -35;
-    pos @kc88_first_22 @kc88_second_5 -105;
-    pos @kc88_first_22 @kc88_second_9 -70;
-    pos @kc88_first_22 @kc88_second_11 -70;
-    pos @kc88_first_22 @kc88_second_12 -240;
-    pos @kc88_first_22 @kc88_second_13 -280;
-    pos @kc88_first_22 @kc88_second_14 -140;
-    pos @kc88_first_22 @kc88_second_15 -105;
-    pos @kc88_first_22 @kc88_second_16 -70;
-    pos @kc88_first_22 @kc88_second_25 -35;
-    pos @kc88_first_22 @kc88_second_26 -70;
-    pos @kc88_first_22 @kc88_second_27 -105;
-    pos @kc88_first_22 @kc88_second_35 -70;
-    pos @kc88_first_22 @kc88_second_39 -70;
-    pos @kc88_first_22 @kc88_second_40 -35;
-    pos @kc88_first_22 @kc88_second_42 -35;
-    pos @kc88_first_22 @kc88_second_43 -140;
-    pos @kc88_first_22 @kc88_second_45 1;
-    pos @kc88_first_22 @kc88_second_47 -70;
-    pos @kc88_first_22 @kc88_second_48 -175;
-    pos @kc88_first_22 @kc88_second_49 -35;
-    pos @kc88_first_22 @kc88_second_56 -105;
-    pos @kc88_first_22 @kc88_second_58 -35;
-    pos @kc88_first_22 @kc88_second_60 -50;
-    pos @kc88_first_22 @kc88_second_61 -105;
-    pos @kc88_first_22 @kc88_second_62 -70;
-    pos @kc88_first_23 @kc88_second_6 -35;
-    pos @kc88_first_23 @kc88_second_12 -240;
-    pos @kc88_first_23 @kc88_second_13 -175;
-    pos @kc88_first_23 @kc88_second_14 -70;
-    pos @kc88_first_23 @kc88_second_15 -70;
-    pos @kc88_first_23 @kc88_second_22 -70;
-    pos @kc88_first_23 @kc88_second_23 -35;
-    pos @kc88_first_23 @kc88_second_34 -35;
-    pos @kc88_first_23 @kc88_second_39 -35;
-    pos @kc88_first_23 @kc88_second_40 -35;
-    pos @kc88_first_23 @kc88_second_43 -70;
-    pos @kc88_first_23 @kc88_second_44 -35;
-    pos @kc88_first_23 @kc88_second_45 1;
-    pos @kc88_first_23 @kc88_second_48 -35;
-    pos @kc88_first_23 @kc88_second_58 -35;
-    pos @kc88_first_23 @kc88_second_62 -35;
-    pos @kc88_first_23 @kc88_second_63 -35;
-    pos @kc88_first_23 @kc88_second_64 -35;
-    pos @kc88_first_24 @kc88_second_1 -70;
-    pos @kc88_first_24 @kc88_second_2 -140;
-    pos @kc88_first_24 @kc88_second_5 -105;
-    pos @kc88_first_24 @kc88_second_11 -70;
-    pos @kc88_first_24 @kc88_second_12 -280;
-    pos @kc88_first_24 @kc88_second_13 -210;
-    pos @kc88_first_24 @kc88_second_14 -70;
-    pos @kc88_first_24 @kc88_second_15 -70;
-    pos @kc88_first_24 @kc88_second_16 -140;
-    pos @kc88_first_24 @kc88_second_19 -70;
-    pos @kc88_first_24 @kc88_second_26 -70;
-    pos @kc88_first_24 @kc88_second_27 -70;
-    pos @kc88_first_24 @kc88_second_32 -70;
-    pos @kc88_first_24 @kc88_second_35 -70;
-    pos @kc88_first_24 @kc88_second_42 -35;
-    pos @kc88_first_24 @kc88_second_43 -140;
-    pos @kc88_first_24 @kc88_second_45 1;
-    pos @kc88_first_24 @kc88_second_48 -140;
-    pos @kc88_first_24 @kc88_second_49 -35;
-    pos @kc88_first_24 @kc88_second_53 -140;
-    pos @kc88_first_24 @kc88_second_55 -105;
-    pos @kc88_first_24 @kc88_second_56 -70;
-    pos @kc88_first_24 @kc88_second_57 -70;
-    pos @kc88_first_24 @kc88_second_61 -70;
-    pos @kc88_first_24 @kc88_second_62 -35;
-    pos @kc88_first_25 @kc88_second_5 -70;
-    pos @kc88_first_25 @kc88_second_9 -70;
-    pos @kc88_first_25 @kc88_second_12 -240;
-    pos @kc88_first_25 @kc88_second_13 -280;
-    pos @kc88_first_25 @kc88_second_14 -175;
-    pos @kc88_first_25 @kc88_second_15 -105;
-    pos @kc88_first_25 @kc88_second_16 -70;
-    pos @kc88_first_25 @kc88_second_25 -35;
-    pos @kc88_first_25 @kc88_second_26 -70;
-    pos @kc88_first_25 @kc88_second_27 -70;
-    pos @kc88_first_25 @kc88_second_35 -70;
-    pos @kc88_first_25 @kc88_second_39 -70;
-    pos @kc88_first_25 @kc88_second_40 -35;
-    pos @kc88_first_25 @kc88_second_43 -140;
-    pos @kc88_first_25 @kc88_second_45 1;
-    pos @kc88_first_25 @kc88_second_47 -70;
-    pos @kc88_first_25 @kc88_second_48 -140;
-    pos @kc88_first_25 @kc88_second_49 -35;
-    pos @kc88_first_25 @kc88_second_53 -50;
-    pos @kc88_first_25 @kc88_second_54 -35;
-    pos @kc88_first_25 @kc88_second_55 -50;
-    pos @kc88_first_25 @kc88_second_56 -105;
-    pos @kc88_first_25 @kc88_second_57 -50;
-    pos @kc88_first_25 @kc88_second_58 -50;
-    pos @kc88_first_25 @kc88_second_60 -35;
-    pos @kc88_first_25 @kc88_second_61 -105;
-    pos @kc88_first_25 @kc88_second_62 -70;
-    pos @kc88_first_26 @kc88_second_9 -35;
-    pos @kc88_first_26 @kc88_second_12 -140;
-    pos @kc88_first_26 @kc88_second_26 -70;
-    pos @kc88_first_26 @kc88_second_39 -35;
-    pos @kc88_first_26 @kc88_second_43 -70;
-    pos @kc88_first_26 @kc88_second_45 1;
-    pos @kc88_first_26 @kc88_second_48 -70;
-    pos @kc88_first_26 @kc88_second_61 -70;
-    pos @kc88_first_26 @kc88_second_62 -35;
-    pos @kc88_first_27 @kc88_second_5 -50;
-    pos @kc88_first_27 @kc88_second_9 -35;
-    pos @kc88_first_27 @kc88_second_11 -35;
-    pos @kc88_first_27 @kc88_second_12 -240;
-    pos @kc88_first_27 @kc88_second_13 -240;
-    pos @kc88_first_27 @kc88_second_14 -105;
-    pos @kc88_first_27 @kc88_second_15 -70;
-    pos @kc88_first_27 @kc88_second_16 -35;
-    pos @kc88_first_27 @kc88_second_26 -35;
-    pos @kc88_first_27 @kc88_second_27 -35;
-    pos @kc88_first_27 @kc88_second_35 -35;
-    pos @kc88_first_27 @kc88_second_39 -50;
-    pos @kc88_first_27 @kc88_second_40 -35;
-    pos @kc88_first_27 @kc88_second_43 -100;
-    pos @kc88_first_27 @kc88_second_45 1;
-    pos @kc88_first_27 @kc88_second_47 -35;
-    pos @kc88_first_27 @kc88_second_48 -140;
-    pos @kc88_first_27 @kc88_second_56 -35;
-    pos @kc88_first_27 @kc88_second_61 -70;
-    pos @kc88_first_27 @kc88_second_62 -35;
-    pos @kc88_first_28 @kc88_second_45 1;
-    pos @kc88_first_29 @kc88_second_8 -70;
-    pos @kc88_first_29 @kc88_second_9 -210;
-    pos @kc88_first_29 @kc88_second_12 -350;
-    pos @kc88_first_29 @kc88_second_13 -350;
-    pos @kc88_first_29 @kc88_second_14 -210;
-    pos @kc88_first_29 @kc88_second_15 -175;
-    pos @kc88_first_29 @kc88_second_25 -70;
-    pos @kc88_first_29 @kc88_second_38 -35;
-    pos @kc88_first_29 @kc88_second_39 -210;
-    pos @kc88_first_29 @kc88_second_40 -210;
-    pos @kc88_first_29 @kc88_second_43 -210;
-    pos @kc88_first_29 @kc88_second_45 1;
-    pos @kc88_first_29 @kc88_second_47 -140;
-    pos @kc88_first_29 @kc88_second_48 -280;
-    pos @kc88_first_29 @kc88_second_58 -210;
-    pos @kc88_first_29 @kc88_second_60 -105;
-    pos @kc88_first_29 @kc88_second_61 -175;
-    pos @kc88_first_29 @kc88_second_62 -140;
-    pos @kc88_first_30 @kc88_second_1 -175;
-    pos @kc88_first_30 @kc88_second_2 -175;
-    pos @kc88_first_30 @kc88_second_5 -70;
-    pos @kc88_first_30 @kc88_second_6 -105;
-    pos @kc88_first_30 @kc88_second_10 -35;
-    pos @kc88_first_30 @kc88_second_11 -105;
-    pos @kc88_first_30 @kc88_second_12 -175;
-    pos @kc88_first_30 @kc88_second_13 -140;
-    pos @kc88_first_30 @kc88_second_14 -70;
-    pos @kc88_first_30 @kc88_second_15 -35;
-    pos @kc88_first_30 @kc88_second_16 -140;
-    pos @kc88_first_30 @kc88_second_17 -70;
-    pos @kc88_first_30 @kc88_second_19 -175;
-    pos @kc88_first_30 @kc88_second_22 -70;
-    pos @kc88_first_30 @kc88_second_29 -105;
-    pos @kc88_first_30 @kc88_second_33 165;
-    pos @kc88_first_30 @kc88_second_34 -105;
-    pos @kc88_first_30 @kc88_second_35 -175;
-    pos @kc88_first_30 @kc88_second_36 -35;
-    pos @kc88_first_30 @kc88_second_38 -70;
-    pos @kc88_first_30 @kc88_second_45 1;
-    pos @kc88_first_30 @kc88_second_50 165;
-    pos @kc88_first_30 @kc88_second_51 -35;
-    pos @kc88_first_30 @kc88_second_63 -70;
-    pos @kc88_first_30 @kc88_second_64 -105;
-    pos @kc88_first_31 @kc88_second_3 -70;
-    pos @kc88_first_31 @kc88_second_4 -35;
-    pos @kc88_first_31 @kc88_second_6 -70;
-    pos @kc88_first_31 @kc88_second_8 -105;
-    pos @kc88_first_31 @kc88_second_17 -35;
-    pos @kc88_first_31 @kc88_second_20 -70;
-    pos @kc88_first_31 @kc88_second_22 -70;
-    pos @kc88_first_31 @kc88_second_23 -140;
-    pos @kc88_first_31 @kc88_second_29 -35;
-    pos @kc88_first_31 @kc88_second_34 -70;
-    pos @kc88_first_31 @kc88_second_36 -35;
-    pos @kc88_first_31 @kc88_second_38 -140;
-    pos @kc88_first_31 @kc88_second_39 -70;
-    pos @kc88_first_31 @kc88_second_45 1;
-    pos @kc88_first_31 @kc88_second_51 -35;
-    pos @kc88_first_31 @kc88_second_52 -35;
-    pos @kc88_first_31 @kc88_second_58 -140;
-    pos @kc88_first_31 @kc88_second_63 -70;
-    pos @kc88_first_31 @kc88_second_64 -70;
-    pos @kc88_first_32 @kc88_second_1 -35;
-    pos @kc88_first_32 @kc88_second_2 -105;
-    pos @kc88_first_32 @kc88_second_3 -70;
-    pos @kc88_first_32 @kc88_second_4 70;
-    pos @kc88_first_32 @kc88_second_5 -70;
-    pos @kc88_first_32 @kc88_second_11 -35;
-    pos @kc88_first_32 @kc88_second_12 -240;
-    pos @kc88_first_32 @kc88_second_13 -175;
-    pos @kc88_first_32 @kc88_second_14 -105;
-    pos @kc88_first_32 @kc88_second_15 -70;
-    pos @kc88_first_32 @kc88_second_16 -70;
-    pos @kc88_first_32 @kc88_second_24 -35;
-    pos @kc88_first_32 @kc88_second_27 -70;
-    pos @kc88_first_32 @kc88_second_35 -35;
-    pos @kc88_first_32 @kc88_second_39 -35;
-    pos @kc88_first_32 @kc88_second_40 -35;
-    pos @kc88_first_32 @kc88_second_42 -35;
-    pos @kc88_first_32 @kc88_second_43 -140;
-    pos @kc88_first_32 @kc88_second_45 1;
-    pos @kc88_first_32 @kc88_second_47 -50;
-    pos @kc88_first_32 @kc88_second_48 -140;
-    pos @kc88_first_32 @kc88_second_49 -35;
-    pos @kc88_first_32 @kc88_second_53 -70;
-    pos @kc88_first_32 @kc88_second_55 -70;
-    pos @kc88_first_32 @kc88_second_57 -70;
-    pos @kc88_first_32 @kc88_second_61 -70;
-    pos @kc88_first_32 @kc88_second_62 -35;
-    pos @kc88_first_33 @kc88_second_3 -35;
-    pos @kc88_first_33 @kc88_second_4 -70;
-    pos @kc88_first_33 @kc88_second_6 -70;
-    pos @kc88_first_33 @kc88_second_8 -70;
-    pos @kc88_first_33 @kc88_second_12 -140;
-    pos @kc88_first_33 @kc88_second_13 -105;
-    pos @kc88_first_33 @kc88_second_14 -70;
-    pos @kc88_first_33 @kc88_second_15 -35;
-    pos @kc88_first_33 @kc88_second_20 -70;
-    pos @kc88_first_33 @kc88_second_22 -105;
-    pos @kc88_first_33 @kc88_second_23 -70;
-    pos @kc88_first_33 @kc88_second_29 -35;
-    pos @kc88_first_33 @kc88_second_34 -70;
-    pos @kc88_first_33 @kc88_second_36 -70;
-    pos @kc88_first_33 @kc88_second_38 -105;
-    pos @kc88_first_33 @kc88_second_39 -70;
-    pos @kc88_first_33 @kc88_second_44 -70;
-    pos @kc88_first_33 @kc88_second_45 1;
-    pos @kc88_first_33 @kc88_second_51 -35;
-    pos @kc88_first_33 @kc88_second_52 -35;
-    pos @kc88_first_33 @kc88_second_63 -70;
-    pos @kc88_first_33 @kc88_second_64 -70;
-    pos @kc88_first_34 @kc88_second_32 -315;
-    pos @kc88_first_34 @kc88_second_45 1;
-    pos @kc88_first_35 @kc88_second_9 -70;
-    pos @kc88_first_35 @kc88_second_12 -240;
-    pos @kc88_first_35 @kc88_second_13 -210;
-    pos @kc88_first_35 @kc88_second_14 -140;
-    pos @kc88_first_35 @kc88_second_15 -105;
-    pos @kc88_first_35 @kc88_second_39 -70;
-    pos @kc88_first_35 @kc88_second_40 -35;
-    pos @kc88_first_35 @kc88_second_43 -140;
-    pos @kc88_first_35 @kc88_second_45 1;
-    pos @kc88_first_35 @kc88_second_47 -50;
-    pos @kc88_first_35 @kc88_second_48 -140;
-    pos @kc88_first_35 @kc88_second_58 -35;
-    pos @kc88_first_35 @kc88_second_60 -35;
-    pos @kc88_first_35 @kc88_second_61 -70;
-    pos @kc88_first_35 @kc88_second_62 -70;
-    pos @kc88_first_36 @kc88_second_9 -35;
-    pos @kc88_first_36 @kc88_second_12 -240;
-    pos @kc88_first_36 @kc88_second_13 -240;
-    pos @kc88_first_36 @kc88_second_14 -140;
-    pos @kc88_first_36 @kc88_second_15 -105;
-    pos @kc88_first_36 @kc88_second_16 -35;
-    pos @kc88_first_36 @kc88_second_26 -35;
-    pos @kc88_first_36 @kc88_second_27 -35;
-    pos @kc88_first_36 @kc88_second_39 -70;
-    pos @kc88_first_36 @kc88_second_40 -35;
-    pos @kc88_first_36 @kc88_second_43 -70;
-    pos @kc88_first_36 @kc88_second_45 1;
-    pos @kc88_first_36 @kc88_second_47 -35;
-    pos @kc88_first_36 @kc88_second_48 -70;
-    pos @kc88_first_36 @kc88_second_60 -35;
-    pos @kc88_first_36 @kc88_second_61 -70;
-    pos @kc88_first_36 @kc88_second_62 -70;
-    pos @kc88_first_37 @kc88_second_5 -70;
-    pos @kc88_first_37 @kc88_second_9 -70;
-    pos @kc88_first_37 @kc88_second_12 -140;
-    pos @kc88_first_37 @kc88_second_13 -210;
-    pos @kc88_first_37 @kc88_second_14 -140;
-    pos @kc88_first_37 @kc88_second_15 -105;
-    pos @kc88_first_37 @kc88_second_16 -70;
-    pos @kc88_first_37 @kc88_second_26 -70;
-    pos @kc88_first_37 @kc88_second_27 -70;
-    pos @kc88_first_37 @kc88_second_35 -50;
-    pos @kc88_first_37 @kc88_second_39 -50;
-    pos @kc88_first_37 @kc88_second_40 -35;
-    pos @kc88_first_37 @kc88_second_45 1;
-    pos @kc88_first_37 @kc88_second_47 -35;
-    pos @kc88_first_37 @kc88_second_48 -140;
-    pos @kc88_first_37 @kc88_second_56 -35;
-    pos @kc88_first_37 @kc88_second_61 -70;
-    pos @kc88_first_37 @kc88_second_62 -35;
-    pos @kc88_first_38 @kc88_second_1 -210;
-    pos @kc88_first_38 @kc88_second_2 -280;
-    pos @kc88_first_38 @kc88_second_6 -280;
-    pos @kc88_first_38 @kc88_second_8 -70;
-    pos @kc88_first_38 @kc88_second_17 -140;
-    pos @kc88_first_38 @kc88_second_19 -350;
-    pos @kc88_first_38 @kc88_second_20 -140;
-    pos @kc88_first_38 @kc88_second_22 -140;
-    pos @kc88_first_38 @kc88_second_23 -70;
-    pos @kc88_first_38 @kc88_second_24 -280;
-    pos @kc88_first_38 @kc88_second_28 -315;
-    pos @kc88_first_38 @kc88_second_29 -140;
-    pos @kc88_first_38 @kc88_second_32 -385;
-    pos @kc88_first_38 @kc88_second_34 -210;
-    pos @kc88_first_38 @kc88_second_35 -70;
-    pos @kc88_first_38 @kc88_second_36 -140;
-    pos @kc88_first_38 @kc88_second_37 -140;
-    pos @kc88_first_38 @kc88_second_38 -140;
-    pos @kc88_first_38 @kc88_second_41 -70;
-    pos @kc88_first_38 @kc88_second_45 1;
-    pos @kc88_first_38 @kc88_second_51 -140;
-    pos @kc88_first_38 @kc88_second_52 -70;
-    pos @kc88_first_38 @kc88_second_53 -140;
-    pos @kc88_first_38 @kc88_second_55 -245;
-    pos @kc88_first_38 @kc88_second_58 -70;
-    pos @kc88_first_38 @kc88_second_59 -70;
-    pos @kc88_first_38 @kc88_second_63 -245;
-    pos @kc88_first_38 @kc88_second_64 -280;
-    pos @kc88_first_38 @kc88_second_65 -315;
-    pos @kc88_first_39 @kc88_second_6 -35;
-    pos @kc88_first_39 @kc88_second_12 -240;
-    pos @kc88_first_39 @kc88_second_13 -140;
-    pos @kc88_first_39 @kc88_second_14 -35;
-    pos @kc88_first_39 @kc88_second_15 -35;
-    pos @kc88_first_39 @kc88_second_34 -35;
-    pos @kc88_first_39 @kc88_second_45 1;
-    pos @kc88_first_39 @kc88_second_63 -35;
-    pos @kc88_first_39 @kc88_second_64 -35;
-    pos @kc88_first_40 @kc88_second_12 -210;
-    pos @kc88_first_40 @kc88_second_13 -175;
-    pos @kc88_first_40 @kc88_second_14 -105;
-    pos @kc88_first_40 @kc88_second_15 -70;
-    pos @kc88_first_40 @kc88_second_43 -70;
-    pos @kc88_first_40 @kc88_second_45 1;
-    pos @kc88_first_40 @kc88_second_48 -105;
-    pos @kc88_first_40 @kc88_second_61 -70;
-    pos @kc88_first_41 @kc88_second_1 -140;
-    pos @kc88_first_41 @kc88_second_2 -175;
-    pos @kc88_first_41 @kc88_second_5 -105;
-    pos @kc88_first_41 @kc88_second_6 -70;
-    pos @kc88_first_41 @kc88_second_11 -70;
-    pos @kc88_first_41 @kc88_second_12 -175;
-    pos @kc88_first_41 @kc88_second_13 -105;
-    pos @kc88_first_41 @kc88_second_14 -70;
-    pos @kc88_first_41 @kc88_second_15 -35;
-    pos @kc88_first_41 @kc88_second_16 -105;
-    pos @kc88_first_41 @kc88_second_17 -35;
-    pos @kc88_first_41 @kc88_second_19 -175;
-    pos @kc88_first_41 @kc88_second_22 -50;
-    pos @kc88_first_41 @kc88_second_24 -105;
-    pos @kc88_first_41 @kc88_second_29 -35;
-    pos @kc88_first_41 @kc88_second_34 -70;
-    pos @kc88_first_41 @kc88_second_35 -140;
-    pos @kc88_first_41 @kc88_second_36 -35;
-    pos @kc88_first_41 @kc88_second_38 -50;
-    pos @kc88_first_41 @kc88_second_45 1;
-    pos @kc88_first_41 @kc88_second_51 -35;
-    pos @kc88_first_41 @kc88_second_53 -105;
-    pos @kc88_first_41 @kc88_second_55 -105;
-    pos @kc88_first_41 @kc88_second_57 -105;
-    pos @kc88_first_41 @kc88_second_63 -50;
-    pos @kc88_first_41 @kc88_second_64 -70;
-    pos @kc88_first_42 @kc88_second_1 -210;
-    pos @kc88_first_42 @kc88_second_2 -280;
-    pos @kc88_first_42 @kc88_second_3 -70;
-    pos @kc88_first_42 @kc88_second_6 -280;
-    pos @kc88_first_42 @kc88_second_8 -35;
-    pos @kc88_first_42 @kc88_second_11 -70;
-    pos @kc88_first_42 @kc88_second_13 -140;
-    pos @kc88_first_42 @kc88_second_14 -35;
-    pos @kc88_first_42 @kc88_second_15 -35;
-    pos @kc88_first_42 @kc88_second_16 -140;
-    pos @kc88_first_42 @kc88_second_17 -105;
-    pos @kc88_first_42 @kc88_second_19 -280;
-    pos @kc88_first_42 @kc88_second_20 -140;
-    pos @kc88_first_42 @kc88_second_22 -140;
-    pos @kc88_first_42 @kc88_second_23 -140;
-    pos @kc88_first_42 @kc88_second_24 -210;
-    pos @kc88_first_42 @kc88_second_34 -280;
-    pos @kc88_first_42 @kc88_second_35 -140;
-    pos @kc88_first_42 @kc88_second_36 -70;
-    pos @kc88_first_42 @kc88_second_37 -140;
-    pos @kc88_first_42 @kc88_second_38 -175;
-    pos @kc88_first_42 @kc88_second_44 -70;
-    pos @kc88_first_42 @kc88_second_45 1;
-    pos @kc88_first_42 @kc88_second_53 -210;
-    pos @kc88_first_42 @kc88_second_55 -175;
-    pos @kc88_first_42 @kc88_second_57 -210;
-    pos @kc88_first_42 @kc88_second_59 -70;
-    pos @kc88_first_42 @kc88_second_63 -175;
-    pos @kc88_first_42 @kc88_second_64 -175;
-    pos @kc88_first_43 @kc88_second_9 -70;
-    pos @kc88_first_43 @kc88_second_12 -240;
-    pos @kc88_first_43 @kc88_second_13 -210;
-    pos @kc88_first_43 @kc88_second_14 -140;
-    pos @kc88_first_43 @kc88_second_15 -105;
-    pos @kc88_first_43 @kc88_second_39 -70;
-    pos @kc88_first_43 @kc88_second_40 -35;
-    pos @kc88_first_43 @kc88_second_43 -140;
-    pos @kc88_first_43 @kc88_second_45 1;
-    pos @kc88_first_43 @kc88_second_47 -50;
-    pos @kc88_first_43 @kc88_second_48 -140;
-    pos @kc88_first_43 @kc88_second_58 -35;
-    pos @kc88_first_43 @kc88_second_60 -35;
-    pos @kc88_first_43 @kc88_second_61 -70;
-    pos @kc88_first_43 @kc88_second_62 -70;
-    pos @kc88_first_44 @kc88_second_8 -35;
-    pos @kc88_first_44 @kc88_second_9 -70;
-    pos @kc88_first_44 @kc88_second_12 -240;
-    pos @kc88_first_44 @kc88_second_13 -210;
-    pos @kc88_first_44 @kc88_second_14 -70;
-    pos @kc88_first_44 @kc88_second_15 -105;
-    pos @kc88_first_44 @kc88_second_22 -35;
-    pos @kc88_first_44 @kc88_second_38 -70;
-    pos @kc88_first_44 @kc88_second_39 -105;
-    pos @kc88_first_44 @kc88_second_40 -70;
-    pos @kc88_first_44 @kc88_second_43 -70;
-    pos @kc88_first_44 @kc88_second_44 -35;
-    pos @kc88_first_44 @kc88_second_45 1;
-    pos @kc88_first_44 @kc88_second_47 -70;
-    pos @kc88_first_44 @kc88_second_48 -70;
-    pos @kc88_first_44 @kc88_second_58 -70;
-    pos @kc88_first_44 @kc88_second_60 -50;
-    pos @kc88_first_44 @kc88_second_62 -70;
-    pos @kc88_first_44 @kc88_second_63 -35;
-    pos @kc88_first_44 @kc88_second_64 -35;
-    pos @kc88_first_45 @kc88_second_6 -70;
-    pos @kc88_first_45 @kc88_second_8 -35;
-    pos @kc88_first_45 @kc88_second_12 -175;
-    pos @kc88_first_45 @kc88_second_13 -140;
-    pos @kc88_first_45 @kc88_second_14 -70;
-    pos @kc88_first_45 @kc88_second_15 -35;
-    pos @kc88_first_45 @kc88_second_17 -70;
-    pos @kc88_first_45 @kc88_second_20 -70;
-    pos @kc88_first_45 @kc88_second_22 -105;
-    pos @kc88_first_45 @kc88_second_29 -35;
-    pos @kc88_first_45 @kc88_second_34 -70;
-    pos @kc88_first_45 @kc88_second_36 -35;
-    pos @kc88_first_45 @kc88_second_38 -105;
-    pos @kc88_first_45 @kc88_second_45 1;
-    pos @kc88_first_45 @kc88_second_51 -35;
-    pos @kc88_first_45 @kc88_second_63 -70;
-    pos @kc88_first_45 @kc88_second_64 -70;
-    pos @kc88_first_46 @kc88_second_3 -140;
-    pos @kc88_first_46 @kc88_second_4 -70;
-    pos @kc88_first_46 @kc88_second_6 -70;
-    pos @kc88_first_46 @kc88_second_8 -210;
-    pos @kc88_first_46 @kc88_second_9 -420;
-    pos @kc88_first_46 @kc88_second_12 -350;
-    pos @kc88_first_46 @kc88_second_13 -420;
-    pos @kc88_first_46 @kc88_second_14 -350;
-    pos @kc88_first_46 @kc88_second_15 -280;
-    pos @kc88_first_46 @kc88_second_17 -70;
-    pos @kc88_first_46 @kc88_second_18 -210;
-    pos @kc88_first_46 @kc88_second_20 -210;
-    pos @kc88_first_46 @kc88_second_22 -70;
-    pos @kc88_first_46 @kc88_second_23 -140;
-    pos @kc88_first_46 @kc88_second_29 -35;
-    pos @kc88_first_46 @kc88_second_31 -140;
-    pos @kc88_first_46 @kc88_second_34 -70;
-    pos @kc88_first_46 @kc88_second_36 -70;
-    pos @kc88_first_46 @kc88_second_38 -210;
-    pos @kc88_first_46 @kc88_second_39 -280;
-    pos @kc88_first_46 @kc88_second_40 -420;
-    pos @kc88_first_46 @kc88_second_43 -350;
-    pos @kc88_first_46 @kc88_second_45 1;
-    pos @kc88_first_46 @kc88_second_46 -35;
-    pos @kc88_first_46 @kc88_second_47 -210;
-    pos @kc88_first_46 @kc88_second_48 -350;
-    pos @kc88_first_46 @kc88_second_51 -35;
-    pos @kc88_first_46 @kc88_second_52 -35;
-    pos @kc88_first_46 @kc88_second_58 -280;
-    pos @kc88_first_46 @kc88_second_60 -175;
-    pos @kc88_first_46 @kc88_second_61 -280;
-    pos @kc88_first_46 @kc88_second_62 -210;
-    pos @kc88_first_46 @kc88_second_63 -70;
-    pos @kc88_first_47 @kc88_second_3 -140;
-    pos @kc88_first_47 @kc88_second_4 -105;
-    pos @kc88_first_47 @kc88_second_6 -70;
-    pos @kc88_first_47 @kc88_second_8 -210;
-    pos @kc88_first_47 @kc88_second_9 -280;
-    pos @kc88_first_47 @kc88_second_12 -350;
-    pos @kc88_first_47 @kc88_second_13 -385;
-    pos @kc88_first_47 @kc88_second_14 -350;
-    pos @kc88_first_47 @kc88_second_15 -280;
-    pos @kc88_first_47 @kc88_second_18 -210;
-    pos @kc88_first_47 @kc88_second_20 -140;
-    pos @kc88_first_47 @kc88_second_22 -105;
-    pos @kc88_first_47 @kc88_second_23 -140;
-    pos @kc88_first_47 @kc88_second_29 -70;
-    pos @kc88_first_47 @kc88_second_31 -175;
-    pos @kc88_first_47 @kc88_second_34 -70;
-    pos @kc88_first_47 @kc88_second_36 -35;
-    pos @kc88_first_47 @kc88_second_38 -175;
-    pos @kc88_first_47 @kc88_second_39 -280;
-    pos @kc88_first_47 @kc88_second_40 -280;
-    pos @kc88_first_47 @kc88_second_43 -280;
-    pos @kc88_first_47 @kc88_second_44 -140;
-    pos @kc88_first_47 @kc88_second_45 1;
-    pos @kc88_first_47 @kc88_second_46 -70;
-    pos @kc88_first_47 @kc88_second_47 -280;
-    pos @kc88_first_47 @kc88_second_48 -350;
-    pos @kc88_first_47 @kc88_second_51 -35;
-    pos @kc88_first_47 @kc88_second_52 -70;
-    pos @kc88_first_47 @kc88_second_58 -245;
-    pos @kc88_first_47 @kc88_second_60 -245;
-    pos @kc88_first_47 @kc88_second_61 -280;
-    pos @kc88_first_47 @kc88_second_62 -210;
-    pos @kc88_first_47 @kc88_second_63 -70;
-    pos @kc88_first_47 @kc88_second_64 -70;
-    pos @kc88_first_48 @kc88_second_3 -70;
-    pos @kc88_first_48 @kc88_second_4 -105;
-    pos @kc88_first_48 @kc88_second_6 -210;
-    pos @kc88_first_48 @kc88_second_7 -70;
-    pos @kc88_first_48 @kc88_second_8 -175;
-    pos @kc88_first_48 @kc88_second_17 -210;
-    pos @kc88_first_48 @kc88_second_20 -140;
-    pos @kc88_first_48 @kc88_second_21 -210;
-    pos @kc88_first_48 @kc88_second_22 -210;
-    pos @kc88_first_48 @kc88_second_23 -210;
-    pos @kc88_first_48 @kc88_second_24 -140;
-    pos @kc88_first_48 @kc88_second_25 -140;
-    pos @kc88_first_48 @kc88_second_27 -140;
-    pos @kc88_first_48 @kc88_second_29 -210;
-    pos @kc88_first_48 @kc88_second_30 -210;
-    pos @kc88_first_48 @kc88_second_31 -140;
-    pos @kc88_first_48 @kc88_second_34 -210;
-    pos @kc88_first_48 @kc88_second_35 -70;
-    pos @kc88_first_48 @kc88_second_36 -175;
-    pos @kc88_first_48 @kc88_second_37 -210;
-    pos @kc88_first_48 @kc88_second_38 -175;
-    pos @kc88_first_48 @kc88_second_39 -210;
-    pos @kc88_first_48 @kc88_second_40 -105;
-    pos @kc88_first_48 @kc88_second_43 -70;
-    pos @kc88_first_48 @kc88_second_44 -105;
-    pos @kc88_first_48 @kc88_second_45 1;
-    pos @kc88_first_48 @kc88_second_46 -35;
-    pos @kc88_first_48 @kc88_second_47 -210;
-    pos @kc88_first_48 @kc88_second_50 -210;
-    pos @kc88_first_48 @kc88_second_51 -210;
-    pos @kc88_first_48 @kc88_second_52 -175;
-    pos @kc88_first_48 @kc88_second_53 -175;
-    pos @kc88_first_48 @kc88_second_55 -210;
-    pos @kc88_first_48 @kc88_second_56 -140;
-    pos @kc88_first_48 @kc88_second_57 -210;
-    pos @kc88_first_48 @kc88_second_58 -210;
-    pos @kc88_first_48 @kc88_second_59 -175;
-    pos @kc88_first_48 @kc88_second_60 -175;
-    pos @kc88_first_48 @kc88_second_63 -210;
-    pos @kc88_first_48 @kc88_second_64 -210;
-    pos @kc88_first_49 @kc88_second_5 -70;
-    pos @kc88_first_49 @kc88_second_11 -35;
-    pos @kc88_first_49 @kc88_second_12 -240;
-    pos @kc88_first_49 @kc88_second_13 -70;
-    pos @kc88_first_49 @kc88_second_14 -140;
-    pos @kc88_first_49 @kc88_second_15 -105;
-    pos @kc88_first_49 @kc88_second_16 -70;
-    pos @kc88_first_49 @kc88_second_26 -70;
-    pos @kc88_first_49 @kc88_second_27 -70;
-    pos @kc88_first_49 @kc88_second_35 -35;
-    pos @kc88_first_49 @kc88_second_39 -70;
-    pos @kc88_first_49 @kc88_second_42 -35;
-    pos @kc88_first_49 @kc88_second_43 -70;
-    pos @kc88_first_49 @kc88_second_45 1;
-    pos @kc88_first_49 @kc88_second_47 -35;
-    pos @kc88_first_49 @kc88_second_48 -140;
-    pos @kc88_first_49 @kc88_second_51 1;
-    pos @kc88_first_49 @kc88_second_56 -35;
-    pos @kc88_first_49 @kc88_second_60 -35;
-    pos @kc88_first_49 @kc88_second_61 -105;
-    pos @kc88_first_49 @kc88_second_62 -70;
-    pos @kc88_first_50 @kc88_second_65 -70;
-    pos @kc88_first_51 @kc88_second_32 -315;
-    pos @kc88_first_51 @kc88_second_66 -70;
-    pos @kc88_first_52 @kc88_second_1 -105;
-    pos @kc88_first_52 @kc88_second_2 -210;
-    pos @kc88_first_52 @kc88_second_6 -140;
-    pos @kc88_first_52 @kc88_second_11 -70;
-    pos @kc88_first_52 @kc88_second_12 -210;
-    pos @kc88_first_52 @kc88_second_13 -210;
-    pos @kc88_first_52 @kc88_second_14 -105;
-    pos @kc88_first_52 @kc88_second_15 -70;
-    pos @kc88_first_52 @kc88_second_16 -140;
-    pos @kc88_first_52 @kc88_second_17 -35;
-    pos @kc88_first_52 @kc88_second_22 -35;
-    pos @kc88_first_52 @kc88_second_24 -210;
-    pos @kc88_first_52 @kc88_second_26 -70;
-    pos @kc88_first_52 @kc88_second_27 -70;
-    pos @kc88_first_52 @kc88_second_29 -35;
-    pos @kc88_first_52 @kc88_second_34 -210;
-    pos @kc88_first_52 @kc88_second_35 -140;
-    pos @kc88_first_52 @kc88_second_42 -35;
-    pos @kc88_first_52 @kc88_second_43 -70;
-    pos @kc88_first_52 @kc88_second_45 1;
-    pos @kc88_first_52 @kc88_second_47 -35;
-    pos @kc88_first_52 @kc88_second_48 -105;
-    pos @kc88_first_52 @kc88_second_53 -210;
-    pos @kc88_first_52 @kc88_second_55 -140;
-    pos @kc88_first_52 @kc88_second_57 -175;
-    pos @kc88_first_52 @kc88_second_61 -35;
-    pos @kc88_first_52 @kc88_second_62 -35;
-    pos @kc88_first_52 @kc88_second_63 -35;
-    pos @kc88_first_52 @kc88_second_64 -70;
-    pos @kc88_first_53 @kc88_second_1 -35;
-    pos @kc88_first_53 @kc88_second_2 -70;
-    pos @kc88_first_53 @kc88_second_5 -105;
-    pos @kc88_first_53 @kc88_second_6 -35;
-    pos @kc88_first_53 @kc88_second_9 -70;
-    pos @kc88_first_53 @kc88_second_11 -70;
-    pos @kc88_first_53 @kc88_second_12 -240;
-    pos @kc88_first_53 @kc88_second_13 -245;
-    pos @kc88_first_53 @kc88_second_14 -140;
-    pos @kc88_first_53 @kc88_second_15 -105;
-    pos @kc88_first_53 @kc88_second_16 -105;
-    pos @kc88_first_53 @kc88_second_18 -70;
-    pos @kc88_first_53 @kc88_second_19 -70;
-    pos @kc88_first_53 @kc88_second_24 -35;
-    pos @kc88_first_53 @kc88_second_25 -70;
-    pos @kc88_first_53 @kc88_second_26 -140;
-    pos @kc88_first_53 @kc88_second_27 -105;
-    pos @kc88_first_53 @kc88_second_34 -35;
-    pos @kc88_first_53 @kc88_second_35 -140;
-    pos @kc88_first_53 @kc88_second_39 -105;
-    pos @kc88_first_53 @kc88_second_40 -70;
-    pos @kc88_first_53 @kc88_second_42 -105;
-    pos @kc88_first_53 @kc88_second_43 -175;
-    pos @kc88_first_53 @kc88_second_45 1;
-    pos @kc88_first_53 @kc88_second_47 -70;
-    pos @kc88_first_53 @kc88_second_48 -140;
-    pos @kc88_first_53 @kc88_second_49 -70;
-    pos @kc88_first_53 @kc88_second_53 -210;
-    pos @kc88_first_53 @kc88_second_54 -70;
-    pos @kc88_first_53 @kc88_second_55 -175;
-    pos @kc88_first_53 @kc88_second_56 -105;
-    pos @kc88_first_53 @kc88_second_57 -175;
-    pos @kc88_first_53 @kc88_second_60 -50;
-    pos @kc88_first_53 @kc88_second_61 -105;
-    pos @kc88_first_53 @kc88_second_62 -70;
-    pos @kc88_first_53 @kc88_second_64 -35;
-    pos @kc88_first_54 @kc88_second_1 -105;
-    pos @kc88_first_54 @kc88_second_2 -210;
-    pos @kc88_first_54 @kc88_second_5 -70;
-    pos @kc88_first_54 @kc88_second_6 -105;
-    pos @kc88_first_54 @kc88_second_13 -70;
-    pos @kc88_first_54 @kc88_second_14 -35;
-    pos @kc88_first_54 @kc88_second_16 -140;
-    pos @kc88_first_54 @kc88_second_17 -70;
-    pos @kc88_first_54 @kc88_second_19 -210;
-    pos @kc88_first_54 @kc88_second_22 -35;
-    pos @kc88_first_54 @kc88_second_24 -210;
-    pos @kc88_first_54 @kc88_second_29 -35;
-    pos @kc88_first_54 @kc88_second_32 -105;
-    pos @kc88_first_54 @kc88_second_34 -105;
-    pos @kc88_first_54 @kc88_second_35 -140;
-    pos @kc88_first_54 @kc88_second_38 -70;
-    pos @kc88_first_54 @kc88_second_45 1;
-    pos @kc88_first_54 @kc88_second_51 -35;
-    pos @kc88_first_54 @kc88_second_53 -245;
-    pos @kc88_first_54 @kc88_second_55 -210;
-    pos @kc88_first_54 @kc88_second_57 -210;
-    pos @kc88_first_54 @kc88_second_63 -70;
-    pos @kc88_first_54 @kc88_second_64 -105;
-    pos @kc88_first_55 @kc88_second_12 -240;
-    pos @kc88_first_55 @kc88_second_13 -140;
-    pos @kc88_first_55 @kc88_second_14 -105;
-    pos @kc88_first_55 @kc88_second_15 -35;
-    pos @kc88_first_55 @kc88_second_33 165;
-    pos @kc88_first_55 @kc88_second_45 1;
-    pos @kc88_first_55 @kc88_second_50 165;
-    pos @kc88_first_56 @kc88_second_1 -140;
-    pos @kc88_first_56 @kc88_second_2 -210;
-    pos @kc88_first_56 @kc88_second_6 -140;
-    pos @kc88_first_56 @kc88_second_12 -175;
-    pos @kc88_first_56 @kc88_second_13 -140;
-    pos @kc88_first_56 @kc88_second_16 -140;
-    pos @kc88_first_56 @kc88_second_19 -210;
-    pos @kc88_first_56 @kc88_second_24 -210;
-    pos @kc88_first_56 @kc88_second_32 -140;
-    pos @kc88_first_56 @kc88_second_34 -140;
-    pos @kc88_first_56 @kc88_second_35 -210;
-    pos @kc88_first_56 @kc88_second_36 -35;
-    pos @kc88_first_56 @kc88_second_45 1;
-    pos @kc88_first_56 @kc88_second_53 -210;
-    pos @kc88_first_56 @kc88_second_55 -175;
-    pos @kc88_first_56 @kc88_second_57 -175;
-    pos @kc88_first_56 @kc88_second_63 -105;
-    pos @kc88_first_56 @kc88_second_64 -210;
-    pos @kc88_first_57 @kc88_second_12 -240;
-    pos @kc88_first_57 @kc88_second_13 -175;
-    pos @kc88_first_57 @kc88_second_14 -70;
-    pos @kc88_first_57 @kc88_second_15 -35;
-    pos @kc88_first_57 @kc88_second_19 -35;
-    pos @kc88_first_57 @kc88_second_26 -35;
-    pos @kc88_first_57 @kc88_second_39 -35;
-    pos @kc88_first_57 @kc88_second_40 -35;
-    pos @kc88_first_57 @kc88_second_43 -70;
-    pos @kc88_first_57 @kc88_second_45 1;
-    pos @kc88_first_57 @kc88_second_47 -35;
-    pos @kc88_first_57 @kc88_second_48 -70;
-    pos @kc88_first_57 @kc88_second_58 -35;
-    pos @kc88_first_57 @kc88_second_60 -35;
-    pos @kc88_first_57 @kc88_second_61 -70;
-    pos @kc88_first_57 @kc88_second_62 -35;
-    pos @kc88_first_58 @kc88_second_13 -35;
-    pos @kc88_first_58 @kc88_second_58 -35;
-    pos @kc88_first_58 @kc88_second_64 -35;
-    pos @kc88_first_59 @kc88_second_12 -175;
-    pos @kc88_first_59 @kc88_second_13 -140;
-    pos @kc88_first_59 @kc88_second_14 -35;
-    pos @kc88_first_59 @kc88_second_45 1;
-    pos @kc88_first_60 @kc88_second_1 -140;
-    pos @kc88_first_60 @kc88_second_2 -280;
-    pos @kc88_first_60 @kc88_second_5 -140;
-    pos @kc88_first_60 @kc88_second_6 -280;
-    pos @kc88_first_60 @kc88_second_8 -70;
-    pos @kc88_first_60 @kc88_second_10 -70;
-    pos @kc88_first_60 @kc88_second_11 -175;
-    pos @kc88_first_60 @kc88_second_12 -240;
-    pos @kc88_first_60 @kc88_second_13 -140;
-    pos @kc88_first_60 @kc88_second_14 -105;
-    pos @kc88_first_60 @kc88_second_15 -70;
-    pos @kc88_first_60 @kc88_second_16 -175;
-    pos @kc88_first_60 @kc88_second_17 -70;
-    pos @kc88_first_60 @kc88_second_19 -280;
-    pos @kc88_first_60 @kc88_second_22 -70;
-    pos @kc88_first_60 @kc88_second_23 -70;
-    pos @kc88_first_60 @kc88_second_24 -210;
-    pos @kc88_first_60 @kc88_second_26 -70;
-    pos @kc88_first_60 @kc88_second_27 -70;
-    pos @kc88_first_60 @kc88_second_29 -70;
-    pos @kc88_first_60 @kc88_second_32 -70;
-    pos @kc88_first_60 @kc88_second_34 -315;
-    pos @kc88_first_60 @kc88_second_35 -140;
-    pos @kc88_first_60 @kc88_second_36 -70;
-    pos @kc88_first_60 @kc88_second_38 -105;
-    pos @kc88_first_60 @kc88_second_45 1;
-    pos @kc88_first_60 @kc88_second_48 -35;
-    pos @kc88_first_60 @kc88_second_51 -50;
-    pos @kc88_first_60 @kc88_second_53 -210;
-    pos @kc88_first_60 @kc88_second_55 -175;
-    pos @kc88_first_60 @kc88_second_57 -210;
-    pos @kc88_first_60 @kc88_second_59 -35;
-    pos @kc88_first_60 @kc88_second_61 -70;
-    pos @kc88_first_60 @kc88_second_62 -35;
-    pos @kc88_first_60 @kc88_second_63 -140;
-    pos @kc88_first_60 @kc88_second_64 -210;
-    pos @kc88_first_61 @kc88_second_1 -35;
-    pos @kc88_first_61 @kc88_second_2 -70;
-    pos @kc88_first_61 @kc88_second_5 -70;
-    pos @kc88_first_61 @kc88_second_11 -35;
-    pos @kc88_first_61 @kc88_second_12 -140;
-    pos @kc88_first_61 @kc88_second_13 -140;
-    pos @kc88_first_61 @kc88_second_14 -70;
-    pos @kc88_first_61 @kc88_second_15 -35;
-    pos @kc88_first_61 @kc88_second_16 -105;
-    pos @kc88_first_61 @kc88_second_26 -35;
-    pos @kc88_first_61 @kc88_second_27 -70;
-    pos @kc88_first_61 @kc88_second_35 -70;
-    pos @kc88_first_61 @kc88_second_43 -70;
-    pos @kc88_first_61 @kc88_second_45 1;
-    pos @kc88_first_61 @kc88_second_53 -175;
-    pos @kc88_first_61 @kc88_second_55 -140;
-    pos @kc88_first_61 @kc88_second_57 -140;
-    pos @kc88_first_61 @kc88_second_61 -35;
-    pos @kc88_first_62 @kc88_second_5 -70;
-    pos @kc88_first_62 @kc88_second_9 -70;
-    pos @kc88_first_62 @kc88_second_11 -35;
-    pos @kc88_first_62 @kc88_second_12 -350;
-    pos @kc88_first_62 @kc88_second_13 -315;
-    pos @kc88_first_62 @kc88_second_14 -175;
-    pos @kc88_first_62 @kc88_second_15 -140;
-    pos @kc88_first_62 @kc88_second_16 -70;
-    pos @kc88_first_62 @kc88_second_18 -70;
-    pos @kc88_first_62 @kc88_second_27 -70;
-    pos @kc88_first_62 @kc88_second_31 -50;
-    pos @kc88_first_62 @kc88_second_39 -140;
-    pos @kc88_first_62 @kc88_second_40 -50;
-    pos @kc88_first_62 @kc88_second_42 -35;
-    pos @kc88_first_62 @kc88_second_43 -175;
-    pos @kc88_first_62 @kc88_second_45 1;
-    pos @kc88_first_62 @kc88_second_47 -70;
-    pos @kc88_first_62 @kc88_second_48 -175;
-    pos @kc88_first_62 @kc88_second_54 -70;
-    pos @kc88_first_62 @kc88_second_58 -70;
-    pos @kc88_first_62 @kc88_second_60 -50;
-    pos @kc88_first_62 @kc88_second_61 -140;
-    pos @kc88_first_62 @kc88_second_62 -105;
-    pos @kc88_first_63 @kc88_second_4 -105;
-    pos @kc88_first_63 @kc88_second_6 -35;
-    pos @kc88_first_63 @kc88_second_8 1;
-    pos @kc88_first_63 @kc88_second_9 -245;
-    pos @kc88_first_63 @kc88_second_12 -210;
-    pos @kc88_first_63 @kc88_second_13 -210;
-    pos @kc88_first_63 @kc88_second_14 -210;
-    pos @kc88_first_63 @kc88_second_15 -175;
-    pos @kc88_first_63 @kc88_second_17 -70;
-    pos @kc88_first_63 @kc88_second_18 -180;
-    pos @kc88_first_63 @kc88_second_20 -140;
-    pos @kc88_first_63 @kc88_second_22 -105;
-    pos @kc88_first_63 @kc88_second_25 -140;
-    pos @kc88_first_63 @kc88_second_29 -105;
-    pos @kc88_first_63 @kc88_second_31 -140;
-    pos @kc88_first_63 @kc88_second_34 -35;
-    pos @kc88_first_63 @kc88_second_36 -35;
-    pos @kc88_first_63 @kc88_second_38 -175;
-    pos @kc88_first_63 @kc88_second_39 -142;
-    pos @kc88_first_63 @kc88_second_40 -245;
-    pos @kc88_first_63 @kc88_second_43 -210;
-    pos @kc88_first_63 @kc88_second_44 -105;
-    pos @kc88_first_63 @kc88_second_45 1;
-    pos @kc88_first_63 @kc88_second_46 -35;
-    pos @kc88_first_63 @kc88_second_47 -210;
-    pos @kc88_first_63 @kc88_second_48 -210;
-    pos @kc88_first_63 @kc88_second_51 -35;
-    pos @kc88_first_63 @kc88_second_58 -280;
-    pos @kc88_first_63 @kc88_second_60 -175;
-    pos @kc88_first_63 @kc88_second_61 -140;
-    pos @kc88_first_63 @kc88_second_62 -140;
-    pos @kc88_first_63 @kc88_second_63 -70;
-    pos @kc88_first_63 @kc88_second_64 -70;
-    pos @kc88_first_64 @kc88_second_1 -175;
-    pos @kc88_first_64 @kc88_second_2 -175;
-    pos @kc88_first_64 @kc88_second_5 -70;
-    pos @kc88_first_64 @kc88_second_6 -105;
-    pos @kc88_first_64 @kc88_second_11 -105;
-    pos @kc88_first_64 @kc88_second_12 -175;
-    pos @kc88_first_64 @kc88_second_13 -140;
-    pos @kc88_first_64 @kc88_second_14 -70;
-    pos @kc88_first_64 @kc88_second_15 -35;
-    pos @kc88_first_64 @kc88_second_16 -140;
-    pos @kc88_first_64 @kc88_second_17 -70;
-    pos @kc88_first_64 @kc88_second_19 -175;
-    pos @kc88_first_64 @kc88_second_22 -70;
-    pos @kc88_first_64 @kc88_second_29 -35;
-    pos @kc88_first_64 @kc88_second_34 -105;
-    pos @kc88_first_64 @kc88_second_35 -175;
-    pos @kc88_first_64 @kc88_second_36 -35;
-    pos @kc88_first_64 @kc88_second_38 -70;
-    pos @kc88_first_64 @kc88_second_45 1;
-    pos @kc88_first_64 @kc88_second_51 -35;
-    pos @kc88_first_64 @kc88_second_53 -140;
-    pos @kc88_first_64 @kc88_second_55 -140;
-    pos @kc88_first_64 @kc88_second_57 -140;
-    pos @kc88_first_64 @kc88_second_63 -70;
-    pos @kc88_first_64 @kc88_second_64 -105;
-    pos @kc88_first_65 @kc88_second_1 -210;
-    pos @kc88_first_65 @kc88_second_2 -210;
-    pos @kc88_first_65 @kc88_second_3 -70;
-    pos @kc88_first_65 @kc88_second_4 -35;
-    pos @kc88_first_65 @kc88_second_6 -210;
-    pos @kc88_first_65 @kc88_second_7 -70;
-    pos @kc88_first_65 @kc88_second_8 -70;
-    pos @kc88_first_65 @kc88_second_16 -70;
-    pos @kc88_first_65 @kc88_second_17 -140;
-    pos @kc88_first_65 @kc88_second_19 -210;
-    pos @kc88_first_65 @kc88_second_20 -140;
-    pos @kc88_first_65 @kc88_second_21 -35;
-    pos @kc88_first_65 @kc88_second_22 -175;
-    pos @kc88_first_65 @kc88_second_23 -140;
-    pos @kc88_first_65 @kc88_second_24 -280;
-    pos @kc88_first_65 @kc88_second_29 -35;
-    pos @kc88_first_65 @kc88_second_30 -35;
-    pos @kc88_first_65 @kc88_second_32 -210;
-    pos @kc88_first_65 @kc88_second_34 -245;
-    pos @kc88_first_65 @kc88_second_35 -140;
-    pos @kc88_first_65 @kc88_second_36 -140;
-    pos @kc88_first_65 @kc88_second_37 -140;
-    pos @kc88_first_65 @kc88_second_38 -140;
-    pos @kc88_first_65 @kc88_second_39 -35;
-    pos @kc88_first_65 @kc88_second_44 -35;
-    pos @kc88_first_65 @kc88_second_45 1;
-    pos @kc88_first_65 @kc88_second_49 -35;
-    pos @kc88_first_65 @kc88_second_51 -140;
-    pos @kc88_first_65 @kc88_second_52 -70;
-    pos @kc88_first_65 @kc88_second_53 -210;
-    pos @kc88_first_65 @kc88_second_55 -210;
-    pos @kc88_first_65 @kc88_second_57 -210;
-    pos @kc88_first_65 @kc88_second_58 -35;
-    pos @kc88_first_65 @kc88_second_63 -175;
-    pos @kc88_first_65 @kc88_second_64 -245;
-    pos @kc88_first_66 @kc88_second_6 -35;
-    pos @kc88_first_66 @kc88_second_12 -240;
-    pos @kc88_first_66 @kc88_second_13 -140;
-    pos @kc88_first_66 @kc88_second_14 -70;
-    pos @kc88_first_66 @kc88_second_15 -35;
-    pos @kc88_first_66 @kc88_second_20 -35;
-    pos @kc88_first_66 @kc88_second_22 -35;
-    pos @kc88_first_66 @kc88_second_34 -70;
-    pos @kc88_first_66 @kc88_second_38 -70;
-    pos @kc88_first_66 @kc88_second_39 -50;
-    pos @kc88_first_66 @kc88_second_45 1;
-    pos @kc88_first_66 @kc88_second_48 -35;
-    pos @kc88_first_66 @kc88_second_63 -35;
-    pos @kc88_first_66 @kc88_second_64 -35;
-    pos @kc88_first_67 @kc88_second_3 -100;
-    pos @kc88_first_67 @kc88_second_4 -50;
-    pos @kc88_first_67 @kc88_second_6 -50;
-    pos @kc88_first_67 @kc88_second_8 -70;
-    pos @kc88_first_67 @kc88_second_9 -140;
-    pos @kc88_first_67 @kc88_second_10 -50;
-    pos @kc88_first_67 @kc88_second_12 -140;
-    pos @kc88_first_67 @kc88_second_13 -100;
-    pos @kc88_first_67 @kc88_second_14 -70;
-    pos @kc88_first_67 @kc88_second_15 -50;
-    pos @kc88_first_67 @kc88_second_18 -70;
-    pos @kc88_first_67 @kc88_second_20 -70;
-    pos @kc88_first_67 @kc88_second_22 -50;
-    pos @kc88_first_67 @kc88_second_23 -70;
-    pos @kc88_first_67 @kc88_second_29 -35;
-    pos @kc88_first_67 @kc88_second_31 -70;
-    pos @kc88_first_67 @kc88_second_33 105;
-    pos @kc88_first_67 @kc88_second_34 -35;
-    pos @kc88_first_67 @kc88_second_38 -70;
-    pos @kc88_first_67 @kc88_second_39 -140;
-    pos @kc88_first_67 @kc88_second_40 -140;
-    pos @kc88_first_67 @kc88_second_43 -140;
-    pos @kc88_first_67 @kc88_second_44 -35;
-    pos @kc88_first_67 @kc88_second_45 1;
-    pos @kc88_first_67 @kc88_second_47 -70;
-    pos @kc88_first_67 @kc88_second_48 -100;
-    pos @kc88_first_67 @kc88_second_50 105;
-    pos @kc88_first_67 @kc88_second_58 -140;
-    pos @kc88_first_67 @kc88_second_60 -70;
-    pos @kc88_first_67 @kc88_second_61 -70;
-    pos @kc88_first_67 @kc88_second_62 -50;
-    pos @kc88_first_67 @kc88_second_63 -35;
-    pos @kc88_first_67 @kc88_second_64 -35;
-    pos @kc88_first_68 @kc88_second_3 -70;
-    pos @kc88_first_68 @kc88_second_4 -50;
-    pos @kc88_first_68 @kc88_second_6 -50;
-    pos @kc88_first_68 @kc88_second_8 -70;
-    pos @kc88_first_68 @kc88_second_9 -140;
-    pos @kc88_first_68 @kc88_second_10 -50;
-    pos @kc88_first_68 @kc88_second_12 -240;
-    pos @kc88_first_68 @kc88_second_13 -240;
-    pos @kc88_first_68 @kc88_second_14 -175;
-    pos @kc88_first_68 @kc88_second_15 -140;
-    pos @kc88_first_68 @kc88_second_18 -70;
-    pos @kc88_first_68 @kc88_second_20 -70;
-    pos @kc88_first_68 @kc88_second_22 -50;
-    pos @kc88_first_68 @kc88_second_23 -70;
-    pos @kc88_first_68 @kc88_second_29 -35;
-    pos @kc88_first_68 @kc88_second_31 -70;
-    pos @kc88_first_68 @kc88_second_34 -35;
-    pos @kc88_first_68 @kc88_second_38 -70;
-    pos @kc88_first_68 @kc88_second_39 -140;
-    pos @kc88_first_68 @kc88_second_40 -140;
-    pos @kc88_first_68 @kc88_second_43 -140;
-    pos @kc88_first_68 @kc88_second_44 -35;
-    pos @kc88_first_68 @kc88_second_45 1;
-    pos @kc88_first_68 @kc88_second_47 -70;
-    pos @kc88_first_68 @kc88_second_48 -140;
-    pos @kc88_first_68 @kc88_second_58 -140;
-    pos @kc88_first_68 @kc88_second_60 -70;
-    pos @kc88_first_68 @kc88_second_61 -105;
-    pos @kc88_first_68 @kc88_second_62 -70;
-    pos @kc88_first_68 @kc88_second_63 -35;
-    pos @kc88_first_68 @kc88_second_64 -35;
-    pos @kc88_first_69 @kc88_second_3 -70;
-    pos @kc88_first_69 @kc88_second_4 -50;
-    pos @kc88_first_69 @kc88_second_6 -50;
-    pos @kc88_first_69 @kc88_second_8 -70;
-    pos @kc88_first_69 @kc88_second_9 -140;
-    pos @kc88_first_69 @kc88_second_10 -50;
-    pos @kc88_first_69 @kc88_second_12 -140;
-    pos @kc88_first_69 @kc88_second_13 -140;
-    pos @kc88_first_69 @kc88_second_14 -105;
-    pos @kc88_first_69 @kc88_second_15 -70;
-    pos @kc88_first_69 @kc88_second_18 -70;
-    pos @kc88_first_69 @kc88_second_20 -70;
-    pos @kc88_first_69 @kc88_second_22 -50;
-    pos @kc88_first_69 @kc88_second_23 -100;
-    pos @kc88_first_69 @kc88_second_29 -35;
-    pos @kc88_first_69 @kc88_second_31 -70;
-    pos @kc88_first_69 @kc88_second_33 105;
-    pos @kc88_first_69 @kc88_second_34 -35;
-    pos @kc88_first_69 @kc88_second_38 -70;
-    pos @kc88_first_69 @kc88_second_39 -140;
-    pos @kc88_first_69 @kc88_second_40 -140;
-    pos @kc88_first_69 @kc88_second_43 -140;
-    pos @kc88_first_69 @kc88_second_44 -35;
-    pos @kc88_first_69 @kc88_second_45 1;
-    pos @kc88_first_69 @kc88_second_47 -70;
-    pos @kc88_first_69 @kc88_second_48 -140;
-    pos @kc88_first_69 @kc88_second_50 105;
-    pos @kc88_first_69 @kc88_second_58 -140;
-    pos @kc88_first_69 @kc88_second_60 -70;
-    pos @kc88_first_69 @kc88_second_61 -70;
-    pos @kc88_first_69 @kc88_second_62 -50;
-    pos @kc88_first_69 @kc88_second_63 -35;
-    pos @kc88_first_69 @kc88_second_64 -35;
-    pos @kc88_first_70 @kc88_second_1 -210;
-    pos @kc88_first_70 @kc88_second_2 -210;
-    pos @kc88_first_70 @kc88_second_3 -35;
-    pos @kc88_first_70 @kc88_second_6 -140;
-    pos @kc88_first_70 @kc88_second_8 -70;
-    pos @kc88_first_70 @kc88_second_10 -35;
-    pos @kc88_first_70 @kc88_second_17 -70;
-    pos @kc88_first_70 @kc88_second_19 -210;
-    pos @kc88_first_70 @kc88_second_20 -70;
-    pos @kc88_first_70 @kc88_second_22 -105;
-    pos @kc88_first_70 @kc88_second_23 -105;
-    pos @kc88_first_70 @kc88_second_24 -175;
-    pos @kc88_first_70 @kc88_second_29 -105;
-    pos @kc88_first_70 @kc88_second_34 -175;
-    pos @kc88_first_70 @kc88_second_35 -140;
-    pos @kc88_first_70 @kc88_second_36 -70;
-    pos @kc88_first_70 @kc88_second_37 -105;
-    pos @kc88_first_70 @kc88_second_38 -105;
-    pos @kc88_first_70 @kc88_second_39 -70;
-    pos @kc88_first_70 @kc88_second_44 -35;
-    pos @kc88_first_70 @kc88_second_45 1;
-    pos @kc88_first_70 @kc88_second_50 -35;
-    pos @kc88_first_70 @kc88_second_51 -70;
-    pos @kc88_first_70 @kc88_second_52 -70;
-    pos @kc88_first_70 @kc88_second_53 -175;
-    pos @kc88_first_70 @kc88_second_55 -175;
-    pos @kc88_first_70 @kc88_second_57 -175;
-    pos @kc88_first_70 @kc88_second_58 -35;
-    pos @kc88_first_70 @kc88_second_59 -35;
-    pos @kc88_first_70 @kc88_second_63 -140;
-    pos @kc88_first_70 @kc88_second_64 -175;
-    pos @kc88_first_71 @kc88_second_5 -70;
-    pos @kc88_first_71 @kc88_second_8 -70;
-    pos @kc88_first_71 @kc88_second_9 -105;
-    pos @kc88_first_71 @kc88_second_11 -35;
-    pos @kc88_first_71 @kc88_second_12 -350;
-    pos @kc88_first_71 @kc88_second_13 -350;
-    pos @kc88_first_71 @kc88_second_14 -245;
-    pos @kc88_first_71 @kc88_second_15 -210;
-    pos @kc88_first_71 @kc88_second_16 -70;
-    pos @kc88_first_71 @kc88_second_18 -210;
-    pos @kc88_first_71 @kc88_second_23 -35;
-    pos @kc88_first_71 @kc88_second_26 -35;
-    pos @kc88_first_71 @kc88_second_27 -70;
-    pos @kc88_first_71 @kc88_second_31 -70;
-    pos @kc88_first_71 @kc88_second_38 -35;
-    pos @kc88_first_71 @kc88_second_39 -245;
-    pos @kc88_first_71 @kc88_second_40 -70;
-    pos @kc88_first_71 @kc88_second_42 -35;
-    pos @kc88_first_71 @kc88_second_43 -240;
-    pos @kc88_first_71 @kc88_second_45 1;
-    pos @kc88_first_71 @kc88_second_47 -105;
-    pos @kc88_first_71 @kc88_second_48 -280;
-    pos @kc88_first_71 @kc88_second_49 -35;
-    pos @kc88_first_71 @kc88_second_54 -35;
-    pos @kc88_first_71 @kc88_second_56 -70;
-    pos @kc88_first_71 @kc88_second_58 -105;
-    pos @kc88_first_71 @kc88_second_59 -35;
-    pos @kc88_first_71 @kc88_second_60 -70;
-    pos @kc88_first_71 @kc88_second_61 -175;
-    pos @kc88_first_71 @kc88_second_62 -140;
-    pos @kc88_first_72 @kc88_second_1 -140;
-    pos @kc88_first_72 @kc88_second_2 -140;
-    pos @kc88_first_72 @kc88_second_6 -140;
-    pos @kc88_first_72 @kc88_second_8 -35;
-    pos @kc88_first_72 @kc88_second_10 -35;
-    pos @kc88_first_72 @kc88_second_17 -35;
-    pos @kc88_first_72 @kc88_second_19 -140;
-    pos @kc88_first_72 @kc88_second_20 -35;
-    pos @kc88_first_72 @kc88_second_22 -70;
-    pos @kc88_first_72 @kc88_second_23 -70;
-    pos @kc88_first_72 @kc88_second_24 -140;
-    pos @kc88_first_72 @kc88_second_29 -70;
-    pos @kc88_first_72 @kc88_second_34 -175;
-    pos @kc88_first_72 @kc88_second_35 -105;
-    pos @kc88_first_72 @kc88_second_36 -70;
-    pos @kc88_first_72 @kc88_second_37 -70;
-    pos @kc88_first_72 @kc88_second_38 -70;
-    pos @kc88_first_72 @kc88_second_39 -35;
-    pos @kc88_first_72 @kc88_second_45 1;
-    pos @kc88_first_72 @kc88_second_50 -35;
-    pos @kc88_first_72 @kc88_second_51 -35;
-    pos @kc88_first_72 @kc88_second_53 -140;
-    pos @kc88_first_72 @kc88_second_55 -140;
-    pos @kc88_first_72 @kc88_second_57 -140;
-    pos @kc88_first_72 @kc88_second_63 -105;
-    pos @kc88_first_72 @kc88_second_64 -105;
+    pos @kc89_first_1 @kc89_second_3 -70;
+    pos @kc89_first_1 @kc89_second_8 -70;
+    pos @kc89_first_1 @kc89_second_9 -140;
+    pos @kc89_first_1 @kc89_second_10 -35;
+    pos @kc89_first_1 @kc89_second_12 -280;
+    pos @kc89_first_1 @kc89_second_13 -280;
+    pos @kc89_first_1 @kc89_second_14 -280;
+    pos @kc89_first_1 @kc89_second_15 -210;
+    pos @kc89_first_1 @kc89_second_20 -70;
+    pos @kc89_first_1 @kc89_second_23 -35;
+    pos @kc89_first_1 @kc89_second_25 -50;
+    pos @kc89_first_1 @kc89_second_31 -70;
+    pos @kc89_first_1 @kc89_second_38 -35;
+    pos @kc89_first_1 @kc89_second_39 -140;
+    pos @kc89_first_1 @kc89_second_40 -105;
+    pos @kc89_first_1 @kc89_second_43 -210;
+    pos @kc89_first_1 @kc89_second_44 -35;
+    pos @kc89_first_1 @kc89_second_45 1;
+    pos @kc89_first_1 @kc89_second_47 -175;
+    pos @kc89_first_1 @kc89_second_48 -210;
+    pos @kc89_first_1 @kc89_second_58 -140;
+    pos @kc89_first_1 @kc89_second_60 -140;
+    pos @kc89_first_1 @kc89_second_61 -210;
+    pos @kc89_first_1 @kc89_second_62 -140;
+    pos @kc89_first_2 @kc89_second_9 -35;
+    pos @kc89_first_2 @kc89_second_12 -70;
+    pos @kc89_first_2 @kc89_second_13 -70;
+    pos @kc89_first_2 @kc89_second_14 -70;
+    pos @kc89_first_2 @kc89_second_15 -35;
+    pos @kc89_first_2 @kc89_second_16 -35;
+    pos @kc89_first_2 @kc89_second_39 -35;
+    pos @kc89_first_2 @kc89_second_45 1;
+    pos @kc89_first_3 @kc89_second_1 -35;
+    pos @kc89_first_3 @kc89_second_2 -70;
+    pos @kc89_first_3 @kc89_second_5 -35;
+    pos @kc89_first_3 @kc89_second_11 -35;
+    pos @kc89_first_3 @kc89_second_12 -35;
+    pos @kc89_first_3 @kc89_second_13 -70;
+    pos @kc89_first_3 @kc89_second_14 -35;
+    pos @kc89_first_3 @kc89_second_16 -70;
+    pos @kc89_first_3 @kc89_second_19 -70;
+    pos @kc89_first_3 @kc89_second_35 -35;
+    pos @kc89_first_3 @kc89_second_45 1;
+    pos @kc89_first_4 @kc89_second_1 -70;
+    pos @kc89_first_4 @kc89_second_2 -140;
+    pos @kc89_first_4 @kc89_second_4 70;
+    pos @kc89_first_4 @kc89_second_5 -70;
+    pos @kc89_first_4 @kc89_second_11 -105;
+    pos @kc89_first_4 @kc89_second_12 -140;
+    pos @kc89_first_4 @kc89_second_13 -140;
+    pos @kc89_first_4 @kc89_second_14 -105;
+    pos @kc89_first_4 @kc89_second_15 -35;
+    pos @kc89_first_4 @kc89_second_16 -140;
+    pos @kc89_first_4 @kc89_second_24 -70;
+    pos @kc89_first_4 @kc89_second_26 -70;
+    pos @kc89_first_4 @kc89_second_27 -35;
+    pos @kc89_first_4 @kc89_second_31 35;
+    pos @kc89_first_4 @kc89_second_34 -70;
+    pos @kc89_first_4 @kc89_second_35 -70;
+    pos @kc89_first_4 @kc89_second_43 -35;
+    pos @kc89_first_4 @kc89_second_45 1;
+    pos @kc89_first_4 @kc89_second_48 -70;
+    pos @kc89_first_4 @kc89_second_53 -70;
+    pos @kc89_first_4 @kc89_second_55 -70;
+    pos @kc89_first_4 @kc89_second_57 -70;
+    pos @kc89_first_4 @kc89_second_61 -35;
+    pos @kc89_first_5 @kc89_second_12 -70;
+    pos @kc89_first_5 @kc89_second_45 1;
+    pos @kc89_first_6 @kc89_second_1 -280;
+    pos @kc89_first_6 @kc89_second_2 -350;
+    pos @kc89_first_6 @kc89_second_3 -140;
+    pos @kc89_first_6 @kc89_second_4 -70;
+    pos @kc89_first_6 @kc89_second_6 -350;
+    pos @kc89_first_6 @kc89_second_7 -140;
+    pos @kc89_first_6 @kc89_second_8 -210;
+    pos @kc89_first_6 @kc89_second_10 -70;
+    pos @kc89_first_6 @kc89_second_17 -240;
+    pos @kc89_first_6 @kc89_second_19 -350;
+    pos @kc89_first_6 @kc89_second_20 -280;
+    pos @kc89_first_6 @kc89_second_21 -240;
+    pos @kc89_first_6 @kc89_second_22 -240;
+    pos @kc89_first_6 @kc89_second_23 -210;
+    pos @kc89_first_6 @kc89_second_24 -350;
+    pos @kc89_first_6 @kc89_second_25 -140;
+    pos @kc89_first_6 @kc89_second_27 -140;
+    pos @kc89_first_6 @kc89_second_29 -240;
+    pos @kc89_first_6 @kc89_second_30 -240;
+    pos @kc89_first_6 @kc89_second_31 -175;
+    pos @kc89_first_6 @kc89_second_34 -350;
+    pos @kc89_first_6 @kc89_second_35 -105;
+    pos @kc89_first_6 @kc89_second_36 -240;
+    pos @kc89_first_6 @kc89_second_37 -210;
+    pos @kc89_first_6 @kc89_second_38 -240;
+    pos @kc89_first_6 @kc89_second_39 -240;
+    pos @kc89_first_6 @kc89_second_41 -240;
+    pos @kc89_first_6 @kc89_second_44 -140;
+    pos @kc89_first_6 @kc89_second_45 1;
+    pos @kc89_first_6 @kc89_second_46 -35;
+    pos @kc89_first_6 @kc89_second_47 -240;
+    pos @kc89_first_6 @kc89_second_49 -240;
+    pos @kc89_first_6 @kc89_second_50 -240;
+    pos @kc89_first_6 @kc89_second_51 -240;
+    pos @kc89_first_6 @kc89_second_52 -240;
+    pos @kc89_first_6 @kc89_second_53 -280;
+    pos @kc89_first_6 @kc89_second_54 -70;
+    pos @kc89_first_6 @kc89_second_55 -240;
+    pos @kc89_first_6 @kc89_second_56 -175;
+    pos @kc89_first_6 @kc89_second_57 -280;
+    pos @kc89_first_6 @kc89_second_58 -240;
+    pos @kc89_first_6 @kc89_second_59 -210;
+    pos @kc89_first_6 @kc89_second_60 -175;
+    pos @kc89_first_6 @kc89_second_63 -175;
+    pos @kc89_first_6 @kc89_second_64 -175;
+    pos @kc89_first_7 @kc89_second_3 -70;
+    pos @kc89_first_7 @kc89_second_8 -105;
+    pos @kc89_first_7 @kc89_second_17 -35;
+    pos @kc89_first_7 @kc89_second_20 -105;
+    pos @kc89_first_7 @kc89_second_22 -105;
+    pos @kc89_first_7 @kc89_second_23 -70;
+    pos @kc89_first_7 @kc89_second_45 1;
+    pos @kc89_first_7 @kc89_second_46 -35;
+    pos @kc89_first_7 @kc89_second_47 -70;
+    pos @kc89_first_7 @kc89_second_51 -50;
+    pos @kc89_first_7 @kc89_second_60 -35;
+    pos @kc89_first_7 @kc89_second_63 -70;
+    pos @kc89_first_7 @kc89_second_64 -70;
+    pos @kc89_first_8 @kc89_second_3 -140;
+    pos @kc89_first_8 @kc89_second_4 -70;
+    pos @kc89_first_8 @kc89_second_6 -70;
+    pos @kc89_first_8 @kc89_second_8 -140;
+    pos @kc89_first_8 @kc89_second_10 -35;
+    pos @kc89_first_8 @kc89_second_17 -70;
+    pos @kc89_first_8 @kc89_second_20 -140;
+    pos @kc89_first_8 @kc89_second_22 -70;
+    pos @kc89_first_8 @kc89_second_23 -105;
+    pos @kc89_first_8 @kc89_second_25 -140;
+    pos @kc89_first_8 @kc89_second_29 -35;
+    pos @kc89_first_8 @kc89_second_31 -105;
+    pos @kc89_first_8 @kc89_second_34 -70;
+    pos @kc89_first_8 @kc89_second_36 -70;
+    pos @kc89_first_8 @kc89_second_38 -105;
+    pos @kc89_first_8 @kc89_second_39 -175;
+    pos @kc89_first_8 @kc89_second_40 -140;
+    pos @kc89_first_8 @kc89_second_41 -35;
+    pos @kc89_first_8 @kc89_second_43 -140;
+    pos @kc89_first_8 @kc89_second_44 -105;
+    pos @kc89_first_8 @kc89_second_45 1;
+    pos @kc89_first_8 @kc89_second_46 -70;
+    pos @kc89_first_8 @kc89_second_47 -140;
+    pos @kc89_first_8 @kc89_second_48 -70;
+    pos @kc89_first_8 @kc89_second_51 -35;
+    pos @kc89_first_8 @kc89_second_52 -35;
+    pos @kc89_first_8 @kc89_second_58 -210;
+    pos @kc89_first_8 @kc89_second_60 -105;
+    pos @kc89_first_8 @kc89_second_61 -70;
+    pos @kc89_first_8 @kc89_second_62 -35;
+    pos @kc89_first_8 @kc89_second_63 -70;
+    pos @kc89_first_8 @kc89_second_64 -35;
+    pos @kc89_first_9 @kc89_second_3 -140;
+    pos @kc89_first_9 @kc89_second_4 -70;
+    pos @kc89_first_9 @kc89_second_6 -70;
+    pos @kc89_first_9 @kc89_second_8 -210;
+    pos @kc89_first_9 @kc89_second_9 -420;
+    pos @kc89_first_9 @kc89_second_10 -70;
+    pos @kc89_first_9 @kc89_second_12 -350;
+    pos @kc89_first_9 @kc89_second_13 -420;
+    pos @kc89_first_9 @kc89_second_14 -350;
+    pos @kc89_first_9 @kc89_second_15 -280;
+    pos @kc89_first_9 @kc89_second_17 -70;
+    pos @kc89_first_9 @kc89_second_18 -210;
+    pos @kc89_first_9 @kc89_second_20 -210;
+    pos @kc89_first_9 @kc89_second_22 -70;
+    pos @kc89_first_9 @kc89_second_23 -140;
+    pos @kc89_first_9 @kc89_second_29 -50;
+    pos @kc89_first_9 @kc89_second_31 -140;
+    pos @kc89_first_9 @kc89_second_34 -70;
+    pos @kc89_first_9 @kc89_second_38 -105;
+    pos @kc89_first_9 @kc89_second_39 -280;
+    pos @kc89_first_9 @kc89_second_40 -350;
+    pos @kc89_first_9 @kc89_second_41 -50;
+    pos @kc89_first_9 @kc89_second_43 -350;
+    pos @kc89_first_9 @kc89_second_45 1;
+    pos @kc89_first_9 @kc89_second_46 -35;
+    pos @kc89_first_9 @kc89_second_47 -210;
+    pos @kc89_first_9 @kc89_second_48 -350;
+    pos @kc89_first_9 @kc89_second_51 -35;
+    pos @kc89_first_9 @kc89_second_52 -35;
+    pos @kc89_first_9 @kc89_second_58 -280;
+    pos @kc89_first_9 @kc89_second_60 -175;
+    pos @kc89_first_9 @kc89_second_61 -280;
+    pos @kc89_first_9 @kc89_second_62 -210;
+    pos @kc89_first_9 @kc89_second_63 -70;
+    pos @kc89_first_9 @kc89_second_64 -70;
+    pos @kc89_first_10 @kc89_second_1 -210;
+    pos @kc89_first_10 @kc89_second_2 -350;
+    pos @kc89_first_10 @kc89_second_5 -70;
+    pos @kc89_first_10 @kc89_second_6 -140;
+    pos @kc89_first_10 @kc89_second_11 -35;
+    pos @kc89_first_10 @kc89_second_12 -70;
+    pos @kc89_first_10 @kc89_second_13 -70;
+    pos @kc89_first_10 @kc89_second_14 -35;
+    pos @kc89_first_10 @kc89_second_16 -70;
+    pos @kc89_first_10 @kc89_second_17 -35;
+    pos @kc89_first_10 @kc89_second_19 -280;
+    pos @kc89_first_10 @kc89_second_22 -70;
+    pos @kc89_first_10 @kc89_second_24 -350;
+    pos @kc89_first_10 @kc89_second_29 -70;
+    pos @kc89_first_10 @kc89_second_32 -140;
+    pos @kc89_first_10 @kc89_second_34 -210;
+    pos @kc89_first_10 @kc89_second_35 -105;
+    pos @kc89_first_10 @kc89_second_38 -70;
+    pos @kc89_first_10 @kc89_second_45 1;
+    pos @kc89_first_10 @kc89_second_53 -210;
+    pos @kc89_first_10 @kc89_second_55 -210;
+    pos @kc89_first_10 @kc89_second_57 -210;
+    pos @kc89_first_10 @kc89_second_61 -70;
+    pos @kc89_first_10 @kc89_second_63 -70;
+    pos @kc89_first_10 @kc89_second_64 -105;
+    pos @kc89_first_11 @kc89_second_1 -70;
+    pos @kc89_first_11 @kc89_second_2 -140;
+    pos @kc89_first_11 @kc89_second_5 -105;
+    pos @kc89_first_11 @kc89_second_6 -35;
+    pos @kc89_first_11 @kc89_second_11 -70;
+    pos @kc89_first_11 @kc89_second_12 -210;
+    pos @kc89_first_11 @kc89_second_13 -175;
+    pos @kc89_first_11 @kc89_second_14 -105;
+    pos @kc89_first_11 @kc89_second_15 -70;
+    pos @kc89_first_11 @kc89_second_16 -140;
+    pos @kc89_first_11 @kc89_second_19 -140;
+    pos @kc89_first_11 @kc89_second_24 -70;
+    pos @kc89_first_11 @kc89_second_26 -70;
+    pos @kc89_first_11 @kc89_second_27 -70;
+    pos @kc89_first_11 @kc89_second_34 -35;
+    pos @kc89_first_11 @kc89_second_35 -140;
+    pos @kc89_first_11 @kc89_second_39 -70;
+    pos @kc89_first_11 @kc89_second_42 -35;
+    pos @kc89_first_11 @kc89_second_43 -35;
+    pos @kc89_first_11 @kc89_second_45 1;
+    pos @kc89_first_11 @kc89_second_48 -70;
+    pos @kc89_first_11 @kc89_second_53 -210;
+    pos @kc89_first_11 @kc89_second_55 -175;
+    pos @kc89_first_11 @kc89_second_56 -35;
+    pos @kc89_first_11 @kc89_second_57 -175;
+    pos @kc89_first_11 @kc89_second_61 -70;
+    pos @kc89_first_11 @kc89_second_62 -35;
+    pos @kc89_first_11 @kc89_second_63 -35;
+    pos @kc89_first_11 @kc89_second_64 -70;
+    pos @kc89_first_12 @kc89_second_1 -140;
+    pos @kc89_first_12 @kc89_second_2 -210;
+    pos @kc89_first_12 @kc89_second_6 -140;
+    pos @kc89_first_12 @kc89_second_17 -70;
+    pos @kc89_first_12 @kc89_second_19 -210;
+    pos @kc89_first_12 @kc89_second_22 -70;
+    pos @kc89_first_12 @kc89_second_24 -350;
+    pos @kc89_first_12 @kc89_second_29 -35;
+    pos @kc89_first_12 @kc89_second_32 -140;
+    pos @kc89_first_12 @kc89_second_34 -140;
+    pos @kc89_first_12 @kc89_second_35 -70;
+    pos @kc89_first_12 @kc89_second_38 -70;
+    pos @kc89_first_12 @kc89_second_45 1;
+    pos @kc89_first_12 @kc89_second_51 -35;
+    pos @kc89_first_12 @kc89_second_53 -210;
+    pos @kc89_first_12 @kc89_second_55 -210;
+    pos @kc89_first_12 @kc89_second_57 -210;
+    pos @kc89_first_12 @kc89_second_63 -70;
+    pos @kc89_first_12 @kc89_second_64 -105;
+    pos @kc89_first_13 @kc89_second_6 -70;
+    pos @kc89_first_13 @kc89_second_12 -70;
+    pos @kc89_first_13 @kc89_second_13 -105;
+    pos @kc89_first_13 @kc89_second_14 -35;
+    pos @kc89_first_13 @kc89_second_22 -35;
+    pos @kc89_first_13 @kc89_second_29 -35;
+    pos @kc89_first_13 @kc89_second_34 -70;
+    pos @kc89_first_13 @kc89_second_38 -70;
+    pos @kc89_first_13 @kc89_second_45 1;
+    pos @kc89_first_13 @kc89_second_63 -70;
+    pos @kc89_first_13 @kc89_second_64 -35;
+    pos @kc89_first_14 @kc89_second_2 -35;
+    pos @kc89_first_14 @kc89_second_11 -35;
+    pos @kc89_first_14 @kc89_second_12 -70;
+    pos @kc89_first_14 @kc89_second_13 -70;
+    pos @kc89_first_14 @kc89_second_14 -35;
+    pos @kc89_first_14 @kc89_second_16 -35;
+    pos @kc89_first_14 @kc89_second_19 -35;
+    pos @kc89_first_14 @kc89_second_25 -35;
+    pos @kc89_first_14 @kc89_second_39 -70;
+    pos @kc89_first_14 @kc89_second_45 1;
+    pos @kc89_first_14 @kc89_second_47 -70;
+    pos @kc89_first_14 @kc89_second_48 -35;
+    pos @kc89_first_14 @kc89_second_56 -35;
+    pos @kc89_first_14 @kc89_second_58 -35;
+    pos @kc89_first_14 @kc89_second_60 -35;
+    pos @kc89_first_14 @kc89_second_62 -35;
+    pos @kc89_first_15 @kc89_second_3 -70;
+    pos @kc89_first_15 @kc89_second_4 -70;
+    pos @kc89_first_15 @kc89_second_6 -35;
+    pos @kc89_first_15 @kc89_second_8 -70;
+    pos @kc89_first_15 @kc89_second_17 -70;
+    pos @kc89_first_15 @kc89_second_20 -140;
+    pos @kc89_first_15 @kc89_second_22 -70;
+    pos @kc89_first_15 @kc89_second_23 -70;
+    pos @kc89_first_15 @kc89_second_25 -70;
+    pos @kc89_first_15 @kc89_second_29 -35;
+    pos @kc89_first_15 @kc89_second_31 -35;
+    pos @kc89_first_15 @kc89_second_36 -35;
+    pos @kc89_first_15 @kc89_second_38 -70;
+    pos @kc89_first_15 @kc89_second_39 -142;
+    pos @kc89_first_15 @kc89_second_40 -35;
+    pos @kc89_first_15 @kc89_second_44 -35;
+    pos @kc89_first_15 @kc89_second_45 1;
+    pos @kc89_first_15 @kc89_second_46 -35;
+    pos @kc89_first_15 @kc89_second_47 -70;
+    pos @kc89_first_15 @kc89_second_51 -35;
+    pos @kc89_first_15 @kc89_second_52 -35;
+    pos @kc89_first_15 @kc89_second_58 -105;
+    pos @kc89_first_15 @kc89_second_60 -35;
+    pos @kc89_first_15 @kc89_second_63 -35;
+    pos @kc89_first_15 @kc89_second_64 -35;
+    pos @kc89_first_16 @kc89_second_1 -280;
+    pos @kc89_first_16 @kc89_second_2 -280;
+    pos @kc89_first_16 @kc89_second_3 -140;
+    pos @kc89_first_16 @kc89_second_4 -70;
+    pos @kc89_first_16 @kc89_second_6 -280;
+    pos @kc89_first_16 @kc89_second_7 -140;
+    pos @kc89_first_16 @kc89_second_8 -175;
+    pos @kc89_first_16 @kc89_second_10 -70;
+    pos @kc89_first_16 @kc89_second_17 -245;
+    pos @kc89_first_16 @kc89_second_19 -280;
+    pos @kc89_first_16 @kc89_second_20 -210;
+    pos @kc89_first_16 @kc89_second_21 -140;
+    pos @kc89_first_16 @kc89_second_22 -280;
+    pos @kc89_first_16 @kc89_second_23 -210;
+    pos @kc89_first_16 @kc89_second_24 -350;
+    pos @kc89_first_16 @kc89_second_25 -70;
+    pos @kc89_first_16 @kc89_second_27 -140;
+    pos @kc89_first_16 @kc89_second_29 -240;
+    pos @kc89_first_16 @kc89_second_30 -140;
+    pos @kc89_first_16 @kc89_second_31 -140;
+    pos @kc89_first_16 @kc89_second_32 -245;
+    pos @kc89_first_16 @kc89_second_34 -315;
+    pos @kc89_first_16 @kc89_second_35 -70;
+    pos @kc89_first_16 @kc89_second_36 -210;
+    pos @kc89_first_16 @kc89_second_37 -210;
+    pos @kc89_first_16 @kc89_second_38 -245;
+    pos @kc89_first_16 @kc89_second_39 -245;
+    pos @kc89_first_16 @kc89_second_40 -70;
+    pos @kc89_first_16 @kc89_second_42 -35;
+    pos @kc89_first_16 @kc89_second_43 -140;
+    pos @kc89_first_16 @kc89_second_44 -140;
+    pos @kc89_first_16 @kc89_second_45 1;
+    pos @kc89_first_16 @kc89_second_46 -70;
+    pos @kc89_first_16 @kc89_second_47 -140;
+    pos @kc89_first_16 @kc89_second_49 -140;
+    pos @kc89_first_16 @kc89_second_50 -140;
+    pos @kc89_first_16 @kc89_second_51 -240;
+    pos @kc89_first_16 @kc89_second_52 -140;
+    pos @kc89_first_16 @kc89_second_53 -280;
+    pos @kc89_first_16 @kc89_second_54 -105;
+    pos @kc89_first_16 @kc89_second_55 -280;
+    pos @kc89_first_16 @kc89_second_56 -140;
+    pos @kc89_first_16 @kc89_second_57 -315;
+    pos @kc89_first_16 @kc89_second_58 -210;
+    pos @kc89_first_16 @kc89_second_59 -210;
+    pos @kc89_first_16 @kc89_second_60 -105;
+    pos @kc89_first_16 @kc89_second_63 -315;
+    pos @kc89_first_16 @kc89_second_64 -350;
+    pos @kc89_first_17 @kc89_second_1 -280;
+    pos @kc89_first_17 @kc89_second_2 -280;
+    pos @kc89_first_17 @kc89_second_3 -105;
+    pos @kc89_first_17 @kc89_second_6 -210;
+    pos @kc89_first_17 @kc89_second_7 -105;
+    pos @kc89_first_17 @kc89_second_8 -105;
+    pos @kc89_first_17 @kc89_second_10 -35;
+    pos @kc89_first_17 @kc89_second_17 -105;
+    pos @kc89_first_17 @kc89_second_19 -280;
+    pos @kc89_first_17 @kc89_second_20 -70;
+    pos @kc89_first_17 @kc89_second_21 -105;
+    pos @kc89_first_17 @kc89_second_22 -140;
+    pos @kc89_first_17 @kc89_second_23 -140;
+    pos @kc89_first_17 @kc89_second_24 -210;
+    pos @kc89_first_17 @kc89_second_27 -70;
+    pos @kc89_first_17 @kc89_second_29 -140;
+    pos @kc89_first_17 @kc89_second_30 -105;
+    pos @kc89_first_17 @kc89_second_32 -210;
+    pos @kc89_first_17 @kc89_second_34 -245;
+    pos @kc89_first_17 @kc89_second_35 -70;
+    pos @kc89_first_17 @kc89_second_36 -140;
+    pos @kc89_first_17 @kc89_second_37 -140;
+    pos @kc89_first_17 @kc89_second_38 -140;
+    pos @kc89_first_17 @kc89_second_39 -105;
+    pos @kc89_first_17 @kc89_second_40 -35;
+    pos @kc89_first_17 @kc89_second_43 -35;
+    pos @kc89_first_17 @kc89_second_44 -70;
+    pos @kc89_first_17 @kc89_second_45 1;
+    pos @kc89_first_17 @kc89_second_46 -35;
+    pos @kc89_first_17 @kc89_second_47 -70;
+    pos @kc89_first_17 @kc89_second_49 -105;
+    pos @kc89_first_17 @kc89_second_50 -70;
+    pos @kc89_first_17 @kc89_second_51 -105;
+    pos @kc89_first_17 @kc89_second_52 -70;
+    pos @kc89_first_17 @kc89_second_53 -210;
+    pos @kc89_first_17 @kc89_second_54 -35;
+    pos @kc89_first_17 @kc89_second_55 -210;
+    pos @kc89_first_17 @kc89_second_56 -70;
+    pos @kc89_first_17 @kc89_second_57 -245;
+    pos @kc89_first_17 @kc89_second_58 -105;
+    pos @kc89_first_17 @kc89_second_59 -105;
+    pos @kc89_first_17 @kc89_second_60 -70;
+    pos @kc89_first_17 @kc89_second_63 -175;
+    pos @kc89_first_17 @kc89_second_64 -245;
+    pos @kc89_first_18 @kc89_second_1 -210;
+    pos @kc89_first_18 @kc89_second_2 -245;
+    pos @kc89_first_18 @kc89_second_3 -35;
+    pos @kc89_first_18 @kc89_second_6 -140;
+    pos @kc89_first_18 @kc89_second_7 -35;
+    pos @kc89_first_18 @kc89_second_8 -70;
+    pos @kc89_first_18 @kc89_second_17 -105;
+    pos @kc89_first_18 @kc89_second_19 -210;
+    pos @kc89_first_18 @kc89_second_20 -70;
+    pos @kc89_first_18 @kc89_second_22 -105;
+    pos @kc89_first_18 @kc89_second_23 -70;
+    pos @kc89_first_18 @kc89_second_24 -140;
+    pos @kc89_first_18 @kc89_second_27 -35;
+    pos @kc89_first_18 @kc89_second_32 -140;
+    pos @kc89_first_18 @kc89_second_34 -140;
+    pos @kc89_first_18 @kc89_second_36 -105;
+    pos @kc89_first_18 @kc89_second_37 -70;
+    pos @kc89_first_18 @kc89_second_38 -105;
+    pos @kc89_first_18 @kc89_second_39 -70;
+    pos @kc89_first_18 @kc89_second_41 -35;
+    pos @kc89_first_18 @kc89_second_45 1;
+    pos @kc89_first_18 @kc89_second_50 -35;
+    pos @kc89_first_18 @kc89_second_51 -70;
+    pos @kc89_first_18 @kc89_second_53 -140;
+    pos @kc89_first_18 @kc89_second_55 -140;
+    pos @kc89_first_18 @kc89_second_57 -175;
+    pos @kc89_first_18 @kc89_second_58 -70;
+    pos @kc89_first_18 @kc89_second_63 -105;
+    pos @kc89_first_18 @kc89_second_64 -140;
+    pos @kc89_first_19 @kc89_second_12 -280;
+    pos @kc89_first_19 @kc89_second_14 -175;
+    pos @kc89_first_19 @kc89_second_15 -140;
+    pos @kc89_first_19 @kc89_second_29 -35;
+    pos @kc89_first_19 @kc89_second_45 1;
+    pos @kc89_first_19 @kc89_second_47 -70;
+    pos @kc89_first_19 @kc89_second_48 -140;
+    pos @kc89_first_19 @kc89_second_58 -70;
+    pos @kc89_first_19 @kc89_second_60 -35;
+    pos @kc89_first_19 @kc89_second_61 -105;
+    pos @kc89_first_19 @kc89_second_62 -70;
+    pos @kc89_first_20 @kc89_second_8 -35;
+    pos @kc89_first_20 @kc89_second_9 -140;
+    pos @kc89_first_20 @kc89_second_12 -280;
+    pos @kc89_first_20 @kc89_second_13 -280;
+    pos @kc89_first_20 @kc89_second_14 -280;
+    pos @kc89_first_20 @kc89_second_15 -175;
+    pos @kc89_first_20 @kc89_second_18 -140;
+    pos @kc89_first_20 @kc89_second_20 -70;
+    pos @kc89_first_20 @kc89_second_25 -70;
+    pos @kc89_first_20 @kc89_second_31 -50;
+    pos @kc89_first_20 @kc89_second_39 -140;
+    pos @kc89_first_20 @kc89_second_40 -105;
+    pos @kc89_first_20 @kc89_second_43 -210;
+    pos @kc89_first_20 @kc89_second_45 1;
+    pos @kc89_first_20 @kc89_second_46 -35;
+    pos @kc89_first_20 @kc89_second_47 -140;
+    pos @kc89_first_20 @kc89_second_48 -210;
+    pos @kc89_first_20 @kc89_second_52 -35;
+    pos @kc89_first_20 @kc89_second_58 -105;
+    pos @kc89_first_20 @kc89_second_60 -105;
+    pos @kc89_first_20 @kc89_second_61 -210;
+    pos @kc89_first_20 @kc89_second_62 -140;
+    pos @kc89_first_21 @kc89_second_1 -140;
+    pos @kc89_first_21 @kc89_second_2 -350;
+    pos @kc89_first_21 @kc89_second_19 -280;
+    pos @kc89_first_21 @kc89_second_38 -70;
+    pos @kc89_first_21 @kc89_second_45 1;
+    pos @kc89_first_21 @kc89_second_64 -210;
+    pos @kc89_first_22 @kc89_second_1 -35;
+    pos @kc89_first_22 @kc89_second_5 -105;
+    pos @kc89_first_22 @kc89_second_9 -70;
+    pos @kc89_first_22 @kc89_second_11 -70;
+    pos @kc89_first_22 @kc89_second_12 -240;
+    pos @kc89_first_22 @kc89_second_13 -280;
+    pos @kc89_first_22 @kc89_second_14 -140;
+    pos @kc89_first_22 @kc89_second_15 -105;
+    pos @kc89_first_22 @kc89_second_16 -70;
+    pos @kc89_first_22 @kc89_second_25 -35;
+    pos @kc89_first_22 @kc89_second_26 -70;
+    pos @kc89_first_22 @kc89_second_27 -105;
+    pos @kc89_first_22 @kc89_second_35 -70;
+    pos @kc89_first_22 @kc89_second_39 -70;
+    pos @kc89_first_22 @kc89_second_40 -35;
+    pos @kc89_first_22 @kc89_second_42 -35;
+    pos @kc89_first_22 @kc89_second_43 -140;
+    pos @kc89_first_22 @kc89_second_45 1;
+    pos @kc89_first_22 @kc89_second_47 -70;
+    pos @kc89_first_22 @kc89_second_48 -175;
+    pos @kc89_first_22 @kc89_second_49 -35;
+    pos @kc89_first_22 @kc89_second_56 -105;
+    pos @kc89_first_22 @kc89_second_58 -35;
+    pos @kc89_first_22 @kc89_second_60 -50;
+    pos @kc89_first_22 @kc89_second_61 -105;
+    pos @kc89_first_22 @kc89_second_62 -70;
+    pos @kc89_first_23 @kc89_second_6 -35;
+    pos @kc89_first_23 @kc89_second_12 -240;
+    pos @kc89_first_23 @kc89_second_13 -175;
+    pos @kc89_first_23 @kc89_second_14 -70;
+    pos @kc89_first_23 @kc89_second_15 -70;
+    pos @kc89_first_23 @kc89_second_22 -70;
+    pos @kc89_first_23 @kc89_second_23 -35;
+    pos @kc89_first_23 @kc89_second_34 -35;
+    pos @kc89_first_23 @kc89_second_39 -35;
+    pos @kc89_first_23 @kc89_second_40 -35;
+    pos @kc89_first_23 @kc89_second_43 -70;
+    pos @kc89_first_23 @kc89_second_44 -35;
+    pos @kc89_first_23 @kc89_second_45 1;
+    pos @kc89_first_23 @kc89_second_48 -35;
+    pos @kc89_first_23 @kc89_second_58 -35;
+    pos @kc89_first_23 @kc89_second_62 -35;
+    pos @kc89_first_23 @kc89_second_63 -35;
+    pos @kc89_first_23 @kc89_second_64 -35;
+    pos @kc89_first_24 @kc89_second_1 -70;
+    pos @kc89_first_24 @kc89_second_2 -140;
+    pos @kc89_first_24 @kc89_second_5 -105;
+    pos @kc89_first_24 @kc89_second_11 -70;
+    pos @kc89_first_24 @kc89_second_12 -280;
+    pos @kc89_first_24 @kc89_second_13 -210;
+    pos @kc89_first_24 @kc89_second_14 -70;
+    pos @kc89_first_24 @kc89_second_15 -70;
+    pos @kc89_first_24 @kc89_second_16 -140;
+    pos @kc89_first_24 @kc89_second_19 -70;
+    pos @kc89_first_24 @kc89_second_26 -70;
+    pos @kc89_first_24 @kc89_second_27 -70;
+    pos @kc89_first_24 @kc89_second_32 -70;
+    pos @kc89_first_24 @kc89_second_35 -70;
+    pos @kc89_first_24 @kc89_second_42 -35;
+    pos @kc89_first_24 @kc89_second_43 -140;
+    pos @kc89_first_24 @kc89_second_45 1;
+    pos @kc89_first_24 @kc89_second_48 -140;
+    pos @kc89_first_24 @kc89_second_49 -35;
+    pos @kc89_first_24 @kc89_second_53 -140;
+    pos @kc89_first_24 @kc89_second_55 -105;
+    pos @kc89_first_24 @kc89_second_56 -70;
+    pos @kc89_first_24 @kc89_second_57 -70;
+    pos @kc89_first_24 @kc89_second_61 -70;
+    pos @kc89_first_24 @kc89_second_62 -35;
+    pos @kc89_first_25 @kc89_second_5 -70;
+    pos @kc89_first_25 @kc89_second_9 -70;
+    pos @kc89_first_25 @kc89_second_12 -240;
+    pos @kc89_first_25 @kc89_second_13 -280;
+    pos @kc89_first_25 @kc89_second_14 -175;
+    pos @kc89_first_25 @kc89_second_15 -105;
+    pos @kc89_first_25 @kc89_second_16 -70;
+    pos @kc89_first_25 @kc89_second_25 -35;
+    pos @kc89_first_25 @kc89_second_26 -70;
+    pos @kc89_first_25 @kc89_second_27 -70;
+    pos @kc89_first_25 @kc89_second_35 -70;
+    pos @kc89_first_25 @kc89_second_39 -70;
+    pos @kc89_first_25 @kc89_second_40 -35;
+    pos @kc89_first_25 @kc89_second_43 -140;
+    pos @kc89_first_25 @kc89_second_45 1;
+    pos @kc89_first_25 @kc89_second_47 -70;
+    pos @kc89_first_25 @kc89_second_48 -140;
+    pos @kc89_first_25 @kc89_second_49 -35;
+    pos @kc89_first_25 @kc89_second_53 -50;
+    pos @kc89_first_25 @kc89_second_54 -35;
+    pos @kc89_first_25 @kc89_second_55 -50;
+    pos @kc89_first_25 @kc89_second_56 -105;
+    pos @kc89_first_25 @kc89_second_57 -50;
+    pos @kc89_first_25 @kc89_second_58 -50;
+    pos @kc89_first_25 @kc89_second_60 -35;
+    pos @kc89_first_25 @kc89_second_61 -105;
+    pos @kc89_first_25 @kc89_second_62 -70;
+    pos @kc89_first_26 @kc89_second_9 -35;
+    pos @kc89_first_26 @kc89_second_12 -140;
+    pos @kc89_first_26 @kc89_second_26 -70;
+    pos @kc89_first_26 @kc89_second_39 -35;
+    pos @kc89_first_26 @kc89_second_43 -70;
+    pos @kc89_first_26 @kc89_second_45 1;
+    pos @kc89_first_26 @kc89_second_48 -70;
+    pos @kc89_first_26 @kc89_second_61 -70;
+    pos @kc89_first_26 @kc89_second_62 -35;
+    pos @kc89_first_27 @kc89_second_5 -50;
+    pos @kc89_first_27 @kc89_second_9 -35;
+    pos @kc89_first_27 @kc89_second_11 -35;
+    pos @kc89_first_27 @kc89_second_12 -240;
+    pos @kc89_first_27 @kc89_second_13 -240;
+    pos @kc89_first_27 @kc89_second_14 -105;
+    pos @kc89_first_27 @kc89_second_15 -70;
+    pos @kc89_first_27 @kc89_second_16 -35;
+    pos @kc89_first_27 @kc89_second_26 -35;
+    pos @kc89_first_27 @kc89_second_27 -35;
+    pos @kc89_first_27 @kc89_second_35 -35;
+    pos @kc89_first_27 @kc89_second_39 -50;
+    pos @kc89_first_27 @kc89_second_40 -35;
+    pos @kc89_first_27 @kc89_second_43 -100;
+    pos @kc89_first_27 @kc89_second_45 1;
+    pos @kc89_first_27 @kc89_second_47 -35;
+    pos @kc89_first_27 @kc89_second_48 -140;
+    pos @kc89_first_27 @kc89_second_56 -35;
+    pos @kc89_first_27 @kc89_second_61 -70;
+    pos @kc89_first_27 @kc89_second_62 -35;
+    pos @kc89_first_28 @kc89_second_45 1;
+    pos @kc89_first_29 @kc89_second_8 -70;
+    pos @kc89_first_29 @kc89_second_9 -210;
+    pos @kc89_first_29 @kc89_second_12 -350;
+    pos @kc89_first_29 @kc89_second_13 -350;
+    pos @kc89_first_29 @kc89_second_14 -210;
+    pos @kc89_first_29 @kc89_second_15 -175;
+    pos @kc89_first_29 @kc89_second_25 -70;
+    pos @kc89_first_29 @kc89_second_38 -35;
+    pos @kc89_first_29 @kc89_second_39 -210;
+    pos @kc89_first_29 @kc89_second_40 -210;
+    pos @kc89_first_29 @kc89_second_43 -210;
+    pos @kc89_first_29 @kc89_second_45 1;
+    pos @kc89_first_29 @kc89_second_47 -140;
+    pos @kc89_first_29 @kc89_second_48 -280;
+    pos @kc89_first_29 @kc89_second_58 -210;
+    pos @kc89_first_29 @kc89_second_60 -105;
+    pos @kc89_first_29 @kc89_second_61 -175;
+    pos @kc89_first_29 @kc89_second_62 -140;
+    pos @kc89_first_30 @kc89_second_1 -175;
+    pos @kc89_first_30 @kc89_second_2 -175;
+    pos @kc89_first_30 @kc89_second_5 -70;
+    pos @kc89_first_30 @kc89_second_6 -105;
+    pos @kc89_first_30 @kc89_second_10 -35;
+    pos @kc89_first_30 @kc89_second_11 -105;
+    pos @kc89_first_30 @kc89_second_12 -175;
+    pos @kc89_first_30 @kc89_second_13 -140;
+    pos @kc89_first_30 @kc89_second_14 -70;
+    pos @kc89_first_30 @kc89_second_15 -35;
+    pos @kc89_first_30 @kc89_second_16 -140;
+    pos @kc89_first_30 @kc89_second_17 -70;
+    pos @kc89_first_30 @kc89_second_19 -175;
+    pos @kc89_first_30 @kc89_second_22 -70;
+    pos @kc89_first_30 @kc89_second_29 -105;
+    pos @kc89_first_30 @kc89_second_33 165;
+    pos @kc89_first_30 @kc89_second_34 -105;
+    pos @kc89_first_30 @kc89_second_35 -175;
+    pos @kc89_first_30 @kc89_second_36 -35;
+    pos @kc89_first_30 @kc89_second_38 -70;
+    pos @kc89_first_30 @kc89_second_45 1;
+    pos @kc89_first_30 @kc89_second_50 165;
+    pos @kc89_first_30 @kc89_second_51 -35;
+    pos @kc89_first_30 @kc89_second_63 -70;
+    pos @kc89_first_30 @kc89_second_64 -105;
+    pos @kc89_first_31 @kc89_second_3 -70;
+    pos @kc89_first_31 @kc89_second_4 -35;
+    pos @kc89_first_31 @kc89_second_6 -70;
+    pos @kc89_first_31 @kc89_second_8 -105;
+    pos @kc89_first_31 @kc89_second_17 -35;
+    pos @kc89_first_31 @kc89_second_20 -70;
+    pos @kc89_first_31 @kc89_second_22 -70;
+    pos @kc89_first_31 @kc89_second_23 -140;
+    pos @kc89_first_31 @kc89_second_29 -35;
+    pos @kc89_first_31 @kc89_second_34 -70;
+    pos @kc89_first_31 @kc89_second_36 -35;
+    pos @kc89_first_31 @kc89_second_38 -140;
+    pos @kc89_first_31 @kc89_second_39 -70;
+    pos @kc89_first_31 @kc89_second_45 1;
+    pos @kc89_first_31 @kc89_second_51 -35;
+    pos @kc89_first_31 @kc89_second_52 -35;
+    pos @kc89_first_31 @kc89_second_58 -140;
+    pos @kc89_first_31 @kc89_second_63 -70;
+    pos @kc89_first_31 @kc89_second_64 -70;
+    pos @kc89_first_32 @kc89_second_1 -35;
+    pos @kc89_first_32 @kc89_second_2 -105;
+    pos @kc89_first_32 @kc89_second_3 -70;
+    pos @kc89_first_32 @kc89_second_4 70;
+    pos @kc89_first_32 @kc89_second_5 -70;
+    pos @kc89_first_32 @kc89_second_11 -35;
+    pos @kc89_first_32 @kc89_second_12 -240;
+    pos @kc89_first_32 @kc89_second_13 -175;
+    pos @kc89_first_32 @kc89_second_14 -105;
+    pos @kc89_first_32 @kc89_second_15 -70;
+    pos @kc89_first_32 @kc89_second_16 -70;
+    pos @kc89_first_32 @kc89_second_24 -35;
+    pos @kc89_first_32 @kc89_second_27 -70;
+    pos @kc89_first_32 @kc89_second_35 -35;
+    pos @kc89_first_32 @kc89_second_39 -35;
+    pos @kc89_first_32 @kc89_second_40 -35;
+    pos @kc89_first_32 @kc89_second_42 -35;
+    pos @kc89_first_32 @kc89_second_43 -140;
+    pos @kc89_first_32 @kc89_second_45 1;
+    pos @kc89_first_32 @kc89_second_47 -50;
+    pos @kc89_first_32 @kc89_second_48 -140;
+    pos @kc89_first_32 @kc89_second_49 -35;
+    pos @kc89_first_32 @kc89_second_53 -70;
+    pos @kc89_first_32 @kc89_second_55 -70;
+    pos @kc89_first_32 @kc89_second_57 -70;
+    pos @kc89_first_32 @kc89_second_61 -70;
+    pos @kc89_first_32 @kc89_second_62 -35;
+    pos @kc89_first_33 @kc89_second_3 -35;
+    pos @kc89_first_33 @kc89_second_4 -70;
+    pos @kc89_first_33 @kc89_second_6 -70;
+    pos @kc89_first_33 @kc89_second_8 -70;
+    pos @kc89_first_33 @kc89_second_12 -140;
+    pos @kc89_first_33 @kc89_second_13 -105;
+    pos @kc89_first_33 @kc89_second_14 -70;
+    pos @kc89_first_33 @kc89_second_15 -35;
+    pos @kc89_first_33 @kc89_second_20 -70;
+    pos @kc89_first_33 @kc89_second_22 -105;
+    pos @kc89_first_33 @kc89_second_23 -70;
+    pos @kc89_first_33 @kc89_second_29 -35;
+    pos @kc89_first_33 @kc89_second_34 -70;
+    pos @kc89_first_33 @kc89_second_36 -70;
+    pos @kc89_first_33 @kc89_second_38 -105;
+    pos @kc89_first_33 @kc89_second_39 -70;
+    pos @kc89_first_33 @kc89_second_44 -70;
+    pos @kc89_first_33 @kc89_second_45 1;
+    pos @kc89_first_33 @kc89_second_51 -35;
+    pos @kc89_first_33 @kc89_second_52 -35;
+    pos @kc89_first_33 @kc89_second_63 -70;
+    pos @kc89_first_33 @kc89_second_64 -70;
+    pos @kc89_first_34 @kc89_second_32 -315;
+    pos @kc89_first_34 @kc89_second_45 1;
+    pos @kc89_first_35 @kc89_second_9 -70;
+    pos @kc89_first_35 @kc89_second_12 -240;
+    pos @kc89_first_35 @kc89_second_13 -210;
+    pos @kc89_first_35 @kc89_second_14 -140;
+    pos @kc89_first_35 @kc89_second_15 -105;
+    pos @kc89_first_35 @kc89_second_39 -70;
+    pos @kc89_first_35 @kc89_second_40 -35;
+    pos @kc89_first_35 @kc89_second_43 -140;
+    pos @kc89_first_35 @kc89_second_45 1;
+    pos @kc89_first_35 @kc89_second_47 -50;
+    pos @kc89_first_35 @kc89_second_48 -140;
+    pos @kc89_first_35 @kc89_second_58 -35;
+    pos @kc89_first_35 @kc89_second_60 -35;
+    pos @kc89_first_35 @kc89_second_61 -70;
+    pos @kc89_first_35 @kc89_second_62 -70;
+    pos @kc89_first_36 @kc89_second_9 -35;
+    pos @kc89_first_36 @kc89_second_12 -240;
+    pos @kc89_first_36 @kc89_second_13 -240;
+    pos @kc89_first_36 @kc89_second_14 -140;
+    pos @kc89_first_36 @kc89_second_15 -105;
+    pos @kc89_first_36 @kc89_second_16 -35;
+    pos @kc89_first_36 @kc89_second_26 -35;
+    pos @kc89_first_36 @kc89_second_27 -35;
+    pos @kc89_first_36 @kc89_second_39 -70;
+    pos @kc89_first_36 @kc89_second_40 -35;
+    pos @kc89_first_36 @kc89_second_43 -70;
+    pos @kc89_first_36 @kc89_second_45 1;
+    pos @kc89_first_36 @kc89_second_47 -35;
+    pos @kc89_first_36 @kc89_second_48 -70;
+    pos @kc89_first_36 @kc89_second_60 -35;
+    pos @kc89_first_36 @kc89_second_61 -70;
+    pos @kc89_first_36 @kc89_second_62 -70;
+    pos @kc89_first_37 @kc89_second_5 -70;
+    pos @kc89_first_37 @kc89_second_9 -70;
+    pos @kc89_first_37 @kc89_second_12 -140;
+    pos @kc89_first_37 @kc89_second_13 -210;
+    pos @kc89_first_37 @kc89_second_14 -140;
+    pos @kc89_first_37 @kc89_second_15 -105;
+    pos @kc89_first_37 @kc89_second_16 -70;
+    pos @kc89_first_37 @kc89_second_26 -70;
+    pos @kc89_first_37 @kc89_second_27 -70;
+    pos @kc89_first_37 @kc89_second_35 -50;
+    pos @kc89_first_37 @kc89_second_39 -50;
+    pos @kc89_first_37 @kc89_second_40 -35;
+    pos @kc89_first_37 @kc89_second_45 1;
+    pos @kc89_first_37 @kc89_second_47 -35;
+    pos @kc89_first_37 @kc89_second_48 -140;
+    pos @kc89_first_37 @kc89_second_56 -35;
+    pos @kc89_first_37 @kc89_second_61 -70;
+    pos @kc89_first_37 @kc89_second_62 -35;
+    pos @kc89_first_38 @kc89_second_1 -210;
+    pos @kc89_first_38 @kc89_second_2 -280;
+    pos @kc89_first_38 @kc89_second_6 -280;
+    pos @kc89_first_38 @kc89_second_8 -70;
+    pos @kc89_first_38 @kc89_second_17 -140;
+    pos @kc89_first_38 @kc89_second_19 -350;
+    pos @kc89_first_38 @kc89_second_20 -140;
+    pos @kc89_first_38 @kc89_second_22 -140;
+    pos @kc89_first_38 @kc89_second_23 -70;
+    pos @kc89_first_38 @kc89_second_24 -280;
+    pos @kc89_first_38 @kc89_second_28 -315;
+    pos @kc89_first_38 @kc89_second_29 -140;
+    pos @kc89_first_38 @kc89_second_32 -385;
+    pos @kc89_first_38 @kc89_second_34 -210;
+    pos @kc89_first_38 @kc89_second_35 -70;
+    pos @kc89_first_38 @kc89_second_36 -140;
+    pos @kc89_first_38 @kc89_second_37 -140;
+    pos @kc89_first_38 @kc89_second_38 -140;
+    pos @kc89_first_38 @kc89_second_41 -70;
+    pos @kc89_first_38 @kc89_second_45 1;
+    pos @kc89_first_38 @kc89_second_51 -140;
+    pos @kc89_first_38 @kc89_second_52 -70;
+    pos @kc89_first_38 @kc89_second_53 -140;
+    pos @kc89_first_38 @kc89_second_55 -245;
+    pos @kc89_first_38 @kc89_second_58 -70;
+    pos @kc89_first_38 @kc89_second_59 -70;
+    pos @kc89_first_38 @kc89_second_63 -245;
+    pos @kc89_first_38 @kc89_second_64 -280;
+    pos @kc89_first_38 @kc89_second_65 -315;
+    pos @kc89_first_39 @kc89_second_6 -35;
+    pos @kc89_first_39 @kc89_second_12 -240;
+    pos @kc89_first_39 @kc89_second_13 -140;
+    pos @kc89_first_39 @kc89_second_14 -35;
+    pos @kc89_first_39 @kc89_second_15 -35;
+    pos @kc89_first_39 @kc89_second_34 -35;
+    pos @kc89_first_39 @kc89_second_45 1;
+    pos @kc89_first_39 @kc89_second_63 -35;
+    pos @kc89_first_39 @kc89_second_64 -35;
+    pos @kc89_first_40 @kc89_second_12 -210;
+    pos @kc89_first_40 @kc89_second_13 -175;
+    pos @kc89_first_40 @kc89_second_14 -105;
+    pos @kc89_first_40 @kc89_second_15 -70;
+    pos @kc89_first_40 @kc89_second_43 -70;
+    pos @kc89_first_40 @kc89_second_45 1;
+    pos @kc89_first_40 @kc89_second_48 -105;
+    pos @kc89_first_40 @kc89_second_61 -70;
+    pos @kc89_first_41 @kc89_second_1 -140;
+    pos @kc89_first_41 @kc89_second_2 -175;
+    pos @kc89_first_41 @kc89_second_5 -105;
+    pos @kc89_first_41 @kc89_second_6 -70;
+    pos @kc89_first_41 @kc89_second_11 -70;
+    pos @kc89_first_41 @kc89_second_12 -175;
+    pos @kc89_first_41 @kc89_second_13 -105;
+    pos @kc89_first_41 @kc89_second_14 -70;
+    pos @kc89_first_41 @kc89_second_15 -35;
+    pos @kc89_first_41 @kc89_second_16 -105;
+    pos @kc89_first_41 @kc89_second_17 -35;
+    pos @kc89_first_41 @kc89_second_19 -175;
+    pos @kc89_first_41 @kc89_second_22 -50;
+    pos @kc89_first_41 @kc89_second_24 -105;
+    pos @kc89_first_41 @kc89_second_29 -35;
+    pos @kc89_first_41 @kc89_second_34 -70;
+    pos @kc89_first_41 @kc89_second_35 -140;
+    pos @kc89_first_41 @kc89_second_36 -35;
+    pos @kc89_first_41 @kc89_second_38 -50;
+    pos @kc89_first_41 @kc89_second_45 1;
+    pos @kc89_first_41 @kc89_second_51 -35;
+    pos @kc89_first_41 @kc89_second_53 -105;
+    pos @kc89_first_41 @kc89_second_55 -105;
+    pos @kc89_first_41 @kc89_second_57 -105;
+    pos @kc89_first_41 @kc89_second_63 -50;
+    pos @kc89_first_41 @kc89_second_64 -70;
+    pos @kc89_first_42 @kc89_second_1 -210;
+    pos @kc89_first_42 @kc89_second_2 -280;
+    pos @kc89_first_42 @kc89_second_3 -70;
+    pos @kc89_first_42 @kc89_second_6 -280;
+    pos @kc89_first_42 @kc89_second_8 -35;
+    pos @kc89_first_42 @kc89_second_11 -70;
+    pos @kc89_first_42 @kc89_second_13 -140;
+    pos @kc89_first_42 @kc89_second_14 -35;
+    pos @kc89_first_42 @kc89_second_15 -35;
+    pos @kc89_first_42 @kc89_second_16 -140;
+    pos @kc89_first_42 @kc89_second_17 -105;
+    pos @kc89_first_42 @kc89_second_19 -280;
+    pos @kc89_first_42 @kc89_second_20 -140;
+    pos @kc89_first_42 @kc89_second_22 -140;
+    pos @kc89_first_42 @kc89_second_23 -140;
+    pos @kc89_first_42 @kc89_second_24 -210;
+    pos @kc89_first_42 @kc89_second_34 -280;
+    pos @kc89_first_42 @kc89_second_35 -140;
+    pos @kc89_first_42 @kc89_second_36 -70;
+    pos @kc89_first_42 @kc89_second_37 -140;
+    pos @kc89_first_42 @kc89_second_38 -175;
+    pos @kc89_first_42 @kc89_second_44 -70;
+    pos @kc89_first_42 @kc89_second_45 1;
+    pos @kc89_first_42 @kc89_second_53 -210;
+    pos @kc89_first_42 @kc89_second_55 -175;
+    pos @kc89_first_42 @kc89_second_57 -210;
+    pos @kc89_first_42 @kc89_second_59 -70;
+    pos @kc89_first_42 @kc89_second_63 -175;
+    pos @kc89_first_42 @kc89_second_64 -175;
+    pos @kc89_first_43 @kc89_second_9 -70;
+    pos @kc89_first_43 @kc89_second_12 -240;
+    pos @kc89_first_43 @kc89_second_13 -210;
+    pos @kc89_first_43 @kc89_second_14 -140;
+    pos @kc89_first_43 @kc89_second_15 -105;
+    pos @kc89_first_43 @kc89_second_39 -70;
+    pos @kc89_first_43 @kc89_second_40 -35;
+    pos @kc89_first_43 @kc89_second_43 -140;
+    pos @kc89_first_43 @kc89_second_45 1;
+    pos @kc89_first_43 @kc89_second_47 -50;
+    pos @kc89_first_43 @kc89_second_48 -140;
+    pos @kc89_first_43 @kc89_second_58 -35;
+    pos @kc89_first_43 @kc89_second_60 -35;
+    pos @kc89_first_43 @kc89_second_61 -70;
+    pos @kc89_first_43 @kc89_second_62 -70;
+    pos @kc89_first_44 @kc89_second_8 -35;
+    pos @kc89_first_44 @kc89_second_9 -70;
+    pos @kc89_first_44 @kc89_second_12 -240;
+    pos @kc89_first_44 @kc89_second_13 -210;
+    pos @kc89_first_44 @kc89_second_14 -70;
+    pos @kc89_first_44 @kc89_second_15 -105;
+    pos @kc89_first_44 @kc89_second_22 -35;
+    pos @kc89_first_44 @kc89_second_38 -70;
+    pos @kc89_first_44 @kc89_second_39 -105;
+    pos @kc89_first_44 @kc89_second_40 -70;
+    pos @kc89_first_44 @kc89_second_43 -70;
+    pos @kc89_first_44 @kc89_second_44 -35;
+    pos @kc89_first_44 @kc89_second_45 1;
+    pos @kc89_first_44 @kc89_second_47 -70;
+    pos @kc89_first_44 @kc89_second_48 -70;
+    pos @kc89_first_44 @kc89_second_58 -70;
+    pos @kc89_first_44 @kc89_second_60 -50;
+    pos @kc89_first_44 @kc89_second_62 -70;
+    pos @kc89_first_44 @kc89_second_63 -35;
+    pos @kc89_first_44 @kc89_second_64 -35;
+    pos @kc89_first_45 @kc89_second_6 -70;
+    pos @kc89_first_45 @kc89_second_8 -35;
+    pos @kc89_first_45 @kc89_second_12 -175;
+    pos @kc89_first_45 @kc89_second_13 -140;
+    pos @kc89_first_45 @kc89_second_14 -70;
+    pos @kc89_first_45 @kc89_second_15 -35;
+    pos @kc89_first_45 @kc89_second_17 -70;
+    pos @kc89_first_45 @kc89_second_20 -70;
+    pos @kc89_first_45 @kc89_second_22 -105;
+    pos @kc89_first_45 @kc89_second_29 -35;
+    pos @kc89_first_45 @kc89_second_34 -70;
+    pos @kc89_first_45 @kc89_second_36 -35;
+    pos @kc89_first_45 @kc89_second_38 -105;
+    pos @kc89_first_45 @kc89_second_45 1;
+    pos @kc89_first_45 @kc89_second_51 -35;
+    pos @kc89_first_45 @kc89_second_63 -70;
+    pos @kc89_first_45 @kc89_second_64 -70;
+    pos @kc89_first_46 @kc89_second_3 -140;
+    pos @kc89_first_46 @kc89_second_4 -70;
+    pos @kc89_first_46 @kc89_second_6 -70;
+    pos @kc89_first_46 @kc89_second_8 -210;
+    pos @kc89_first_46 @kc89_second_9 -420;
+    pos @kc89_first_46 @kc89_second_12 -350;
+    pos @kc89_first_46 @kc89_second_13 -420;
+    pos @kc89_first_46 @kc89_second_14 -350;
+    pos @kc89_first_46 @kc89_second_15 -280;
+    pos @kc89_first_46 @kc89_second_17 -70;
+    pos @kc89_first_46 @kc89_second_18 -210;
+    pos @kc89_first_46 @kc89_second_20 -210;
+    pos @kc89_first_46 @kc89_second_22 -70;
+    pos @kc89_first_46 @kc89_second_23 -140;
+    pos @kc89_first_46 @kc89_second_29 -35;
+    pos @kc89_first_46 @kc89_second_31 -140;
+    pos @kc89_first_46 @kc89_second_34 -70;
+    pos @kc89_first_46 @kc89_second_36 -70;
+    pos @kc89_first_46 @kc89_second_38 -210;
+    pos @kc89_first_46 @kc89_second_39 -280;
+    pos @kc89_first_46 @kc89_second_40 -420;
+    pos @kc89_first_46 @kc89_second_43 -350;
+    pos @kc89_first_46 @kc89_second_45 1;
+    pos @kc89_first_46 @kc89_second_46 -35;
+    pos @kc89_first_46 @kc89_second_47 -210;
+    pos @kc89_first_46 @kc89_second_48 -350;
+    pos @kc89_first_46 @kc89_second_51 -35;
+    pos @kc89_first_46 @kc89_second_52 -35;
+    pos @kc89_first_46 @kc89_second_58 -280;
+    pos @kc89_first_46 @kc89_second_60 -175;
+    pos @kc89_first_46 @kc89_second_61 -280;
+    pos @kc89_first_46 @kc89_second_62 -210;
+    pos @kc89_first_46 @kc89_second_63 -70;
+    pos @kc89_first_47 @kc89_second_3 -140;
+    pos @kc89_first_47 @kc89_second_4 -105;
+    pos @kc89_first_47 @kc89_second_6 -70;
+    pos @kc89_first_47 @kc89_second_8 -210;
+    pos @kc89_first_47 @kc89_second_9 -280;
+    pos @kc89_first_47 @kc89_second_12 -350;
+    pos @kc89_first_47 @kc89_second_13 -385;
+    pos @kc89_first_47 @kc89_second_14 -350;
+    pos @kc89_first_47 @kc89_second_15 -280;
+    pos @kc89_first_47 @kc89_second_18 -210;
+    pos @kc89_first_47 @kc89_second_20 -140;
+    pos @kc89_first_47 @kc89_second_22 -105;
+    pos @kc89_first_47 @kc89_second_23 -140;
+    pos @kc89_first_47 @kc89_second_29 -70;
+    pos @kc89_first_47 @kc89_second_31 -175;
+    pos @kc89_first_47 @kc89_second_34 -70;
+    pos @kc89_first_47 @kc89_second_36 -35;
+    pos @kc89_first_47 @kc89_second_38 -175;
+    pos @kc89_first_47 @kc89_second_39 -280;
+    pos @kc89_first_47 @kc89_second_40 -280;
+    pos @kc89_first_47 @kc89_second_43 -280;
+    pos @kc89_first_47 @kc89_second_44 -140;
+    pos @kc89_first_47 @kc89_second_45 1;
+    pos @kc89_first_47 @kc89_second_46 -70;
+    pos @kc89_first_47 @kc89_second_47 -280;
+    pos @kc89_first_47 @kc89_second_48 -350;
+    pos @kc89_first_47 @kc89_second_51 -35;
+    pos @kc89_first_47 @kc89_second_52 -70;
+    pos @kc89_first_47 @kc89_second_58 -245;
+    pos @kc89_first_47 @kc89_second_60 -245;
+    pos @kc89_first_47 @kc89_second_61 -280;
+    pos @kc89_first_47 @kc89_second_62 -210;
+    pos @kc89_first_47 @kc89_second_63 -70;
+    pos @kc89_first_47 @kc89_second_64 -70;
+    pos @kc89_first_48 @kc89_second_3 -70;
+    pos @kc89_first_48 @kc89_second_4 -105;
+    pos @kc89_first_48 @kc89_second_6 -210;
+    pos @kc89_first_48 @kc89_second_7 -70;
+    pos @kc89_first_48 @kc89_second_8 -175;
+    pos @kc89_first_48 @kc89_second_17 -210;
+    pos @kc89_first_48 @kc89_second_20 -140;
+    pos @kc89_first_48 @kc89_second_21 -210;
+    pos @kc89_first_48 @kc89_second_22 -210;
+    pos @kc89_first_48 @kc89_second_23 -210;
+    pos @kc89_first_48 @kc89_second_24 -140;
+    pos @kc89_first_48 @kc89_second_25 -140;
+    pos @kc89_first_48 @kc89_second_27 -140;
+    pos @kc89_first_48 @kc89_second_29 -210;
+    pos @kc89_first_48 @kc89_second_30 -210;
+    pos @kc89_first_48 @kc89_second_31 -140;
+    pos @kc89_first_48 @kc89_second_34 -210;
+    pos @kc89_first_48 @kc89_second_35 -70;
+    pos @kc89_first_48 @kc89_second_36 -175;
+    pos @kc89_first_48 @kc89_second_37 -210;
+    pos @kc89_first_48 @kc89_second_38 -175;
+    pos @kc89_first_48 @kc89_second_39 -210;
+    pos @kc89_first_48 @kc89_second_40 -105;
+    pos @kc89_first_48 @kc89_second_43 -70;
+    pos @kc89_first_48 @kc89_second_44 -105;
+    pos @kc89_first_48 @kc89_second_45 1;
+    pos @kc89_first_48 @kc89_second_46 -35;
+    pos @kc89_first_48 @kc89_second_47 -210;
+    pos @kc89_first_48 @kc89_second_50 -210;
+    pos @kc89_first_48 @kc89_second_51 -210;
+    pos @kc89_first_48 @kc89_second_52 -175;
+    pos @kc89_first_48 @kc89_second_53 -175;
+    pos @kc89_first_48 @kc89_second_55 -210;
+    pos @kc89_first_48 @kc89_second_56 -140;
+    pos @kc89_first_48 @kc89_second_57 -210;
+    pos @kc89_first_48 @kc89_second_58 -210;
+    pos @kc89_first_48 @kc89_second_59 -175;
+    pos @kc89_first_48 @kc89_second_60 -175;
+    pos @kc89_first_48 @kc89_second_63 -210;
+    pos @kc89_first_48 @kc89_second_64 -210;
+    pos @kc89_first_49 @kc89_second_5 -70;
+    pos @kc89_first_49 @kc89_second_11 -35;
+    pos @kc89_first_49 @kc89_second_12 -240;
+    pos @kc89_first_49 @kc89_second_13 -70;
+    pos @kc89_first_49 @kc89_second_14 -140;
+    pos @kc89_first_49 @kc89_second_15 -105;
+    pos @kc89_first_49 @kc89_second_16 -70;
+    pos @kc89_first_49 @kc89_second_26 -70;
+    pos @kc89_first_49 @kc89_second_27 -70;
+    pos @kc89_first_49 @kc89_second_35 -35;
+    pos @kc89_first_49 @kc89_second_39 -70;
+    pos @kc89_first_49 @kc89_second_42 -35;
+    pos @kc89_first_49 @kc89_second_43 -70;
+    pos @kc89_first_49 @kc89_second_45 1;
+    pos @kc89_first_49 @kc89_second_47 -35;
+    pos @kc89_first_49 @kc89_second_48 -140;
+    pos @kc89_first_49 @kc89_second_51 1;
+    pos @kc89_first_49 @kc89_second_56 -35;
+    pos @kc89_first_49 @kc89_second_60 -35;
+    pos @kc89_first_49 @kc89_second_61 -105;
+    pos @kc89_first_49 @kc89_second_62 -70;
+    pos @kc89_first_50 @kc89_second_65 -70;
+    pos @kc89_first_51 @kc89_second_32 -315;
+    pos @kc89_first_51 @kc89_second_66 -70;
+    pos @kc89_first_52 @kc89_second_1 -105;
+    pos @kc89_first_52 @kc89_second_2 -210;
+    pos @kc89_first_52 @kc89_second_6 -140;
+    pos @kc89_first_52 @kc89_second_11 -70;
+    pos @kc89_first_52 @kc89_second_12 -210;
+    pos @kc89_first_52 @kc89_second_13 -210;
+    pos @kc89_first_52 @kc89_second_14 -105;
+    pos @kc89_first_52 @kc89_second_15 -70;
+    pos @kc89_first_52 @kc89_second_16 -140;
+    pos @kc89_first_52 @kc89_second_17 -35;
+    pos @kc89_first_52 @kc89_second_22 -35;
+    pos @kc89_first_52 @kc89_second_24 -210;
+    pos @kc89_first_52 @kc89_second_26 -70;
+    pos @kc89_first_52 @kc89_second_27 -70;
+    pos @kc89_first_52 @kc89_second_29 -35;
+    pos @kc89_first_52 @kc89_second_34 -210;
+    pos @kc89_first_52 @kc89_second_35 -140;
+    pos @kc89_first_52 @kc89_second_42 -35;
+    pos @kc89_first_52 @kc89_second_43 -70;
+    pos @kc89_first_52 @kc89_second_45 1;
+    pos @kc89_first_52 @kc89_second_47 -35;
+    pos @kc89_first_52 @kc89_second_48 -105;
+    pos @kc89_first_52 @kc89_second_53 -210;
+    pos @kc89_first_52 @kc89_second_55 -140;
+    pos @kc89_first_52 @kc89_second_57 -175;
+    pos @kc89_first_52 @kc89_second_61 -35;
+    pos @kc89_first_52 @kc89_second_62 -35;
+    pos @kc89_first_52 @kc89_second_63 -35;
+    pos @kc89_first_52 @kc89_second_64 -70;
+    pos @kc89_first_53 @kc89_second_1 -35;
+    pos @kc89_first_53 @kc89_second_2 -70;
+    pos @kc89_first_53 @kc89_second_5 -105;
+    pos @kc89_first_53 @kc89_second_6 -35;
+    pos @kc89_first_53 @kc89_second_9 -70;
+    pos @kc89_first_53 @kc89_second_11 -70;
+    pos @kc89_first_53 @kc89_second_12 -240;
+    pos @kc89_first_53 @kc89_second_13 -245;
+    pos @kc89_first_53 @kc89_second_14 -140;
+    pos @kc89_first_53 @kc89_second_15 -105;
+    pos @kc89_first_53 @kc89_second_16 -105;
+    pos @kc89_first_53 @kc89_second_18 -70;
+    pos @kc89_first_53 @kc89_second_19 -70;
+    pos @kc89_first_53 @kc89_second_24 -35;
+    pos @kc89_first_53 @kc89_second_25 -70;
+    pos @kc89_first_53 @kc89_second_26 -140;
+    pos @kc89_first_53 @kc89_second_27 -105;
+    pos @kc89_first_53 @kc89_second_34 -35;
+    pos @kc89_first_53 @kc89_second_35 -140;
+    pos @kc89_first_53 @kc89_second_39 -105;
+    pos @kc89_first_53 @kc89_second_40 -70;
+    pos @kc89_first_53 @kc89_second_42 -105;
+    pos @kc89_first_53 @kc89_second_43 -175;
+    pos @kc89_first_53 @kc89_second_45 1;
+    pos @kc89_first_53 @kc89_second_47 -70;
+    pos @kc89_first_53 @kc89_second_48 -140;
+    pos @kc89_first_53 @kc89_second_49 -70;
+    pos @kc89_first_53 @kc89_second_53 -210;
+    pos @kc89_first_53 @kc89_second_54 -70;
+    pos @kc89_first_53 @kc89_second_55 -175;
+    pos @kc89_first_53 @kc89_second_56 -105;
+    pos @kc89_first_53 @kc89_second_57 -175;
+    pos @kc89_first_53 @kc89_second_60 -50;
+    pos @kc89_first_53 @kc89_second_61 -105;
+    pos @kc89_first_53 @kc89_second_62 -70;
+    pos @kc89_first_53 @kc89_second_64 -35;
+    pos @kc89_first_54 @kc89_second_1 -105;
+    pos @kc89_first_54 @kc89_second_2 -210;
+    pos @kc89_first_54 @kc89_second_5 -70;
+    pos @kc89_first_54 @kc89_second_6 -105;
+    pos @kc89_first_54 @kc89_second_13 -70;
+    pos @kc89_first_54 @kc89_second_14 -35;
+    pos @kc89_first_54 @kc89_second_16 -140;
+    pos @kc89_first_54 @kc89_second_17 -70;
+    pos @kc89_first_54 @kc89_second_19 -210;
+    pos @kc89_first_54 @kc89_second_22 -35;
+    pos @kc89_first_54 @kc89_second_24 -210;
+    pos @kc89_first_54 @kc89_second_29 -35;
+    pos @kc89_first_54 @kc89_second_32 -105;
+    pos @kc89_first_54 @kc89_second_34 -105;
+    pos @kc89_first_54 @kc89_second_35 -140;
+    pos @kc89_first_54 @kc89_second_38 -70;
+    pos @kc89_first_54 @kc89_second_45 1;
+    pos @kc89_first_54 @kc89_second_51 -35;
+    pos @kc89_first_54 @kc89_second_53 -245;
+    pos @kc89_first_54 @kc89_second_55 -210;
+    pos @kc89_first_54 @kc89_second_57 -210;
+    pos @kc89_first_54 @kc89_second_63 -70;
+    pos @kc89_first_54 @kc89_second_64 -105;
+    pos @kc89_first_55 @kc89_second_12 -240;
+    pos @kc89_first_55 @kc89_second_13 -140;
+    pos @kc89_first_55 @kc89_second_14 -105;
+    pos @kc89_first_55 @kc89_second_15 -35;
+    pos @kc89_first_55 @kc89_second_33 165;
+    pos @kc89_first_55 @kc89_second_45 1;
+    pos @kc89_first_55 @kc89_second_50 165;
+    pos @kc89_first_56 @kc89_second_1 -140;
+    pos @kc89_first_56 @kc89_second_2 -210;
+    pos @kc89_first_56 @kc89_second_6 -140;
+    pos @kc89_first_56 @kc89_second_12 -175;
+    pos @kc89_first_56 @kc89_second_13 -140;
+    pos @kc89_first_56 @kc89_second_16 -140;
+    pos @kc89_first_56 @kc89_second_19 -210;
+    pos @kc89_first_56 @kc89_second_24 -210;
+    pos @kc89_first_56 @kc89_second_32 -140;
+    pos @kc89_first_56 @kc89_second_34 -140;
+    pos @kc89_first_56 @kc89_second_35 -210;
+    pos @kc89_first_56 @kc89_second_36 -35;
+    pos @kc89_first_56 @kc89_second_45 1;
+    pos @kc89_first_56 @kc89_second_53 -210;
+    pos @kc89_first_56 @kc89_second_55 -175;
+    pos @kc89_first_56 @kc89_second_57 -175;
+    pos @kc89_first_56 @kc89_second_63 -105;
+    pos @kc89_first_56 @kc89_second_64 -210;
+    pos @kc89_first_57 @kc89_second_12 -240;
+    pos @kc89_first_57 @kc89_second_13 -175;
+    pos @kc89_first_57 @kc89_second_14 -70;
+    pos @kc89_first_57 @kc89_second_15 -35;
+    pos @kc89_first_57 @kc89_second_19 -35;
+    pos @kc89_first_57 @kc89_second_26 -35;
+    pos @kc89_first_57 @kc89_second_39 -35;
+    pos @kc89_first_57 @kc89_second_40 -35;
+    pos @kc89_first_57 @kc89_second_43 -70;
+    pos @kc89_first_57 @kc89_second_45 1;
+    pos @kc89_first_57 @kc89_second_47 -35;
+    pos @kc89_first_57 @kc89_second_48 -70;
+    pos @kc89_first_57 @kc89_second_58 -35;
+    pos @kc89_first_57 @kc89_second_60 -35;
+    pos @kc89_first_57 @kc89_second_61 -70;
+    pos @kc89_first_57 @kc89_second_62 -35;
+    pos @kc89_first_58 @kc89_second_13 -35;
+    pos @kc89_first_58 @kc89_second_58 -35;
+    pos @kc89_first_58 @kc89_second_64 -35;
+    pos @kc89_first_59 @kc89_second_12 -175;
+    pos @kc89_first_59 @kc89_second_13 -140;
+    pos @kc89_first_59 @kc89_second_14 -35;
+    pos @kc89_first_59 @kc89_second_45 1;
+    pos @kc89_first_60 @kc89_second_1 -140;
+    pos @kc89_first_60 @kc89_second_2 -280;
+    pos @kc89_first_60 @kc89_second_5 -140;
+    pos @kc89_first_60 @kc89_second_6 -280;
+    pos @kc89_first_60 @kc89_second_8 -70;
+    pos @kc89_first_60 @kc89_second_10 -70;
+    pos @kc89_first_60 @kc89_second_11 -175;
+    pos @kc89_first_60 @kc89_second_12 -240;
+    pos @kc89_first_60 @kc89_second_13 -140;
+    pos @kc89_first_60 @kc89_second_14 -105;
+    pos @kc89_first_60 @kc89_second_15 -70;
+    pos @kc89_first_60 @kc89_second_16 -175;
+    pos @kc89_first_60 @kc89_second_17 -70;
+    pos @kc89_first_60 @kc89_second_19 -280;
+    pos @kc89_first_60 @kc89_second_22 -70;
+    pos @kc89_first_60 @kc89_second_23 -70;
+    pos @kc89_first_60 @kc89_second_24 -210;
+    pos @kc89_first_60 @kc89_second_26 -70;
+    pos @kc89_first_60 @kc89_second_27 -70;
+    pos @kc89_first_60 @kc89_second_29 -70;
+    pos @kc89_first_60 @kc89_second_32 -70;
+    pos @kc89_first_60 @kc89_second_34 -315;
+    pos @kc89_first_60 @kc89_second_35 -140;
+    pos @kc89_first_60 @kc89_second_36 -70;
+    pos @kc89_first_60 @kc89_second_38 -105;
+    pos @kc89_first_60 @kc89_second_45 1;
+    pos @kc89_first_60 @kc89_second_48 -35;
+    pos @kc89_first_60 @kc89_second_51 -50;
+    pos @kc89_first_60 @kc89_second_53 -210;
+    pos @kc89_first_60 @kc89_second_55 -175;
+    pos @kc89_first_60 @kc89_second_57 -210;
+    pos @kc89_first_60 @kc89_second_59 -35;
+    pos @kc89_first_60 @kc89_second_61 -70;
+    pos @kc89_first_60 @kc89_second_62 -35;
+    pos @kc89_first_60 @kc89_second_63 -140;
+    pos @kc89_first_60 @kc89_second_64 -210;
+    pos @kc89_first_61 @kc89_second_1 -35;
+    pos @kc89_first_61 @kc89_second_2 -70;
+    pos @kc89_first_61 @kc89_second_5 -70;
+    pos @kc89_first_61 @kc89_second_11 -35;
+    pos @kc89_first_61 @kc89_second_12 -140;
+    pos @kc89_first_61 @kc89_second_13 -140;
+    pos @kc89_first_61 @kc89_second_14 -70;
+    pos @kc89_first_61 @kc89_second_15 -35;
+    pos @kc89_first_61 @kc89_second_16 -105;
+    pos @kc89_first_61 @kc89_second_26 -35;
+    pos @kc89_first_61 @kc89_second_27 -70;
+    pos @kc89_first_61 @kc89_second_35 -70;
+    pos @kc89_first_61 @kc89_second_43 -70;
+    pos @kc89_first_61 @kc89_second_45 1;
+    pos @kc89_first_61 @kc89_second_53 -175;
+    pos @kc89_first_61 @kc89_second_55 -140;
+    pos @kc89_first_61 @kc89_second_57 -140;
+    pos @kc89_first_61 @kc89_second_61 -35;
+    pos @kc89_first_62 @kc89_second_5 -70;
+    pos @kc89_first_62 @kc89_second_9 -70;
+    pos @kc89_first_62 @kc89_second_11 -35;
+    pos @kc89_first_62 @kc89_second_12 -350;
+    pos @kc89_first_62 @kc89_second_13 -315;
+    pos @kc89_first_62 @kc89_second_14 -175;
+    pos @kc89_first_62 @kc89_second_15 -140;
+    pos @kc89_first_62 @kc89_second_16 -70;
+    pos @kc89_first_62 @kc89_second_18 -70;
+    pos @kc89_first_62 @kc89_second_27 -70;
+    pos @kc89_first_62 @kc89_second_31 -50;
+    pos @kc89_first_62 @kc89_second_39 -140;
+    pos @kc89_first_62 @kc89_second_40 -50;
+    pos @kc89_first_62 @kc89_second_42 -35;
+    pos @kc89_first_62 @kc89_second_43 -175;
+    pos @kc89_first_62 @kc89_second_45 1;
+    pos @kc89_first_62 @kc89_second_47 -70;
+    pos @kc89_first_62 @kc89_second_48 -175;
+    pos @kc89_first_62 @kc89_second_54 -70;
+    pos @kc89_first_62 @kc89_second_58 -70;
+    pos @kc89_first_62 @kc89_second_60 -50;
+    pos @kc89_first_62 @kc89_second_61 -140;
+    pos @kc89_first_62 @kc89_second_62 -105;
+    pos @kc89_first_63 @kc89_second_4 -105;
+    pos @kc89_first_63 @kc89_second_6 -35;
+    pos @kc89_first_63 @kc89_second_8 1;
+    pos @kc89_first_63 @kc89_second_9 -245;
+    pos @kc89_first_63 @kc89_second_12 -210;
+    pos @kc89_first_63 @kc89_second_13 -210;
+    pos @kc89_first_63 @kc89_second_14 -210;
+    pos @kc89_first_63 @kc89_second_15 -175;
+    pos @kc89_first_63 @kc89_second_17 -70;
+    pos @kc89_first_63 @kc89_second_18 -180;
+    pos @kc89_first_63 @kc89_second_20 -140;
+    pos @kc89_first_63 @kc89_second_22 -105;
+    pos @kc89_first_63 @kc89_second_25 -140;
+    pos @kc89_first_63 @kc89_second_29 -105;
+    pos @kc89_first_63 @kc89_second_31 -140;
+    pos @kc89_first_63 @kc89_second_34 -35;
+    pos @kc89_first_63 @kc89_second_36 -35;
+    pos @kc89_first_63 @kc89_second_38 -175;
+    pos @kc89_first_63 @kc89_second_39 -142;
+    pos @kc89_first_63 @kc89_second_40 -245;
+    pos @kc89_first_63 @kc89_second_43 -210;
+    pos @kc89_first_63 @kc89_second_44 -105;
+    pos @kc89_first_63 @kc89_second_45 1;
+    pos @kc89_first_63 @kc89_second_46 -35;
+    pos @kc89_first_63 @kc89_second_47 -210;
+    pos @kc89_first_63 @kc89_second_48 -210;
+    pos @kc89_first_63 @kc89_second_51 -35;
+    pos @kc89_first_63 @kc89_second_58 -280;
+    pos @kc89_first_63 @kc89_second_60 -175;
+    pos @kc89_first_63 @kc89_second_61 -140;
+    pos @kc89_first_63 @kc89_second_62 -140;
+    pos @kc89_first_63 @kc89_second_63 -70;
+    pos @kc89_first_63 @kc89_second_64 -70;
+    pos @kc89_first_64 @kc89_second_1 -175;
+    pos @kc89_first_64 @kc89_second_2 -175;
+    pos @kc89_first_64 @kc89_second_5 -70;
+    pos @kc89_first_64 @kc89_second_6 -105;
+    pos @kc89_first_64 @kc89_second_11 -105;
+    pos @kc89_first_64 @kc89_second_12 -175;
+    pos @kc89_first_64 @kc89_second_13 -140;
+    pos @kc89_first_64 @kc89_second_14 -70;
+    pos @kc89_first_64 @kc89_second_15 -35;
+    pos @kc89_first_64 @kc89_second_16 -140;
+    pos @kc89_first_64 @kc89_second_17 -70;
+    pos @kc89_first_64 @kc89_second_19 -175;
+    pos @kc89_first_64 @kc89_second_22 -70;
+    pos @kc89_first_64 @kc89_second_29 -35;
+    pos @kc89_first_64 @kc89_second_34 -105;
+    pos @kc89_first_64 @kc89_second_35 -175;
+    pos @kc89_first_64 @kc89_second_36 -35;
+    pos @kc89_first_64 @kc89_second_38 -70;
+    pos @kc89_first_64 @kc89_second_45 1;
+    pos @kc89_first_64 @kc89_second_51 -35;
+    pos @kc89_first_64 @kc89_second_53 -140;
+    pos @kc89_first_64 @kc89_second_55 -140;
+    pos @kc89_first_64 @kc89_second_57 -140;
+    pos @kc89_first_64 @kc89_second_63 -70;
+    pos @kc89_first_64 @kc89_second_64 -105;
+    pos @kc89_first_65 @kc89_second_1 -210;
+    pos @kc89_first_65 @kc89_second_2 -210;
+    pos @kc89_first_65 @kc89_second_3 -70;
+    pos @kc89_first_65 @kc89_second_4 -35;
+    pos @kc89_first_65 @kc89_second_6 -210;
+    pos @kc89_first_65 @kc89_second_7 -70;
+    pos @kc89_first_65 @kc89_second_8 -70;
+    pos @kc89_first_65 @kc89_second_16 -70;
+    pos @kc89_first_65 @kc89_second_17 -140;
+    pos @kc89_first_65 @kc89_second_19 -210;
+    pos @kc89_first_65 @kc89_second_20 -140;
+    pos @kc89_first_65 @kc89_second_21 -35;
+    pos @kc89_first_65 @kc89_second_22 -175;
+    pos @kc89_first_65 @kc89_second_23 -140;
+    pos @kc89_first_65 @kc89_second_24 -280;
+    pos @kc89_first_65 @kc89_second_29 -35;
+    pos @kc89_first_65 @kc89_second_30 -35;
+    pos @kc89_first_65 @kc89_second_32 -210;
+    pos @kc89_first_65 @kc89_second_34 -245;
+    pos @kc89_first_65 @kc89_second_35 -140;
+    pos @kc89_first_65 @kc89_second_36 -140;
+    pos @kc89_first_65 @kc89_second_37 -140;
+    pos @kc89_first_65 @kc89_second_38 -140;
+    pos @kc89_first_65 @kc89_second_39 -35;
+    pos @kc89_first_65 @kc89_second_44 -35;
+    pos @kc89_first_65 @kc89_second_45 1;
+    pos @kc89_first_65 @kc89_second_49 -35;
+    pos @kc89_first_65 @kc89_second_51 -140;
+    pos @kc89_first_65 @kc89_second_52 -70;
+    pos @kc89_first_65 @kc89_second_53 -210;
+    pos @kc89_first_65 @kc89_second_55 -210;
+    pos @kc89_first_65 @kc89_second_57 -210;
+    pos @kc89_first_65 @kc89_second_58 -35;
+    pos @kc89_first_65 @kc89_second_63 -175;
+    pos @kc89_first_65 @kc89_second_64 -245;
+    pos @kc89_first_66 @kc89_second_6 -35;
+    pos @kc89_first_66 @kc89_second_12 -240;
+    pos @kc89_first_66 @kc89_second_13 -140;
+    pos @kc89_first_66 @kc89_second_14 -70;
+    pos @kc89_first_66 @kc89_second_15 -35;
+    pos @kc89_first_66 @kc89_second_20 -35;
+    pos @kc89_first_66 @kc89_second_22 -35;
+    pos @kc89_first_66 @kc89_second_34 -70;
+    pos @kc89_first_66 @kc89_second_38 -70;
+    pos @kc89_first_66 @kc89_second_39 -50;
+    pos @kc89_first_66 @kc89_second_45 1;
+    pos @kc89_first_66 @kc89_second_48 -35;
+    pos @kc89_first_66 @kc89_second_63 -35;
+    pos @kc89_first_66 @kc89_second_64 -35;
+    pos @kc89_first_67 @kc89_second_3 -100;
+    pos @kc89_first_67 @kc89_second_4 -50;
+    pos @kc89_first_67 @kc89_second_6 -50;
+    pos @kc89_first_67 @kc89_second_8 -70;
+    pos @kc89_first_67 @kc89_second_9 -140;
+    pos @kc89_first_67 @kc89_second_10 -50;
+    pos @kc89_first_67 @kc89_second_12 -140;
+    pos @kc89_first_67 @kc89_second_13 -100;
+    pos @kc89_first_67 @kc89_second_14 -70;
+    pos @kc89_first_67 @kc89_second_15 -50;
+    pos @kc89_first_67 @kc89_second_18 -70;
+    pos @kc89_first_67 @kc89_second_20 -70;
+    pos @kc89_first_67 @kc89_second_22 -50;
+    pos @kc89_first_67 @kc89_second_23 -70;
+    pos @kc89_first_67 @kc89_second_29 -35;
+    pos @kc89_first_67 @kc89_second_31 -70;
+    pos @kc89_first_67 @kc89_second_33 105;
+    pos @kc89_first_67 @kc89_second_34 -35;
+    pos @kc89_first_67 @kc89_second_38 -70;
+    pos @kc89_first_67 @kc89_second_39 -140;
+    pos @kc89_first_67 @kc89_second_40 -140;
+    pos @kc89_first_67 @kc89_second_43 -140;
+    pos @kc89_first_67 @kc89_second_44 -35;
+    pos @kc89_first_67 @kc89_second_45 1;
+    pos @kc89_first_67 @kc89_second_47 -70;
+    pos @kc89_first_67 @kc89_second_48 -100;
+    pos @kc89_first_67 @kc89_second_50 105;
+    pos @kc89_first_67 @kc89_second_58 -140;
+    pos @kc89_first_67 @kc89_second_60 -70;
+    pos @kc89_first_67 @kc89_second_61 -70;
+    pos @kc89_first_67 @kc89_second_62 -50;
+    pos @kc89_first_67 @kc89_second_63 -35;
+    pos @kc89_first_67 @kc89_second_64 -35;
+    pos @kc89_first_68 @kc89_second_3 -70;
+    pos @kc89_first_68 @kc89_second_4 -50;
+    pos @kc89_first_68 @kc89_second_6 -50;
+    pos @kc89_first_68 @kc89_second_8 -70;
+    pos @kc89_first_68 @kc89_second_9 -140;
+    pos @kc89_first_68 @kc89_second_10 -50;
+    pos @kc89_first_68 @kc89_second_12 -240;
+    pos @kc89_first_68 @kc89_second_13 -240;
+    pos @kc89_first_68 @kc89_second_14 -175;
+    pos @kc89_first_68 @kc89_second_15 -140;
+    pos @kc89_first_68 @kc89_second_18 -70;
+    pos @kc89_first_68 @kc89_second_20 -70;
+    pos @kc89_first_68 @kc89_second_22 -50;
+    pos @kc89_first_68 @kc89_second_23 -70;
+    pos @kc89_first_68 @kc89_second_29 -35;
+    pos @kc89_first_68 @kc89_second_31 -70;
+    pos @kc89_first_68 @kc89_second_34 -35;
+    pos @kc89_first_68 @kc89_second_38 -70;
+    pos @kc89_first_68 @kc89_second_39 -140;
+    pos @kc89_first_68 @kc89_second_40 -140;
+    pos @kc89_first_68 @kc89_second_43 -140;
+    pos @kc89_first_68 @kc89_second_44 -35;
+    pos @kc89_first_68 @kc89_second_45 1;
+    pos @kc89_first_68 @kc89_second_47 -70;
+    pos @kc89_first_68 @kc89_second_48 -140;
+    pos @kc89_first_68 @kc89_second_58 -140;
+    pos @kc89_first_68 @kc89_second_60 -70;
+    pos @kc89_first_68 @kc89_second_61 -105;
+    pos @kc89_first_68 @kc89_second_62 -70;
+    pos @kc89_first_68 @kc89_second_63 -35;
+    pos @kc89_first_68 @kc89_second_64 -35;
+    pos @kc89_first_69 @kc89_second_3 -70;
+    pos @kc89_first_69 @kc89_second_4 -50;
+    pos @kc89_first_69 @kc89_second_6 -50;
+    pos @kc89_first_69 @kc89_second_8 -70;
+    pos @kc89_first_69 @kc89_second_9 -140;
+    pos @kc89_first_69 @kc89_second_10 -50;
+    pos @kc89_first_69 @kc89_second_12 -140;
+    pos @kc89_first_69 @kc89_second_13 -140;
+    pos @kc89_first_69 @kc89_second_14 -105;
+    pos @kc89_first_69 @kc89_second_15 -70;
+    pos @kc89_first_69 @kc89_second_18 -70;
+    pos @kc89_first_69 @kc89_second_20 -70;
+    pos @kc89_first_69 @kc89_second_22 -50;
+    pos @kc89_first_69 @kc89_second_23 -100;
+    pos @kc89_first_69 @kc89_second_29 -35;
+    pos @kc89_first_69 @kc89_second_31 -70;
+    pos @kc89_first_69 @kc89_second_33 105;
+    pos @kc89_first_69 @kc89_second_34 -35;
+    pos @kc89_first_69 @kc89_second_38 -70;
+    pos @kc89_first_69 @kc89_second_39 -140;
+    pos @kc89_first_69 @kc89_second_40 -140;
+    pos @kc89_first_69 @kc89_second_43 -140;
+    pos @kc89_first_69 @kc89_second_44 -35;
+    pos @kc89_first_69 @kc89_second_45 1;
+    pos @kc89_first_69 @kc89_second_47 -70;
+    pos @kc89_first_69 @kc89_second_48 -140;
+    pos @kc89_first_69 @kc89_second_50 105;
+    pos @kc89_first_69 @kc89_second_58 -140;
+    pos @kc89_first_69 @kc89_second_60 -70;
+    pos @kc89_first_69 @kc89_second_61 -70;
+    pos @kc89_first_69 @kc89_second_62 -50;
+    pos @kc89_first_69 @kc89_second_63 -35;
+    pos @kc89_first_69 @kc89_second_64 -35;
+    pos @kc89_first_70 @kc89_second_1 -210;
+    pos @kc89_first_70 @kc89_second_2 -210;
+    pos @kc89_first_70 @kc89_second_3 -35;
+    pos @kc89_first_70 @kc89_second_6 -140;
+    pos @kc89_first_70 @kc89_second_8 -70;
+    pos @kc89_first_70 @kc89_second_10 -35;
+    pos @kc89_first_70 @kc89_second_17 -70;
+    pos @kc89_first_70 @kc89_second_19 -210;
+    pos @kc89_first_70 @kc89_second_20 -70;
+    pos @kc89_first_70 @kc89_second_22 -105;
+    pos @kc89_first_70 @kc89_second_23 -105;
+    pos @kc89_first_70 @kc89_second_24 -175;
+    pos @kc89_first_70 @kc89_second_29 -105;
+    pos @kc89_first_70 @kc89_second_34 -175;
+    pos @kc89_first_70 @kc89_second_35 -140;
+    pos @kc89_first_70 @kc89_second_36 -70;
+    pos @kc89_first_70 @kc89_second_37 -105;
+    pos @kc89_first_70 @kc89_second_38 -105;
+    pos @kc89_first_70 @kc89_second_39 -70;
+    pos @kc89_first_70 @kc89_second_44 -35;
+    pos @kc89_first_70 @kc89_second_45 1;
+    pos @kc89_first_70 @kc89_second_50 -35;
+    pos @kc89_first_70 @kc89_second_51 -70;
+    pos @kc89_first_70 @kc89_second_52 -70;
+    pos @kc89_first_70 @kc89_second_53 -175;
+    pos @kc89_first_70 @kc89_second_55 -175;
+    pos @kc89_first_70 @kc89_second_57 -175;
+    pos @kc89_first_70 @kc89_second_58 -35;
+    pos @kc89_first_70 @kc89_second_59 -35;
+    pos @kc89_first_70 @kc89_second_63 -140;
+    pos @kc89_first_70 @kc89_second_64 -175;
+    pos @kc89_first_71 @kc89_second_5 -70;
+    pos @kc89_first_71 @kc89_second_8 -70;
+    pos @kc89_first_71 @kc89_second_9 -105;
+    pos @kc89_first_71 @kc89_second_11 -35;
+    pos @kc89_first_71 @kc89_second_12 -350;
+    pos @kc89_first_71 @kc89_second_13 -350;
+    pos @kc89_first_71 @kc89_second_14 -245;
+    pos @kc89_first_71 @kc89_second_15 -210;
+    pos @kc89_first_71 @kc89_second_16 -70;
+    pos @kc89_first_71 @kc89_second_18 -210;
+    pos @kc89_first_71 @kc89_second_23 -35;
+    pos @kc89_first_71 @kc89_second_26 -35;
+    pos @kc89_first_71 @kc89_second_27 -70;
+    pos @kc89_first_71 @kc89_second_31 -70;
+    pos @kc89_first_71 @kc89_second_38 -35;
+    pos @kc89_first_71 @kc89_second_39 -245;
+    pos @kc89_first_71 @kc89_second_40 -70;
+    pos @kc89_first_71 @kc89_second_42 -35;
+    pos @kc89_first_71 @kc89_second_43 -240;
+    pos @kc89_first_71 @kc89_second_45 1;
+    pos @kc89_first_71 @kc89_second_47 -105;
+    pos @kc89_first_71 @kc89_second_48 -280;
+    pos @kc89_first_71 @kc89_second_49 -35;
+    pos @kc89_first_71 @kc89_second_54 -35;
+    pos @kc89_first_71 @kc89_second_56 -70;
+    pos @kc89_first_71 @kc89_second_58 -105;
+    pos @kc89_first_71 @kc89_second_59 -35;
+    pos @kc89_first_71 @kc89_second_60 -70;
+    pos @kc89_first_71 @kc89_second_61 -175;
+    pos @kc89_first_71 @kc89_second_62 -140;
+    pos @kc89_first_72 @kc89_second_1 -140;
+    pos @kc89_first_72 @kc89_second_2 -140;
+    pos @kc89_first_72 @kc89_second_6 -140;
+    pos @kc89_first_72 @kc89_second_8 -35;
+    pos @kc89_first_72 @kc89_second_10 -35;
+    pos @kc89_first_72 @kc89_second_17 -35;
+    pos @kc89_first_72 @kc89_second_19 -140;
+    pos @kc89_first_72 @kc89_second_20 -35;
+    pos @kc89_first_72 @kc89_second_22 -70;
+    pos @kc89_first_72 @kc89_second_23 -70;
+    pos @kc89_first_72 @kc89_second_24 -140;
+    pos @kc89_first_72 @kc89_second_29 -70;
+    pos @kc89_first_72 @kc89_second_34 -175;
+    pos @kc89_first_72 @kc89_second_35 -105;
+    pos @kc89_first_72 @kc89_second_36 -70;
+    pos @kc89_first_72 @kc89_second_37 -70;
+    pos @kc89_first_72 @kc89_second_38 -70;
+    pos @kc89_first_72 @kc89_second_39 -35;
+    pos @kc89_first_72 @kc89_second_45 1;
+    pos @kc89_first_72 @kc89_second_50 -35;
+    pos @kc89_first_72 @kc89_second_51 -35;
+    pos @kc89_first_72 @kc89_second_53 -140;
+    pos @kc89_first_72 @kc89_second_55 -140;
+    pos @kc89_first_72 @kc89_second_57 -140;
+    pos @kc89_first_72 @kc89_second_63 -105;
+    pos @kc89_first_72 @kc89_second_64 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -10722,7 +10757,7 @@ lookup mark_Mark_positioning {
   pos base [\C \uni0421 \uni216D ] <anchor 676 -20> mark @bottom_cedilla
 	<anchor 680 0> mark @bottom_center
 	<anchor 923 1380> mark @top_center;
-  pos base [\G \Q \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \G.cv21 ] <anchor 923 1380> mark @top_center
+  pos base [\G \Q \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \G.cv21 \Q.cv29 ] <anchor 923 1380> mark @top_center
 	<anchor 680 0> mark @bottom_center;
   pos base [\U ] <anchor 607 -20> mark @bottom_cedilla
 	<anchor 854 1380> mark @top_center
@@ -12302,7 +12337,7 @@ lookup mark_Mark_positioning {
 	<anchor 407 0> mark @bottom_center;
   pos base [\f.sc \gamma.sc \uni03DD.sc \uni0433.sc ] <anchor 619 1200> mark @top_center
 	<anchor 120 0> mark @bottom_center;
-  pos base [\g.sc \q.sc \x.sc \uni01E5.sc \theta.sc \chi.sc \uni0445.sc \uni0473.sc \uni04D9.sc \g.sc.cv21 ] <anchor 550 0> mark @bottom_center
+  pos base [\g.sc \q.sc \x.sc \uni01E5.sc \theta.sc \chi.sc \uni0445.sc \uni0473.sc \uni04D9.sc \g.sc.cv21 \q.sc.cv29 ] <anchor 550 0> mark @bottom_center
 	<anchor 762 1200> mark @top_center;
   pos base [\h.sc \etatonos.sc \eta.sc \uni043D.sc \uni1F20.sc \uni1F21.sc \uni1F22.sc \uni1F23.sc \uni1F24.sc \uni1F25.sc \uni1F26.sc \uni1F27.sc \uni1F74.sc \uni1F75.sc ] <anchor 501 -80> mark @bottom_ypogegrammeni
 	<anchor 116 -20> mark @bottom_cedilla
@@ -14197,7 +14232,8 @@ feature mkmk {
 	\lcaron.cv28 \ldot.cv28 \lslash.cv28 \uni019A.cv28 \uni01C9.cv28 
 	\uni0234.cv28 \uni026D.cv28 \uni026E.cv28 \uni02AA.cv28 \uni02AB.cv28 
 	\uni02E1.cv28 \uni1E37.cv28 \uni1E39.cv28 \uni1E3B.cv28 \uni1E3D.cv28 
-	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \dollar.ss05 
+	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \Q.cv29 \uni051A.cv29 
+	\uni213A.cv29 \uni24C6.cv29 \q.sc.cv29 \uni051B.sc.cv29 \dollar.ss05 
 	\cent.ss05 \sterling.ss05 \lira.ss05 \peseta.ss05 \uni20AA.ss05 \Euro.ss05 
 	\uni20B2.ss05 \one.ss06 \one.ss06.pnum \one.ss06.tnum \one.ss06.onum 
 	\one.ss06.onum.tnum \one.ss06.superior \one.ss06.superior.pnum 

--- a/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/28 21:36:43</string>
+    <string>2026/07/28 21:56:18</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/27 23:38:34</string>
+    <string>2026/07/28 21:36:43</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/Q_.cv29.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/Q_.cv29.glif
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.cv29" format="2">
+  <advance width="1725"/>
+  <anchor x="923" y="1380" name="top_center"/>
+  <anchor x="680" y="0" name="bottom_center"/>
+  <outline>
+    <contour>
+      <point x="1560" y="0" type="line"/>
+      <point x="680" y="0" type="line"/>
+      <point x="1049" y="336" type="line"/>
+      <point x="1619" y="336" type="line"/>
+    </contour>
+    <contour>
+      <point x="887" y="1174" type="curve" smooth="yes"/>
+      <point x="538" y="1174"/>
+      <point x="423" y="853"/>
+      <point x="423" y="647" type="curve" smooth="yes"/>
+      <point x="423" y="458"/>
+      <point x="527" y="336"/>
+      <point x="739" y="336" type="curve" smooth="yes"/>
+      <point x="1088" y="336"/>
+      <point x="1203" y="657"/>
+      <point x="1203" y="863" type="curve" smooth="yes"/>
+      <point x="1203" y="1052"/>
+      <point x="1099" y="1174"/>
+    </contour>
+    <contour>
+      <point x="38" y="594" type="curve" smooth="yes"/>
+      <point x="38" y="1045"/>
+      <point x="368" y="1510"/>
+      <point x="946" y="1510" type="curve" smooth="yes"/>
+      <point x="1349" y="1510"/>
+      <point x="1588" y="1276"/>
+      <point x="1588" y="916" type="curve" smooth="yes"/>
+      <point x="1588" y="465"/>
+      <point x="1258" y="0"/>
+      <point x="680" y="0" type="curve" smooth="yes"/>
+      <point x="277" y="0"/>
+      <point x="38" y="234"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict/>
+  </lib>
+</glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/contents.plist
@@ -9106,6 +9106,18 @@
     <string>uni24A_7.cv28.glif</string>
     <key>uni24DB.cv28</key>
     <string>uni24D_B_.cv28.glif</string>
+    <key>Q.cv29</key>
+    <string>Q_.cv29.glif</string>
+    <key>uni051A.cv29</key>
+    <string>uni051A_.cv29.glif</string>
+    <key>uni213A.cv29</key>
+    <string>uni213A_.cv29.glif</string>
+    <key>uni24C6.cv29</key>
+    <string>uni24C_6.cv29.glif</string>
+    <key>q.sc.cv29</key>
+    <string>q.sc.cv29.glif</string>
+    <key>uni051B.sc.cv29</key>
+    <string>uni051B_.sc.cv29.glif</string>
     <key>dollar.ss05</key>
     <string>dollar.ss05.glif</string>
     <key>cent.ss05</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/q.sc.cv29.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/q.sc.cv29.glif
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="q.sc.cv29" format="2">
+  <advance width="1441"/>
+  <anchor x="550" y="0" name="bottom_center"/>
+  <anchor x="762" y="1200" name="top_center"/>
+  <outline>
+    <contour>
+      <point x="1276" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="946" y="320" type="line"/>
+      <point x="1332" y="320" type="line"/>
+    </contour>
+    <contour>
+      <point x="710" y="910" type="curve" smooth="yes"/>
+      <point x="440" y="910"/>
+      <point x="381" y="657"/>
+      <point x="381" y="536" type="curve" smooth="yes"/>
+      <point x="381" y="402"/>
+      <point x="454" y="320"/>
+      <point x="606" y="320" type="curve" smooth="yes"/>
+      <point x="876" y="320"/>
+      <point x="936" y="573"/>
+      <point x="936" y="694" type="curve" smooth="yes"/>
+      <point x="936" y="828"/>
+      <point x="862" y="910"/>
+    </contour>
+    <contour>
+      <point x="16" y="482" type="curve" smooth="yes"/>
+      <point x="16" y="837"/>
+      <point x="268" y="1230"/>
+      <point x="767" y="1230" type="curve" smooth="yes"/>
+      <point x="1111" y="1230"/>
+      <point x="1301" y="1038"/>
+      <point x="1301" y="748" type="curve" smooth="yes"/>
+      <point x="1301" y="393"/>
+      <point x="1049" y="0"/>
+      <point x="550" y="0" type="curve" smooth="yes"/>
+      <point x="206" y="0"/>
+      <point x="16" y="192"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni051A_.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051A.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1725"/>
+  <anchor x="923" y="1381" name="top_center"/>
+  <anchor x="680" y="1" name="bottom_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="Q.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni051A_.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051A.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051B.sc.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051B.sc.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1441"/>
+  <anchor x="550" y="1" name="bottom_center"/>
+  <anchor x="762" y="1201" name="top_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="q.sc.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni213A_.cv29.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni213A_.cv29.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni213A.cv29" format="2">
+  <advance width="1610"/>
+  <outline>
+    <contour>
+      <point x="1716" y="1620" type="line"/>
+      <point x="1560" y="740" type="line"/>
+      <point x="1279" y="1050" type="line"/>
+      <point x="1380" y="1620" type="line"/>
+    </contour>
+    <contour>
+      <point x="872" y="1120" type="curve" smooth="yes"/>
+      <point x="514" y="1120"/>
+      <point x="379" y="865"/>
+      <point x="379" y="656" type="curve" smooth="yes"/>
+      <point x="379" y="461"/>
+      <point x="518" y="360"/>
+      <point x="738" y="360" type="curve" smooth="yes"/>
+      <point x="1096" y="360"/>
+      <point x="1232" y="615"/>
+      <point x="1232" y="824" type="curve" smooth="yes"/>
+      <point x="1232" y="1019"/>
+      <point x="1092" y="1120"/>
+    </contour>
+    <contour>
+      <point x="1576" y="905" type="curve" smooth="yes"/>
+      <point x="1576" y="447"/>
+      <point x="1243" y="-20"/>
+      <point x="671" y="-20" type="curve" smooth="yes"/>
+      <point x="277" y="-20"/>
+      <point x="35" y="209"/>
+      <point x="35" y="575" type="curve" smooth="yes"/>
+      <point x="35" y="1033"/>
+      <point x="367" y="1500"/>
+      <point x="939" y="1500" type="curve" smooth="yes"/>
+      <point x="1333" y="1500"/>
+      <point x="1576" y="1271"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni24C_6.cv29.glif
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/glyphs/uni24C_6.cv29.glif
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni24C6.cv29" format="2">
+  <advance width="1720"/>
+  <outline>
+    <contour>
+      <point x="220" y="740" type="curve" smooth="yes"/>
+      <point x="220" y="380"/>
+      <point x="500" y="100"/>
+      <point x="860" y="100" type="curve" smooth="yes"/>
+      <point x="1220" y="100"/>
+      <point x="1500" y="380"/>
+      <point x="1500" y="740" type="curve" smooth="yes"/>
+      <point x="1500" y="1100"/>
+      <point x="1220" y="1380"/>
+      <point x="860" y="1380" type="curve" smooth="yes"/>
+      <point x="500" y="1380"/>
+      <point x="220" y="1100"/>
+    </contour>
+    <contour>
+      <point x="100" y="740" type="curve" smooth="yes"/>
+      <point x="100" y="1160"/>
+      <point x="440" y="1500"/>
+      <point x="860" y="1500" type="curve" smooth="yes"/>
+      <point x="1280" y="1500"/>
+      <point x="1620" y="1160"/>
+      <point x="1620" y="740" type="curve" smooth="yes"/>
+      <point x="1620" y="320"/>
+      <point x="1280" y="-20"/>
+      <point x="860" y="-20" type="curve" smooth="yes"/>
+      <point x="440" y="-20"/>
+      <point x="100" y="320"/>
+    </contour>
+    <contour>
+      <point x="385" y="651" type="curve" smooth="yes"/>
+      <point x="385" y="906"/>
+      <point x="560" y="1187"/>
+      <point x="925" y="1187" type="curve" smooth="yes"/>
+      <point x="1165" y="1187"/>
+      <point x="1311" y="1060"/>
+      <point x="1311" y="845" type="curve" smooth="yes"/>
+      <point x="1311" y="591"/>
+      <point x="1138" y="311"/>
+      <point x="771" y="311" type="curve" smooth="yes"/>
+      <point x="531" y="311"/>
+      <point x="385" y="436"/>
+    </contour>
+    <contour>
+      <point x="813" y="551" type="curve" smooth="yes"/>
+      <point x="984" y="551"/>
+      <point x="1036" y="706"/>
+      <point x="1036" y="800" type="curve" smooth="yes"/>
+      <point x="1036" y="891"/>
+      <point x="985" y="947"/>
+      <point x="883" y="947" type="curve" smooth="yes"/>
+      <point x="712" y="947"/>
+      <point x="660" y="792"/>
+      <point x="660" y="698" type="curve" smooth="yes"/>
+      <point x="660" y="607"/>
+      <point x="711" y="551"/>
+    </contour>
+    <contour>
+      <point x="1297" y="311" type="line"/>
+      <point x="771" y="311" type="line"/>
+      <point x="1013" y="551" type="line"/>
+      <point x="1339" y="551" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Italic.ufo/features.fea
+++ b/sources/Giphurs-Italic.ufo/features.fea
@@ -2261,6 +2261,16 @@ lookup cv28_Alternative_small_letter_l {
     sub \uni24A7 by \uni24A7.cv28 ;
 } cv28_Alternative_small_letter_l;
 
+lookup cv29_Alternative_letter_Q {
+  lookupflag 0;
+    sub \Q by \Q.cv29 ;
+    sub \uni051A by \uni051A.cv29 ;
+    sub \uni213A by \uni213A.cv29 ;
+    sub \uni24C6 by \uni24C6.cv29 ;
+    sub \q.sc by \q.sc.cv29 ;
+    sub \uni051B.sc by \uni051B.sc.cv29 ;
+} cv29_Alternative_letter_Q;
+
 lookup ss01_Alternative_digits_set_A {
   lookupflag 0;
     sub \eight by \eight.cv08 ;
@@ -4564,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \uni0456 \acutecomb  by \iacute;
     sub \i \acutecomb  by \iacute;
+    sub \uni0456 \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4621,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4709,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5641,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6775,29 +6785,6 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
-
 feature locl {
 
  script cyrl;
@@ -6884,6 +6871,29 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
+
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
 
 feature ss09 {
   featureNames {
@@ -7743,6 +7753,29 @@ feature cv28 {
       lookup cv28_Alternative_small_letter_l;
 } cv28;
 
+feature cv29 {
+
+ script DFLT;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script copt;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script cyrl;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script grek;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script latn;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+} cv29;
+
 feature ss01 {
   featureNames {
     name 3 1 0x409 "Alternative numbers set 1";
@@ -8264,7 +8297,7 @@ feature calt {
 
 lookup kern_Horizontal_kerning {
   lookupflag 0;
-    @kc88_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
+    @kc89_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
 	\Aogonek \Aring \Aringacute \Atilde \Delta \Lambda \backslash \uni01CD 
 	\uni01DE \uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
@@ -8273,12 +8306,12 @@ lookup kern_Horizontal_kerning {
 	\uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F88 \uni1F89 \uni1F8A \uni1F8B 
 	\uni1F8C \uni1F8D \uni1F8E \uni1F8F \uni1FB8 \uni1FB9 \uni1FBA \uni1FBB 
 	\uni1FBC \uni212B \uniA656 ];
-    @kc88_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
+    @kc89_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
 	\uni0412 \uni0417 \uni0432.loclBGR \uni0498 \uni04DE \uni1E02 \uni1E04 
 	\uni1E06 \uni1E9E \uniA7B4 \uniA7B5 ];
-    @kc88_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
+    @kc89_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
 	\uni03FE \uni0421 \uni0464 \uni0480 \uni04AA \uni1E08 \uni2103 \uni216D ];
-    @kc88_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
+    @kc89_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
 	\Gcommaaccent.cv21 \Gdotaccent.cv21 \O \Oacute \Obreve \Ocircumflex 
 	\Odieresis \Ograve \Ohungarumlaut \Omacron \Omicron \Omicrontonos 
 	\Oslash \Oslashacute \Otilde \Theta \uni0189 \uni018A \uni018F 
@@ -8291,42 +8324,42 @@ lookup kern_Horizontal_kerning {
 	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
 	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
 	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
-    @kc88_first_5 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
+    @kc89_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
+	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
+	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
+	\uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA 
+	\uni1FFB \uni1FFC \uni20B2 \uni20B2.ss05 ];
+    @kc89_first_6 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
 	\uni0422 \uni0490 \uni0492 \uni04A4 \uni04AC \uni1E6A \uni1E6C \uni1E6E 
 	\uni1E70 ];
-    @kc88_first_6 = [\Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
-	\uni01E4 \uni03A9 \uni051A \uni1E20 \uni1F68 \uni1F69 \uni1F6A \uni1F6B 
-	\uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 \uni1FA9 \uni1FAA \uni1FAB 
-	\uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA \uni1FFB \uni1FFC \uni20B2 
-	\uni20B2.ss05 ];
-    @kc88_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+    @kc89_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2165 \uni2166 \uni2167 \uni216A \uni216B 
 	\uniA7AE ];
-    @kc88_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
+    @kc89_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc88_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
+    @kc89_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
 	\uniA7AD ];
-    @kc88_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
-    @kc88_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
-    @kc88_first_12 = [\Psi \uni0470 ];
-    @kc88_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
+    @kc89_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
+    @kc89_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
+    @kc89_first_12 = [\Psi \uni0470 ];
+    @kc89_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc88_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
+    @kc89_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
 	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
 	\uni2107 ];
-    @kc88_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
+    @kc89_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
-    @kc88_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
+    @kc89_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
 	\uni2163 \uni2164 \universal ];
-    @kc88_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_first_19 = [\a \a.cv23 \aacute \aacute.cv23 \abreve \abreve.cv23 \acircumflex 
+    @kc89_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_first_19 = [\a \a.cv23 \aacute \aacute.cv23 \abreve \abreve.cv23 \acircumflex 
 	\acircumflex.cv23 \adieresis \adieresis.cv23 \agrave \agrave.cv23 
 	\amacron \amacron.cv23 \aogonek \aogonek.cv23 \aring \aring.cv23 
 	\aringacute.cv23 \atilde \atilde.cv23 \u \u.cv25 \uacute \uacute.cv25 
@@ -8350,7 +8383,7 @@ lookup kern_Horizontal_kerning {
 	\uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 \uni1EED 
 	\uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 \uniA657 
 	\uogonek \uogonek.cv25 \uring \uring.cv25 \utilde \utilde.cv25 ];
-    @kc88_first_20 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
+    @kc89_first_20 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
 	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
 	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
 	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
@@ -8363,7 +8396,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
 	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
 	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
-    @kc88_first_21 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_first_21 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8417,7 +8450,7 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_first_22 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
+    @kc89_first_22 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
 	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
@@ -8430,28 +8463,28 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
-    @kc88_first_23 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
+    @kc89_first_23 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
 	\uni1FB7 \uni2C65 ];
-    @kc88_first_24 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_first_24 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_first_25 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
+    @kc89_first_25 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
 	\uni0253 \uni029A \uni03F1 \uni03F8 \uni0440 \uni0444 \uni1E03 \uni1E05 
 	\uni1E07 \uni1E55 \uni1E57 \uni20AF \uni2114 ];
-    @kc88_first_26 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
+    @kc89_first_26 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
 	\uni1E05.sc \uni1E07.sc \uniA7B5.sc ];
-    @kc88_first_27 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
+    @kc89_first_27 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
 	\uni0188 \uni023C \uni0255 \uni0297 \uni03F2 \uni03F5 \uni0441 \uni0454 
 	\uni0465 \uni04AB \uni1E09 \uni217D ];
-    @kc88_first_28 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
+    @kc89_first_28 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
 	\uni037C.sc \uni03F2.sc \uni0441.sc \uni0454.sc \uni0465.sc 
 	\uni0481.sc \uni1E09.sc ];
-    @kc88_first_29 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+    @kc89_first_29 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8507,14 +8540,14 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_first_30 = [\chi ];
-    @kc88_first_31 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
+    @kc89_first_30 = [\chi ];
+    @kc89_first_31 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
 	\uni0436.sc \uni0445.sc \uni0497.sc \uni049B.sc \uni049D.sc 
 	\uni049F.sc \uni04A1.sc \uni04B3.sc \uni04C2.sc \uni04DD.sc 
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc88_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
+    @kc89_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
 	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
 	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
@@ -8526,7 +8559,7 @@ lookup kern_Horizontal_kerning {
 	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
 	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
 	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
-    @kc88_first_33 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_first_33 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8536,7 +8569,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2175.sc 
 	\uni2176.sc \uni2177.sc \uni217A.sc \uni217B.sc ];
-    @kc88_first_34 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
+    @kc89_first_34 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
 	\eight.cv18.numr \eight.cv18.numr.pnum \eight.cv18.numr.tnum 
 	\eight.numr \eight.numr.pnum \eight.numr.tnum \five.cv05.numr 
 	\five.cv05.numr.pnum \five.cv05.numr.tnum \five.cv15.numr 
@@ -8574,142 +8607,142 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.numr.tnum \zero.numr \zero.numr.pnum 
 	\zero.numr.tnum \zero.zero.numr \zero.zero.numr.pnum 
 	\zero.zero.numr.tnum ];
-    @kc88_first_35 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
+    @kc89_first_35 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
 	\uni1F26 \uni1F27 \uni1F74 \uni1F75 \uni1F90 \uni1F91 \uni1F92 \uni1F93 
 	\uni1F94 \uni1F95 \uni1F96 \uni1F97 \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 
 	\uni1FC7 ];
-    @kc88_first_36 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_first_36 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0433 \uni0437 
 	\uni0453 \uni0455 \uni0479 \uni0493 \uni0499 \uni04DF \uni04F7 \uni04FB 
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
-    @kc88_first_37 = [\eth \uni1EFC \uni1EFD ];
-    @kc88_first_38 = [\fraction ];
-    @kc88_first_39 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc88_first_40 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \uni0260.sc \uni051B.sc \uni1F60.sc \uni1F61.sc 
-	\uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc 
-	\uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc \uni1FA1.sc 
-	\uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc 
-	\uni1FF7.sc ];
-    @kc88_first_41 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc89_first_37 = [\eth \uni1EFC \uni1EFD ];
+    @kc89_first_38 = [\fraction ];
+    @kc89_first_39 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
+    @kc89_first_40 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
+	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
+	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
+	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
+    @kc89_first_41 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc88_first_42 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_first_42 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc88_first_43 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc89_first_43 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc88_first_44 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc89_first_44 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc88_first_45 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc89_first_45 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc88_first_46 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
+    @kc89_first_46 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
 	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc88_first_47 = [\lambda \uni019B ];
-    @kc88_first_48 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc88_first_49 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc89_first_47 = [\lambda \uni019B ];
+    @kc89_first_48 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc89_first_49 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc88_first_50 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc88_first_51 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc88_first_52 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc89_first_50 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc89_first_51 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc89_first_52 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc88_first_53 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_first_54 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc88_first_55 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc88_first_56 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc89_first_53 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_first_54 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc89_first_55 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc89_first_56 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc88_first_57 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_first_57 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc88_first_58 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+    @kc89_first_58 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
 	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_first_59 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+    @kc89_first_59 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
 	\uni1E71 ];
-    @kc88_first_60 = [\tau \uni0491 \uni04A5 ];
-    @kc88_first_61 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc88_first_62 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc88_first_63 = [\uni0196 \uni01AA ];
-    @kc88_first_64 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_first_60 = [\tau \uni0491 \uni04A5 ];
+    @kc89_first_61 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
+    @kc89_first_62 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc89_first_63 = [\uni0196 \uni01AA ];
+    @kc89_first_64 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
 	\ygrave ];
-    @kc88_first_65 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_first_65 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_first_66 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
+    @kc89_first_66 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
 	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
 	\zdotaccent ];
-    @kc88_first_67 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
+    @kc89_first_67 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
-    @kc88_first_68 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
+    @kc89_first_68 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
 	\uni052D \uni052F ];
-    @kc88_first_69 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
+    @kc89_first_69 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
 	\uni04B7.sc \uni04C6.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
 	\uni0525.sc \uni052F.sc ];
-    @kc88_first_70 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
-    @kc88_first_71 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
-    @kc88_first_72 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_first_70 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
+    @kc89_first_71 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
+    @kc89_first_72 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
+    @kc89_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
 	\Aring \Aringacute \Atilde \Delta \Lambda \slash \uni01CD \uni01DE 
 	\uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
 	\uni1EA0 \uni1EA2 \uni1EA4 \uni1EA6 \uni1EA8 \uni1EAA \uni1EAC \uni1EAE 
 	\uni1EB0 \uni1EB2 \uni1EB4 \uni1EB6 \uni1FB8 \uni1FB9 \uni1FBC \uni212B ];
-    @kc88_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
-    @kc88_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
+    @kc89_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
+    @kc89_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
 	\Gbreve \Gbreve.cv21 \Gcaron \Gcaron.cv21 \Gcircumflex 
 	\Gcircumflex.cv21 \Gcommaaccent \Gcommaaccent.cv21 \Gdotaccent 
 	\Gdotaccent.cv21 \O \OE \Oacute \Obreve \Ocircumflex \Odieresis \Ograve 
 	\Ohorn \Ohungarumlaut \Omacron \Omicron \Omicrontonos \Oslash 
-	\Oslashacute \Otilde \Q \Theta \colonmonetary \emptyset \uni0187 
-	\uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
+	\Oslashacute \Otilde \Q \Q.cv29 \Theta \colonmonetary \emptyset 
+	\uni0187 \uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
 	\uni01E4.cv21 \uni01EA \uni01EC \uni01F4 \uni01F4.cv21 \uni020C 
 	\uni020E \uni022A \uni022C \uni022E \uni0230 \uni023B \uni024A \uni0298 
 	\uni03D8 \uni03F4 \uni03FE \uni0404 \uni041E \uni0421 \uni0472 \uni047A 
 	\uni0480 \uni04AA \uni04BC \uni04BE \uni04D8 \uni04DA \uni04E6 \uni04E8 
-	\uni04EA \uni050C \uni051A \uni1E08 \uni1E20 \uni1E20.cv21 \uni1E4C 
-	\uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE \uni1ED0 \uni1ED2 \uni1ED4 
-	\uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE \uni1EE0 \uni1EE2 \uni20A2 
-	\uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE \uni216D \uni2180 \uni2182 
-	\uni2185 ];
-    @kc88_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
-    @kc88_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+	\uni04EA \uni050C \uni051A \uni051A.cv29 \uni1E08 \uni1E20 
+	\uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE 
+	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
+	\uni1EE0 \uni1EE2 \uni20A2 \uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE 
+	\uni216D \uni2180 \uni2182 \uni2185 ];
+    @kc89_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
+    @kc89_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
-    @kc88_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc88_second_7 = [\Omega \uni03A9 \uni1FFC ];
-    @kc88_second_8 = [\Phi \uni0424 ];
-    @kc88_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc88_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
+    @kc89_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
+    @kc89_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc89_second_8 = [\Phi \uni0424 ];
+    @kc89_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
+    @kc89_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
 	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc88_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
+    @kc89_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
 	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc88_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
+    @kc89_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
 	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
-    @kc88_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
+    @kc89_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
 	\uni2166 \uni2167 \universal ];
-    @kc88_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
+    @kc89_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
 	\uni04FE \uni1E8A \uni1E8C \uni2169 \uni216A \uni216B ];
-    @kc88_second_17 = [\a \a.cv23 \a.sc \aacute \aacute.cv23 \aacute.sc \abreve \abreve.cv23 \abreve.sc 
+    @kc89_second_17 = [\a \a.cv23 \a.sc \aacute \aacute.cv23 \aacute.sc \abreve \abreve.cv23 \abreve.sc 
 	\acircumflex \acircumflex.cv23 \acircumflex.sc \adieresis 
 	\adieresis.cv23 \adieresis.sc \ae.cv23 \aeacute.cv23 \agrave 
 	\agrave.cv23 \agrave.sc \alpha \alpha.sc \alphatonos \amacron 
@@ -8743,7 +8776,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F87 \uni1F87.sc \uni1FB0 \uni1FB0.sc \uni1FB1 \uni1FB1.sc 
 	\uni1FB2 \uni1FB2.sc \uni1FB3 \uni1FB3.sc \uni1FB4 \uni1FB4.sc 
 	\uni1FB6 \uni1FB6.sc \uni1FB7 \uni1FB7.sc \uni217E \uniA7C8 ];
-    @kc88_second_18 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_second_18 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8797,16 +8830,16 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_second_19 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
-    @kc88_second_20 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_second_19 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
+    @kc89_second_20 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_second_21 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
+    @kc89_second_21 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
 	\uniA7B4 \uniA7B5 ];
-    @kc88_second_22 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
+    @kc89_second_22 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
@@ -8820,25 +8853,26 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
-    @kc88_second_23 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
+    @kc89_second_23 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
 	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
 	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc 
-	\uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc 
-	\uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc 
-	\uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc 
-	\uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc 
-	\uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc 
-	\uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc 
-	\uni050D.sc \uni051B.sc \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
-	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
-	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc ];
-    @kc88_second_24 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+	\q.sc \q.sc.cv29 \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc 
+	\uni01E5.sc \uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc 
+	\uni020F.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc 
+	\uni023C.sc \uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc 
+	\uni037C.sc \uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc 
+	\uni0444.loclBGR.sc \uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc 
+	\uni04AB.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni050D.sc \uni051B.sc \uni051B.sc.cv29 \uni1E09.sc 
+	\uni1E21.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc 
+	\uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc 
+	\uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc 
+	\uni217D.sc ];
+    @kc89_second_24 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8894,11 +8928,11 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_second_25 = [\chi \gamma \uni04AF \uni04B1 ];
-    @kc88_second_26 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
+    @kc89_second_25 = [\chi \gamma \uni04AF \uni04B1 ];
+    @kc89_second_26 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
 	\uni04DD.sc \uni04FD.sc \uni04FF.sc \uni1E8B.sc \uni1E8D.sc 
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
-    @kc88_second_27 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_second_27 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8908,7 +8942,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
 	\uni2178.sc ];
-    @kc88_second_28 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
+    @kc89_second_28 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
 	\five.cv05.dnom.pnum \five.cv05.dnom.tnum \five.cv15.dnom 
@@ -8944,12 +8978,12 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.dnom.tnum \zero.cv20.zero.dnom 
 	\zero.cv20.zero.dnom.tnum \zero.dnom \zero.dnom.tnum 
 	\zero.zero.dnom \zero.zero.dnom.tnum ];
-    @kc88_second_29 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_second_29 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0433 \uni0437 
 	\uni0453 \uni0455 \uni0479 \uni0493 \uni0499 \uni04DF \uni04F7 \uni04FB 
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
-    @kc88_second_30 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
+    @kc89_second_30 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
 	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
 	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
 	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
@@ -8972,1624 +9006,1625 @@ lookup kern_Horizontal_kerning {
 	\uni1F7B \uni1FE6 \uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 
 	\upsilon \upsilondieresistonos \upsilontonos \uring \uring.cv25 
 	\utilde \utilde.cv25 ];
-    @kc88_second_31 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
+    @kc89_second_31 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
 	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc88_second_32 = [\fraction ];
-    @kc88_second_33 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc88_second_34 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+    @kc89_second_32 = [\fraction ];
+    @kc89_second_33 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc89_second_34 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc88_second_35 = [\lambda \uni019B ];
-    @kc88_second_36 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc89_second_35 = [\lambda \uni019B ];
+    @kc89_second_36 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc88_second_37 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+    @kc89_second_37 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
 	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
 	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
 	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
 	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc88_second_38 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_second_39 = [\pi \tau \uni044A \uni04B5 ];
-    @kc88_second_40 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc89_second_38 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_second_39 = [\pi \tau \uni044A \uni04B5 ];
+    @kc89_second_40 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc88_second_41 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_second_41 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc88_second_42 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc89_second_42 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_second_43 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_second_43 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
 	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
 	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc88_second_44 = [\theta \uni0478 \uniA64C ];
-    @kc88_second_45 = [\tonos2 ];
-    @kc88_second_46 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc88_second_47 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_second_44 = [\theta \uni0478 \uniA64C ];
+    @kc89_second_45 = [\tonos2 ];
+    @kc89_second_46 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc89_second_47 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc88_second_48 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_second_48 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_second_49 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
+    @kc89_second_49 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
 	\z \zacute \zcaron \zdotaccent ];
-    @kc88_second_50 = [\uni0237 ];
-    @kc88_second_51 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc88_second_52 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc88_second_53 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc88_second_54 = [\uni042F \uni0518 ];
-    @kc88_second_55 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc89_second_50 = [\uni0237 ];
+    @kc89_second_51 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc89_second_52 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc89_second_53 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc89_second_54 = [\uni042F \uni0518 ];
+    @kc89_second_55 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc88_second_56 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc89_second_56 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc88_second_57 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
-    @kc88_second_58 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc88_second_59 = [\uni044F.sc \uni0519.sc ];
-    @kc88_second_60 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc89_second_57 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
+    @kc89_second_58 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc89_second_59 = [\uni044F.sc \uni0519.sc ];
+    @kc89_second_60 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc88_second_61 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc88_second_62 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_second_61 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc89_second_62 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_63 = [\uni0500 \uni0502 ];
-    @kc88_second_64 = [\uni0501.sc \uni0503.sc ];
-    @kc88_second_65 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
+    @kc89_second_63 = [\uni0500 \uni0502 ];
+    @kc89_second_64 = [\uni0501.sc \uni0503.sc ];
+    @kc89_second_65 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
 	\zero.cv20.zero.dnom.pnum \zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc88_second_66 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
+    @kc89_second_66 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
 	\zero.cv20.zero.numr.pnum \zero.numr.pnum \zero.zero.numr.pnum ];
-    pos @kc88_first_1 @kc88_second_3 -70;
-    pos @kc88_first_1 @kc88_second_8 -70;
-    pos @kc88_first_1 @kc88_second_9 -140;
-    pos @kc88_first_1 @kc88_second_10 -35;
-    pos @kc88_first_1 @kc88_second_12 -280;
-    pos @kc88_first_1 @kc88_second_13 -280;
-    pos @kc88_first_1 @kc88_second_14 -280;
-    pos @kc88_first_1 @kc88_second_15 -210;
-    pos @kc88_first_1 @kc88_second_20 -70;
-    pos @kc88_first_1 @kc88_second_23 -35;
-    pos @kc88_first_1 @kc88_second_25 -50;
-    pos @kc88_first_1 @kc88_second_31 -70;
-    pos @kc88_first_1 @kc88_second_38 -35;
-    pos @kc88_first_1 @kc88_second_39 -140;
-    pos @kc88_first_1 @kc88_second_40 -105;
-    pos @kc88_first_1 @kc88_second_43 -210;
-    pos @kc88_first_1 @kc88_second_44 -35;
-    pos @kc88_first_1 @kc88_second_45 1;
-    pos @kc88_first_1 @kc88_second_47 -175;
-    pos @kc88_first_1 @kc88_second_48 -210;
-    pos @kc88_first_1 @kc88_second_58 -140;
-    pos @kc88_first_1 @kc88_second_60 -140;
-    pos @kc88_first_1 @kc88_second_61 -210;
-    pos @kc88_first_1 @kc88_second_62 -140;
-    pos @kc88_first_2 @kc88_second_9 -35;
-    pos @kc88_first_2 @kc88_second_12 -70;
-    pos @kc88_first_2 @kc88_second_13 -70;
-    pos @kc88_first_2 @kc88_second_14 -70;
-    pos @kc88_first_2 @kc88_second_15 -35;
-    pos @kc88_first_2 @kc88_second_16 -35;
-    pos @kc88_first_2 @kc88_second_39 -35;
-    pos @kc88_first_2 @kc88_second_45 1;
-    pos @kc88_first_3 @kc88_second_1 -35;
-    pos @kc88_first_3 @kc88_second_2 -70;
-    pos @kc88_first_3 @kc88_second_5 -35;
-    pos @kc88_first_3 @kc88_second_11 -35;
-    pos @kc88_first_3 @kc88_second_12 -35;
-    pos @kc88_first_3 @kc88_second_13 -70;
-    pos @kc88_first_3 @kc88_second_14 -35;
-    pos @kc88_first_3 @kc88_second_16 -70;
-    pos @kc88_first_3 @kc88_second_19 -70;
-    pos @kc88_first_3 @kc88_second_35 -35;
-    pos @kc88_first_3 @kc88_second_45 1;
-    pos @kc88_first_4 @kc88_second_1 -70;
-    pos @kc88_first_4 @kc88_second_2 -140;
-    pos @kc88_first_4 @kc88_second_4 70;
-    pos @kc88_first_4 @kc88_second_5 -70;
-    pos @kc88_first_4 @kc88_second_11 -105;
-    pos @kc88_first_4 @kc88_second_12 -140;
-    pos @kc88_first_4 @kc88_second_13 -140;
-    pos @kc88_first_4 @kc88_second_14 -105;
-    pos @kc88_first_4 @kc88_second_15 -35;
-    pos @kc88_first_4 @kc88_second_16 -140;
-    pos @kc88_first_4 @kc88_second_24 -70;
-    pos @kc88_first_4 @kc88_second_26 -70;
-    pos @kc88_first_4 @kc88_second_27 -35;
-    pos @kc88_first_4 @kc88_second_31 35;
-    pos @kc88_first_4 @kc88_second_34 -70;
-    pos @kc88_first_4 @kc88_second_35 -70;
-    pos @kc88_first_4 @kc88_second_43 -35;
-    pos @kc88_first_4 @kc88_second_45 1;
-    pos @kc88_first_4 @kc88_second_48 -70;
-    pos @kc88_first_4 @kc88_second_53 -70;
-    pos @kc88_first_4 @kc88_second_55 -70;
-    pos @kc88_first_4 @kc88_second_57 -70;
-    pos @kc88_first_4 @kc88_second_61 -35;
-    pos @kc88_first_5 @kc88_second_1 -280;
-    pos @kc88_first_5 @kc88_second_2 -350;
-    pos @kc88_first_5 @kc88_second_3 -140;
-    pos @kc88_first_5 @kc88_second_4 -70;
-    pos @kc88_first_5 @kc88_second_6 -350;
-    pos @kc88_first_5 @kc88_second_7 -140;
-    pos @kc88_first_5 @kc88_second_8 -210;
-    pos @kc88_first_5 @kc88_second_10 -70;
-    pos @kc88_first_5 @kc88_second_17 -240;
-    pos @kc88_first_5 @kc88_second_19 -350;
-    pos @kc88_first_5 @kc88_second_20 -280;
-    pos @kc88_first_5 @kc88_second_21 -240;
-    pos @kc88_first_5 @kc88_second_22 -240;
-    pos @kc88_first_5 @kc88_second_23 -210;
-    pos @kc88_first_5 @kc88_second_24 -350;
-    pos @kc88_first_5 @kc88_second_25 -140;
-    pos @kc88_first_5 @kc88_second_27 -140;
-    pos @kc88_first_5 @kc88_second_29 -240;
-    pos @kc88_first_5 @kc88_second_30 -240;
-    pos @kc88_first_5 @kc88_second_31 -175;
-    pos @kc88_first_5 @kc88_second_34 -350;
-    pos @kc88_first_5 @kc88_second_35 -105;
-    pos @kc88_first_5 @kc88_second_36 -240;
-    pos @kc88_first_5 @kc88_second_37 -210;
-    pos @kc88_first_5 @kc88_second_38 -240;
-    pos @kc88_first_5 @kc88_second_39 -240;
-    pos @kc88_first_5 @kc88_second_41 -240;
-    pos @kc88_first_5 @kc88_second_44 -140;
-    pos @kc88_first_5 @kc88_second_45 1;
-    pos @kc88_first_5 @kc88_second_46 -35;
-    pos @kc88_first_5 @kc88_second_47 -240;
-    pos @kc88_first_5 @kc88_second_49 -240;
-    pos @kc88_first_5 @kc88_second_50 -240;
-    pos @kc88_first_5 @kc88_second_51 -240;
-    pos @kc88_first_5 @kc88_second_52 -240;
-    pos @kc88_first_5 @kc88_second_53 -280;
-    pos @kc88_first_5 @kc88_second_54 -70;
-    pos @kc88_first_5 @kc88_second_55 -240;
-    pos @kc88_first_5 @kc88_second_56 -175;
-    pos @kc88_first_5 @kc88_second_57 -280;
-    pos @kc88_first_5 @kc88_second_58 -240;
-    pos @kc88_first_5 @kc88_second_59 -210;
-    pos @kc88_first_5 @kc88_second_60 -175;
-    pos @kc88_first_5 @kc88_second_63 -175;
-    pos @kc88_first_5 @kc88_second_64 -175;
-    pos @kc88_first_6 @kc88_second_45 1;
-    pos @kc88_first_7 @kc88_second_3 -70;
-    pos @kc88_first_7 @kc88_second_8 -105;
-    pos @kc88_first_7 @kc88_second_17 -35;
-    pos @kc88_first_7 @kc88_second_20 -105;
-    pos @kc88_first_7 @kc88_second_22 -105;
-    pos @kc88_first_7 @kc88_second_23 -70;
-    pos @kc88_first_7 @kc88_second_45 1;
-    pos @kc88_first_7 @kc88_second_46 -35;
-    pos @kc88_first_7 @kc88_second_47 -70;
-    pos @kc88_first_7 @kc88_second_51 -50;
-    pos @kc88_first_7 @kc88_second_60 -35;
-    pos @kc88_first_7 @kc88_second_63 -70;
-    pos @kc88_first_7 @kc88_second_64 -70;
-    pos @kc88_first_8 @kc88_second_3 -140;
-    pos @kc88_first_8 @kc88_second_4 -70;
-    pos @kc88_first_8 @kc88_second_6 -70;
-    pos @kc88_first_8 @kc88_second_8 -140;
-    pos @kc88_first_8 @kc88_second_10 -35;
-    pos @kc88_first_8 @kc88_second_17 -70;
-    pos @kc88_first_8 @kc88_second_20 -140;
-    pos @kc88_first_8 @kc88_second_22 -70;
-    pos @kc88_first_8 @kc88_second_23 -105;
-    pos @kc88_first_8 @kc88_second_25 -140;
-    pos @kc88_first_8 @kc88_second_29 -35;
-    pos @kc88_first_8 @kc88_second_31 -105;
-    pos @kc88_first_8 @kc88_second_34 -70;
-    pos @kc88_first_8 @kc88_second_36 -70;
-    pos @kc88_first_8 @kc88_second_38 -105;
-    pos @kc88_first_8 @kc88_second_39 -175;
-    pos @kc88_first_8 @kc88_second_40 -140;
-    pos @kc88_first_8 @kc88_second_41 -35;
-    pos @kc88_first_8 @kc88_second_43 -140;
-    pos @kc88_first_8 @kc88_second_44 -105;
-    pos @kc88_first_8 @kc88_second_45 1;
-    pos @kc88_first_8 @kc88_second_46 -70;
-    pos @kc88_first_8 @kc88_second_47 -140;
-    pos @kc88_first_8 @kc88_second_48 -70;
-    pos @kc88_first_8 @kc88_second_51 -35;
-    pos @kc88_first_8 @kc88_second_52 -35;
-    pos @kc88_first_8 @kc88_second_58 -210;
-    pos @kc88_first_8 @kc88_second_60 -105;
-    pos @kc88_first_8 @kc88_second_61 -70;
-    pos @kc88_first_8 @kc88_second_62 -35;
-    pos @kc88_first_8 @kc88_second_63 -70;
-    pos @kc88_first_8 @kc88_second_64 -35;
-    pos @kc88_first_9 @kc88_second_3 -140;
-    pos @kc88_first_9 @kc88_second_4 -70;
-    pos @kc88_first_9 @kc88_second_6 -70;
-    pos @kc88_first_9 @kc88_second_8 -210;
-    pos @kc88_first_9 @kc88_second_9 -420;
-    pos @kc88_first_9 @kc88_second_10 -70;
-    pos @kc88_first_9 @kc88_second_12 -350;
-    pos @kc88_first_9 @kc88_second_13 -420;
-    pos @kc88_first_9 @kc88_second_14 -350;
-    pos @kc88_first_9 @kc88_second_15 -280;
-    pos @kc88_first_9 @kc88_second_17 -70;
-    pos @kc88_first_9 @kc88_second_18 -210;
-    pos @kc88_first_9 @kc88_second_20 -210;
-    pos @kc88_first_9 @kc88_second_22 -70;
-    pos @kc88_first_9 @kc88_second_23 -140;
-    pos @kc88_first_9 @kc88_second_29 -50;
-    pos @kc88_first_9 @kc88_second_31 -140;
-    pos @kc88_first_9 @kc88_second_34 -70;
-    pos @kc88_first_9 @kc88_second_38 -105;
-    pos @kc88_first_9 @kc88_second_39 -280;
-    pos @kc88_first_9 @kc88_second_40 -350;
-    pos @kc88_first_9 @kc88_second_41 -50;
-    pos @kc88_first_9 @kc88_second_43 -350;
-    pos @kc88_first_9 @kc88_second_45 1;
-    pos @kc88_first_9 @kc88_second_46 -35;
-    pos @kc88_first_9 @kc88_second_47 -210;
-    pos @kc88_first_9 @kc88_second_48 -350;
-    pos @kc88_first_9 @kc88_second_51 -35;
-    pos @kc88_first_9 @kc88_second_52 -35;
-    pos @kc88_first_9 @kc88_second_58 -280;
-    pos @kc88_first_9 @kc88_second_60 -175;
-    pos @kc88_first_9 @kc88_second_61 -280;
-    pos @kc88_first_9 @kc88_second_62 -210;
-    pos @kc88_first_9 @kc88_second_63 -70;
-    pos @kc88_first_9 @kc88_second_64 -70;
-    pos @kc88_first_10 @kc88_second_1 -210;
-    pos @kc88_first_10 @kc88_second_2 -350;
-    pos @kc88_first_10 @kc88_second_5 -70;
-    pos @kc88_first_10 @kc88_second_6 -140;
-    pos @kc88_first_10 @kc88_second_11 -35;
-    pos @kc88_first_10 @kc88_second_12 -70;
-    pos @kc88_first_10 @kc88_second_13 -70;
-    pos @kc88_first_10 @kc88_second_14 -35;
-    pos @kc88_first_10 @kc88_second_16 -70;
-    pos @kc88_first_10 @kc88_second_17 -35;
-    pos @kc88_first_10 @kc88_second_19 -280;
-    pos @kc88_first_10 @kc88_second_22 -70;
-    pos @kc88_first_10 @kc88_second_24 -350;
-    pos @kc88_first_10 @kc88_second_29 -70;
-    pos @kc88_first_10 @kc88_second_32 -140;
-    pos @kc88_first_10 @kc88_second_34 -210;
-    pos @kc88_first_10 @kc88_second_35 -105;
-    pos @kc88_first_10 @kc88_second_38 -70;
-    pos @kc88_first_10 @kc88_second_45 1;
-    pos @kc88_first_10 @kc88_second_53 -210;
-    pos @kc88_first_10 @kc88_second_55 -210;
-    pos @kc88_first_10 @kc88_second_57 -210;
-    pos @kc88_first_10 @kc88_second_61 -70;
-    pos @kc88_first_10 @kc88_second_63 -70;
-    pos @kc88_first_10 @kc88_second_64 -105;
-    pos @kc88_first_11 @kc88_second_1 -70;
-    pos @kc88_first_11 @kc88_second_2 -140;
-    pos @kc88_first_11 @kc88_second_5 -105;
-    pos @kc88_first_11 @kc88_second_6 -35;
-    pos @kc88_first_11 @kc88_second_11 -70;
-    pos @kc88_first_11 @kc88_second_12 -210;
-    pos @kc88_first_11 @kc88_second_13 -175;
-    pos @kc88_first_11 @kc88_second_14 -105;
-    pos @kc88_first_11 @kc88_second_15 -70;
-    pos @kc88_first_11 @kc88_second_16 -140;
-    pos @kc88_first_11 @kc88_second_19 -140;
-    pos @kc88_first_11 @kc88_second_24 -70;
-    pos @kc88_first_11 @kc88_second_26 -70;
-    pos @kc88_first_11 @kc88_second_27 -70;
-    pos @kc88_first_11 @kc88_second_34 -35;
-    pos @kc88_first_11 @kc88_second_35 -140;
-    pos @kc88_first_11 @kc88_second_39 -70;
-    pos @kc88_first_11 @kc88_second_42 -35;
-    pos @kc88_first_11 @kc88_second_43 -35;
-    pos @kc88_first_11 @kc88_second_45 1;
-    pos @kc88_first_11 @kc88_second_48 -70;
-    pos @kc88_first_11 @kc88_second_53 -210;
-    pos @kc88_first_11 @kc88_second_55 -175;
-    pos @kc88_first_11 @kc88_second_56 -35;
-    pos @kc88_first_11 @kc88_second_57 -175;
-    pos @kc88_first_11 @kc88_second_61 -70;
-    pos @kc88_first_11 @kc88_second_62 -35;
-    pos @kc88_first_11 @kc88_second_63 -35;
-    pos @kc88_first_11 @kc88_second_64 -70;
-    pos @kc88_first_12 @kc88_second_1 -140;
-    pos @kc88_first_12 @kc88_second_2 -210;
-    pos @kc88_first_12 @kc88_second_6 -140;
-    pos @kc88_first_12 @kc88_second_17 -70;
-    pos @kc88_first_12 @kc88_second_19 -210;
-    pos @kc88_first_12 @kc88_second_22 -70;
-    pos @kc88_first_12 @kc88_second_24 -350;
-    pos @kc88_first_12 @kc88_second_29 -35;
-    pos @kc88_first_12 @kc88_second_32 -140;
-    pos @kc88_first_12 @kc88_second_34 -140;
-    pos @kc88_first_12 @kc88_second_35 -70;
-    pos @kc88_first_12 @kc88_second_38 -70;
-    pos @kc88_first_12 @kc88_second_45 1;
-    pos @kc88_first_12 @kc88_second_51 -35;
-    pos @kc88_first_12 @kc88_second_53 -210;
-    pos @kc88_first_12 @kc88_second_55 -210;
-    pos @kc88_first_12 @kc88_second_57 -210;
-    pos @kc88_first_12 @kc88_second_63 -70;
-    pos @kc88_first_12 @kc88_second_64 -105;
-    pos @kc88_first_13 @kc88_second_6 -70;
-    pos @kc88_first_13 @kc88_second_12 -70;
-    pos @kc88_first_13 @kc88_second_13 -105;
-    pos @kc88_first_13 @kc88_second_14 -35;
-    pos @kc88_first_13 @kc88_second_22 -35;
-    pos @kc88_first_13 @kc88_second_29 -35;
-    pos @kc88_first_13 @kc88_second_34 -70;
-    pos @kc88_first_13 @kc88_second_38 -70;
-    pos @kc88_first_13 @kc88_second_45 1;
-    pos @kc88_first_13 @kc88_second_63 -70;
-    pos @kc88_first_13 @kc88_second_64 -35;
-    pos @kc88_first_14 @kc88_second_2 -35;
-    pos @kc88_first_14 @kc88_second_11 -35;
-    pos @kc88_first_14 @kc88_second_12 -70;
-    pos @kc88_first_14 @kc88_second_13 -70;
-    pos @kc88_first_14 @kc88_second_14 -35;
-    pos @kc88_first_14 @kc88_second_16 -35;
-    pos @kc88_first_14 @kc88_second_19 -35;
-    pos @kc88_first_14 @kc88_second_25 -35;
-    pos @kc88_first_14 @kc88_second_39 -70;
-    pos @kc88_first_14 @kc88_second_45 1;
-    pos @kc88_first_14 @kc88_second_47 -70;
-    pos @kc88_first_14 @kc88_second_48 -35;
-    pos @kc88_first_14 @kc88_second_56 -35;
-    pos @kc88_first_14 @kc88_second_58 -35;
-    pos @kc88_first_14 @kc88_second_60 -35;
-    pos @kc88_first_14 @kc88_second_62 -35;
-    pos @kc88_first_15 @kc88_second_3 -70;
-    pos @kc88_first_15 @kc88_second_4 -70;
-    pos @kc88_first_15 @kc88_second_6 -35;
-    pos @kc88_first_15 @kc88_second_8 -70;
-    pos @kc88_first_15 @kc88_second_17 -70;
-    pos @kc88_first_15 @kc88_second_20 -140;
-    pos @kc88_first_15 @kc88_second_22 -70;
-    pos @kc88_first_15 @kc88_second_23 -70;
-    pos @kc88_first_15 @kc88_second_25 -70;
-    pos @kc88_first_15 @kc88_second_29 -35;
-    pos @kc88_first_15 @kc88_second_31 -35;
-    pos @kc88_first_15 @kc88_second_36 -35;
-    pos @kc88_first_15 @kc88_second_38 -70;
-    pos @kc88_first_15 @kc88_second_39 -142;
-    pos @kc88_first_15 @kc88_second_40 -35;
-    pos @kc88_first_15 @kc88_second_44 -35;
-    pos @kc88_first_15 @kc88_second_45 1;
-    pos @kc88_first_15 @kc88_second_46 -35;
-    pos @kc88_first_15 @kc88_second_47 -70;
-    pos @kc88_first_15 @kc88_second_51 -35;
-    pos @kc88_first_15 @kc88_second_52 -35;
-    pos @kc88_first_15 @kc88_second_58 -105;
-    pos @kc88_first_15 @kc88_second_60 -35;
-    pos @kc88_first_15 @kc88_second_63 -35;
-    pos @kc88_first_15 @kc88_second_64 -35;
-    pos @kc88_first_16 @kc88_second_1 -280;
-    pos @kc88_first_16 @kc88_second_2 -280;
-    pos @kc88_first_16 @kc88_second_3 -140;
-    pos @kc88_first_16 @kc88_second_4 -70;
-    pos @kc88_first_16 @kc88_second_6 -280;
-    pos @kc88_first_16 @kc88_second_7 -140;
-    pos @kc88_first_16 @kc88_second_8 -175;
-    pos @kc88_first_16 @kc88_second_10 -70;
-    pos @kc88_first_16 @kc88_second_17 -245;
-    pos @kc88_first_16 @kc88_second_19 -280;
-    pos @kc88_first_16 @kc88_second_20 -210;
-    pos @kc88_first_16 @kc88_second_21 -140;
-    pos @kc88_first_16 @kc88_second_22 -280;
-    pos @kc88_first_16 @kc88_second_23 -210;
-    pos @kc88_first_16 @kc88_second_24 -350;
-    pos @kc88_first_16 @kc88_second_25 -70;
-    pos @kc88_first_16 @kc88_second_27 -140;
-    pos @kc88_first_16 @kc88_second_29 -240;
-    pos @kc88_first_16 @kc88_second_30 -140;
-    pos @kc88_first_16 @kc88_second_31 -140;
-    pos @kc88_first_16 @kc88_second_32 -245;
-    pos @kc88_first_16 @kc88_second_34 -315;
-    pos @kc88_first_16 @kc88_second_35 -70;
-    pos @kc88_first_16 @kc88_second_36 -210;
-    pos @kc88_first_16 @kc88_second_37 -210;
-    pos @kc88_first_16 @kc88_second_38 -245;
-    pos @kc88_first_16 @kc88_second_39 -245;
-    pos @kc88_first_16 @kc88_second_40 -70;
-    pos @kc88_first_16 @kc88_second_42 -35;
-    pos @kc88_first_16 @kc88_second_43 -140;
-    pos @kc88_first_16 @kc88_second_44 -140;
-    pos @kc88_first_16 @kc88_second_45 1;
-    pos @kc88_first_16 @kc88_second_46 -70;
-    pos @kc88_first_16 @kc88_second_47 -140;
-    pos @kc88_first_16 @kc88_second_49 -140;
-    pos @kc88_first_16 @kc88_second_50 -140;
-    pos @kc88_first_16 @kc88_second_51 -240;
-    pos @kc88_first_16 @kc88_second_52 -140;
-    pos @kc88_first_16 @kc88_second_53 -280;
-    pos @kc88_first_16 @kc88_second_54 -105;
-    pos @kc88_first_16 @kc88_second_55 -280;
-    pos @kc88_first_16 @kc88_second_56 -140;
-    pos @kc88_first_16 @kc88_second_57 -315;
-    pos @kc88_first_16 @kc88_second_58 -210;
-    pos @kc88_first_16 @kc88_second_59 -210;
-    pos @kc88_first_16 @kc88_second_60 -105;
-    pos @kc88_first_16 @kc88_second_63 -315;
-    pos @kc88_first_16 @kc88_second_64 -350;
-    pos @kc88_first_17 @kc88_second_1 -280;
-    pos @kc88_first_17 @kc88_second_2 -280;
-    pos @kc88_first_17 @kc88_second_3 -105;
-    pos @kc88_first_17 @kc88_second_6 -210;
-    pos @kc88_first_17 @kc88_second_7 -105;
-    pos @kc88_first_17 @kc88_second_8 -105;
-    pos @kc88_first_17 @kc88_second_10 -35;
-    pos @kc88_first_17 @kc88_second_17 -105;
-    pos @kc88_first_17 @kc88_second_19 -280;
-    pos @kc88_first_17 @kc88_second_20 -70;
-    pos @kc88_first_17 @kc88_second_21 -105;
-    pos @kc88_first_17 @kc88_second_22 -140;
-    pos @kc88_first_17 @kc88_second_23 -140;
-    pos @kc88_first_17 @kc88_second_24 -210;
-    pos @kc88_first_17 @kc88_second_27 -70;
-    pos @kc88_first_17 @kc88_second_29 -140;
-    pos @kc88_first_17 @kc88_second_30 -105;
-    pos @kc88_first_17 @kc88_second_32 -210;
-    pos @kc88_first_17 @kc88_second_34 -245;
-    pos @kc88_first_17 @kc88_second_35 -70;
-    pos @kc88_first_17 @kc88_second_36 -140;
-    pos @kc88_first_17 @kc88_second_37 -140;
-    pos @kc88_first_17 @kc88_second_38 -140;
-    pos @kc88_first_17 @kc88_second_39 -105;
-    pos @kc88_first_17 @kc88_second_40 -35;
-    pos @kc88_first_17 @kc88_second_43 -35;
-    pos @kc88_first_17 @kc88_second_44 -70;
-    pos @kc88_first_17 @kc88_second_45 1;
-    pos @kc88_first_17 @kc88_second_46 -35;
-    pos @kc88_first_17 @kc88_second_47 -70;
-    pos @kc88_first_17 @kc88_second_49 -105;
-    pos @kc88_first_17 @kc88_second_50 -70;
-    pos @kc88_first_17 @kc88_second_51 -105;
-    pos @kc88_first_17 @kc88_second_52 -70;
-    pos @kc88_first_17 @kc88_second_53 -210;
-    pos @kc88_first_17 @kc88_second_54 -35;
-    pos @kc88_first_17 @kc88_second_55 -210;
-    pos @kc88_first_17 @kc88_second_56 -70;
-    pos @kc88_first_17 @kc88_second_57 -245;
-    pos @kc88_first_17 @kc88_second_58 -105;
-    pos @kc88_first_17 @kc88_second_59 -105;
-    pos @kc88_first_17 @kc88_second_60 -70;
-    pos @kc88_first_17 @kc88_second_63 -175;
-    pos @kc88_first_17 @kc88_second_64 -245;
-    pos @kc88_first_18 @kc88_second_1 -210;
-    pos @kc88_first_18 @kc88_second_2 -245;
-    pos @kc88_first_18 @kc88_second_3 -35;
-    pos @kc88_first_18 @kc88_second_6 -140;
-    pos @kc88_first_18 @kc88_second_7 -35;
-    pos @kc88_first_18 @kc88_second_8 -70;
-    pos @kc88_first_18 @kc88_second_17 -105;
-    pos @kc88_first_18 @kc88_second_19 -210;
-    pos @kc88_first_18 @kc88_second_20 -70;
-    pos @kc88_first_18 @kc88_second_22 -105;
-    pos @kc88_first_18 @kc88_second_23 -70;
-    pos @kc88_first_18 @kc88_second_24 -140;
-    pos @kc88_first_18 @kc88_second_27 -35;
-    pos @kc88_first_18 @kc88_second_32 -140;
-    pos @kc88_first_18 @kc88_second_34 -140;
-    pos @kc88_first_18 @kc88_second_36 -105;
-    pos @kc88_first_18 @kc88_second_37 -70;
-    pos @kc88_first_18 @kc88_second_38 -105;
-    pos @kc88_first_18 @kc88_second_39 -70;
-    pos @kc88_first_18 @kc88_second_41 -35;
-    pos @kc88_first_18 @kc88_second_45 1;
-    pos @kc88_first_18 @kc88_second_50 -35;
-    pos @kc88_first_18 @kc88_second_51 -70;
-    pos @kc88_first_18 @kc88_second_53 -140;
-    pos @kc88_first_18 @kc88_second_55 -140;
-    pos @kc88_first_18 @kc88_second_57 -175;
-    pos @kc88_first_18 @kc88_second_58 -70;
-    pos @kc88_first_18 @kc88_second_63 -105;
-    pos @kc88_first_18 @kc88_second_64 -140;
-    pos @kc88_first_19 @kc88_second_12 -280;
-    pos @kc88_first_19 @kc88_second_14 -175;
-    pos @kc88_first_19 @kc88_second_15 -140;
-    pos @kc88_first_19 @kc88_second_29 -35;
-    pos @kc88_first_19 @kc88_second_45 1;
-    pos @kc88_first_19 @kc88_second_47 -70;
-    pos @kc88_first_19 @kc88_second_48 -140;
-    pos @kc88_first_19 @kc88_second_58 -70;
-    pos @kc88_first_19 @kc88_second_60 -35;
-    pos @kc88_first_19 @kc88_second_61 -105;
-    pos @kc88_first_19 @kc88_second_62 -70;
-    pos @kc88_first_20 @kc88_second_8 -35;
-    pos @kc88_first_20 @kc88_second_9 -140;
-    pos @kc88_first_20 @kc88_second_12 -280;
-    pos @kc88_first_20 @kc88_second_13 -280;
-    pos @kc88_first_20 @kc88_second_14 -280;
-    pos @kc88_first_20 @kc88_second_15 -175;
-    pos @kc88_first_20 @kc88_second_18 -140;
-    pos @kc88_first_20 @kc88_second_20 -70;
-    pos @kc88_first_20 @kc88_second_25 -70;
-    pos @kc88_first_20 @kc88_second_31 -50;
-    pos @kc88_first_20 @kc88_second_39 -140;
-    pos @kc88_first_20 @kc88_second_40 -105;
-    pos @kc88_first_20 @kc88_second_43 -210;
-    pos @kc88_first_20 @kc88_second_45 1;
-    pos @kc88_first_20 @kc88_second_46 -35;
-    pos @kc88_first_20 @kc88_second_47 -140;
-    pos @kc88_first_20 @kc88_second_48 -210;
-    pos @kc88_first_20 @kc88_second_52 -35;
-    pos @kc88_first_20 @kc88_second_58 -105;
-    pos @kc88_first_20 @kc88_second_60 -105;
-    pos @kc88_first_20 @kc88_second_61 -210;
-    pos @kc88_first_20 @kc88_second_62 -140;
-    pos @kc88_first_21 @kc88_second_1 -140;
-    pos @kc88_first_21 @kc88_second_2 -350;
-    pos @kc88_first_21 @kc88_second_19 -280;
-    pos @kc88_first_21 @kc88_second_38 -70;
-    pos @kc88_first_21 @kc88_second_45 1;
-    pos @kc88_first_21 @kc88_second_64 -210;
-    pos @kc88_first_22 @kc88_second_1 -35;
-    pos @kc88_first_22 @kc88_second_5 -105;
-    pos @kc88_first_22 @kc88_second_9 -70;
-    pos @kc88_first_22 @kc88_second_11 -70;
-    pos @kc88_first_22 @kc88_second_12 -240;
-    pos @kc88_first_22 @kc88_second_13 -280;
-    pos @kc88_first_22 @kc88_second_14 -140;
-    pos @kc88_first_22 @kc88_second_15 -105;
-    pos @kc88_first_22 @kc88_second_16 -70;
-    pos @kc88_first_22 @kc88_second_25 -35;
-    pos @kc88_first_22 @kc88_second_26 -70;
-    pos @kc88_first_22 @kc88_second_27 -105;
-    pos @kc88_first_22 @kc88_second_35 -70;
-    pos @kc88_first_22 @kc88_second_39 -70;
-    pos @kc88_first_22 @kc88_second_40 -35;
-    pos @kc88_first_22 @kc88_second_42 -35;
-    pos @kc88_first_22 @kc88_second_43 -140;
-    pos @kc88_first_22 @kc88_second_45 1;
-    pos @kc88_first_22 @kc88_second_47 -70;
-    pos @kc88_first_22 @kc88_second_48 -175;
-    pos @kc88_first_22 @kc88_second_49 -35;
-    pos @kc88_first_22 @kc88_second_56 -105;
-    pos @kc88_first_22 @kc88_second_58 -35;
-    pos @kc88_first_22 @kc88_second_60 -50;
-    pos @kc88_first_22 @kc88_second_61 -105;
-    pos @kc88_first_22 @kc88_second_62 -70;
-    pos @kc88_first_23 @kc88_second_6 -35;
-    pos @kc88_first_23 @kc88_second_12 -240;
-    pos @kc88_first_23 @kc88_second_13 -175;
-    pos @kc88_first_23 @kc88_second_14 -70;
-    pos @kc88_first_23 @kc88_second_15 -70;
-    pos @kc88_first_23 @kc88_second_22 -70;
-    pos @kc88_first_23 @kc88_second_23 -35;
-    pos @kc88_first_23 @kc88_second_34 -35;
-    pos @kc88_first_23 @kc88_second_39 -35;
-    pos @kc88_first_23 @kc88_second_40 -35;
-    pos @kc88_first_23 @kc88_second_43 -70;
-    pos @kc88_first_23 @kc88_second_44 -35;
-    pos @kc88_first_23 @kc88_second_45 1;
-    pos @kc88_first_23 @kc88_second_48 -35;
-    pos @kc88_first_23 @kc88_second_58 -35;
-    pos @kc88_first_23 @kc88_second_62 -35;
-    pos @kc88_first_23 @kc88_second_63 -35;
-    pos @kc88_first_23 @kc88_second_64 -35;
-    pos @kc88_first_24 @kc88_second_1 -70;
-    pos @kc88_first_24 @kc88_second_2 -140;
-    pos @kc88_first_24 @kc88_second_5 -105;
-    pos @kc88_first_24 @kc88_second_11 -70;
-    pos @kc88_first_24 @kc88_second_12 -280;
-    pos @kc88_first_24 @kc88_second_13 -210;
-    pos @kc88_first_24 @kc88_second_14 -70;
-    pos @kc88_first_24 @kc88_second_15 -70;
-    pos @kc88_first_24 @kc88_second_16 -140;
-    pos @kc88_first_24 @kc88_second_19 -70;
-    pos @kc88_first_24 @kc88_second_26 -70;
-    pos @kc88_first_24 @kc88_second_27 -70;
-    pos @kc88_first_24 @kc88_second_32 -70;
-    pos @kc88_first_24 @kc88_second_35 -70;
-    pos @kc88_first_24 @kc88_second_42 -35;
-    pos @kc88_first_24 @kc88_second_43 -140;
-    pos @kc88_first_24 @kc88_second_45 1;
-    pos @kc88_first_24 @kc88_second_48 -140;
-    pos @kc88_first_24 @kc88_second_49 -35;
-    pos @kc88_first_24 @kc88_second_53 -140;
-    pos @kc88_first_24 @kc88_second_55 -105;
-    pos @kc88_first_24 @kc88_second_56 -70;
-    pos @kc88_first_24 @kc88_second_57 -70;
-    pos @kc88_first_24 @kc88_second_61 -70;
-    pos @kc88_first_24 @kc88_second_62 -35;
-    pos @kc88_first_25 @kc88_second_5 -70;
-    pos @kc88_first_25 @kc88_second_9 -70;
-    pos @kc88_first_25 @kc88_second_12 -240;
-    pos @kc88_first_25 @kc88_second_13 -280;
-    pos @kc88_first_25 @kc88_second_14 -175;
-    pos @kc88_first_25 @kc88_second_15 -105;
-    pos @kc88_first_25 @kc88_second_16 -70;
-    pos @kc88_first_25 @kc88_second_25 -35;
-    pos @kc88_first_25 @kc88_second_26 -70;
-    pos @kc88_first_25 @kc88_second_27 -70;
-    pos @kc88_first_25 @kc88_second_35 -70;
-    pos @kc88_first_25 @kc88_second_39 -70;
-    pos @kc88_first_25 @kc88_second_40 -35;
-    pos @kc88_first_25 @kc88_second_43 -140;
-    pos @kc88_first_25 @kc88_second_45 1;
-    pos @kc88_first_25 @kc88_second_47 -70;
-    pos @kc88_first_25 @kc88_second_48 -140;
-    pos @kc88_first_25 @kc88_second_49 -35;
-    pos @kc88_first_25 @kc88_second_53 -50;
-    pos @kc88_first_25 @kc88_second_54 -35;
-    pos @kc88_first_25 @kc88_second_55 -50;
-    pos @kc88_first_25 @kc88_second_56 -105;
-    pos @kc88_first_25 @kc88_second_57 -50;
-    pos @kc88_first_25 @kc88_second_58 -50;
-    pos @kc88_first_25 @kc88_second_60 -35;
-    pos @kc88_first_25 @kc88_second_61 -105;
-    pos @kc88_first_25 @kc88_second_62 -70;
-    pos @kc88_first_26 @kc88_second_9 -35;
-    pos @kc88_first_26 @kc88_second_12 -140;
-    pos @kc88_first_26 @kc88_second_26 -70;
-    pos @kc88_first_26 @kc88_second_39 -35;
-    pos @kc88_first_26 @kc88_second_43 -70;
-    pos @kc88_first_26 @kc88_second_45 1;
-    pos @kc88_first_26 @kc88_second_48 -70;
-    pos @kc88_first_26 @kc88_second_61 -70;
-    pos @kc88_first_26 @kc88_second_62 -35;
-    pos @kc88_first_27 @kc88_second_5 -50;
-    pos @kc88_first_27 @kc88_second_9 -35;
-    pos @kc88_first_27 @kc88_second_11 -35;
-    pos @kc88_first_27 @kc88_second_12 -240;
-    pos @kc88_first_27 @kc88_second_13 -240;
-    pos @kc88_first_27 @kc88_second_14 -105;
-    pos @kc88_first_27 @kc88_second_15 -70;
-    pos @kc88_first_27 @kc88_second_16 -35;
-    pos @kc88_first_27 @kc88_second_26 -35;
-    pos @kc88_first_27 @kc88_second_27 -35;
-    pos @kc88_first_27 @kc88_second_35 -35;
-    pos @kc88_first_27 @kc88_second_39 -50;
-    pos @kc88_first_27 @kc88_second_40 -35;
-    pos @kc88_first_27 @kc88_second_43 -100;
-    pos @kc88_first_27 @kc88_second_45 1;
-    pos @kc88_first_27 @kc88_second_47 -35;
-    pos @kc88_first_27 @kc88_second_48 -140;
-    pos @kc88_first_27 @kc88_second_56 -35;
-    pos @kc88_first_27 @kc88_second_61 -70;
-    pos @kc88_first_27 @kc88_second_62 -35;
-    pos @kc88_first_28 @kc88_second_45 1;
-    pos @kc88_first_29 @kc88_second_8 -70;
-    pos @kc88_first_29 @kc88_second_9 -210;
-    pos @kc88_first_29 @kc88_second_12 -350;
-    pos @kc88_first_29 @kc88_second_13 -350;
-    pos @kc88_first_29 @kc88_second_14 -210;
-    pos @kc88_first_29 @kc88_second_15 -175;
-    pos @kc88_first_29 @kc88_second_25 -70;
-    pos @kc88_first_29 @kc88_second_38 -35;
-    pos @kc88_first_29 @kc88_second_39 -210;
-    pos @kc88_first_29 @kc88_second_40 -210;
-    pos @kc88_first_29 @kc88_second_43 -210;
-    pos @kc88_first_29 @kc88_second_45 1;
-    pos @kc88_first_29 @kc88_second_47 -140;
-    pos @kc88_first_29 @kc88_second_48 -280;
-    pos @kc88_first_29 @kc88_second_58 -210;
-    pos @kc88_first_29 @kc88_second_60 -105;
-    pos @kc88_first_29 @kc88_second_61 -175;
-    pos @kc88_first_29 @kc88_second_62 -140;
-    pos @kc88_first_30 @kc88_second_1 -175;
-    pos @kc88_first_30 @kc88_second_2 -175;
-    pos @kc88_first_30 @kc88_second_5 -70;
-    pos @kc88_first_30 @kc88_second_6 -105;
-    pos @kc88_first_30 @kc88_second_10 -35;
-    pos @kc88_first_30 @kc88_second_11 -105;
-    pos @kc88_first_30 @kc88_second_12 -175;
-    pos @kc88_first_30 @kc88_second_13 -140;
-    pos @kc88_first_30 @kc88_second_14 -70;
-    pos @kc88_first_30 @kc88_second_15 -35;
-    pos @kc88_first_30 @kc88_second_16 -140;
-    pos @kc88_first_30 @kc88_second_17 -70;
-    pos @kc88_first_30 @kc88_second_19 -175;
-    pos @kc88_first_30 @kc88_second_22 -70;
-    pos @kc88_first_30 @kc88_second_29 -105;
-    pos @kc88_first_30 @kc88_second_33 105;
-    pos @kc88_first_30 @kc88_second_34 -105;
-    pos @kc88_first_30 @kc88_second_35 -175;
-    pos @kc88_first_30 @kc88_second_36 -35;
-    pos @kc88_first_30 @kc88_second_38 -70;
-    pos @kc88_first_30 @kc88_second_45 1;
-    pos @kc88_first_30 @kc88_second_50 105;
-    pos @kc88_first_30 @kc88_second_51 -35;
-    pos @kc88_first_30 @kc88_second_63 -70;
-    pos @kc88_first_30 @kc88_second_64 -105;
-    pos @kc88_first_31 @kc88_second_3 -70;
-    pos @kc88_first_31 @kc88_second_4 -35;
-    pos @kc88_first_31 @kc88_second_6 -70;
-    pos @kc88_first_31 @kc88_second_8 -105;
-    pos @kc88_first_31 @kc88_second_17 -35;
-    pos @kc88_first_31 @kc88_second_20 -70;
-    pos @kc88_first_31 @kc88_second_22 -70;
-    pos @kc88_first_31 @kc88_second_23 -140;
-    pos @kc88_first_31 @kc88_second_29 -35;
-    pos @kc88_first_31 @kc88_second_34 -70;
-    pos @kc88_first_31 @kc88_second_36 -35;
-    pos @kc88_first_31 @kc88_second_38 -140;
-    pos @kc88_first_31 @kc88_second_39 -70;
-    pos @kc88_first_31 @kc88_second_45 1;
-    pos @kc88_first_31 @kc88_second_51 -35;
-    pos @kc88_first_31 @kc88_second_52 -35;
-    pos @kc88_first_31 @kc88_second_58 -140;
-    pos @kc88_first_31 @kc88_second_63 -70;
-    pos @kc88_first_31 @kc88_second_64 -70;
-    pos @kc88_first_32 @kc88_second_1 -35;
-    pos @kc88_first_32 @kc88_second_2 -105;
-    pos @kc88_first_32 @kc88_second_3 -70;
-    pos @kc88_first_32 @kc88_second_4 70;
-    pos @kc88_first_32 @kc88_second_5 -70;
-    pos @kc88_first_32 @kc88_second_11 -35;
-    pos @kc88_first_32 @kc88_second_12 -240;
-    pos @kc88_first_32 @kc88_second_13 -175;
-    pos @kc88_first_32 @kc88_second_14 -105;
-    pos @kc88_first_32 @kc88_second_15 -70;
-    pos @kc88_first_32 @kc88_second_16 -70;
-    pos @kc88_first_32 @kc88_second_24 -35;
-    pos @kc88_first_32 @kc88_second_27 -70;
-    pos @kc88_first_32 @kc88_second_35 -35;
-    pos @kc88_first_32 @kc88_second_39 -35;
-    pos @kc88_first_32 @kc88_second_40 -35;
-    pos @kc88_first_32 @kc88_second_42 -35;
-    pos @kc88_first_32 @kc88_second_43 -140;
-    pos @kc88_first_32 @kc88_second_45 1;
-    pos @kc88_first_32 @kc88_second_47 -50;
-    pos @kc88_first_32 @kc88_second_48 -140;
-    pos @kc88_first_32 @kc88_second_49 -35;
-    pos @kc88_first_32 @kc88_second_53 -70;
-    pos @kc88_first_32 @kc88_second_55 -70;
-    pos @kc88_first_32 @kc88_second_57 -70;
-    pos @kc88_first_32 @kc88_second_61 -70;
-    pos @kc88_first_32 @kc88_second_62 -35;
-    pos @kc88_first_33 @kc88_second_3 -35;
-    pos @kc88_first_33 @kc88_second_4 -70;
-    pos @kc88_first_33 @kc88_second_6 -70;
-    pos @kc88_first_33 @kc88_second_8 -70;
-    pos @kc88_first_33 @kc88_second_12 -140;
-    pos @kc88_first_33 @kc88_second_13 -105;
-    pos @kc88_first_33 @kc88_second_14 -70;
-    pos @kc88_first_33 @kc88_second_15 -35;
-    pos @kc88_first_33 @kc88_second_20 -70;
-    pos @kc88_first_33 @kc88_second_22 -105;
-    pos @kc88_first_33 @kc88_second_23 -70;
-    pos @kc88_first_33 @kc88_second_29 -35;
-    pos @kc88_first_33 @kc88_second_34 -70;
-    pos @kc88_first_33 @kc88_second_36 -70;
-    pos @kc88_first_33 @kc88_second_38 -105;
-    pos @kc88_first_33 @kc88_second_39 -70;
-    pos @kc88_first_33 @kc88_second_44 -70;
-    pos @kc88_first_33 @kc88_second_45 1;
-    pos @kc88_first_33 @kc88_second_51 -35;
-    pos @kc88_first_33 @kc88_second_52 -35;
-    pos @kc88_first_33 @kc88_second_63 -70;
-    pos @kc88_first_33 @kc88_second_64 -70;
-    pos @kc88_first_34 @kc88_second_32 -315;
-    pos @kc88_first_34 @kc88_second_45 1;
-    pos @kc88_first_35 @kc88_second_9 -70;
-    pos @kc88_first_35 @kc88_second_12 -240;
-    pos @kc88_first_35 @kc88_second_13 -210;
-    pos @kc88_first_35 @kc88_second_14 -140;
-    pos @kc88_first_35 @kc88_second_15 -105;
-    pos @kc88_first_35 @kc88_second_39 -70;
-    pos @kc88_first_35 @kc88_second_40 -35;
-    pos @kc88_first_35 @kc88_second_43 -140;
-    pos @kc88_first_35 @kc88_second_45 1;
-    pos @kc88_first_35 @kc88_second_47 -50;
-    pos @kc88_first_35 @kc88_second_48 -140;
-    pos @kc88_first_35 @kc88_second_58 -35;
-    pos @kc88_first_35 @kc88_second_60 -35;
-    pos @kc88_first_35 @kc88_second_61 -70;
-    pos @kc88_first_35 @kc88_second_62 -70;
-    pos @kc88_first_36 @kc88_second_9 -35;
-    pos @kc88_first_36 @kc88_second_12 -240;
-    pos @kc88_first_36 @kc88_second_13 -240;
-    pos @kc88_first_36 @kc88_second_14 -140;
-    pos @kc88_first_36 @kc88_second_15 -105;
-    pos @kc88_first_36 @kc88_second_16 -35;
-    pos @kc88_first_36 @kc88_second_26 -35;
-    pos @kc88_first_36 @kc88_second_27 -35;
-    pos @kc88_first_36 @kc88_second_39 -70;
-    pos @kc88_first_36 @kc88_second_40 -35;
-    pos @kc88_first_36 @kc88_second_43 -70;
-    pos @kc88_first_36 @kc88_second_45 1;
-    pos @kc88_first_36 @kc88_second_47 -35;
-    pos @kc88_first_36 @kc88_second_48 -70;
-    pos @kc88_first_36 @kc88_second_60 -35;
-    pos @kc88_first_36 @kc88_second_61 -70;
-    pos @kc88_first_36 @kc88_second_62 -70;
-    pos @kc88_first_37 @kc88_second_5 -70;
-    pos @kc88_first_37 @kc88_second_9 -70;
-    pos @kc88_first_37 @kc88_second_12 -140;
-    pos @kc88_first_37 @kc88_second_13 -210;
-    pos @kc88_first_37 @kc88_second_14 -140;
-    pos @kc88_first_37 @kc88_second_15 -105;
-    pos @kc88_first_37 @kc88_second_16 -70;
-    pos @kc88_first_37 @kc88_second_26 -70;
-    pos @kc88_first_37 @kc88_second_27 -70;
-    pos @kc88_first_37 @kc88_second_35 -50;
-    pos @kc88_first_37 @kc88_second_39 -50;
-    pos @kc88_first_37 @kc88_second_40 -35;
-    pos @kc88_first_37 @kc88_second_45 1;
-    pos @kc88_first_37 @kc88_second_47 -35;
-    pos @kc88_first_37 @kc88_second_48 -140;
-    pos @kc88_first_37 @kc88_second_56 -35;
-    pos @kc88_first_37 @kc88_second_61 -70;
-    pos @kc88_first_37 @kc88_second_62 -35;
-    pos @kc88_first_38 @kc88_second_1 -210;
-    pos @kc88_first_38 @kc88_second_2 -280;
-    pos @kc88_first_38 @kc88_second_6 -280;
-    pos @kc88_first_38 @kc88_second_8 -70;
-    pos @kc88_first_38 @kc88_second_17 -140;
-    pos @kc88_first_38 @kc88_second_19 -350;
-    pos @kc88_first_38 @kc88_second_20 -140;
-    pos @kc88_first_38 @kc88_second_22 -140;
-    pos @kc88_first_38 @kc88_second_23 -70;
-    pos @kc88_first_38 @kc88_second_24 -280;
-    pos @kc88_first_38 @kc88_second_28 -315;
-    pos @kc88_first_38 @kc88_second_29 -140;
-    pos @kc88_first_38 @kc88_second_32 -385;
-    pos @kc88_first_38 @kc88_second_34 -210;
-    pos @kc88_first_38 @kc88_second_35 -70;
-    pos @kc88_first_38 @kc88_second_36 -140;
-    pos @kc88_first_38 @kc88_second_37 -140;
-    pos @kc88_first_38 @kc88_second_38 -140;
-    pos @kc88_first_38 @kc88_second_41 -70;
-    pos @kc88_first_38 @kc88_second_45 1;
-    pos @kc88_first_38 @kc88_second_51 -140;
-    pos @kc88_first_38 @kc88_second_52 -70;
-    pos @kc88_first_38 @kc88_second_53 -140;
-    pos @kc88_first_38 @kc88_second_55 -245;
-    pos @kc88_first_38 @kc88_second_58 -70;
-    pos @kc88_first_38 @kc88_second_59 -70;
-    pos @kc88_first_38 @kc88_second_63 -245;
-    pos @kc88_first_38 @kc88_second_64 -280;
-    pos @kc88_first_38 @kc88_second_65 -315;
-    pos @kc88_first_39 @kc88_second_6 -35;
-    pos @kc88_first_39 @kc88_second_12 -240;
-    pos @kc88_first_39 @kc88_second_13 -140;
-    pos @kc88_first_39 @kc88_second_14 -35;
-    pos @kc88_first_39 @kc88_second_15 -35;
-    pos @kc88_first_39 @kc88_second_34 -35;
-    pos @kc88_first_39 @kc88_second_45 1;
-    pos @kc88_first_39 @kc88_second_63 -35;
-    pos @kc88_first_39 @kc88_second_64 -35;
-    pos @kc88_first_40 @kc88_second_12 -210;
-    pos @kc88_first_40 @kc88_second_13 -175;
-    pos @kc88_first_40 @kc88_second_14 -105;
-    pos @kc88_first_40 @kc88_second_15 -70;
-    pos @kc88_first_40 @kc88_second_43 -70;
-    pos @kc88_first_40 @kc88_second_45 1;
-    pos @kc88_first_40 @kc88_second_48 -105;
-    pos @kc88_first_40 @kc88_second_61 -70;
-    pos @kc88_first_41 @kc88_second_1 -140;
-    pos @kc88_first_41 @kc88_second_2 -175;
-    pos @kc88_first_41 @kc88_second_5 -105;
-    pos @kc88_first_41 @kc88_second_6 -70;
-    pos @kc88_first_41 @kc88_second_11 -70;
-    pos @kc88_first_41 @kc88_second_12 -175;
-    pos @kc88_first_41 @kc88_second_13 -105;
-    pos @kc88_first_41 @kc88_second_14 -70;
-    pos @kc88_first_41 @kc88_second_15 -35;
-    pos @kc88_first_41 @kc88_second_16 -105;
-    pos @kc88_first_41 @kc88_second_17 -35;
-    pos @kc88_first_41 @kc88_second_19 -175;
-    pos @kc88_first_41 @kc88_second_22 -50;
-    pos @kc88_first_41 @kc88_second_24 -105;
-    pos @kc88_first_41 @kc88_second_29 -35;
-    pos @kc88_first_41 @kc88_second_34 -70;
-    pos @kc88_first_41 @kc88_second_35 -140;
-    pos @kc88_first_41 @kc88_second_36 -35;
-    pos @kc88_first_41 @kc88_second_38 -50;
-    pos @kc88_first_41 @kc88_second_45 1;
-    pos @kc88_first_41 @kc88_second_51 -35;
-    pos @kc88_first_41 @kc88_second_53 -105;
-    pos @kc88_first_41 @kc88_second_55 -105;
-    pos @kc88_first_41 @kc88_second_57 -105;
-    pos @kc88_first_41 @kc88_second_63 -50;
-    pos @kc88_first_41 @kc88_second_64 -70;
-    pos @kc88_first_42 @kc88_second_1 -210;
-    pos @kc88_first_42 @kc88_second_2 -280;
-    pos @kc88_first_42 @kc88_second_3 -70;
-    pos @kc88_first_42 @kc88_second_6 -280;
-    pos @kc88_first_42 @kc88_second_8 -35;
-    pos @kc88_first_42 @kc88_second_11 -70;
-    pos @kc88_first_42 @kc88_second_13 -140;
-    pos @kc88_first_42 @kc88_second_14 -35;
-    pos @kc88_first_42 @kc88_second_15 -35;
-    pos @kc88_first_42 @kc88_second_16 -140;
-    pos @kc88_first_42 @kc88_second_17 -105;
-    pos @kc88_first_42 @kc88_second_19 -280;
-    pos @kc88_first_42 @kc88_second_20 -140;
-    pos @kc88_first_42 @kc88_second_22 -140;
-    pos @kc88_first_42 @kc88_second_23 -140;
-    pos @kc88_first_42 @kc88_second_24 -210;
-    pos @kc88_first_42 @kc88_second_34 -280;
-    pos @kc88_first_42 @kc88_second_35 -140;
-    pos @kc88_first_42 @kc88_second_36 -70;
-    pos @kc88_first_42 @kc88_second_37 -140;
-    pos @kc88_first_42 @kc88_second_38 -175;
-    pos @kc88_first_42 @kc88_second_44 -70;
-    pos @kc88_first_42 @kc88_second_45 1;
-    pos @kc88_first_42 @kc88_second_53 -210;
-    pos @kc88_first_42 @kc88_second_55 -175;
-    pos @kc88_first_42 @kc88_second_57 -210;
-    pos @kc88_first_42 @kc88_second_59 -70;
-    pos @kc88_first_42 @kc88_second_63 -175;
-    pos @kc88_first_42 @kc88_second_64 -175;
-    pos @kc88_first_43 @kc88_second_9 -70;
-    pos @kc88_first_43 @kc88_second_12 -240;
-    pos @kc88_first_43 @kc88_second_13 -210;
-    pos @kc88_first_43 @kc88_second_14 -140;
-    pos @kc88_first_43 @kc88_second_15 -105;
-    pos @kc88_first_43 @kc88_second_39 -70;
-    pos @kc88_first_43 @kc88_second_40 -35;
-    pos @kc88_first_43 @kc88_second_43 -140;
-    pos @kc88_first_43 @kc88_second_45 1;
-    pos @kc88_first_43 @kc88_second_47 -50;
-    pos @kc88_first_43 @kc88_second_48 -140;
-    pos @kc88_first_43 @kc88_second_58 -35;
-    pos @kc88_first_43 @kc88_second_60 -35;
-    pos @kc88_first_43 @kc88_second_61 -70;
-    pos @kc88_first_43 @kc88_second_62 -70;
-    pos @kc88_first_44 @kc88_second_8 -35;
-    pos @kc88_first_44 @kc88_second_9 -70;
-    pos @kc88_first_44 @kc88_second_12 -240;
-    pos @kc88_first_44 @kc88_second_13 -210;
-    pos @kc88_first_44 @kc88_second_14 -70;
-    pos @kc88_first_44 @kc88_second_15 -105;
-    pos @kc88_first_44 @kc88_second_22 -35;
-    pos @kc88_first_44 @kc88_second_38 -70;
-    pos @kc88_first_44 @kc88_second_39 -105;
-    pos @kc88_first_44 @kc88_second_40 -70;
-    pos @kc88_first_44 @kc88_second_43 -70;
-    pos @kc88_first_44 @kc88_second_44 -35;
-    pos @kc88_first_44 @kc88_second_45 1;
-    pos @kc88_first_44 @kc88_second_47 -70;
-    pos @kc88_first_44 @kc88_second_48 -70;
-    pos @kc88_first_44 @kc88_second_58 -70;
-    pos @kc88_first_44 @kc88_second_60 -50;
-    pos @kc88_first_44 @kc88_second_62 -70;
-    pos @kc88_first_44 @kc88_second_63 -35;
-    pos @kc88_first_44 @kc88_second_64 -35;
-    pos @kc88_first_45 @kc88_second_6 -70;
-    pos @kc88_first_45 @kc88_second_8 -35;
-    pos @kc88_first_45 @kc88_second_12 -175;
-    pos @kc88_first_45 @kc88_second_13 -140;
-    pos @kc88_first_45 @kc88_second_14 -70;
-    pos @kc88_first_45 @kc88_second_15 -35;
-    pos @kc88_first_45 @kc88_second_17 -70;
-    pos @kc88_first_45 @kc88_second_20 -70;
-    pos @kc88_first_45 @kc88_second_22 -105;
-    pos @kc88_first_45 @kc88_second_29 -35;
-    pos @kc88_first_45 @kc88_second_34 -70;
-    pos @kc88_first_45 @kc88_second_36 -35;
-    pos @kc88_first_45 @kc88_second_38 -105;
-    pos @kc88_first_45 @kc88_second_45 1;
-    pos @kc88_first_45 @kc88_second_51 -35;
-    pos @kc88_first_45 @kc88_second_63 -70;
-    pos @kc88_first_45 @kc88_second_64 -70;
-    pos @kc88_first_46 @kc88_second_3 -140;
-    pos @kc88_first_46 @kc88_second_4 -70;
-    pos @kc88_first_46 @kc88_second_6 -70;
-    pos @kc88_first_46 @kc88_second_8 -210;
-    pos @kc88_first_46 @kc88_second_9 -420;
-    pos @kc88_first_46 @kc88_second_12 -350;
-    pos @kc88_first_46 @kc88_second_13 -420;
-    pos @kc88_first_46 @kc88_second_14 -350;
-    pos @kc88_first_46 @kc88_second_15 -280;
-    pos @kc88_first_46 @kc88_second_17 -70;
-    pos @kc88_first_46 @kc88_second_18 -210;
-    pos @kc88_first_46 @kc88_second_20 -210;
-    pos @kc88_first_46 @kc88_second_22 -70;
-    pos @kc88_first_46 @kc88_second_23 -140;
-    pos @kc88_first_46 @kc88_second_29 -35;
-    pos @kc88_first_46 @kc88_second_31 -140;
-    pos @kc88_first_46 @kc88_second_34 -70;
-    pos @kc88_first_46 @kc88_second_36 -70;
-    pos @kc88_first_46 @kc88_second_38 -210;
-    pos @kc88_first_46 @kc88_second_39 -280;
-    pos @kc88_first_46 @kc88_second_40 -420;
-    pos @kc88_first_46 @kc88_second_43 -350;
-    pos @kc88_first_46 @kc88_second_45 1;
-    pos @kc88_first_46 @kc88_second_46 -35;
-    pos @kc88_first_46 @kc88_second_47 -210;
-    pos @kc88_first_46 @kc88_second_48 -350;
-    pos @kc88_first_46 @kc88_second_51 -35;
-    pos @kc88_first_46 @kc88_second_52 -35;
-    pos @kc88_first_46 @kc88_second_58 -280;
-    pos @kc88_first_46 @kc88_second_60 -175;
-    pos @kc88_first_46 @kc88_second_61 -280;
-    pos @kc88_first_46 @kc88_second_62 -210;
-    pos @kc88_first_46 @kc88_second_63 -70;
-    pos @kc88_first_47 @kc88_second_3 -140;
-    pos @kc88_first_47 @kc88_second_4 -105;
-    pos @kc88_first_47 @kc88_second_6 -70;
-    pos @kc88_first_47 @kc88_second_8 -210;
-    pos @kc88_first_47 @kc88_second_9 -280;
-    pos @kc88_first_47 @kc88_second_12 -350;
-    pos @kc88_first_47 @kc88_second_13 -385;
-    pos @kc88_first_47 @kc88_second_14 -350;
-    pos @kc88_first_47 @kc88_second_15 -280;
-    pos @kc88_first_47 @kc88_second_18 -210;
-    pos @kc88_first_47 @kc88_second_20 -140;
-    pos @kc88_first_47 @kc88_second_22 -105;
-    pos @kc88_first_47 @kc88_second_23 -140;
-    pos @kc88_first_47 @kc88_second_29 -70;
-    pos @kc88_first_47 @kc88_second_31 -175;
-    pos @kc88_first_47 @kc88_second_34 -70;
-    pos @kc88_first_47 @kc88_second_36 -35;
-    pos @kc88_first_47 @kc88_second_38 -175;
-    pos @kc88_first_47 @kc88_second_39 -280;
-    pos @kc88_first_47 @kc88_second_40 -280;
-    pos @kc88_first_47 @kc88_second_43 -280;
-    pos @kc88_first_47 @kc88_second_44 -140;
-    pos @kc88_first_47 @kc88_second_45 1;
-    pos @kc88_first_47 @kc88_second_46 -70;
-    pos @kc88_first_47 @kc88_second_47 -280;
-    pos @kc88_first_47 @kc88_second_48 -350;
-    pos @kc88_first_47 @kc88_second_51 -35;
-    pos @kc88_first_47 @kc88_second_52 -70;
-    pos @kc88_first_47 @kc88_second_58 -245;
-    pos @kc88_first_47 @kc88_second_60 -245;
-    pos @kc88_first_47 @kc88_second_61 -280;
-    pos @kc88_first_47 @kc88_second_62 -210;
-    pos @kc88_first_47 @kc88_second_63 -70;
-    pos @kc88_first_47 @kc88_second_64 -70;
-    pos @kc88_first_48 @kc88_second_3 -70;
-    pos @kc88_first_48 @kc88_second_4 -105;
-    pos @kc88_first_48 @kc88_second_6 -210;
-    pos @kc88_first_48 @kc88_second_7 -70;
-    pos @kc88_first_48 @kc88_second_8 -175;
-    pos @kc88_first_48 @kc88_second_17 -210;
-    pos @kc88_first_48 @kc88_second_20 -140;
-    pos @kc88_first_48 @kc88_second_21 -210;
-    pos @kc88_first_48 @kc88_second_22 -210;
-    pos @kc88_first_48 @kc88_second_23 -210;
-    pos @kc88_first_48 @kc88_second_24 -140;
-    pos @kc88_first_48 @kc88_second_25 -140;
-    pos @kc88_first_48 @kc88_second_27 -140;
-    pos @kc88_first_48 @kc88_second_29 -210;
-    pos @kc88_first_48 @kc88_second_30 -210;
-    pos @kc88_first_48 @kc88_second_31 -140;
-    pos @kc88_first_48 @kc88_second_34 -210;
-    pos @kc88_first_48 @kc88_second_35 -70;
-    pos @kc88_first_48 @kc88_second_36 -175;
-    pos @kc88_first_48 @kc88_second_37 -210;
-    pos @kc88_first_48 @kc88_second_38 -175;
-    pos @kc88_first_48 @kc88_second_39 -210;
-    pos @kc88_first_48 @kc88_second_40 -105;
-    pos @kc88_first_48 @kc88_second_43 -70;
-    pos @kc88_first_48 @kc88_second_44 -105;
-    pos @kc88_first_48 @kc88_second_45 1;
-    pos @kc88_first_48 @kc88_second_46 -35;
-    pos @kc88_first_48 @kc88_second_47 -210;
-    pos @kc88_first_48 @kc88_second_50 -210;
-    pos @kc88_first_48 @kc88_second_51 -210;
-    pos @kc88_first_48 @kc88_second_52 -175;
-    pos @kc88_first_48 @kc88_second_53 -175;
-    pos @kc88_first_48 @kc88_second_55 -210;
-    pos @kc88_first_48 @kc88_second_56 -140;
-    pos @kc88_first_48 @kc88_second_57 -210;
-    pos @kc88_first_48 @kc88_second_58 -210;
-    pos @kc88_first_48 @kc88_second_59 -175;
-    pos @kc88_first_48 @kc88_second_60 -175;
-    pos @kc88_first_48 @kc88_second_63 -210;
-    pos @kc88_first_48 @kc88_second_64 -210;
-    pos @kc88_first_49 @kc88_second_5 -70;
-    pos @kc88_first_49 @kc88_second_11 -35;
-    pos @kc88_first_49 @kc88_second_12 -240;
-    pos @kc88_first_49 @kc88_second_13 -70;
-    pos @kc88_first_49 @kc88_second_14 -140;
-    pos @kc88_first_49 @kc88_second_15 -105;
-    pos @kc88_first_49 @kc88_second_16 -70;
-    pos @kc88_first_49 @kc88_second_26 -70;
-    pos @kc88_first_49 @kc88_second_27 -70;
-    pos @kc88_first_49 @kc88_second_35 -35;
-    pos @kc88_first_49 @kc88_second_39 -70;
-    pos @kc88_first_49 @kc88_second_42 -35;
-    pos @kc88_first_49 @kc88_second_43 -70;
-    pos @kc88_first_49 @kc88_second_45 1;
-    pos @kc88_first_49 @kc88_second_47 -35;
-    pos @kc88_first_49 @kc88_second_48 -140;
-    pos @kc88_first_49 @kc88_second_51 1;
-    pos @kc88_first_49 @kc88_second_56 -35;
-    pos @kc88_first_49 @kc88_second_60 -35;
-    pos @kc88_first_49 @kc88_second_61 -105;
-    pos @kc88_first_49 @kc88_second_62 -70;
-    pos @kc88_first_50 @kc88_second_65 -140;
-    pos @kc88_first_51 @kc88_second_32 -315;
-    pos @kc88_first_51 @kc88_second_66 -140;
-    pos @kc88_first_52 @kc88_second_1 -105;
-    pos @kc88_first_52 @kc88_second_2 -210;
-    pos @kc88_first_52 @kc88_second_6 -140;
-    pos @kc88_first_52 @kc88_second_11 -70;
-    pos @kc88_first_52 @kc88_second_12 -210;
-    pos @kc88_first_52 @kc88_second_13 -210;
-    pos @kc88_first_52 @kc88_second_14 -105;
-    pos @kc88_first_52 @kc88_second_15 -70;
-    pos @kc88_first_52 @kc88_second_16 -140;
-    pos @kc88_first_52 @kc88_second_17 -35;
-    pos @kc88_first_52 @kc88_second_22 -35;
-    pos @kc88_first_52 @kc88_second_24 -210;
-    pos @kc88_first_52 @kc88_second_26 -70;
-    pos @kc88_first_52 @kc88_second_27 -70;
-    pos @kc88_first_52 @kc88_second_29 -35;
-    pos @kc88_first_52 @kc88_second_34 -210;
-    pos @kc88_first_52 @kc88_second_35 -140;
-    pos @kc88_first_52 @kc88_second_42 -35;
-    pos @kc88_first_52 @kc88_second_43 -70;
-    pos @kc88_first_52 @kc88_second_45 1;
-    pos @kc88_first_52 @kc88_second_47 -35;
-    pos @kc88_first_52 @kc88_second_48 -105;
-    pos @kc88_first_52 @kc88_second_53 -210;
-    pos @kc88_first_52 @kc88_second_55 -140;
-    pos @kc88_first_52 @kc88_second_57 -175;
-    pos @kc88_first_52 @kc88_second_61 -35;
-    pos @kc88_first_52 @kc88_second_62 -35;
-    pos @kc88_first_52 @kc88_second_63 -35;
-    pos @kc88_first_52 @kc88_second_64 -70;
-    pos @kc88_first_53 @kc88_second_1 -35;
-    pos @kc88_first_53 @kc88_second_2 -70;
-    pos @kc88_first_53 @kc88_second_5 -105;
-    pos @kc88_first_53 @kc88_second_6 -35;
-    pos @kc88_first_53 @kc88_second_9 -70;
-    pos @kc88_first_53 @kc88_second_11 -70;
-    pos @kc88_first_53 @kc88_second_12 -240;
-    pos @kc88_first_53 @kc88_second_13 -245;
-    pos @kc88_first_53 @kc88_second_14 -140;
-    pos @kc88_first_53 @kc88_second_15 -105;
-    pos @kc88_first_53 @kc88_second_16 -105;
-    pos @kc88_first_53 @kc88_second_18 -70;
-    pos @kc88_first_53 @kc88_second_19 -70;
-    pos @kc88_first_53 @kc88_second_24 -35;
-    pos @kc88_first_53 @kc88_second_25 -70;
-    pos @kc88_first_53 @kc88_second_26 -140;
-    pos @kc88_first_53 @kc88_second_27 -105;
-    pos @kc88_first_53 @kc88_second_34 -35;
-    pos @kc88_first_53 @kc88_second_35 -140;
-    pos @kc88_first_53 @kc88_second_39 -105;
-    pos @kc88_first_53 @kc88_second_40 -70;
-    pos @kc88_first_53 @kc88_second_42 -105;
-    pos @kc88_first_53 @kc88_second_43 -175;
-    pos @kc88_first_53 @kc88_second_45 1;
-    pos @kc88_first_53 @kc88_second_47 -70;
-    pos @kc88_first_53 @kc88_second_48 -140;
-    pos @kc88_first_53 @kc88_second_49 -70;
-    pos @kc88_first_53 @kc88_second_53 -210;
-    pos @kc88_first_53 @kc88_second_54 -70;
-    pos @kc88_first_53 @kc88_second_55 -175;
-    pos @kc88_first_53 @kc88_second_56 -105;
-    pos @kc88_first_53 @kc88_second_57 -175;
-    pos @kc88_first_53 @kc88_second_60 -50;
-    pos @kc88_first_53 @kc88_second_61 -105;
-    pos @kc88_first_53 @kc88_second_62 -70;
-    pos @kc88_first_53 @kc88_second_64 -35;
-    pos @kc88_first_54 @kc88_second_1 -105;
-    pos @kc88_first_54 @kc88_second_2 -210;
-    pos @kc88_first_54 @kc88_second_5 -70;
-    pos @kc88_first_54 @kc88_second_6 -105;
-    pos @kc88_first_54 @kc88_second_13 -70;
-    pos @kc88_first_54 @kc88_second_14 -35;
-    pos @kc88_first_54 @kc88_second_16 -140;
-    pos @kc88_first_54 @kc88_second_17 -70;
-    pos @kc88_first_54 @kc88_second_19 -210;
-    pos @kc88_first_54 @kc88_second_22 -35;
-    pos @kc88_first_54 @kc88_second_24 -210;
-    pos @kc88_first_54 @kc88_second_29 -35;
-    pos @kc88_first_54 @kc88_second_32 -105;
-    pos @kc88_first_54 @kc88_second_34 -105;
-    pos @kc88_first_54 @kc88_second_35 -140;
-    pos @kc88_first_54 @kc88_second_38 -70;
-    pos @kc88_first_54 @kc88_second_45 1;
-    pos @kc88_first_54 @kc88_second_51 -35;
-    pos @kc88_first_54 @kc88_second_53 -245;
-    pos @kc88_first_54 @kc88_second_55 -210;
-    pos @kc88_first_54 @kc88_second_57 -210;
-    pos @kc88_first_54 @kc88_second_63 -70;
-    pos @kc88_first_54 @kc88_second_64 -105;
-    pos @kc88_first_55 @kc88_second_12 -240;
-    pos @kc88_first_55 @kc88_second_13 -140;
-    pos @kc88_first_55 @kc88_second_14 -105;
-    pos @kc88_first_55 @kc88_second_15 -35;
-    pos @kc88_first_55 @kc88_second_33 44;
-    pos @kc88_first_55 @kc88_second_45 1;
-    pos @kc88_first_55 @kc88_second_50 44;
-    pos @kc88_first_56 @kc88_second_1 -140;
-    pos @kc88_first_56 @kc88_second_2 -210;
-    pos @kc88_first_56 @kc88_second_6 -140;
-    pos @kc88_first_56 @kc88_second_12 -175;
-    pos @kc88_first_56 @kc88_second_13 -140;
-    pos @kc88_first_56 @kc88_second_16 -140;
-    pos @kc88_first_56 @kc88_second_19 -210;
-    pos @kc88_first_56 @kc88_second_24 -210;
-    pos @kc88_first_56 @kc88_second_32 -140;
-    pos @kc88_first_56 @kc88_second_34 -140;
-    pos @kc88_first_56 @kc88_second_35 -210;
-    pos @kc88_first_56 @kc88_second_36 -35;
-    pos @kc88_first_56 @kc88_second_45 1;
-    pos @kc88_first_56 @kc88_second_53 -210;
-    pos @kc88_first_56 @kc88_second_55 -175;
-    pos @kc88_first_56 @kc88_second_57 -175;
-    pos @kc88_first_56 @kc88_second_63 -105;
-    pos @kc88_first_56 @kc88_second_64 -210;
-    pos @kc88_first_57 @kc88_second_12 -240;
-    pos @kc88_first_57 @kc88_second_13 -175;
-    pos @kc88_first_57 @kc88_second_14 -70;
-    pos @kc88_first_57 @kc88_second_15 -35;
-    pos @kc88_first_57 @kc88_second_19 -35;
-    pos @kc88_first_57 @kc88_second_26 -35;
-    pos @kc88_first_57 @kc88_second_39 -35;
-    pos @kc88_first_57 @kc88_second_40 -35;
-    pos @kc88_first_57 @kc88_second_43 -70;
-    pos @kc88_first_57 @kc88_second_45 1;
-    pos @kc88_first_57 @kc88_second_47 -35;
-    pos @kc88_first_57 @kc88_second_48 -70;
-    pos @kc88_first_57 @kc88_second_58 -35;
-    pos @kc88_first_57 @kc88_second_60 -35;
-    pos @kc88_first_57 @kc88_second_61 -70;
-    pos @kc88_first_57 @kc88_second_62 -35;
-    pos @kc88_first_58 @kc88_second_13 -35;
-    pos @kc88_first_58 @kc88_second_58 -35;
-    pos @kc88_first_58 @kc88_second_64 -35;
-    pos @kc88_first_59 @kc88_second_12 -175;
-    pos @kc88_first_59 @kc88_second_13 -140;
-    pos @kc88_first_59 @kc88_second_14 -35;
-    pos @kc88_first_59 @kc88_second_45 1;
-    pos @kc88_first_60 @kc88_second_1 -140;
-    pos @kc88_first_60 @kc88_second_2 -280;
-    pos @kc88_first_60 @kc88_second_5 -140;
-    pos @kc88_first_60 @kc88_second_6 -280;
-    pos @kc88_first_60 @kc88_second_8 -70;
-    pos @kc88_first_60 @kc88_second_10 -70;
-    pos @kc88_first_60 @kc88_second_11 -175;
-    pos @kc88_first_60 @kc88_second_12 -240;
-    pos @kc88_first_60 @kc88_second_13 -140;
-    pos @kc88_first_60 @kc88_second_14 -105;
-    pos @kc88_first_60 @kc88_second_15 -70;
-    pos @kc88_first_60 @kc88_second_16 -175;
-    pos @kc88_first_60 @kc88_second_17 -70;
-    pos @kc88_first_60 @kc88_second_19 -280;
-    pos @kc88_first_60 @kc88_second_22 -70;
-    pos @kc88_first_60 @kc88_second_23 -70;
-    pos @kc88_first_60 @kc88_second_24 -210;
-    pos @kc88_first_60 @kc88_second_26 -70;
-    pos @kc88_first_60 @kc88_second_27 -70;
-    pos @kc88_first_60 @kc88_second_29 -70;
-    pos @kc88_first_60 @kc88_second_32 -70;
-    pos @kc88_first_60 @kc88_second_34 -315;
-    pos @kc88_first_60 @kc88_second_35 -140;
-    pos @kc88_first_60 @kc88_second_36 -70;
-    pos @kc88_first_60 @kc88_second_38 -105;
-    pos @kc88_first_60 @kc88_second_45 1;
-    pos @kc88_first_60 @kc88_second_48 -35;
-    pos @kc88_first_60 @kc88_second_51 -50;
-    pos @kc88_first_60 @kc88_second_53 -210;
-    pos @kc88_first_60 @kc88_second_55 -175;
-    pos @kc88_first_60 @kc88_second_57 -210;
-    pos @kc88_first_60 @kc88_second_59 -35;
-    pos @kc88_first_60 @kc88_second_61 -70;
-    pos @kc88_first_60 @kc88_second_62 -35;
-    pos @kc88_first_60 @kc88_second_63 -140;
-    pos @kc88_first_60 @kc88_second_64 -210;
-    pos @kc88_first_61 @kc88_second_1 -35;
-    pos @kc88_first_61 @kc88_second_2 -70;
-    pos @kc88_first_61 @kc88_second_5 -70;
-    pos @kc88_first_61 @kc88_second_11 -35;
-    pos @kc88_first_61 @kc88_second_12 -140;
-    pos @kc88_first_61 @kc88_second_13 -140;
-    pos @kc88_first_61 @kc88_second_14 -70;
-    pos @kc88_first_61 @kc88_second_15 -35;
-    pos @kc88_first_61 @kc88_second_16 -105;
-    pos @kc88_first_61 @kc88_second_26 -35;
-    pos @kc88_first_61 @kc88_second_27 -70;
-    pos @kc88_first_61 @kc88_second_35 -70;
-    pos @kc88_first_61 @kc88_second_43 -70;
-    pos @kc88_first_61 @kc88_second_45 1;
-    pos @kc88_first_61 @kc88_second_53 -175;
-    pos @kc88_first_61 @kc88_second_55 -140;
-    pos @kc88_first_61 @kc88_second_57 -140;
-    pos @kc88_first_61 @kc88_second_61 -35;
-    pos @kc88_first_62 @kc88_second_5 -70;
-    pos @kc88_first_62 @kc88_second_9 -70;
-    pos @kc88_first_62 @kc88_second_11 -35;
-    pos @kc88_first_62 @kc88_second_12 -350;
-    pos @kc88_first_62 @kc88_second_13 -315;
-    pos @kc88_first_62 @kc88_second_14 -175;
-    pos @kc88_first_62 @kc88_second_15 -140;
-    pos @kc88_first_62 @kc88_second_16 -70;
-    pos @kc88_first_62 @kc88_second_18 -70;
-    pos @kc88_first_62 @kc88_second_27 -70;
-    pos @kc88_first_62 @kc88_second_31 -50;
-    pos @kc88_first_62 @kc88_second_39 -140;
-    pos @kc88_first_62 @kc88_second_40 -50;
-    pos @kc88_first_62 @kc88_second_42 -35;
-    pos @kc88_first_62 @kc88_second_43 -175;
-    pos @kc88_first_62 @kc88_second_45 1;
-    pos @kc88_first_62 @kc88_second_47 -70;
-    pos @kc88_first_62 @kc88_second_48 -175;
-    pos @kc88_first_62 @kc88_second_54 -70;
-    pos @kc88_first_62 @kc88_second_58 -70;
-    pos @kc88_first_62 @kc88_second_60 -50;
-    pos @kc88_first_62 @kc88_second_61 -140;
-    pos @kc88_first_62 @kc88_second_62 -105;
-    pos @kc88_first_63 @kc88_second_4 -105;
-    pos @kc88_first_63 @kc88_second_6 -35;
-    pos @kc88_first_63 @kc88_second_8 1;
-    pos @kc88_first_63 @kc88_second_9 -245;
-    pos @kc88_first_63 @kc88_second_12 -210;
-    pos @kc88_first_63 @kc88_second_13 -210;
-    pos @kc88_first_63 @kc88_second_14 -210;
-    pos @kc88_first_63 @kc88_second_15 -175;
-    pos @kc88_first_63 @kc88_second_17 -70;
-    pos @kc88_first_63 @kc88_second_18 -180;
-    pos @kc88_first_63 @kc88_second_20 -140;
-    pos @kc88_first_63 @kc88_second_22 -105;
-    pos @kc88_first_63 @kc88_second_25 -140;
-    pos @kc88_first_63 @kc88_second_29 -105;
-    pos @kc88_first_63 @kc88_second_31 -140;
-    pos @kc88_first_63 @kc88_second_34 -35;
-    pos @kc88_first_63 @kc88_second_36 -35;
-    pos @kc88_first_63 @kc88_second_38 -175;
-    pos @kc88_first_63 @kc88_second_39 -142;
-    pos @kc88_first_63 @kc88_second_40 -245;
-    pos @kc88_first_63 @kc88_second_43 -210;
-    pos @kc88_first_63 @kc88_second_44 -105;
-    pos @kc88_first_63 @kc88_second_45 1;
-    pos @kc88_first_63 @kc88_second_46 -35;
-    pos @kc88_first_63 @kc88_second_47 -210;
-    pos @kc88_first_63 @kc88_second_48 -210;
-    pos @kc88_first_63 @kc88_second_51 -35;
-    pos @kc88_first_63 @kc88_second_58 -280;
-    pos @kc88_first_63 @kc88_second_60 -175;
-    pos @kc88_first_63 @kc88_second_61 -140;
-    pos @kc88_first_63 @kc88_second_62 -140;
-    pos @kc88_first_63 @kc88_second_63 -70;
-    pos @kc88_first_63 @kc88_second_64 -70;
-    pos @kc88_first_64 @kc88_second_1 -175;
-    pos @kc88_first_64 @kc88_second_2 -175;
-    pos @kc88_first_64 @kc88_second_5 -70;
-    pos @kc88_first_64 @kc88_second_6 -105;
-    pos @kc88_first_64 @kc88_second_11 -105;
-    pos @kc88_first_64 @kc88_second_12 -175;
-    pos @kc88_first_64 @kc88_second_13 -140;
-    pos @kc88_first_64 @kc88_second_14 -70;
-    pos @kc88_first_64 @kc88_second_15 -35;
-    pos @kc88_first_64 @kc88_second_16 -140;
-    pos @kc88_first_64 @kc88_second_17 -70;
-    pos @kc88_first_64 @kc88_second_19 -175;
-    pos @kc88_first_64 @kc88_second_22 -70;
-    pos @kc88_first_64 @kc88_second_29 -35;
-    pos @kc88_first_64 @kc88_second_34 -105;
-    pos @kc88_first_64 @kc88_second_35 -175;
-    pos @kc88_first_64 @kc88_second_36 -35;
-    pos @kc88_first_64 @kc88_second_38 -70;
-    pos @kc88_first_64 @kc88_second_45 1;
-    pos @kc88_first_64 @kc88_second_51 -35;
-    pos @kc88_first_64 @kc88_second_53 -140;
-    pos @kc88_first_64 @kc88_second_55 -140;
-    pos @kc88_first_64 @kc88_second_57 -140;
-    pos @kc88_first_64 @kc88_second_63 -70;
-    pos @kc88_first_64 @kc88_second_64 -105;
-    pos @kc88_first_65 @kc88_second_1 -210;
-    pos @kc88_first_65 @kc88_second_2 -210;
-    pos @kc88_first_65 @kc88_second_3 -70;
-    pos @kc88_first_65 @kc88_second_4 -35;
-    pos @kc88_first_65 @kc88_second_6 -210;
-    pos @kc88_first_65 @kc88_second_7 -70;
-    pos @kc88_first_65 @kc88_second_8 -70;
-    pos @kc88_first_65 @kc88_second_16 -70;
-    pos @kc88_first_65 @kc88_second_17 -140;
-    pos @kc88_first_65 @kc88_second_19 -210;
-    pos @kc88_first_65 @kc88_second_20 -140;
-    pos @kc88_first_65 @kc88_second_21 -35;
-    pos @kc88_first_65 @kc88_second_22 -175;
-    pos @kc88_first_65 @kc88_second_23 -140;
-    pos @kc88_first_65 @kc88_second_24 -280;
-    pos @kc88_first_65 @kc88_second_29 -35;
-    pos @kc88_first_65 @kc88_second_30 -35;
-    pos @kc88_first_65 @kc88_second_32 -210;
-    pos @kc88_first_65 @kc88_second_34 -245;
-    pos @kc88_first_65 @kc88_second_35 -140;
-    pos @kc88_first_65 @kc88_second_36 -140;
-    pos @kc88_first_65 @kc88_second_37 -140;
-    pos @kc88_first_65 @kc88_second_38 -140;
-    pos @kc88_first_65 @kc88_second_39 -35;
-    pos @kc88_first_65 @kc88_second_44 -35;
-    pos @kc88_first_65 @kc88_second_45 1;
-    pos @kc88_first_65 @kc88_second_49 -35;
-    pos @kc88_first_65 @kc88_second_51 -140;
-    pos @kc88_first_65 @kc88_second_52 -70;
-    pos @kc88_first_65 @kc88_second_53 -210;
-    pos @kc88_first_65 @kc88_second_55 -210;
-    pos @kc88_first_65 @kc88_second_57 -210;
-    pos @kc88_first_65 @kc88_second_58 -35;
-    pos @kc88_first_65 @kc88_second_63 -175;
-    pos @kc88_first_65 @kc88_second_64 -245;
-    pos @kc88_first_66 @kc88_second_6 -35;
-    pos @kc88_first_66 @kc88_second_12 -240;
-    pos @kc88_first_66 @kc88_second_13 -140;
-    pos @kc88_first_66 @kc88_second_14 -70;
-    pos @kc88_first_66 @kc88_second_15 -35;
-    pos @kc88_first_66 @kc88_second_20 -35;
-    pos @kc88_first_66 @kc88_second_22 -35;
-    pos @kc88_first_66 @kc88_second_34 -70;
-    pos @kc88_first_66 @kc88_second_38 -70;
-    pos @kc88_first_66 @kc88_second_39 -50;
-    pos @kc88_first_66 @kc88_second_45 1;
-    pos @kc88_first_66 @kc88_second_48 -35;
-    pos @kc88_first_66 @kc88_second_63 -35;
-    pos @kc88_first_66 @kc88_second_64 -35;
-    pos @kc88_first_67 @kc88_second_3 -100;
-    pos @kc88_first_67 @kc88_second_4 -50;
-    pos @kc88_first_67 @kc88_second_6 -50;
-    pos @kc88_first_67 @kc88_second_8 -70;
-    pos @kc88_first_67 @kc88_second_9 -140;
-    pos @kc88_first_67 @kc88_second_10 -50;
-    pos @kc88_first_67 @kc88_second_12 -140;
-    pos @kc88_first_67 @kc88_second_13 -100;
-    pos @kc88_first_67 @kc88_second_14 -70;
-    pos @kc88_first_67 @kc88_second_15 -50;
-    pos @kc88_first_67 @kc88_second_18 -70;
-    pos @kc88_first_67 @kc88_second_20 -70;
-    pos @kc88_first_67 @kc88_second_22 -50;
-    pos @kc88_first_67 @kc88_second_23 -70;
-    pos @kc88_first_67 @kc88_second_29 -35;
-    pos @kc88_first_67 @kc88_second_31 -70;
-    pos @kc88_first_67 @kc88_second_33 105;
-    pos @kc88_first_67 @kc88_second_34 -35;
-    pos @kc88_first_67 @kc88_second_38 -70;
-    pos @kc88_first_67 @kc88_second_39 -140;
-    pos @kc88_first_67 @kc88_second_40 -140;
-    pos @kc88_first_67 @kc88_second_43 -140;
-    pos @kc88_first_67 @kc88_second_44 -35;
-    pos @kc88_first_67 @kc88_second_45 1;
-    pos @kc88_first_67 @kc88_second_47 -70;
-    pos @kc88_first_67 @kc88_second_48 -100;
-    pos @kc88_first_67 @kc88_second_50 105;
-    pos @kc88_first_67 @kc88_second_58 -140;
-    pos @kc88_first_67 @kc88_second_60 -70;
-    pos @kc88_first_67 @kc88_second_61 -70;
-    pos @kc88_first_67 @kc88_second_62 -50;
-    pos @kc88_first_67 @kc88_second_63 -35;
-    pos @kc88_first_67 @kc88_second_64 -35;
-    pos @kc88_first_68 @kc88_second_3 -70;
-    pos @kc88_first_68 @kc88_second_4 -50;
-    pos @kc88_first_68 @kc88_second_6 -50;
-    pos @kc88_first_68 @kc88_second_8 -70;
-    pos @kc88_first_68 @kc88_second_9 -140;
-    pos @kc88_first_68 @kc88_second_10 -50;
-    pos @kc88_first_68 @kc88_second_12 -240;
-    pos @kc88_first_68 @kc88_second_13 -240;
-    pos @kc88_first_68 @kc88_second_14 -175;
-    pos @kc88_first_68 @kc88_second_15 -140;
-    pos @kc88_first_68 @kc88_second_18 -70;
-    pos @kc88_first_68 @kc88_second_20 -70;
-    pos @kc88_first_68 @kc88_second_22 -50;
-    pos @kc88_first_68 @kc88_second_23 -70;
-    pos @kc88_first_68 @kc88_second_29 -35;
-    pos @kc88_first_68 @kc88_second_31 -70;
-    pos @kc88_first_68 @kc88_second_34 -35;
-    pos @kc88_first_68 @kc88_second_38 -70;
-    pos @kc88_first_68 @kc88_second_39 -140;
-    pos @kc88_first_68 @kc88_second_40 -140;
-    pos @kc88_first_68 @kc88_second_43 -140;
-    pos @kc88_first_68 @kc88_second_44 -35;
-    pos @kc88_first_68 @kc88_second_45 1;
-    pos @kc88_first_68 @kc88_second_47 -70;
-    pos @kc88_first_68 @kc88_second_48 -140;
-    pos @kc88_first_68 @kc88_second_58 -140;
-    pos @kc88_first_68 @kc88_second_60 -70;
-    pos @kc88_first_68 @kc88_second_61 -105;
-    pos @kc88_first_68 @kc88_second_62 -70;
-    pos @kc88_first_68 @kc88_second_63 -35;
-    pos @kc88_first_68 @kc88_second_64 -35;
-    pos @kc88_first_69 @kc88_second_3 -70;
-    pos @kc88_first_69 @kc88_second_4 -50;
-    pos @kc88_first_69 @kc88_second_6 -50;
-    pos @kc88_first_69 @kc88_second_8 -70;
-    pos @kc88_first_69 @kc88_second_9 -140;
-    pos @kc88_first_69 @kc88_second_10 -50;
-    pos @kc88_first_69 @kc88_second_12 -140;
-    pos @kc88_first_69 @kc88_second_13 -140;
-    pos @kc88_first_69 @kc88_second_14 -105;
-    pos @kc88_first_69 @kc88_second_15 -70;
-    pos @kc88_first_69 @kc88_second_18 -70;
-    pos @kc88_first_69 @kc88_second_20 -70;
-    pos @kc88_first_69 @kc88_second_22 -50;
-    pos @kc88_first_69 @kc88_second_23 -100;
-    pos @kc88_first_69 @kc88_second_29 -35;
-    pos @kc88_first_69 @kc88_second_31 -70;
-    pos @kc88_first_69 @kc88_second_33 105;
-    pos @kc88_first_69 @kc88_second_34 -35;
-    pos @kc88_first_69 @kc88_second_38 -70;
-    pos @kc88_first_69 @kc88_second_39 -140;
-    pos @kc88_first_69 @kc88_second_40 -140;
-    pos @kc88_first_69 @kc88_second_43 -140;
-    pos @kc88_first_69 @kc88_second_44 -35;
-    pos @kc88_first_69 @kc88_second_45 1;
-    pos @kc88_first_69 @kc88_second_47 -70;
-    pos @kc88_first_69 @kc88_second_48 -140;
-    pos @kc88_first_69 @kc88_second_50 105;
-    pos @kc88_first_69 @kc88_second_58 -140;
-    pos @kc88_first_69 @kc88_second_60 -70;
-    pos @kc88_first_69 @kc88_second_61 -70;
-    pos @kc88_first_69 @kc88_second_62 -50;
-    pos @kc88_first_69 @kc88_second_63 -35;
-    pos @kc88_first_69 @kc88_second_64 -35;
-    pos @kc88_first_70 @kc88_second_1 -210;
-    pos @kc88_first_70 @kc88_second_2 -210;
-    pos @kc88_first_70 @kc88_second_3 -35;
-    pos @kc88_first_70 @kc88_second_6 -140;
-    pos @kc88_first_70 @kc88_second_8 -70;
-    pos @kc88_first_70 @kc88_second_10 -35;
-    pos @kc88_first_70 @kc88_second_17 -70;
-    pos @kc88_first_70 @kc88_second_19 -210;
-    pos @kc88_first_70 @kc88_second_20 -70;
-    pos @kc88_first_70 @kc88_second_22 -105;
-    pos @kc88_first_70 @kc88_second_23 -105;
-    pos @kc88_first_70 @kc88_second_24 -175;
-    pos @kc88_first_70 @kc88_second_29 -105;
-    pos @kc88_first_70 @kc88_second_34 -175;
-    pos @kc88_first_70 @kc88_second_35 -140;
-    pos @kc88_first_70 @kc88_second_36 -70;
-    pos @kc88_first_70 @kc88_second_37 -105;
-    pos @kc88_first_70 @kc88_second_38 -105;
-    pos @kc88_first_70 @kc88_second_39 -70;
-    pos @kc88_first_70 @kc88_second_44 -35;
-    pos @kc88_first_70 @kc88_second_45 1;
-    pos @kc88_first_70 @kc88_second_50 -35;
-    pos @kc88_first_70 @kc88_second_51 -70;
-    pos @kc88_first_70 @kc88_second_52 -70;
-    pos @kc88_first_70 @kc88_second_53 -175;
-    pos @kc88_first_70 @kc88_second_55 -175;
-    pos @kc88_first_70 @kc88_second_57 -175;
-    pos @kc88_first_70 @kc88_second_58 -35;
-    pos @kc88_first_70 @kc88_second_59 -35;
-    pos @kc88_first_70 @kc88_second_63 -140;
-    pos @kc88_first_70 @kc88_second_64 -175;
-    pos @kc88_first_71 @kc88_second_5 -70;
-    pos @kc88_first_71 @kc88_second_8 -70;
-    pos @kc88_first_71 @kc88_second_9 -105;
-    pos @kc88_first_71 @kc88_second_11 -35;
-    pos @kc88_first_71 @kc88_second_12 -350;
-    pos @kc88_first_71 @kc88_second_13 -350;
-    pos @kc88_first_71 @kc88_second_14 -245;
-    pos @kc88_first_71 @kc88_second_15 -210;
-    pos @kc88_first_71 @kc88_second_16 -70;
-    pos @kc88_first_71 @kc88_second_18 -210;
-    pos @kc88_first_71 @kc88_second_23 -35;
-    pos @kc88_first_71 @kc88_second_26 -35;
-    pos @kc88_first_71 @kc88_second_27 -70;
-    pos @kc88_first_71 @kc88_second_31 -70;
-    pos @kc88_first_71 @kc88_second_38 -35;
-    pos @kc88_first_71 @kc88_second_39 -245;
-    pos @kc88_first_71 @kc88_second_40 -70;
-    pos @kc88_first_71 @kc88_second_42 -35;
-    pos @kc88_first_71 @kc88_second_43 -240;
-    pos @kc88_first_71 @kc88_second_45 1;
-    pos @kc88_first_71 @kc88_second_47 -105;
-    pos @kc88_first_71 @kc88_second_48 -280;
-    pos @kc88_first_71 @kc88_second_49 -35;
-    pos @kc88_first_71 @kc88_second_54 -35;
-    pos @kc88_first_71 @kc88_second_56 -70;
-    pos @kc88_first_71 @kc88_second_58 -105;
-    pos @kc88_first_71 @kc88_second_59 -35;
-    pos @kc88_first_71 @kc88_second_60 -70;
-    pos @kc88_first_71 @kc88_second_61 -175;
-    pos @kc88_first_71 @kc88_second_62 -140;
-    pos @kc88_first_72 @kc88_second_1 -140;
-    pos @kc88_first_72 @kc88_second_2 -140;
-    pos @kc88_first_72 @kc88_second_6 -140;
-    pos @kc88_first_72 @kc88_second_8 -35;
-    pos @kc88_first_72 @kc88_second_10 -35;
-    pos @kc88_first_72 @kc88_second_17 -35;
-    pos @kc88_first_72 @kc88_second_19 -140;
-    pos @kc88_first_72 @kc88_second_20 -35;
-    pos @kc88_first_72 @kc88_second_22 -70;
-    pos @kc88_first_72 @kc88_second_23 -70;
-    pos @kc88_first_72 @kc88_second_24 -140;
-    pos @kc88_first_72 @kc88_second_29 -70;
-    pos @kc88_first_72 @kc88_second_34 -175;
-    pos @kc88_first_72 @kc88_second_35 -105;
-    pos @kc88_first_72 @kc88_second_36 -70;
-    pos @kc88_first_72 @kc88_second_37 -70;
-    pos @kc88_first_72 @kc88_second_38 -70;
-    pos @kc88_first_72 @kc88_second_39 -35;
-    pos @kc88_first_72 @kc88_second_45 1;
-    pos @kc88_first_72 @kc88_second_50 -35;
-    pos @kc88_first_72 @kc88_second_51 -35;
-    pos @kc88_first_72 @kc88_second_53 -140;
-    pos @kc88_first_72 @kc88_second_55 -140;
-    pos @kc88_first_72 @kc88_second_57 -140;
-    pos @kc88_first_72 @kc88_second_63 -105;
-    pos @kc88_first_72 @kc88_second_64 -105;
+    pos @kc89_first_1 @kc89_second_3 -70;
+    pos @kc89_first_1 @kc89_second_8 -70;
+    pos @kc89_first_1 @kc89_second_9 -140;
+    pos @kc89_first_1 @kc89_second_10 -35;
+    pos @kc89_first_1 @kc89_second_12 -280;
+    pos @kc89_first_1 @kc89_second_13 -280;
+    pos @kc89_first_1 @kc89_second_14 -280;
+    pos @kc89_first_1 @kc89_second_15 -210;
+    pos @kc89_first_1 @kc89_second_20 -70;
+    pos @kc89_first_1 @kc89_second_23 -35;
+    pos @kc89_first_1 @kc89_second_25 -50;
+    pos @kc89_first_1 @kc89_second_31 -70;
+    pos @kc89_first_1 @kc89_second_38 -35;
+    pos @kc89_first_1 @kc89_second_39 -140;
+    pos @kc89_first_1 @kc89_second_40 -105;
+    pos @kc89_first_1 @kc89_second_43 -210;
+    pos @kc89_first_1 @kc89_second_44 -35;
+    pos @kc89_first_1 @kc89_second_45 1;
+    pos @kc89_first_1 @kc89_second_47 -175;
+    pos @kc89_first_1 @kc89_second_48 -210;
+    pos @kc89_first_1 @kc89_second_58 -140;
+    pos @kc89_first_1 @kc89_second_60 -140;
+    pos @kc89_first_1 @kc89_second_61 -210;
+    pos @kc89_first_1 @kc89_second_62 -140;
+    pos @kc89_first_2 @kc89_second_9 -35;
+    pos @kc89_first_2 @kc89_second_12 -70;
+    pos @kc89_first_2 @kc89_second_13 -70;
+    pos @kc89_first_2 @kc89_second_14 -70;
+    pos @kc89_first_2 @kc89_second_15 -35;
+    pos @kc89_first_2 @kc89_second_16 -35;
+    pos @kc89_first_2 @kc89_second_39 -35;
+    pos @kc89_first_2 @kc89_second_45 1;
+    pos @kc89_first_3 @kc89_second_1 -35;
+    pos @kc89_first_3 @kc89_second_2 -70;
+    pos @kc89_first_3 @kc89_second_5 -35;
+    pos @kc89_first_3 @kc89_second_11 -35;
+    pos @kc89_first_3 @kc89_second_12 -35;
+    pos @kc89_first_3 @kc89_second_13 -70;
+    pos @kc89_first_3 @kc89_second_14 -35;
+    pos @kc89_first_3 @kc89_second_16 -70;
+    pos @kc89_first_3 @kc89_second_19 -70;
+    pos @kc89_first_3 @kc89_second_35 -35;
+    pos @kc89_first_3 @kc89_second_45 1;
+    pos @kc89_first_4 @kc89_second_1 -70;
+    pos @kc89_first_4 @kc89_second_2 -140;
+    pos @kc89_first_4 @kc89_second_4 70;
+    pos @kc89_first_4 @kc89_second_5 -70;
+    pos @kc89_first_4 @kc89_second_11 -105;
+    pos @kc89_first_4 @kc89_second_12 -140;
+    pos @kc89_first_4 @kc89_second_13 -140;
+    pos @kc89_first_4 @kc89_second_14 -105;
+    pos @kc89_first_4 @kc89_second_15 -35;
+    pos @kc89_first_4 @kc89_second_16 -140;
+    pos @kc89_first_4 @kc89_second_24 -70;
+    pos @kc89_first_4 @kc89_second_26 -70;
+    pos @kc89_first_4 @kc89_second_27 -35;
+    pos @kc89_first_4 @kc89_second_31 35;
+    pos @kc89_first_4 @kc89_second_34 -70;
+    pos @kc89_first_4 @kc89_second_35 -70;
+    pos @kc89_first_4 @kc89_second_43 -35;
+    pos @kc89_first_4 @kc89_second_45 1;
+    pos @kc89_first_4 @kc89_second_48 -70;
+    pos @kc89_first_4 @kc89_second_53 -70;
+    pos @kc89_first_4 @kc89_second_55 -70;
+    pos @kc89_first_4 @kc89_second_57 -70;
+    pos @kc89_first_4 @kc89_second_61 -35;
+    pos @kc89_first_5 @kc89_second_12 -70;
+    pos @kc89_first_5 @kc89_second_45 1;
+    pos @kc89_first_6 @kc89_second_1 -280;
+    pos @kc89_first_6 @kc89_second_2 -350;
+    pos @kc89_first_6 @kc89_second_3 -140;
+    pos @kc89_first_6 @kc89_second_4 -70;
+    pos @kc89_first_6 @kc89_second_6 -350;
+    pos @kc89_first_6 @kc89_second_7 -140;
+    pos @kc89_first_6 @kc89_second_8 -210;
+    pos @kc89_first_6 @kc89_second_10 -70;
+    pos @kc89_first_6 @kc89_second_17 -240;
+    pos @kc89_first_6 @kc89_second_19 -350;
+    pos @kc89_first_6 @kc89_second_20 -280;
+    pos @kc89_first_6 @kc89_second_21 -240;
+    pos @kc89_first_6 @kc89_second_22 -240;
+    pos @kc89_first_6 @kc89_second_23 -210;
+    pos @kc89_first_6 @kc89_second_24 -350;
+    pos @kc89_first_6 @kc89_second_25 -140;
+    pos @kc89_first_6 @kc89_second_27 -140;
+    pos @kc89_first_6 @kc89_second_29 -240;
+    pos @kc89_first_6 @kc89_second_30 -240;
+    pos @kc89_first_6 @kc89_second_31 -175;
+    pos @kc89_first_6 @kc89_second_34 -350;
+    pos @kc89_first_6 @kc89_second_35 -105;
+    pos @kc89_first_6 @kc89_second_36 -240;
+    pos @kc89_first_6 @kc89_second_37 -210;
+    pos @kc89_first_6 @kc89_second_38 -240;
+    pos @kc89_first_6 @kc89_second_39 -240;
+    pos @kc89_first_6 @kc89_second_41 -240;
+    pos @kc89_first_6 @kc89_second_44 -140;
+    pos @kc89_first_6 @kc89_second_45 1;
+    pos @kc89_first_6 @kc89_second_46 -35;
+    pos @kc89_first_6 @kc89_second_47 -240;
+    pos @kc89_first_6 @kc89_second_49 -240;
+    pos @kc89_first_6 @kc89_second_50 -240;
+    pos @kc89_first_6 @kc89_second_51 -240;
+    pos @kc89_first_6 @kc89_second_52 -240;
+    pos @kc89_first_6 @kc89_second_53 -280;
+    pos @kc89_first_6 @kc89_second_54 -70;
+    pos @kc89_first_6 @kc89_second_55 -240;
+    pos @kc89_first_6 @kc89_second_56 -175;
+    pos @kc89_first_6 @kc89_second_57 -280;
+    pos @kc89_first_6 @kc89_second_58 -240;
+    pos @kc89_first_6 @kc89_second_59 -210;
+    pos @kc89_first_6 @kc89_second_60 -175;
+    pos @kc89_first_6 @kc89_second_63 -175;
+    pos @kc89_first_6 @kc89_second_64 -175;
+    pos @kc89_first_7 @kc89_second_3 -70;
+    pos @kc89_first_7 @kc89_second_8 -105;
+    pos @kc89_first_7 @kc89_second_17 -35;
+    pos @kc89_first_7 @kc89_second_20 -105;
+    pos @kc89_first_7 @kc89_second_22 -105;
+    pos @kc89_first_7 @kc89_second_23 -70;
+    pos @kc89_first_7 @kc89_second_45 1;
+    pos @kc89_first_7 @kc89_second_46 -35;
+    pos @kc89_first_7 @kc89_second_47 -70;
+    pos @kc89_first_7 @kc89_second_51 -50;
+    pos @kc89_first_7 @kc89_second_60 -35;
+    pos @kc89_first_7 @kc89_second_63 -70;
+    pos @kc89_first_7 @kc89_second_64 -70;
+    pos @kc89_first_8 @kc89_second_3 -140;
+    pos @kc89_first_8 @kc89_second_4 -70;
+    pos @kc89_first_8 @kc89_second_6 -70;
+    pos @kc89_first_8 @kc89_second_8 -140;
+    pos @kc89_first_8 @kc89_second_10 -35;
+    pos @kc89_first_8 @kc89_second_17 -70;
+    pos @kc89_first_8 @kc89_second_20 -140;
+    pos @kc89_first_8 @kc89_second_22 -70;
+    pos @kc89_first_8 @kc89_second_23 -105;
+    pos @kc89_first_8 @kc89_second_25 -140;
+    pos @kc89_first_8 @kc89_second_29 -35;
+    pos @kc89_first_8 @kc89_second_31 -105;
+    pos @kc89_first_8 @kc89_second_34 -70;
+    pos @kc89_first_8 @kc89_second_36 -70;
+    pos @kc89_first_8 @kc89_second_38 -105;
+    pos @kc89_first_8 @kc89_second_39 -175;
+    pos @kc89_first_8 @kc89_second_40 -140;
+    pos @kc89_first_8 @kc89_second_41 -35;
+    pos @kc89_first_8 @kc89_second_43 -140;
+    pos @kc89_first_8 @kc89_second_44 -105;
+    pos @kc89_first_8 @kc89_second_45 1;
+    pos @kc89_first_8 @kc89_second_46 -70;
+    pos @kc89_first_8 @kc89_second_47 -140;
+    pos @kc89_first_8 @kc89_second_48 -70;
+    pos @kc89_first_8 @kc89_second_51 -35;
+    pos @kc89_first_8 @kc89_second_52 -35;
+    pos @kc89_first_8 @kc89_second_58 -210;
+    pos @kc89_first_8 @kc89_second_60 -105;
+    pos @kc89_first_8 @kc89_second_61 -70;
+    pos @kc89_first_8 @kc89_second_62 -35;
+    pos @kc89_first_8 @kc89_second_63 -70;
+    pos @kc89_first_8 @kc89_second_64 -35;
+    pos @kc89_first_9 @kc89_second_3 -140;
+    pos @kc89_first_9 @kc89_second_4 -70;
+    pos @kc89_first_9 @kc89_second_6 -70;
+    pos @kc89_first_9 @kc89_second_8 -210;
+    pos @kc89_first_9 @kc89_second_9 -420;
+    pos @kc89_first_9 @kc89_second_10 -70;
+    pos @kc89_first_9 @kc89_second_12 -350;
+    pos @kc89_first_9 @kc89_second_13 -420;
+    pos @kc89_first_9 @kc89_second_14 -350;
+    pos @kc89_first_9 @kc89_second_15 -280;
+    pos @kc89_first_9 @kc89_second_17 -70;
+    pos @kc89_first_9 @kc89_second_18 -210;
+    pos @kc89_first_9 @kc89_second_20 -210;
+    pos @kc89_first_9 @kc89_second_22 -70;
+    pos @kc89_first_9 @kc89_second_23 -140;
+    pos @kc89_first_9 @kc89_second_29 -50;
+    pos @kc89_first_9 @kc89_second_31 -140;
+    pos @kc89_first_9 @kc89_second_34 -70;
+    pos @kc89_first_9 @kc89_second_38 -105;
+    pos @kc89_first_9 @kc89_second_39 -280;
+    pos @kc89_first_9 @kc89_second_40 -350;
+    pos @kc89_first_9 @kc89_second_41 -50;
+    pos @kc89_first_9 @kc89_second_43 -350;
+    pos @kc89_first_9 @kc89_second_45 1;
+    pos @kc89_first_9 @kc89_second_46 -35;
+    pos @kc89_first_9 @kc89_second_47 -210;
+    pos @kc89_first_9 @kc89_second_48 -350;
+    pos @kc89_first_9 @kc89_second_51 -35;
+    pos @kc89_first_9 @kc89_second_52 -35;
+    pos @kc89_first_9 @kc89_second_58 -280;
+    pos @kc89_first_9 @kc89_second_60 -175;
+    pos @kc89_first_9 @kc89_second_61 -280;
+    pos @kc89_first_9 @kc89_second_62 -210;
+    pos @kc89_first_9 @kc89_second_63 -70;
+    pos @kc89_first_9 @kc89_second_64 -70;
+    pos @kc89_first_10 @kc89_second_1 -210;
+    pos @kc89_first_10 @kc89_second_2 -350;
+    pos @kc89_first_10 @kc89_second_5 -70;
+    pos @kc89_first_10 @kc89_second_6 -140;
+    pos @kc89_first_10 @kc89_second_11 -35;
+    pos @kc89_first_10 @kc89_second_12 -70;
+    pos @kc89_first_10 @kc89_second_13 -70;
+    pos @kc89_first_10 @kc89_second_14 -35;
+    pos @kc89_first_10 @kc89_second_16 -70;
+    pos @kc89_first_10 @kc89_second_17 -35;
+    pos @kc89_first_10 @kc89_second_19 -280;
+    pos @kc89_first_10 @kc89_second_22 -70;
+    pos @kc89_first_10 @kc89_second_24 -350;
+    pos @kc89_first_10 @kc89_second_29 -70;
+    pos @kc89_first_10 @kc89_second_32 -140;
+    pos @kc89_first_10 @kc89_second_34 -210;
+    pos @kc89_first_10 @kc89_second_35 -105;
+    pos @kc89_first_10 @kc89_second_38 -70;
+    pos @kc89_first_10 @kc89_second_45 1;
+    pos @kc89_first_10 @kc89_second_53 -210;
+    pos @kc89_first_10 @kc89_second_55 -210;
+    pos @kc89_first_10 @kc89_second_57 -210;
+    pos @kc89_first_10 @kc89_second_61 -70;
+    pos @kc89_first_10 @kc89_second_63 -70;
+    pos @kc89_first_10 @kc89_second_64 -105;
+    pos @kc89_first_11 @kc89_second_1 -70;
+    pos @kc89_first_11 @kc89_second_2 -140;
+    pos @kc89_first_11 @kc89_second_5 -105;
+    pos @kc89_first_11 @kc89_second_6 -35;
+    pos @kc89_first_11 @kc89_second_11 -70;
+    pos @kc89_first_11 @kc89_second_12 -210;
+    pos @kc89_first_11 @kc89_second_13 -175;
+    pos @kc89_first_11 @kc89_second_14 -105;
+    pos @kc89_first_11 @kc89_second_15 -70;
+    pos @kc89_first_11 @kc89_second_16 -140;
+    pos @kc89_first_11 @kc89_second_19 -140;
+    pos @kc89_first_11 @kc89_second_24 -70;
+    pos @kc89_first_11 @kc89_second_26 -70;
+    pos @kc89_first_11 @kc89_second_27 -70;
+    pos @kc89_first_11 @kc89_second_34 -35;
+    pos @kc89_first_11 @kc89_second_35 -140;
+    pos @kc89_first_11 @kc89_second_39 -70;
+    pos @kc89_first_11 @kc89_second_42 -35;
+    pos @kc89_first_11 @kc89_second_43 -35;
+    pos @kc89_first_11 @kc89_second_45 1;
+    pos @kc89_first_11 @kc89_second_48 -70;
+    pos @kc89_first_11 @kc89_second_53 -210;
+    pos @kc89_first_11 @kc89_second_55 -175;
+    pos @kc89_first_11 @kc89_second_56 -35;
+    pos @kc89_first_11 @kc89_second_57 -175;
+    pos @kc89_first_11 @kc89_second_61 -70;
+    pos @kc89_first_11 @kc89_second_62 -35;
+    pos @kc89_first_11 @kc89_second_63 -35;
+    pos @kc89_first_11 @kc89_second_64 -70;
+    pos @kc89_first_12 @kc89_second_1 -140;
+    pos @kc89_first_12 @kc89_second_2 -210;
+    pos @kc89_first_12 @kc89_second_6 -140;
+    pos @kc89_first_12 @kc89_second_17 -70;
+    pos @kc89_first_12 @kc89_second_19 -210;
+    pos @kc89_first_12 @kc89_second_22 -70;
+    pos @kc89_first_12 @kc89_second_24 -350;
+    pos @kc89_first_12 @kc89_second_29 -35;
+    pos @kc89_first_12 @kc89_second_32 -140;
+    pos @kc89_first_12 @kc89_second_34 -140;
+    pos @kc89_first_12 @kc89_second_35 -70;
+    pos @kc89_first_12 @kc89_second_38 -70;
+    pos @kc89_first_12 @kc89_second_45 1;
+    pos @kc89_first_12 @kc89_second_51 -35;
+    pos @kc89_first_12 @kc89_second_53 -210;
+    pos @kc89_first_12 @kc89_second_55 -210;
+    pos @kc89_first_12 @kc89_second_57 -210;
+    pos @kc89_first_12 @kc89_second_63 -70;
+    pos @kc89_first_12 @kc89_second_64 -105;
+    pos @kc89_first_13 @kc89_second_6 -70;
+    pos @kc89_first_13 @kc89_second_12 -70;
+    pos @kc89_first_13 @kc89_second_13 -105;
+    pos @kc89_first_13 @kc89_second_14 -35;
+    pos @kc89_first_13 @kc89_second_22 -35;
+    pos @kc89_first_13 @kc89_second_29 -35;
+    pos @kc89_first_13 @kc89_second_34 -70;
+    pos @kc89_first_13 @kc89_second_38 -70;
+    pos @kc89_first_13 @kc89_second_45 1;
+    pos @kc89_first_13 @kc89_second_63 -70;
+    pos @kc89_first_13 @kc89_second_64 -35;
+    pos @kc89_first_14 @kc89_second_2 -35;
+    pos @kc89_first_14 @kc89_second_11 -35;
+    pos @kc89_first_14 @kc89_second_12 -70;
+    pos @kc89_first_14 @kc89_second_13 -70;
+    pos @kc89_first_14 @kc89_second_14 -35;
+    pos @kc89_first_14 @kc89_second_16 -35;
+    pos @kc89_first_14 @kc89_second_19 -35;
+    pos @kc89_first_14 @kc89_second_25 -35;
+    pos @kc89_first_14 @kc89_second_39 -70;
+    pos @kc89_first_14 @kc89_second_45 1;
+    pos @kc89_first_14 @kc89_second_47 -70;
+    pos @kc89_first_14 @kc89_second_48 -35;
+    pos @kc89_first_14 @kc89_second_56 -35;
+    pos @kc89_first_14 @kc89_second_58 -35;
+    pos @kc89_first_14 @kc89_second_60 -35;
+    pos @kc89_first_14 @kc89_second_62 -35;
+    pos @kc89_first_15 @kc89_second_3 -70;
+    pos @kc89_first_15 @kc89_second_4 -70;
+    pos @kc89_first_15 @kc89_second_6 -35;
+    pos @kc89_first_15 @kc89_second_8 -70;
+    pos @kc89_first_15 @kc89_second_17 -70;
+    pos @kc89_first_15 @kc89_second_20 -140;
+    pos @kc89_first_15 @kc89_second_22 -70;
+    pos @kc89_first_15 @kc89_second_23 -70;
+    pos @kc89_first_15 @kc89_second_25 -70;
+    pos @kc89_first_15 @kc89_second_29 -35;
+    pos @kc89_first_15 @kc89_second_31 -35;
+    pos @kc89_first_15 @kc89_second_36 -35;
+    pos @kc89_first_15 @kc89_second_38 -70;
+    pos @kc89_first_15 @kc89_second_39 -142;
+    pos @kc89_first_15 @kc89_second_40 -35;
+    pos @kc89_first_15 @kc89_second_44 -35;
+    pos @kc89_first_15 @kc89_second_45 1;
+    pos @kc89_first_15 @kc89_second_46 -35;
+    pos @kc89_first_15 @kc89_second_47 -70;
+    pos @kc89_first_15 @kc89_second_51 -35;
+    pos @kc89_first_15 @kc89_second_52 -35;
+    pos @kc89_first_15 @kc89_second_58 -105;
+    pos @kc89_first_15 @kc89_second_60 -35;
+    pos @kc89_first_15 @kc89_second_63 -35;
+    pos @kc89_first_15 @kc89_second_64 -35;
+    pos @kc89_first_16 @kc89_second_1 -280;
+    pos @kc89_first_16 @kc89_second_2 -280;
+    pos @kc89_first_16 @kc89_second_3 -140;
+    pos @kc89_first_16 @kc89_second_4 -70;
+    pos @kc89_first_16 @kc89_second_6 -280;
+    pos @kc89_first_16 @kc89_second_7 -140;
+    pos @kc89_first_16 @kc89_second_8 -175;
+    pos @kc89_first_16 @kc89_second_10 -70;
+    pos @kc89_first_16 @kc89_second_17 -245;
+    pos @kc89_first_16 @kc89_second_19 -280;
+    pos @kc89_first_16 @kc89_second_20 -210;
+    pos @kc89_first_16 @kc89_second_21 -140;
+    pos @kc89_first_16 @kc89_second_22 -280;
+    pos @kc89_first_16 @kc89_second_23 -210;
+    pos @kc89_first_16 @kc89_second_24 -350;
+    pos @kc89_first_16 @kc89_second_25 -70;
+    pos @kc89_first_16 @kc89_second_27 -140;
+    pos @kc89_first_16 @kc89_second_29 -240;
+    pos @kc89_first_16 @kc89_second_30 -140;
+    pos @kc89_first_16 @kc89_second_31 -140;
+    pos @kc89_first_16 @kc89_second_32 -245;
+    pos @kc89_first_16 @kc89_second_34 -315;
+    pos @kc89_first_16 @kc89_second_35 -70;
+    pos @kc89_first_16 @kc89_second_36 -210;
+    pos @kc89_first_16 @kc89_second_37 -210;
+    pos @kc89_first_16 @kc89_second_38 -245;
+    pos @kc89_first_16 @kc89_second_39 -245;
+    pos @kc89_first_16 @kc89_second_40 -70;
+    pos @kc89_first_16 @kc89_second_42 -35;
+    pos @kc89_first_16 @kc89_second_43 -140;
+    pos @kc89_first_16 @kc89_second_44 -140;
+    pos @kc89_first_16 @kc89_second_45 1;
+    pos @kc89_first_16 @kc89_second_46 -70;
+    pos @kc89_first_16 @kc89_second_47 -140;
+    pos @kc89_first_16 @kc89_second_49 -140;
+    pos @kc89_first_16 @kc89_second_50 -140;
+    pos @kc89_first_16 @kc89_second_51 -240;
+    pos @kc89_first_16 @kc89_second_52 -140;
+    pos @kc89_first_16 @kc89_second_53 -280;
+    pos @kc89_first_16 @kc89_second_54 -105;
+    pos @kc89_first_16 @kc89_second_55 -280;
+    pos @kc89_first_16 @kc89_second_56 -140;
+    pos @kc89_first_16 @kc89_second_57 -315;
+    pos @kc89_first_16 @kc89_second_58 -210;
+    pos @kc89_first_16 @kc89_second_59 -210;
+    pos @kc89_first_16 @kc89_second_60 -105;
+    pos @kc89_first_16 @kc89_second_63 -315;
+    pos @kc89_first_16 @kc89_second_64 -350;
+    pos @kc89_first_17 @kc89_second_1 -280;
+    pos @kc89_first_17 @kc89_second_2 -280;
+    pos @kc89_first_17 @kc89_second_3 -105;
+    pos @kc89_first_17 @kc89_second_6 -210;
+    pos @kc89_first_17 @kc89_second_7 -105;
+    pos @kc89_first_17 @kc89_second_8 -105;
+    pos @kc89_first_17 @kc89_second_10 -35;
+    pos @kc89_first_17 @kc89_second_17 -105;
+    pos @kc89_first_17 @kc89_second_19 -280;
+    pos @kc89_first_17 @kc89_second_20 -70;
+    pos @kc89_first_17 @kc89_second_21 -105;
+    pos @kc89_first_17 @kc89_second_22 -140;
+    pos @kc89_first_17 @kc89_second_23 -140;
+    pos @kc89_first_17 @kc89_second_24 -210;
+    pos @kc89_first_17 @kc89_second_27 -70;
+    pos @kc89_first_17 @kc89_second_29 -140;
+    pos @kc89_first_17 @kc89_second_30 -105;
+    pos @kc89_first_17 @kc89_second_32 -210;
+    pos @kc89_first_17 @kc89_second_34 -245;
+    pos @kc89_first_17 @kc89_second_35 -70;
+    pos @kc89_first_17 @kc89_second_36 -140;
+    pos @kc89_first_17 @kc89_second_37 -140;
+    pos @kc89_first_17 @kc89_second_38 -140;
+    pos @kc89_first_17 @kc89_second_39 -105;
+    pos @kc89_first_17 @kc89_second_40 -35;
+    pos @kc89_first_17 @kc89_second_43 -35;
+    pos @kc89_first_17 @kc89_second_44 -70;
+    pos @kc89_first_17 @kc89_second_45 1;
+    pos @kc89_first_17 @kc89_second_46 -35;
+    pos @kc89_first_17 @kc89_second_47 -70;
+    pos @kc89_first_17 @kc89_second_49 -105;
+    pos @kc89_first_17 @kc89_second_50 -70;
+    pos @kc89_first_17 @kc89_second_51 -105;
+    pos @kc89_first_17 @kc89_second_52 -70;
+    pos @kc89_first_17 @kc89_second_53 -210;
+    pos @kc89_first_17 @kc89_second_54 -35;
+    pos @kc89_first_17 @kc89_second_55 -210;
+    pos @kc89_first_17 @kc89_second_56 -70;
+    pos @kc89_first_17 @kc89_second_57 -245;
+    pos @kc89_first_17 @kc89_second_58 -105;
+    pos @kc89_first_17 @kc89_second_59 -105;
+    pos @kc89_first_17 @kc89_second_60 -70;
+    pos @kc89_first_17 @kc89_second_63 -175;
+    pos @kc89_first_17 @kc89_second_64 -245;
+    pos @kc89_first_18 @kc89_second_1 -210;
+    pos @kc89_first_18 @kc89_second_2 -245;
+    pos @kc89_first_18 @kc89_second_3 -35;
+    pos @kc89_first_18 @kc89_second_6 -140;
+    pos @kc89_first_18 @kc89_second_7 -35;
+    pos @kc89_first_18 @kc89_second_8 -70;
+    pos @kc89_first_18 @kc89_second_17 -105;
+    pos @kc89_first_18 @kc89_second_19 -210;
+    pos @kc89_first_18 @kc89_second_20 -70;
+    pos @kc89_first_18 @kc89_second_22 -105;
+    pos @kc89_first_18 @kc89_second_23 -70;
+    pos @kc89_first_18 @kc89_second_24 -140;
+    pos @kc89_first_18 @kc89_second_27 -35;
+    pos @kc89_first_18 @kc89_second_32 -140;
+    pos @kc89_first_18 @kc89_second_34 -140;
+    pos @kc89_first_18 @kc89_second_36 -105;
+    pos @kc89_first_18 @kc89_second_37 -70;
+    pos @kc89_first_18 @kc89_second_38 -105;
+    pos @kc89_first_18 @kc89_second_39 -70;
+    pos @kc89_first_18 @kc89_second_41 -35;
+    pos @kc89_first_18 @kc89_second_45 1;
+    pos @kc89_first_18 @kc89_second_50 -35;
+    pos @kc89_first_18 @kc89_second_51 -70;
+    pos @kc89_first_18 @kc89_second_53 -140;
+    pos @kc89_first_18 @kc89_second_55 -140;
+    pos @kc89_first_18 @kc89_second_57 -175;
+    pos @kc89_first_18 @kc89_second_58 -70;
+    pos @kc89_first_18 @kc89_second_63 -105;
+    pos @kc89_first_18 @kc89_second_64 -140;
+    pos @kc89_first_19 @kc89_second_12 -280;
+    pos @kc89_first_19 @kc89_second_14 -175;
+    pos @kc89_first_19 @kc89_second_15 -140;
+    pos @kc89_first_19 @kc89_second_29 -35;
+    pos @kc89_first_19 @kc89_second_45 1;
+    pos @kc89_first_19 @kc89_second_47 -70;
+    pos @kc89_first_19 @kc89_second_48 -140;
+    pos @kc89_first_19 @kc89_second_58 -70;
+    pos @kc89_first_19 @kc89_second_60 -35;
+    pos @kc89_first_19 @kc89_second_61 -105;
+    pos @kc89_first_19 @kc89_second_62 -70;
+    pos @kc89_first_20 @kc89_second_8 -35;
+    pos @kc89_first_20 @kc89_second_9 -140;
+    pos @kc89_first_20 @kc89_second_12 -280;
+    pos @kc89_first_20 @kc89_second_13 -280;
+    pos @kc89_first_20 @kc89_second_14 -280;
+    pos @kc89_first_20 @kc89_second_15 -175;
+    pos @kc89_first_20 @kc89_second_18 -140;
+    pos @kc89_first_20 @kc89_second_20 -70;
+    pos @kc89_first_20 @kc89_second_25 -70;
+    pos @kc89_first_20 @kc89_second_31 -50;
+    pos @kc89_first_20 @kc89_second_39 -140;
+    pos @kc89_first_20 @kc89_second_40 -105;
+    pos @kc89_first_20 @kc89_second_43 -210;
+    pos @kc89_first_20 @kc89_second_45 1;
+    pos @kc89_first_20 @kc89_second_46 -35;
+    pos @kc89_first_20 @kc89_second_47 -140;
+    pos @kc89_first_20 @kc89_second_48 -210;
+    pos @kc89_first_20 @kc89_second_52 -35;
+    pos @kc89_first_20 @kc89_second_58 -105;
+    pos @kc89_first_20 @kc89_second_60 -105;
+    pos @kc89_first_20 @kc89_second_61 -210;
+    pos @kc89_first_20 @kc89_second_62 -140;
+    pos @kc89_first_21 @kc89_second_1 -140;
+    pos @kc89_first_21 @kc89_second_2 -350;
+    pos @kc89_first_21 @kc89_second_19 -280;
+    pos @kc89_first_21 @kc89_second_38 -70;
+    pos @kc89_first_21 @kc89_second_45 1;
+    pos @kc89_first_21 @kc89_second_64 -210;
+    pos @kc89_first_22 @kc89_second_1 -35;
+    pos @kc89_first_22 @kc89_second_5 -105;
+    pos @kc89_first_22 @kc89_second_9 -70;
+    pos @kc89_first_22 @kc89_second_11 -70;
+    pos @kc89_first_22 @kc89_second_12 -240;
+    pos @kc89_first_22 @kc89_second_13 -280;
+    pos @kc89_first_22 @kc89_second_14 -140;
+    pos @kc89_first_22 @kc89_second_15 -105;
+    pos @kc89_first_22 @kc89_second_16 -70;
+    pos @kc89_first_22 @kc89_second_25 -35;
+    pos @kc89_first_22 @kc89_second_26 -70;
+    pos @kc89_first_22 @kc89_second_27 -105;
+    pos @kc89_first_22 @kc89_second_35 -70;
+    pos @kc89_first_22 @kc89_second_39 -70;
+    pos @kc89_first_22 @kc89_second_40 -35;
+    pos @kc89_first_22 @kc89_second_42 -35;
+    pos @kc89_first_22 @kc89_second_43 -140;
+    pos @kc89_first_22 @kc89_second_45 1;
+    pos @kc89_first_22 @kc89_second_47 -70;
+    pos @kc89_first_22 @kc89_second_48 -175;
+    pos @kc89_first_22 @kc89_second_49 -35;
+    pos @kc89_first_22 @kc89_second_56 -105;
+    pos @kc89_first_22 @kc89_second_58 -35;
+    pos @kc89_first_22 @kc89_second_60 -50;
+    pos @kc89_first_22 @kc89_second_61 -105;
+    pos @kc89_first_22 @kc89_second_62 -70;
+    pos @kc89_first_23 @kc89_second_6 -35;
+    pos @kc89_first_23 @kc89_second_12 -240;
+    pos @kc89_first_23 @kc89_second_13 -175;
+    pos @kc89_first_23 @kc89_second_14 -70;
+    pos @kc89_first_23 @kc89_second_15 -70;
+    pos @kc89_first_23 @kc89_second_22 -70;
+    pos @kc89_first_23 @kc89_second_23 -35;
+    pos @kc89_first_23 @kc89_second_34 -35;
+    pos @kc89_first_23 @kc89_second_39 -35;
+    pos @kc89_first_23 @kc89_second_40 -35;
+    pos @kc89_first_23 @kc89_second_43 -70;
+    pos @kc89_first_23 @kc89_second_44 -35;
+    pos @kc89_first_23 @kc89_second_45 1;
+    pos @kc89_first_23 @kc89_second_48 -35;
+    pos @kc89_first_23 @kc89_second_58 -35;
+    pos @kc89_first_23 @kc89_second_62 -35;
+    pos @kc89_first_23 @kc89_second_63 -35;
+    pos @kc89_first_23 @kc89_second_64 -35;
+    pos @kc89_first_24 @kc89_second_1 -70;
+    pos @kc89_first_24 @kc89_second_2 -140;
+    pos @kc89_first_24 @kc89_second_5 -105;
+    pos @kc89_first_24 @kc89_second_11 -70;
+    pos @kc89_first_24 @kc89_second_12 -280;
+    pos @kc89_first_24 @kc89_second_13 -210;
+    pos @kc89_first_24 @kc89_second_14 -70;
+    pos @kc89_first_24 @kc89_second_15 -70;
+    pos @kc89_first_24 @kc89_second_16 -140;
+    pos @kc89_first_24 @kc89_second_19 -70;
+    pos @kc89_first_24 @kc89_second_26 -70;
+    pos @kc89_first_24 @kc89_second_27 -70;
+    pos @kc89_first_24 @kc89_second_32 -70;
+    pos @kc89_first_24 @kc89_second_35 -70;
+    pos @kc89_first_24 @kc89_second_42 -35;
+    pos @kc89_first_24 @kc89_second_43 -140;
+    pos @kc89_first_24 @kc89_second_45 1;
+    pos @kc89_first_24 @kc89_second_48 -140;
+    pos @kc89_first_24 @kc89_second_49 -35;
+    pos @kc89_first_24 @kc89_second_53 -140;
+    pos @kc89_first_24 @kc89_second_55 -105;
+    pos @kc89_first_24 @kc89_second_56 -70;
+    pos @kc89_first_24 @kc89_second_57 -70;
+    pos @kc89_first_24 @kc89_second_61 -70;
+    pos @kc89_first_24 @kc89_second_62 -35;
+    pos @kc89_first_25 @kc89_second_5 -70;
+    pos @kc89_first_25 @kc89_second_9 -70;
+    pos @kc89_first_25 @kc89_second_12 -240;
+    pos @kc89_first_25 @kc89_second_13 -280;
+    pos @kc89_first_25 @kc89_second_14 -175;
+    pos @kc89_first_25 @kc89_second_15 -105;
+    pos @kc89_first_25 @kc89_second_16 -70;
+    pos @kc89_first_25 @kc89_second_25 -35;
+    pos @kc89_first_25 @kc89_second_26 -70;
+    pos @kc89_first_25 @kc89_second_27 -70;
+    pos @kc89_first_25 @kc89_second_35 -70;
+    pos @kc89_first_25 @kc89_second_39 -70;
+    pos @kc89_first_25 @kc89_second_40 -35;
+    pos @kc89_first_25 @kc89_second_43 -140;
+    pos @kc89_first_25 @kc89_second_45 1;
+    pos @kc89_first_25 @kc89_second_47 -70;
+    pos @kc89_first_25 @kc89_second_48 -140;
+    pos @kc89_first_25 @kc89_second_49 -35;
+    pos @kc89_first_25 @kc89_second_53 -50;
+    pos @kc89_first_25 @kc89_second_54 -35;
+    pos @kc89_first_25 @kc89_second_55 -50;
+    pos @kc89_first_25 @kc89_second_56 -105;
+    pos @kc89_first_25 @kc89_second_57 -50;
+    pos @kc89_first_25 @kc89_second_58 -50;
+    pos @kc89_first_25 @kc89_second_60 -35;
+    pos @kc89_first_25 @kc89_second_61 -105;
+    pos @kc89_first_25 @kc89_second_62 -70;
+    pos @kc89_first_26 @kc89_second_9 -35;
+    pos @kc89_first_26 @kc89_second_12 -140;
+    pos @kc89_first_26 @kc89_second_26 -70;
+    pos @kc89_first_26 @kc89_second_39 -35;
+    pos @kc89_first_26 @kc89_second_43 -70;
+    pos @kc89_first_26 @kc89_second_45 1;
+    pos @kc89_first_26 @kc89_second_48 -70;
+    pos @kc89_first_26 @kc89_second_61 -70;
+    pos @kc89_first_26 @kc89_second_62 -35;
+    pos @kc89_first_27 @kc89_second_5 -50;
+    pos @kc89_first_27 @kc89_second_9 -35;
+    pos @kc89_first_27 @kc89_second_11 -35;
+    pos @kc89_first_27 @kc89_second_12 -240;
+    pos @kc89_first_27 @kc89_second_13 -240;
+    pos @kc89_first_27 @kc89_second_14 -105;
+    pos @kc89_first_27 @kc89_second_15 -70;
+    pos @kc89_first_27 @kc89_second_16 -35;
+    pos @kc89_first_27 @kc89_second_26 -35;
+    pos @kc89_first_27 @kc89_second_27 -35;
+    pos @kc89_first_27 @kc89_second_35 -35;
+    pos @kc89_first_27 @kc89_second_39 -50;
+    pos @kc89_first_27 @kc89_second_40 -35;
+    pos @kc89_first_27 @kc89_second_43 -100;
+    pos @kc89_first_27 @kc89_second_45 1;
+    pos @kc89_first_27 @kc89_second_47 -35;
+    pos @kc89_first_27 @kc89_second_48 -140;
+    pos @kc89_first_27 @kc89_second_56 -35;
+    pos @kc89_first_27 @kc89_second_61 -70;
+    pos @kc89_first_27 @kc89_second_62 -35;
+    pos @kc89_first_28 @kc89_second_45 1;
+    pos @kc89_first_29 @kc89_second_8 -70;
+    pos @kc89_first_29 @kc89_second_9 -210;
+    pos @kc89_first_29 @kc89_second_12 -350;
+    pos @kc89_first_29 @kc89_second_13 -350;
+    pos @kc89_first_29 @kc89_second_14 -210;
+    pos @kc89_first_29 @kc89_second_15 -175;
+    pos @kc89_first_29 @kc89_second_25 -70;
+    pos @kc89_first_29 @kc89_second_38 -35;
+    pos @kc89_first_29 @kc89_second_39 -210;
+    pos @kc89_first_29 @kc89_second_40 -210;
+    pos @kc89_first_29 @kc89_second_43 -210;
+    pos @kc89_first_29 @kc89_second_45 1;
+    pos @kc89_first_29 @kc89_second_47 -140;
+    pos @kc89_first_29 @kc89_second_48 -280;
+    pos @kc89_first_29 @kc89_second_58 -210;
+    pos @kc89_first_29 @kc89_second_60 -105;
+    pos @kc89_first_29 @kc89_second_61 -175;
+    pos @kc89_first_29 @kc89_second_62 -140;
+    pos @kc89_first_30 @kc89_second_1 -175;
+    pos @kc89_first_30 @kc89_second_2 -175;
+    pos @kc89_first_30 @kc89_second_5 -70;
+    pos @kc89_first_30 @kc89_second_6 -105;
+    pos @kc89_first_30 @kc89_second_10 -35;
+    pos @kc89_first_30 @kc89_second_11 -105;
+    pos @kc89_first_30 @kc89_second_12 -175;
+    pos @kc89_first_30 @kc89_second_13 -140;
+    pos @kc89_first_30 @kc89_second_14 -70;
+    pos @kc89_first_30 @kc89_second_15 -35;
+    pos @kc89_first_30 @kc89_second_16 -140;
+    pos @kc89_first_30 @kc89_second_17 -70;
+    pos @kc89_first_30 @kc89_second_19 -175;
+    pos @kc89_first_30 @kc89_second_22 -70;
+    pos @kc89_first_30 @kc89_second_29 -105;
+    pos @kc89_first_30 @kc89_second_33 105;
+    pos @kc89_first_30 @kc89_second_34 -105;
+    pos @kc89_first_30 @kc89_second_35 -175;
+    pos @kc89_first_30 @kc89_second_36 -35;
+    pos @kc89_first_30 @kc89_second_38 -70;
+    pos @kc89_first_30 @kc89_second_45 1;
+    pos @kc89_first_30 @kc89_second_50 105;
+    pos @kc89_first_30 @kc89_second_51 -35;
+    pos @kc89_first_30 @kc89_second_63 -70;
+    pos @kc89_first_30 @kc89_second_64 -105;
+    pos @kc89_first_31 @kc89_second_3 -70;
+    pos @kc89_first_31 @kc89_second_4 -35;
+    pos @kc89_first_31 @kc89_second_6 -70;
+    pos @kc89_first_31 @kc89_second_8 -105;
+    pos @kc89_first_31 @kc89_second_17 -35;
+    pos @kc89_first_31 @kc89_second_20 -70;
+    pos @kc89_first_31 @kc89_second_22 -70;
+    pos @kc89_first_31 @kc89_second_23 -140;
+    pos @kc89_first_31 @kc89_second_29 -35;
+    pos @kc89_first_31 @kc89_second_34 -70;
+    pos @kc89_first_31 @kc89_second_36 -35;
+    pos @kc89_first_31 @kc89_second_38 -140;
+    pos @kc89_first_31 @kc89_second_39 -70;
+    pos @kc89_first_31 @kc89_second_45 1;
+    pos @kc89_first_31 @kc89_second_51 -35;
+    pos @kc89_first_31 @kc89_second_52 -35;
+    pos @kc89_first_31 @kc89_second_58 -140;
+    pos @kc89_first_31 @kc89_second_63 -70;
+    pos @kc89_first_31 @kc89_second_64 -70;
+    pos @kc89_first_32 @kc89_second_1 -35;
+    pos @kc89_first_32 @kc89_second_2 -105;
+    pos @kc89_first_32 @kc89_second_3 -70;
+    pos @kc89_first_32 @kc89_second_4 70;
+    pos @kc89_first_32 @kc89_second_5 -70;
+    pos @kc89_first_32 @kc89_second_11 -35;
+    pos @kc89_first_32 @kc89_second_12 -240;
+    pos @kc89_first_32 @kc89_second_13 -175;
+    pos @kc89_first_32 @kc89_second_14 -105;
+    pos @kc89_first_32 @kc89_second_15 -70;
+    pos @kc89_first_32 @kc89_second_16 -70;
+    pos @kc89_first_32 @kc89_second_24 -35;
+    pos @kc89_first_32 @kc89_second_27 -70;
+    pos @kc89_first_32 @kc89_second_35 -35;
+    pos @kc89_first_32 @kc89_second_39 -35;
+    pos @kc89_first_32 @kc89_second_40 -35;
+    pos @kc89_first_32 @kc89_second_42 -35;
+    pos @kc89_first_32 @kc89_second_43 -140;
+    pos @kc89_first_32 @kc89_second_45 1;
+    pos @kc89_first_32 @kc89_second_47 -50;
+    pos @kc89_first_32 @kc89_second_48 -140;
+    pos @kc89_first_32 @kc89_second_49 -35;
+    pos @kc89_first_32 @kc89_second_53 -70;
+    pos @kc89_first_32 @kc89_second_55 -70;
+    pos @kc89_first_32 @kc89_second_57 -70;
+    pos @kc89_first_32 @kc89_second_61 -70;
+    pos @kc89_first_32 @kc89_second_62 -35;
+    pos @kc89_first_33 @kc89_second_3 -35;
+    pos @kc89_first_33 @kc89_second_4 -70;
+    pos @kc89_first_33 @kc89_second_6 -70;
+    pos @kc89_first_33 @kc89_second_8 -70;
+    pos @kc89_first_33 @kc89_second_12 -140;
+    pos @kc89_first_33 @kc89_second_13 -105;
+    pos @kc89_first_33 @kc89_second_14 -70;
+    pos @kc89_first_33 @kc89_second_15 -35;
+    pos @kc89_first_33 @kc89_second_20 -70;
+    pos @kc89_first_33 @kc89_second_22 -105;
+    pos @kc89_first_33 @kc89_second_23 -70;
+    pos @kc89_first_33 @kc89_second_29 -35;
+    pos @kc89_first_33 @kc89_second_34 -70;
+    pos @kc89_first_33 @kc89_second_36 -70;
+    pos @kc89_first_33 @kc89_second_38 -105;
+    pos @kc89_first_33 @kc89_second_39 -70;
+    pos @kc89_first_33 @kc89_second_44 -70;
+    pos @kc89_first_33 @kc89_second_45 1;
+    pos @kc89_first_33 @kc89_second_51 -35;
+    pos @kc89_first_33 @kc89_second_52 -35;
+    pos @kc89_first_33 @kc89_second_63 -70;
+    pos @kc89_first_33 @kc89_second_64 -70;
+    pos @kc89_first_34 @kc89_second_32 -315;
+    pos @kc89_first_34 @kc89_second_45 1;
+    pos @kc89_first_35 @kc89_second_9 -70;
+    pos @kc89_first_35 @kc89_second_12 -240;
+    pos @kc89_first_35 @kc89_second_13 -210;
+    pos @kc89_first_35 @kc89_second_14 -140;
+    pos @kc89_first_35 @kc89_second_15 -105;
+    pos @kc89_first_35 @kc89_second_39 -70;
+    pos @kc89_first_35 @kc89_second_40 -35;
+    pos @kc89_first_35 @kc89_second_43 -140;
+    pos @kc89_first_35 @kc89_second_45 1;
+    pos @kc89_first_35 @kc89_second_47 -50;
+    pos @kc89_first_35 @kc89_second_48 -140;
+    pos @kc89_first_35 @kc89_second_58 -35;
+    pos @kc89_first_35 @kc89_second_60 -35;
+    pos @kc89_first_35 @kc89_second_61 -70;
+    pos @kc89_first_35 @kc89_second_62 -70;
+    pos @kc89_first_36 @kc89_second_9 -35;
+    pos @kc89_first_36 @kc89_second_12 -240;
+    pos @kc89_first_36 @kc89_second_13 -240;
+    pos @kc89_first_36 @kc89_second_14 -140;
+    pos @kc89_first_36 @kc89_second_15 -105;
+    pos @kc89_first_36 @kc89_second_16 -35;
+    pos @kc89_first_36 @kc89_second_26 -35;
+    pos @kc89_first_36 @kc89_second_27 -35;
+    pos @kc89_first_36 @kc89_second_39 -70;
+    pos @kc89_first_36 @kc89_second_40 -35;
+    pos @kc89_first_36 @kc89_second_43 -70;
+    pos @kc89_first_36 @kc89_second_45 1;
+    pos @kc89_first_36 @kc89_second_47 -35;
+    pos @kc89_first_36 @kc89_second_48 -70;
+    pos @kc89_first_36 @kc89_second_60 -35;
+    pos @kc89_first_36 @kc89_second_61 -70;
+    pos @kc89_first_36 @kc89_second_62 -70;
+    pos @kc89_first_37 @kc89_second_5 -70;
+    pos @kc89_first_37 @kc89_second_9 -70;
+    pos @kc89_first_37 @kc89_second_12 -140;
+    pos @kc89_first_37 @kc89_second_13 -210;
+    pos @kc89_first_37 @kc89_second_14 -140;
+    pos @kc89_first_37 @kc89_second_15 -105;
+    pos @kc89_first_37 @kc89_second_16 -70;
+    pos @kc89_first_37 @kc89_second_26 -70;
+    pos @kc89_first_37 @kc89_second_27 -70;
+    pos @kc89_first_37 @kc89_second_35 -50;
+    pos @kc89_first_37 @kc89_second_39 -50;
+    pos @kc89_first_37 @kc89_second_40 -35;
+    pos @kc89_first_37 @kc89_second_45 1;
+    pos @kc89_first_37 @kc89_second_47 -35;
+    pos @kc89_first_37 @kc89_second_48 -140;
+    pos @kc89_first_37 @kc89_second_56 -35;
+    pos @kc89_first_37 @kc89_second_61 -70;
+    pos @kc89_first_37 @kc89_second_62 -35;
+    pos @kc89_first_38 @kc89_second_1 -210;
+    pos @kc89_first_38 @kc89_second_2 -280;
+    pos @kc89_first_38 @kc89_second_6 -280;
+    pos @kc89_first_38 @kc89_second_8 -70;
+    pos @kc89_first_38 @kc89_second_17 -140;
+    pos @kc89_first_38 @kc89_second_19 -350;
+    pos @kc89_first_38 @kc89_second_20 -140;
+    pos @kc89_first_38 @kc89_second_22 -140;
+    pos @kc89_first_38 @kc89_second_23 -70;
+    pos @kc89_first_38 @kc89_second_24 -280;
+    pos @kc89_first_38 @kc89_second_28 -315;
+    pos @kc89_first_38 @kc89_second_29 -140;
+    pos @kc89_first_38 @kc89_second_32 -385;
+    pos @kc89_first_38 @kc89_second_34 -210;
+    pos @kc89_first_38 @kc89_second_35 -70;
+    pos @kc89_first_38 @kc89_second_36 -140;
+    pos @kc89_first_38 @kc89_second_37 -140;
+    pos @kc89_first_38 @kc89_second_38 -140;
+    pos @kc89_first_38 @kc89_second_41 -70;
+    pos @kc89_first_38 @kc89_second_45 1;
+    pos @kc89_first_38 @kc89_second_51 -140;
+    pos @kc89_first_38 @kc89_second_52 -70;
+    pos @kc89_first_38 @kc89_second_53 -140;
+    pos @kc89_first_38 @kc89_second_55 -245;
+    pos @kc89_first_38 @kc89_second_58 -70;
+    pos @kc89_first_38 @kc89_second_59 -70;
+    pos @kc89_first_38 @kc89_second_63 -245;
+    pos @kc89_first_38 @kc89_second_64 -280;
+    pos @kc89_first_38 @kc89_second_65 -315;
+    pos @kc89_first_39 @kc89_second_6 -35;
+    pos @kc89_first_39 @kc89_second_12 -240;
+    pos @kc89_first_39 @kc89_second_13 -140;
+    pos @kc89_first_39 @kc89_second_14 -35;
+    pos @kc89_first_39 @kc89_second_15 -35;
+    pos @kc89_first_39 @kc89_second_34 -35;
+    pos @kc89_first_39 @kc89_second_45 1;
+    pos @kc89_first_39 @kc89_second_63 -35;
+    pos @kc89_first_39 @kc89_second_64 -35;
+    pos @kc89_first_40 @kc89_second_12 -210;
+    pos @kc89_first_40 @kc89_second_13 -175;
+    pos @kc89_first_40 @kc89_second_14 -105;
+    pos @kc89_first_40 @kc89_second_15 -70;
+    pos @kc89_first_40 @kc89_second_43 -70;
+    pos @kc89_first_40 @kc89_second_45 1;
+    pos @kc89_first_40 @kc89_second_48 -105;
+    pos @kc89_first_40 @kc89_second_61 -70;
+    pos @kc89_first_41 @kc89_second_1 -140;
+    pos @kc89_first_41 @kc89_second_2 -175;
+    pos @kc89_first_41 @kc89_second_5 -105;
+    pos @kc89_first_41 @kc89_second_6 -70;
+    pos @kc89_first_41 @kc89_second_11 -70;
+    pos @kc89_first_41 @kc89_second_12 -175;
+    pos @kc89_first_41 @kc89_second_13 -105;
+    pos @kc89_first_41 @kc89_second_14 -70;
+    pos @kc89_first_41 @kc89_second_15 -35;
+    pos @kc89_first_41 @kc89_second_16 -105;
+    pos @kc89_first_41 @kc89_second_17 -35;
+    pos @kc89_first_41 @kc89_second_19 -175;
+    pos @kc89_first_41 @kc89_second_22 -50;
+    pos @kc89_first_41 @kc89_second_24 -105;
+    pos @kc89_first_41 @kc89_second_29 -35;
+    pos @kc89_first_41 @kc89_second_34 -70;
+    pos @kc89_first_41 @kc89_second_35 -140;
+    pos @kc89_first_41 @kc89_second_36 -35;
+    pos @kc89_first_41 @kc89_second_38 -50;
+    pos @kc89_first_41 @kc89_second_45 1;
+    pos @kc89_first_41 @kc89_second_51 -35;
+    pos @kc89_first_41 @kc89_second_53 -105;
+    pos @kc89_first_41 @kc89_second_55 -105;
+    pos @kc89_first_41 @kc89_second_57 -105;
+    pos @kc89_first_41 @kc89_second_63 -50;
+    pos @kc89_first_41 @kc89_second_64 -70;
+    pos @kc89_first_42 @kc89_second_1 -210;
+    pos @kc89_first_42 @kc89_second_2 -280;
+    pos @kc89_first_42 @kc89_second_3 -70;
+    pos @kc89_first_42 @kc89_second_6 -280;
+    pos @kc89_first_42 @kc89_second_8 -35;
+    pos @kc89_first_42 @kc89_second_11 -70;
+    pos @kc89_first_42 @kc89_second_13 -140;
+    pos @kc89_first_42 @kc89_second_14 -35;
+    pos @kc89_first_42 @kc89_second_15 -35;
+    pos @kc89_first_42 @kc89_second_16 -140;
+    pos @kc89_first_42 @kc89_second_17 -105;
+    pos @kc89_first_42 @kc89_second_19 -280;
+    pos @kc89_first_42 @kc89_second_20 -140;
+    pos @kc89_first_42 @kc89_second_22 -140;
+    pos @kc89_first_42 @kc89_second_23 -140;
+    pos @kc89_first_42 @kc89_second_24 -210;
+    pos @kc89_first_42 @kc89_second_34 -280;
+    pos @kc89_first_42 @kc89_second_35 -140;
+    pos @kc89_first_42 @kc89_second_36 -70;
+    pos @kc89_first_42 @kc89_second_37 -140;
+    pos @kc89_first_42 @kc89_second_38 -175;
+    pos @kc89_first_42 @kc89_second_44 -70;
+    pos @kc89_first_42 @kc89_second_45 1;
+    pos @kc89_first_42 @kc89_second_53 -210;
+    pos @kc89_first_42 @kc89_second_55 -175;
+    pos @kc89_first_42 @kc89_second_57 -210;
+    pos @kc89_first_42 @kc89_second_59 -70;
+    pos @kc89_first_42 @kc89_second_63 -175;
+    pos @kc89_first_42 @kc89_second_64 -175;
+    pos @kc89_first_43 @kc89_second_9 -70;
+    pos @kc89_first_43 @kc89_second_12 -240;
+    pos @kc89_first_43 @kc89_second_13 -210;
+    pos @kc89_first_43 @kc89_second_14 -140;
+    pos @kc89_first_43 @kc89_second_15 -105;
+    pos @kc89_first_43 @kc89_second_39 -70;
+    pos @kc89_first_43 @kc89_second_40 -35;
+    pos @kc89_first_43 @kc89_second_43 -140;
+    pos @kc89_first_43 @kc89_second_45 1;
+    pos @kc89_first_43 @kc89_second_47 -50;
+    pos @kc89_first_43 @kc89_second_48 -140;
+    pos @kc89_first_43 @kc89_second_58 -35;
+    pos @kc89_first_43 @kc89_second_60 -35;
+    pos @kc89_first_43 @kc89_second_61 -70;
+    pos @kc89_first_43 @kc89_second_62 -70;
+    pos @kc89_first_44 @kc89_second_8 -35;
+    pos @kc89_first_44 @kc89_second_9 -70;
+    pos @kc89_first_44 @kc89_second_12 -240;
+    pos @kc89_first_44 @kc89_second_13 -210;
+    pos @kc89_first_44 @kc89_second_14 -70;
+    pos @kc89_first_44 @kc89_second_15 -105;
+    pos @kc89_first_44 @kc89_second_22 -35;
+    pos @kc89_first_44 @kc89_second_38 -70;
+    pos @kc89_first_44 @kc89_second_39 -105;
+    pos @kc89_first_44 @kc89_second_40 -70;
+    pos @kc89_first_44 @kc89_second_43 -70;
+    pos @kc89_first_44 @kc89_second_44 -35;
+    pos @kc89_first_44 @kc89_second_45 1;
+    pos @kc89_first_44 @kc89_second_47 -70;
+    pos @kc89_first_44 @kc89_second_48 -70;
+    pos @kc89_first_44 @kc89_second_58 -70;
+    pos @kc89_first_44 @kc89_second_60 -50;
+    pos @kc89_first_44 @kc89_second_62 -70;
+    pos @kc89_first_44 @kc89_second_63 -35;
+    pos @kc89_first_44 @kc89_second_64 -35;
+    pos @kc89_first_45 @kc89_second_6 -70;
+    pos @kc89_first_45 @kc89_second_8 -35;
+    pos @kc89_first_45 @kc89_second_12 -175;
+    pos @kc89_first_45 @kc89_second_13 -140;
+    pos @kc89_first_45 @kc89_second_14 -70;
+    pos @kc89_first_45 @kc89_second_15 -35;
+    pos @kc89_first_45 @kc89_second_17 -70;
+    pos @kc89_first_45 @kc89_second_20 -70;
+    pos @kc89_first_45 @kc89_second_22 -105;
+    pos @kc89_first_45 @kc89_second_29 -35;
+    pos @kc89_first_45 @kc89_second_34 -70;
+    pos @kc89_first_45 @kc89_second_36 -35;
+    pos @kc89_first_45 @kc89_second_38 -105;
+    pos @kc89_first_45 @kc89_second_45 1;
+    pos @kc89_first_45 @kc89_second_51 -35;
+    pos @kc89_first_45 @kc89_second_63 -70;
+    pos @kc89_first_45 @kc89_second_64 -70;
+    pos @kc89_first_46 @kc89_second_3 -140;
+    pos @kc89_first_46 @kc89_second_4 -70;
+    pos @kc89_first_46 @kc89_second_6 -70;
+    pos @kc89_first_46 @kc89_second_8 -210;
+    pos @kc89_first_46 @kc89_second_9 -420;
+    pos @kc89_first_46 @kc89_second_12 -350;
+    pos @kc89_first_46 @kc89_second_13 -420;
+    pos @kc89_first_46 @kc89_second_14 -350;
+    pos @kc89_first_46 @kc89_second_15 -280;
+    pos @kc89_first_46 @kc89_second_17 -70;
+    pos @kc89_first_46 @kc89_second_18 -210;
+    pos @kc89_first_46 @kc89_second_20 -210;
+    pos @kc89_first_46 @kc89_second_22 -70;
+    pos @kc89_first_46 @kc89_second_23 -140;
+    pos @kc89_first_46 @kc89_second_29 -35;
+    pos @kc89_first_46 @kc89_second_31 -140;
+    pos @kc89_first_46 @kc89_second_34 -70;
+    pos @kc89_first_46 @kc89_second_36 -70;
+    pos @kc89_first_46 @kc89_second_38 -210;
+    pos @kc89_first_46 @kc89_second_39 -280;
+    pos @kc89_first_46 @kc89_second_40 -420;
+    pos @kc89_first_46 @kc89_second_43 -350;
+    pos @kc89_first_46 @kc89_second_45 1;
+    pos @kc89_first_46 @kc89_second_46 -35;
+    pos @kc89_first_46 @kc89_second_47 -210;
+    pos @kc89_first_46 @kc89_second_48 -350;
+    pos @kc89_first_46 @kc89_second_51 -35;
+    pos @kc89_first_46 @kc89_second_52 -35;
+    pos @kc89_first_46 @kc89_second_58 -280;
+    pos @kc89_first_46 @kc89_second_60 -175;
+    pos @kc89_first_46 @kc89_second_61 -280;
+    pos @kc89_first_46 @kc89_second_62 -210;
+    pos @kc89_first_46 @kc89_second_63 -70;
+    pos @kc89_first_47 @kc89_second_3 -140;
+    pos @kc89_first_47 @kc89_second_4 -105;
+    pos @kc89_first_47 @kc89_second_6 -70;
+    pos @kc89_first_47 @kc89_second_8 -210;
+    pos @kc89_first_47 @kc89_second_9 -280;
+    pos @kc89_first_47 @kc89_second_12 -350;
+    pos @kc89_first_47 @kc89_second_13 -385;
+    pos @kc89_first_47 @kc89_second_14 -350;
+    pos @kc89_first_47 @kc89_second_15 -280;
+    pos @kc89_first_47 @kc89_second_18 -210;
+    pos @kc89_first_47 @kc89_second_20 -140;
+    pos @kc89_first_47 @kc89_second_22 -105;
+    pos @kc89_first_47 @kc89_second_23 -140;
+    pos @kc89_first_47 @kc89_second_29 -70;
+    pos @kc89_first_47 @kc89_second_31 -175;
+    pos @kc89_first_47 @kc89_second_34 -70;
+    pos @kc89_first_47 @kc89_second_36 -35;
+    pos @kc89_first_47 @kc89_second_38 -175;
+    pos @kc89_first_47 @kc89_second_39 -280;
+    pos @kc89_first_47 @kc89_second_40 -280;
+    pos @kc89_first_47 @kc89_second_43 -280;
+    pos @kc89_first_47 @kc89_second_44 -140;
+    pos @kc89_first_47 @kc89_second_45 1;
+    pos @kc89_first_47 @kc89_second_46 -70;
+    pos @kc89_first_47 @kc89_second_47 -280;
+    pos @kc89_first_47 @kc89_second_48 -350;
+    pos @kc89_first_47 @kc89_second_51 -35;
+    pos @kc89_first_47 @kc89_second_52 -70;
+    pos @kc89_first_47 @kc89_second_58 -245;
+    pos @kc89_first_47 @kc89_second_60 -245;
+    pos @kc89_first_47 @kc89_second_61 -280;
+    pos @kc89_first_47 @kc89_second_62 -210;
+    pos @kc89_first_47 @kc89_second_63 -70;
+    pos @kc89_first_47 @kc89_second_64 -70;
+    pos @kc89_first_48 @kc89_second_3 -70;
+    pos @kc89_first_48 @kc89_second_4 -105;
+    pos @kc89_first_48 @kc89_second_6 -210;
+    pos @kc89_first_48 @kc89_second_7 -70;
+    pos @kc89_first_48 @kc89_second_8 -175;
+    pos @kc89_first_48 @kc89_second_17 -210;
+    pos @kc89_first_48 @kc89_second_20 -140;
+    pos @kc89_first_48 @kc89_second_21 -210;
+    pos @kc89_first_48 @kc89_second_22 -210;
+    pos @kc89_first_48 @kc89_second_23 -210;
+    pos @kc89_first_48 @kc89_second_24 -140;
+    pos @kc89_first_48 @kc89_second_25 -140;
+    pos @kc89_first_48 @kc89_second_27 -140;
+    pos @kc89_first_48 @kc89_second_29 -210;
+    pos @kc89_first_48 @kc89_second_30 -210;
+    pos @kc89_first_48 @kc89_second_31 -140;
+    pos @kc89_first_48 @kc89_second_34 -210;
+    pos @kc89_first_48 @kc89_second_35 -70;
+    pos @kc89_first_48 @kc89_second_36 -175;
+    pos @kc89_first_48 @kc89_second_37 -210;
+    pos @kc89_first_48 @kc89_second_38 -175;
+    pos @kc89_first_48 @kc89_second_39 -210;
+    pos @kc89_first_48 @kc89_second_40 -105;
+    pos @kc89_first_48 @kc89_second_43 -70;
+    pos @kc89_first_48 @kc89_second_44 -105;
+    pos @kc89_first_48 @kc89_second_45 1;
+    pos @kc89_first_48 @kc89_second_46 -35;
+    pos @kc89_first_48 @kc89_second_47 -210;
+    pos @kc89_first_48 @kc89_second_50 -210;
+    pos @kc89_first_48 @kc89_second_51 -210;
+    pos @kc89_first_48 @kc89_second_52 -175;
+    pos @kc89_first_48 @kc89_second_53 -175;
+    pos @kc89_first_48 @kc89_second_55 -210;
+    pos @kc89_first_48 @kc89_second_56 -140;
+    pos @kc89_first_48 @kc89_second_57 -210;
+    pos @kc89_first_48 @kc89_second_58 -210;
+    pos @kc89_first_48 @kc89_second_59 -175;
+    pos @kc89_first_48 @kc89_second_60 -175;
+    pos @kc89_first_48 @kc89_second_63 -210;
+    pos @kc89_first_48 @kc89_second_64 -210;
+    pos @kc89_first_49 @kc89_second_5 -70;
+    pos @kc89_first_49 @kc89_second_11 -35;
+    pos @kc89_first_49 @kc89_second_12 -240;
+    pos @kc89_first_49 @kc89_second_13 -70;
+    pos @kc89_first_49 @kc89_second_14 -140;
+    pos @kc89_first_49 @kc89_second_15 -105;
+    pos @kc89_first_49 @kc89_second_16 -70;
+    pos @kc89_first_49 @kc89_second_26 -70;
+    pos @kc89_first_49 @kc89_second_27 -70;
+    pos @kc89_first_49 @kc89_second_35 -35;
+    pos @kc89_first_49 @kc89_second_39 -70;
+    pos @kc89_first_49 @kc89_second_42 -35;
+    pos @kc89_first_49 @kc89_second_43 -70;
+    pos @kc89_first_49 @kc89_second_45 1;
+    pos @kc89_first_49 @kc89_second_47 -35;
+    pos @kc89_first_49 @kc89_second_48 -140;
+    pos @kc89_first_49 @kc89_second_51 1;
+    pos @kc89_first_49 @kc89_second_56 -35;
+    pos @kc89_first_49 @kc89_second_60 -35;
+    pos @kc89_first_49 @kc89_second_61 -105;
+    pos @kc89_first_49 @kc89_second_62 -70;
+    pos @kc89_first_50 @kc89_second_65 -140;
+    pos @kc89_first_51 @kc89_second_32 -315;
+    pos @kc89_first_51 @kc89_second_66 -140;
+    pos @kc89_first_52 @kc89_second_1 -105;
+    pos @kc89_first_52 @kc89_second_2 -210;
+    pos @kc89_first_52 @kc89_second_6 -140;
+    pos @kc89_first_52 @kc89_second_11 -70;
+    pos @kc89_first_52 @kc89_second_12 -210;
+    pos @kc89_first_52 @kc89_second_13 -210;
+    pos @kc89_first_52 @kc89_second_14 -105;
+    pos @kc89_first_52 @kc89_second_15 -70;
+    pos @kc89_first_52 @kc89_second_16 -140;
+    pos @kc89_first_52 @kc89_second_17 -35;
+    pos @kc89_first_52 @kc89_second_22 -35;
+    pos @kc89_first_52 @kc89_second_24 -210;
+    pos @kc89_first_52 @kc89_second_26 -70;
+    pos @kc89_first_52 @kc89_second_27 -70;
+    pos @kc89_first_52 @kc89_second_29 -35;
+    pos @kc89_first_52 @kc89_second_34 -210;
+    pos @kc89_first_52 @kc89_second_35 -140;
+    pos @kc89_first_52 @kc89_second_42 -35;
+    pos @kc89_first_52 @kc89_second_43 -70;
+    pos @kc89_first_52 @kc89_second_45 1;
+    pos @kc89_first_52 @kc89_second_47 -35;
+    pos @kc89_first_52 @kc89_second_48 -105;
+    pos @kc89_first_52 @kc89_second_53 -210;
+    pos @kc89_first_52 @kc89_second_55 -140;
+    pos @kc89_first_52 @kc89_second_57 -175;
+    pos @kc89_first_52 @kc89_second_61 -35;
+    pos @kc89_first_52 @kc89_second_62 -35;
+    pos @kc89_first_52 @kc89_second_63 -35;
+    pos @kc89_first_52 @kc89_second_64 -70;
+    pos @kc89_first_53 @kc89_second_1 -35;
+    pos @kc89_first_53 @kc89_second_2 -70;
+    pos @kc89_first_53 @kc89_second_5 -105;
+    pos @kc89_first_53 @kc89_second_6 -35;
+    pos @kc89_first_53 @kc89_second_9 -70;
+    pos @kc89_first_53 @kc89_second_11 -70;
+    pos @kc89_first_53 @kc89_second_12 -240;
+    pos @kc89_first_53 @kc89_second_13 -245;
+    pos @kc89_first_53 @kc89_second_14 -140;
+    pos @kc89_first_53 @kc89_second_15 -105;
+    pos @kc89_first_53 @kc89_second_16 -105;
+    pos @kc89_first_53 @kc89_second_18 -70;
+    pos @kc89_first_53 @kc89_second_19 -70;
+    pos @kc89_first_53 @kc89_second_24 -35;
+    pos @kc89_first_53 @kc89_second_25 -70;
+    pos @kc89_first_53 @kc89_second_26 -140;
+    pos @kc89_first_53 @kc89_second_27 -105;
+    pos @kc89_first_53 @kc89_second_34 -35;
+    pos @kc89_first_53 @kc89_second_35 -140;
+    pos @kc89_first_53 @kc89_second_39 -105;
+    pos @kc89_first_53 @kc89_second_40 -70;
+    pos @kc89_first_53 @kc89_second_42 -105;
+    pos @kc89_first_53 @kc89_second_43 -175;
+    pos @kc89_first_53 @kc89_second_45 1;
+    pos @kc89_first_53 @kc89_second_47 -70;
+    pos @kc89_first_53 @kc89_second_48 -140;
+    pos @kc89_first_53 @kc89_second_49 -70;
+    pos @kc89_first_53 @kc89_second_53 -210;
+    pos @kc89_first_53 @kc89_second_54 -70;
+    pos @kc89_first_53 @kc89_second_55 -175;
+    pos @kc89_first_53 @kc89_second_56 -105;
+    pos @kc89_first_53 @kc89_second_57 -175;
+    pos @kc89_first_53 @kc89_second_60 -50;
+    pos @kc89_first_53 @kc89_second_61 -105;
+    pos @kc89_first_53 @kc89_second_62 -70;
+    pos @kc89_first_53 @kc89_second_64 -35;
+    pos @kc89_first_54 @kc89_second_1 -105;
+    pos @kc89_first_54 @kc89_second_2 -210;
+    pos @kc89_first_54 @kc89_second_5 -70;
+    pos @kc89_first_54 @kc89_second_6 -105;
+    pos @kc89_first_54 @kc89_second_13 -70;
+    pos @kc89_first_54 @kc89_second_14 -35;
+    pos @kc89_first_54 @kc89_second_16 -140;
+    pos @kc89_first_54 @kc89_second_17 -70;
+    pos @kc89_first_54 @kc89_second_19 -210;
+    pos @kc89_first_54 @kc89_second_22 -35;
+    pos @kc89_first_54 @kc89_second_24 -210;
+    pos @kc89_first_54 @kc89_second_29 -35;
+    pos @kc89_first_54 @kc89_second_32 -105;
+    pos @kc89_first_54 @kc89_second_34 -105;
+    pos @kc89_first_54 @kc89_second_35 -140;
+    pos @kc89_first_54 @kc89_second_38 -70;
+    pos @kc89_first_54 @kc89_second_45 1;
+    pos @kc89_first_54 @kc89_second_51 -35;
+    pos @kc89_first_54 @kc89_second_53 -245;
+    pos @kc89_first_54 @kc89_second_55 -210;
+    pos @kc89_first_54 @kc89_second_57 -210;
+    pos @kc89_first_54 @kc89_second_63 -70;
+    pos @kc89_first_54 @kc89_second_64 -105;
+    pos @kc89_first_55 @kc89_second_12 -240;
+    pos @kc89_first_55 @kc89_second_13 -140;
+    pos @kc89_first_55 @kc89_second_14 -105;
+    pos @kc89_first_55 @kc89_second_15 -35;
+    pos @kc89_first_55 @kc89_second_33 44;
+    pos @kc89_first_55 @kc89_second_45 1;
+    pos @kc89_first_55 @kc89_second_50 44;
+    pos @kc89_first_56 @kc89_second_1 -140;
+    pos @kc89_first_56 @kc89_second_2 -210;
+    pos @kc89_first_56 @kc89_second_6 -140;
+    pos @kc89_first_56 @kc89_second_12 -175;
+    pos @kc89_first_56 @kc89_second_13 -140;
+    pos @kc89_first_56 @kc89_second_16 -140;
+    pos @kc89_first_56 @kc89_second_19 -210;
+    pos @kc89_first_56 @kc89_second_24 -210;
+    pos @kc89_first_56 @kc89_second_32 -140;
+    pos @kc89_first_56 @kc89_second_34 -140;
+    pos @kc89_first_56 @kc89_second_35 -210;
+    pos @kc89_first_56 @kc89_second_36 -35;
+    pos @kc89_first_56 @kc89_second_45 1;
+    pos @kc89_first_56 @kc89_second_53 -210;
+    pos @kc89_first_56 @kc89_second_55 -175;
+    pos @kc89_first_56 @kc89_second_57 -175;
+    pos @kc89_first_56 @kc89_second_63 -105;
+    pos @kc89_first_56 @kc89_second_64 -210;
+    pos @kc89_first_57 @kc89_second_12 -240;
+    pos @kc89_first_57 @kc89_second_13 -175;
+    pos @kc89_first_57 @kc89_second_14 -70;
+    pos @kc89_first_57 @kc89_second_15 -35;
+    pos @kc89_first_57 @kc89_second_19 -35;
+    pos @kc89_first_57 @kc89_second_26 -35;
+    pos @kc89_first_57 @kc89_second_39 -35;
+    pos @kc89_first_57 @kc89_second_40 -35;
+    pos @kc89_first_57 @kc89_second_43 -70;
+    pos @kc89_first_57 @kc89_second_45 1;
+    pos @kc89_first_57 @kc89_second_47 -35;
+    pos @kc89_first_57 @kc89_second_48 -70;
+    pos @kc89_first_57 @kc89_second_58 -35;
+    pos @kc89_first_57 @kc89_second_60 -35;
+    pos @kc89_first_57 @kc89_second_61 -70;
+    pos @kc89_first_57 @kc89_second_62 -35;
+    pos @kc89_first_58 @kc89_second_13 -35;
+    pos @kc89_first_58 @kc89_second_58 -35;
+    pos @kc89_first_58 @kc89_second_64 -35;
+    pos @kc89_first_59 @kc89_second_12 -175;
+    pos @kc89_first_59 @kc89_second_13 -140;
+    pos @kc89_first_59 @kc89_second_14 -35;
+    pos @kc89_first_59 @kc89_second_45 1;
+    pos @kc89_first_60 @kc89_second_1 -140;
+    pos @kc89_first_60 @kc89_second_2 -280;
+    pos @kc89_first_60 @kc89_second_5 -140;
+    pos @kc89_first_60 @kc89_second_6 -280;
+    pos @kc89_first_60 @kc89_second_8 -70;
+    pos @kc89_first_60 @kc89_second_10 -70;
+    pos @kc89_first_60 @kc89_second_11 -175;
+    pos @kc89_first_60 @kc89_second_12 -240;
+    pos @kc89_first_60 @kc89_second_13 -140;
+    pos @kc89_first_60 @kc89_second_14 -105;
+    pos @kc89_first_60 @kc89_second_15 -70;
+    pos @kc89_first_60 @kc89_second_16 -175;
+    pos @kc89_first_60 @kc89_second_17 -70;
+    pos @kc89_first_60 @kc89_second_19 -280;
+    pos @kc89_first_60 @kc89_second_22 -70;
+    pos @kc89_first_60 @kc89_second_23 -70;
+    pos @kc89_first_60 @kc89_second_24 -210;
+    pos @kc89_first_60 @kc89_second_26 -70;
+    pos @kc89_first_60 @kc89_second_27 -70;
+    pos @kc89_first_60 @kc89_second_29 -70;
+    pos @kc89_first_60 @kc89_second_32 -70;
+    pos @kc89_first_60 @kc89_second_34 -315;
+    pos @kc89_first_60 @kc89_second_35 -140;
+    pos @kc89_first_60 @kc89_second_36 -70;
+    pos @kc89_first_60 @kc89_second_38 -105;
+    pos @kc89_first_60 @kc89_second_45 1;
+    pos @kc89_first_60 @kc89_second_48 -35;
+    pos @kc89_first_60 @kc89_second_51 -50;
+    pos @kc89_first_60 @kc89_second_53 -210;
+    pos @kc89_first_60 @kc89_second_55 -175;
+    pos @kc89_first_60 @kc89_second_57 -210;
+    pos @kc89_first_60 @kc89_second_59 -35;
+    pos @kc89_first_60 @kc89_second_61 -70;
+    pos @kc89_first_60 @kc89_second_62 -35;
+    pos @kc89_first_60 @kc89_second_63 -140;
+    pos @kc89_first_60 @kc89_second_64 -210;
+    pos @kc89_first_61 @kc89_second_1 -35;
+    pos @kc89_first_61 @kc89_second_2 -70;
+    pos @kc89_first_61 @kc89_second_5 -70;
+    pos @kc89_first_61 @kc89_second_11 -35;
+    pos @kc89_first_61 @kc89_second_12 -140;
+    pos @kc89_first_61 @kc89_second_13 -140;
+    pos @kc89_first_61 @kc89_second_14 -70;
+    pos @kc89_first_61 @kc89_second_15 -35;
+    pos @kc89_first_61 @kc89_second_16 -105;
+    pos @kc89_first_61 @kc89_second_26 -35;
+    pos @kc89_first_61 @kc89_second_27 -70;
+    pos @kc89_first_61 @kc89_second_35 -70;
+    pos @kc89_first_61 @kc89_second_43 -70;
+    pos @kc89_first_61 @kc89_second_45 1;
+    pos @kc89_first_61 @kc89_second_53 -175;
+    pos @kc89_first_61 @kc89_second_55 -140;
+    pos @kc89_first_61 @kc89_second_57 -140;
+    pos @kc89_first_61 @kc89_second_61 -35;
+    pos @kc89_first_62 @kc89_second_5 -70;
+    pos @kc89_first_62 @kc89_second_9 -70;
+    pos @kc89_first_62 @kc89_second_11 -35;
+    pos @kc89_first_62 @kc89_second_12 -350;
+    pos @kc89_first_62 @kc89_second_13 -315;
+    pos @kc89_first_62 @kc89_second_14 -175;
+    pos @kc89_first_62 @kc89_second_15 -140;
+    pos @kc89_first_62 @kc89_second_16 -70;
+    pos @kc89_first_62 @kc89_second_18 -70;
+    pos @kc89_first_62 @kc89_second_27 -70;
+    pos @kc89_first_62 @kc89_second_31 -50;
+    pos @kc89_first_62 @kc89_second_39 -140;
+    pos @kc89_first_62 @kc89_second_40 -50;
+    pos @kc89_first_62 @kc89_second_42 -35;
+    pos @kc89_first_62 @kc89_second_43 -175;
+    pos @kc89_first_62 @kc89_second_45 1;
+    pos @kc89_first_62 @kc89_second_47 -70;
+    pos @kc89_first_62 @kc89_second_48 -175;
+    pos @kc89_first_62 @kc89_second_54 -70;
+    pos @kc89_first_62 @kc89_second_58 -70;
+    pos @kc89_first_62 @kc89_second_60 -50;
+    pos @kc89_first_62 @kc89_second_61 -140;
+    pos @kc89_first_62 @kc89_second_62 -105;
+    pos @kc89_first_63 @kc89_second_4 -105;
+    pos @kc89_first_63 @kc89_second_6 -35;
+    pos @kc89_first_63 @kc89_second_8 1;
+    pos @kc89_first_63 @kc89_second_9 -245;
+    pos @kc89_first_63 @kc89_second_12 -210;
+    pos @kc89_first_63 @kc89_second_13 -210;
+    pos @kc89_first_63 @kc89_second_14 -210;
+    pos @kc89_first_63 @kc89_second_15 -175;
+    pos @kc89_first_63 @kc89_second_17 -70;
+    pos @kc89_first_63 @kc89_second_18 -180;
+    pos @kc89_first_63 @kc89_second_20 -140;
+    pos @kc89_first_63 @kc89_second_22 -105;
+    pos @kc89_first_63 @kc89_second_25 -140;
+    pos @kc89_first_63 @kc89_second_29 -105;
+    pos @kc89_first_63 @kc89_second_31 -140;
+    pos @kc89_first_63 @kc89_second_34 -35;
+    pos @kc89_first_63 @kc89_second_36 -35;
+    pos @kc89_first_63 @kc89_second_38 -175;
+    pos @kc89_first_63 @kc89_second_39 -142;
+    pos @kc89_first_63 @kc89_second_40 -245;
+    pos @kc89_first_63 @kc89_second_43 -210;
+    pos @kc89_first_63 @kc89_second_44 -105;
+    pos @kc89_first_63 @kc89_second_45 1;
+    pos @kc89_first_63 @kc89_second_46 -35;
+    pos @kc89_first_63 @kc89_second_47 -210;
+    pos @kc89_first_63 @kc89_second_48 -210;
+    pos @kc89_first_63 @kc89_second_51 -35;
+    pos @kc89_first_63 @kc89_second_58 -280;
+    pos @kc89_first_63 @kc89_second_60 -175;
+    pos @kc89_first_63 @kc89_second_61 -140;
+    pos @kc89_first_63 @kc89_second_62 -140;
+    pos @kc89_first_63 @kc89_second_63 -70;
+    pos @kc89_first_63 @kc89_second_64 -70;
+    pos @kc89_first_64 @kc89_second_1 -175;
+    pos @kc89_first_64 @kc89_second_2 -175;
+    pos @kc89_first_64 @kc89_second_5 -70;
+    pos @kc89_first_64 @kc89_second_6 -105;
+    pos @kc89_first_64 @kc89_second_11 -105;
+    pos @kc89_first_64 @kc89_second_12 -175;
+    pos @kc89_first_64 @kc89_second_13 -140;
+    pos @kc89_first_64 @kc89_second_14 -70;
+    pos @kc89_first_64 @kc89_second_15 -35;
+    pos @kc89_first_64 @kc89_second_16 -140;
+    pos @kc89_first_64 @kc89_second_17 -70;
+    pos @kc89_first_64 @kc89_second_19 -175;
+    pos @kc89_first_64 @kc89_second_22 -70;
+    pos @kc89_first_64 @kc89_second_29 -35;
+    pos @kc89_first_64 @kc89_second_34 -105;
+    pos @kc89_first_64 @kc89_second_35 -175;
+    pos @kc89_first_64 @kc89_second_36 -35;
+    pos @kc89_first_64 @kc89_second_38 -70;
+    pos @kc89_first_64 @kc89_second_45 1;
+    pos @kc89_first_64 @kc89_second_51 -35;
+    pos @kc89_first_64 @kc89_second_53 -140;
+    pos @kc89_first_64 @kc89_second_55 -140;
+    pos @kc89_first_64 @kc89_second_57 -140;
+    pos @kc89_first_64 @kc89_second_63 -70;
+    pos @kc89_first_64 @kc89_second_64 -105;
+    pos @kc89_first_65 @kc89_second_1 -210;
+    pos @kc89_first_65 @kc89_second_2 -210;
+    pos @kc89_first_65 @kc89_second_3 -70;
+    pos @kc89_first_65 @kc89_second_4 -35;
+    pos @kc89_first_65 @kc89_second_6 -210;
+    pos @kc89_first_65 @kc89_second_7 -70;
+    pos @kc89_first_65 @kc89_second_8 -70;
+    pos @kc89_first_65 @kc89_second_16 -70;
+    pos @kc89_first_65 @kc89_second_17 -140;
+    pos @kc89_first_65 @kc89_second_19 -210;
+    pos @kc89_first_65 @kc89_second_20 -140;
+    pos @kc89_first_65 @kc89_second_21 -35;
+    pos @kc89_first_65 @kc89_second_22 -175;
+    pos @kc89_first_65 @kc89_second_23 -140;
+    pos @kc89_first_65 @kc89_second_24 -280;
+    pos @kc89_first_65 @kc89_second_29 -35;
+    pos @kc89_first_65 @kc89_second_30 -35;
+    pos @kc89_first_65 @kc89_second_32 -210;
+    pos @kc89_first_65 @kc89_second_34 -245;
+    pos @kc89_first_65 @kc89_second_35 -140;
+    pos @kc89_first_65 @kc89_second_36 -140;
+    pos @kc89_first_65 @kc89_second_37 -140;
+    pos @kc89_first_65 @kc89_second_38 -140;
+    pos @kc89_first_65 @kc89_second_39 -35;
+    pos @kc89_first_65 @kc89_second_44 -35;
+    pos @kc89_first_65 @kc89_second_45 1;
+    pos @kc89_first_65 @kc89_second_49 -35;
+    pos @kc89_first_65 @kc89_second_51 -140;
+    pos @kc89_first_65 @kc89_second_52 -70;
+    pos @kc89_first_65 @kc89_second_53 -210;
+    pos @kc89_first_65 @kc89_second_55 -210;
+    pos @kc89_first_65 @kc89_second_57 -210;
+    pos @kc89_first_65 @kc89_second_58 -35;
+    pos @kc89_first_65 @kc89_second_63 -175;
+    pos @kc89_first_65 @kc89_second_64 -245;
+    pos @kc89_first_66 @kc89_second_6 -35;
+    pos @kc89_first_66 @kc89_second_12 -240;
+    pos @kc89_first_66 @kc89_second_13 -140;
+    pos @kc89_first_66 @kc89_second_14 -70;
+    pos @kc89_first_66 @kc89_second_15 -35;
+    pos @kc89_first_66 @kc89_second_20 -35;
+    pos @kc89_first_66 @kc89_second_22 -35;
+    pos @kc89_first_66 @kc89_second_34 -70;
+    pos @kc89_first_66 @kc89_second_38 -70;
+    pos @kc89_first_66 @kc89_second_39 -50;
+    pos @kc89_first_66 @kc89_second_45 1;
+    pos @kc89_first_66 @kc89_second_48 -35;
+    pos @kc89_first_66 @kc89_second_63 -35;
+    pos @kc89_first_66 @kc89_second_64 -35;
+    pos @kc89_first_67 @kc89_second_3 -100;
+    pos @kc89_first_67 @kc89_second_4 -50;
+    pos @kc89_first_67 @kc89_second_6 -50;
+    pos @kc89_first_67 @kc89_second_8 -70;
+    pos @kc89_first_67 @kc89_second_9 -140;
+    pos @kc89_first_67 @kc89_second_10 -50;
+    pos @kc89_first_67 @kc89_second_12 -140;
+    pos @kc89_first_67 @kc89_second_13 -100;
+    pos @kc89_first_67 @kc89_second_14 -70;
+    pos @kc89_first_67 @kc89_second_15 -50;
+    pos @kc89_first_67 @kc89_second_18 -70;
+    pos @kc89_first_67 @kc89_second_20 -70;
+    pos @kc89_first_67 @kc89_second_22 -50;
+    pos @kc89_first_67 @kc89_second_23 -70;
+    pos @kc89_first_67 @kc89_second_29 -35;
+    pos @kc89_first_67 @kc89_second_31 -70;
+    pos @kc89_first_67 @kc89_second_33 105;
+    pos @kc89_first_67 @kc89_second_34 -35;
+    pos @kc89_first_67 @kc89_second_38 -70;
+    pos @kc89_first_67 @kc89_second_39 -140;
+    pos @kc89_first_67 @kc89_second_40 -140;
+    pos @kc89_first_67 @kc89_second_43 -140;
+    pos @kc89_first_67 @kc89_second_44 -35;
+    pos @kc89_first_67 @kc89_second_45 1;
+    pos @kc89_first_67 @kc89_second_47 -70;
+    pos @kc89_first_67 @kc89_second_48 -100;
+    pos @kc89_first_67 @kc89_second_50 105;
+    pos @kc89_first_67 @kc89_second_58 -140;
+    pos @kc89_first_67 @kc89_second_60 -70;
+    pos @kc89_first_67 @kc89_second_61 -70;
+    pos @kc89_first_67 @kc89_second_62 -50;
+    pos @kc89_first_67 @kc89_second_63 -35;
+    pos @kc89_first_67 @kc89_second_64 -35;
+    pos @kc89_first_68 @kc89_second_3 -70;
+    pos @kc89_first_68 @kc89_second_4 -50;
+    pos @kc89_first_68 @kc89_second_6 -50;
+    pos @kc89_first_68 @kc89_second_8 -70;
+    pos @kc89_first_68 @kc89_second_9 -140;
+    pos @kc89_first_68 @kc89_second_10 -50;
+    pos @kc89_first_68 @kc89_second_12 -240;
+    pos @kc89_first_68 @kc89_second_13 -240;
+    pos @kc89_first_68 @kc89_second_14 -175;
+    pos @kc89_first_68 @kc89_second_15 -140;
+    pos @kc89_first_68 @kc89_second_18 -70;
+    pos @kc89_first_68 @kc89_second_20 -70;
+    pos @kc89_first_68 @kc89_second_22 -50;
+    pos @kc89_first_68 @kc89_second_23 -70;
+    pos @kc89_first_68 @kc89_second_29 -35;
+    pos @kc89_first_68 @kc89_second_31 -70;
+    pos @kc89_first_68 @kc89_second_34 -35;
+    pos @kc89_first_68 @kc89_second_38 -70;
+    pos @kc89_first_68 @kc89_second_39 -140;
+    pos @kc89_first_68 @kc89_second_40 -140;
+    pos @kc89_first_68 @kc89_second_43 -140;
+    pos @kc89_first_68 @kc89_second_44 -35;
+    pos @kc89_first_68 @kc89_second_45 1;
+    pos @kc89_first_68 @kc89_second_47 -70;
+    pos @kc89_first_68 @kc89_second_48 -140;
+    pos @kc89_first_68 @kc89_second_58 -140;
+    pos @kc89_first_68 @kc89_second_60 -70;
+    pos @kc89_first_68 @kc89_second_61 -105;
+    pos @kc89_first_68 @kc89_second_62 -70;
+    pos @kc89_first_68 @kc89_second_63 -35;
+    pos @kc89_first_68 @kc89_second_64 -35;
+    pos @kc89_first_69 @kc89_second_3 -70;
+    pos @kc89_first_69 @kc89_second_4 -50;
+    pos @kc89_first_69 @kc89_second_6 -50;
+    pos @kc89_first_69 @kc89_second_8 -70;
+    pos @kc89_first_69 @kc89_second_9 -140;
+    pos @kc89_first_69 @kc89_second_10 -50;
+    pos @kc89_first_69 @kc89_second_12 -140;
+    pos @kc89_first_69 @kc89_second_13 -140;
+    pos @kc89_first_69 @kc89_second_14 -105;
+    pos @kc89_first_69 @kc89_second_15 -70;
+    pos @kc89_first_69 @kc89_second_18 -70;
+    pos @kc89_first_69 @kc89_second_20 -70;
+    pos @kc89_first_69 @kc89_second_22 -50;
+    pos @kc89_first_69 @kc89_second_23 -100;
+    pos @kc89_first_69 @kc89_second_29 -35;
+    pos @kc89_first_69 @kc89_second_31 -70;
+    pos @kc89_first_69 @kc89_second_33 105;
+    pos @kc89_first_69 @kc89_second_34 -35;
+    pos @kc89_first_69 @kc89_second_38 -70;
+    pos @kc89_first_69 @kc89_second_39 -140;
+    pos @kc89_first_69 @kc89_second_40 -140;
+    pos @kc89_first_69 @kc89_second_43 -140;
+    pos @kc89_first_69 @kc89_second_44 -35;
+    pos @kc89_first_69 @kc89_second_45 1;
+    pos @kc89_first_69 @kc89_second_47 -70;
+    pos @kc89_first_69 @kc89_second_48 -140;
+    pos @kc89_first_69 @kc89_second_50 105;
+    pos @kc89_first_69 @kc89_second_58 -140;
+    pos @kc89_first_69 @kc89_second_60 -70;
+    pos @kc89_first_69 @kc89_second_61 -70;
+    pos @kc89_first_69 @kc89_second_62 -50;
+    pos @kc89_first_69 @kc89_second_63 -35;
+    pos @kc89_first_69 @kc89_second_64 -35;
+    pos @kc89_first_70 @kc89_second_1 -210;
+    pos @kc89_first_70 @kc89_second_2 -210;
+    pos @kc89_first_70 @kc89_second_3 -35;
+    pos @kc89_first_70 @kc89_second_6 -140;
+    pos @kc89_first_70 @kc89_second_8 -70;
+    pos @kc89_first_70 @kc89_second_10 -35;
+    pos @kc89_first_70 @kc89_second_17 -70;
+    pos @kc89_first_70 @kc89_second_19 -210;
+    pos @kc89_first_70 @kc89_second_20 -70;
+    pos @kc89_first_70 @kc89_second_22 -105;
+    pos @kc89_first_70 @kc89_second_23 -105;
+    pos @kc89_first_70 @kc89_second_24 -175;
+    pos @kc89_first_70 @kc89_second_29 -105;
+    pos @kc89_first_70 @kc89_second_34 -175;
+    pos @kc89_first_70 @kc89_second_35 -140;
+    pos @kc89_first_70 @kc89_second_36 -70;
+    pos @kc89_first_70 @kc89_second_37 -105;
+    pos @kc89_first_70 @kc89_second_38 -105;
+    pos @kc89_first_70 @kc89_second_39 -70;
+    pos @kc89_first_70 @kc89_second_44 -35;
+    pos @kc89_first_70 @kc89_second_45 1;
+    pos @kc89_first_70 @kc89_second_50 -35;
+    pos @kc89_first_70 @kc89_second_51 -70;
+    pos @kc89_first_70 @kc89_second_52 -70;
+    pos @kc89_first_70 @kc89_second_53 -175;
+    pos @kc89_first_70 @kc89_second_55 -175;
+    pos @kc89_first_70 @kc89_second_57 -175;
+    pos @kc89_first_70 @kc89_second_58 -35;
+    pos @kc89_first_70 @kc89_second_59 -35;
+    pos @kc89_first_70 @kc89_second_63 -140;
+    pos @kc89_first_70 @kc89_second_64 -175;
+    pos @kc89_first_71 @kc89_second_5 -70;
+    pos @kc89_first_71 @kc89_second_8 -70;
+    pos @kc89_first_71 @kc89_second_9 -105;
+    pos @kc89_first_71 @kc89_second_11 -35;
+    pos @kc89_first_71 @kc89_second_12 -350;
+    pos @kc89_first_71 @kc89_second_13 -350;
+    pos @kc89_first_71 @kc89_second_14 -245;
+    pos @kc89_first_71 @kc89_second_15 -210;
+    pos @kc89_first_71 @kc89_second_16 -70;
+    pos @kc89_first_71 @kc89_second_18 -210;
+    pos @kc89_first_71 @kc89_second_23 -35;
+    pos @kc89_first_71 @kc89_second_26 -35;
+    pos @kc89_first_71 @kc89_second_27 -70;
+    pos @kc89_first_71 @kc89_second_31 -70;
+    pos @kc89_first_71 @kc89_second_38 -35;
+    pos @kc89_first_71 @kc89_second_39 -245;
+    pos @kc89_first_71 @kc89_second_40 -70;
+    pos @kc89_first_71 @kc89_second_42 -35;
+    pos @kc89_first_71 @kc89_second_43 -240;
+    pos @kc89_first_71 @kc89_second_45 1;
+    pos @kc89_first_71 @kc89_second_47 -105;
+    pos @kc89_first_71 @kc89_second_48 -280;
+    pos @kc89_first_71 @kc89_second_49 -35;
+    pos @kc89_first_71 @kc89_second_54 -35;
+    pos @kc89_first_71 @kc89_second_56 -70;
+    pos @kc89_first_71 @kc89_second_58 -105;
+    pos @kc89_first_71 @kc89_second_59 -35;
+    pos @kc89_first_71 @kc89_second_60 -70;
+    pos @kc89_first_71 @kc89_second_61 -175;
+    pos @kc89_first_71 @kc89_second_62 -140;
+    pos @kc89_first_72 @kc89_second_1 -140;
+    pos @kc89_first_72 @kc89_second_2 -140;
+    pos @kc89_first_72 @kc89_second_6 -140;
+    pos @kc89_first_72 @kc89_second_8 -35;
+    pos @kc89_first_72 @kc89_second_10 -35;
+    pos @kc89_first_72 @kc89_second_17 -35;
+    pos @kc89_first_72 @kc89_second_19 -140;
+    pos @kc89_first_72 @kc89_second_20 -35;
+    pos @kc89_first_72 @kc89_second_22 -70;
+    pos @kc89_first_72 @kc89_second_23 -70;
+    pos @kc89_first_72 @kc89_second_24 -140;
+    pos @kc89_first_72 @kc89_second_29 -70;
+    pos @kc89_first_72 @kc89_second_34 -175;
+    pos @kc89_first_72 @kc89_second_35 -105;
+    pos @kc89_first_72 @kc89_second_36 -70;
+    pos @kc89_first_72 @kc89_second_37 -70;
+    pos @kc89_first_72 @kc89_second_38 -70;
+    pos @kc89_first_72 @kc89_second_39 -35;
+    pos @kc89_first_72 @kc89_second_45 1;
+    pos @kc89_first_72 @kc89_second_50 -35;
+    pos @kc89_first_72 @kc89_second_51 -35;
+    pos @kc89_first_72 @kc89_second_53 -140;
+    pos @kc89_first_72 @kc89_second_55 -140;
+    pos @kc89_first_72 @kc89_second_57 -140;
+    pos @kc89_first_72 @kc89_second_63 -105;
+    pos @kc89_first_72 @kc89_second_64 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -10722,7 +10757,7 @@ lookup mark_Mark_positioning {
   pos base [\C \uni0421 \uni216D ] <anchor 914 1380> mark @top_center
 	<anchor 671 0> mark @bottom_center
 	<anchor 667 -20> mark @bottom_cedilla;
-  pos base [\G \Q \Oslash \uni01B1 \Theta \uni04E8 \uni051A \uni2127 \G.cv21 ] <anchor 671 0> mark @bottom_center
+  pos base [\G \Q \Oslash \uni01B1 \Theta \uni04E8 \uni051A \uni2127 \G.cv21 \Q.cv29 ] <anchor 671 0> mark @bottom_center
 	<anchor 914 1380> mark @top_center;
   pos base [\U ] <anchor 565 -20> mark @bottom_cedilla
 	<anchor 731 0> mark @bottom_right
@@ -12148,7 +12183,7 @@ lookup mark_Mark_positioning {
 	<anchor 399 0> mark @bottom_center;
   pos base [\f.sc \gamma.sc \uni03DD.sc \uni0433.sc ] <anchor 100 0> mark @bottom_center
 	<anchor 611 1200> mark @top_center;
-  pos base [\g.sc \q.sc \uni028A.sc \theta.sc \uni0473.sc \uni04D9.sc \uni04E9.sc ] <anchor 776 1200> mark @top_center
+  pos base [\g.sc \q.sc \uni028A.sc \theta.sc \uni0473.sc \uni04D9.sc \uni04E9.sc \q.sc.cv29 ] <anchor 776 1200> mark @top_center
 	<anchor 564 0> mark @bottom_center;
   pos base [\h.sc \etatonos.sc \eta.sc \uni043D.sc \uni1F20.sc \uni1F21.sc \uni1F22.sc \uni1F23.sc \uni1F24.sc \uni1F25.sc \uni1F26.sc \uni1F27.sc \uni1F74.sc \uni1F75.sc ] <anchor 475 -80> mark @bottom_ypogegrammeni
 	<anchor 96 -20> mark @bottom_cedilla
@@ -13246,6 +13281,7 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
+#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 
@@ -13972,7 +14008,8 @@ feature mkmk {
 	\lcaron.cv28 \ldot.cv28 \lslash.cv28 \uni019A.cv28 \uni01C9.cv28 
 	\uni0234.cv28 \uni026D.cv28 \uni026E.cv28 \uni02AA.cv28 \uni02AB.cv28 
 	\uni02E1.cv28 \uni1E37.cv28 \uni1E39.cv28 \uni1E3B.cv28 \uni1E3D.cv28 
-	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \dollar.ss05 
+	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \Q.cv29 \uni051A.cv29 
+	\uni213A.cv29 \uni24C6.cv29 \q.sc.cv29 \uni051B.sc.cv29 \dollar.ss05 
 	\cent.ss05 \sterling.ss05 \lira.ss05 \peseta.ss05 \uni20AA.ss05 \Euro.ss05 
 	\uni20B2.ss05 \one.ss06 \one.ss06.pnum \one.ss06.tnum \one.ss06.onum 
 	\one.ss06.onum.tnum \one.ss06.superior \one.ss06.superior.pnum 

--- a/sources/Giphurs-Italic.ufo/features.fea
+++ b/sources/Giphurs-Italic.ufo/features.fea
@@ -4574,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \i \acutecomb  by \iacute;
     sub \uni0456 \acutecomb  by \iacute;
+    sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4631,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4719,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5651,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6785,6 +6785,29 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
+
 feature locl {
 
  script cyrl;
@@ -6871,29 +6894,6 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
-
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
 
 feature ss09 {
   featureNames {
@@ -12981,6 +12981,10 @@ lookup mark_Mark_positioning {
 	<anchor 382 1600> mark @top_center;
   pos base [\uni1E3B.cv28 ] <anchor 343 1380> mark @top_center
 	<anchor 61 -220> mark @bottom_center;
+  pos base [\uni051A.cv29 ] <anchor 671 1> mark @bottom_center
+	<anchor 914 1381> mark @top_center;
+  pos base [\uni051B.sc.cv29 ] <anchor 776 1201> mark @top_center
+	<anchor 564 1> mark @bottom_center;
   pos base [\dotlessuni0268 ] <anchor 201 -20> mark @bottom_cedilla
 	<anchor 388 1040> mark @top_center
 	<anchor 205 0> mark @bottom_center
@@ -13281,7 +13285,6 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
-#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 

--- a/sources/Giphurs-Italic.ufo/fontinfo.plist
+++ b/sources/Giphurs-Italic.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/28 21:34:07</string>
+    <string>2026/07/28 21:56:03</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Italic.ufo/fontinfo.plist
+++ b/sources/Giphurs-Italic.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/27 23:38:11</string>
+    <string>2026/07/28 21:34:07</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Italic.ufo/glyphs/Q_.cv29.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/Q_.cv29.glif
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.cv29" format="2">
+  <advance width="1672"/>
+  <anchor x="671" y="0" name="bottom_center"/>
+  <anchor x="914" y="1380" name="top_center"/>
+  <outline>
+    <contour>
+      <point x="1472" y="0" type="line"/>
+      <point x="671" y="0" type="line"/>
+      <point x="1068" y="168" type="line"/>
+      <point x="1502" y="168" type="line"/>
+    </contour>
+    <contour>
+      <point x="906" y="1332" type="curve" smooth="yes"/>
+      <point x="541" y="1332"/>
+      <point x="280" y="980"/>
+      <point x="280" y="617" type="curve" smooth="yes"/>
+      <point x="280" y="342"/>
+      <point x="449" y="168"/>
+      <point x="701" y="168" type="curve" smooth="yes"/>
+      <point x="1066" y="168"/>
+      <point x="1326" y="520"/>
+      <point x="1326" y="883" type="curve" smooth="yes"/>
+      <point x="1326" y="1158"/>
+      <point x="1158" y="1332"/>
+    </contour>
+    <contour>
+      <point x="88" y="595" type="curve" smooth="yes"/>
+      <point x="88" y="1065"/>
+      <point x="461" y="1500"/>
+      <point x="935" y="1500" type="curve" smooth="yes"/>
+      <point x="1282" y="1500"/>
+      <point x="1518" y="1261"/>
+      <point x="1518" y="905" type="curve" smooth="yes"/>
+      <point x="1518" y="435"/>
+      <point x="1145" y="0"/>
+      <point x="671" y="0" type="curve" smooth="yes"/>
+      <point x="324" y="0"/>
+      <point x="88" y="239"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict/>
+  </lib>
+</glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-Italic.ufo/glyphs/contents.plist
@@ -9106,6 +9106,18 @@
     <string>uni24A_7.cv28.glif</string>
     <key>uni24DB.cv28</key>
     <string>uni24D_B_.cv28.glif</string>
+    <key>Q.cv29</key>
+    <string>Q_.cv29.glif</string>
+    <key>uni051A.cv29</key>
+    <string>uni051A_.cv29.glif</string>
+    <key>uni213A.cv29</key>
+    <string>uni213A_.cv29.glif</string>
+    <key>uni24C6.cv29</key>
+    <string>uni24C_6.cv29.glif</string>
+    <key>q.sc.cv29</key>
+    <string>q.sc.cv29.glif</string>
+    <key>uni051B.sc.cv29</key>
+    <string>uni051B_.sc.cv29.glif</string>
     <key>dollar.ss05</key>
     <string>dollar.ss05.glif</string>
     <key>cent.ss05</key>

--- a/sources/Giphurs-Italic.ufo/glyphs/q.sc.cv29.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/q.sc.cv29.glif
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="q.sc.cv29" format="2">
+  <advance width="1438"/>
+  <anchor x="776" y="1200" name="top_center"/>
+  <anchor x="564" y="0" name="bottom_center"/>
+  <outline>
+    <contour>
+      <point x="1238" y="0" type="line"/>
+      <point x="564" y="0" type="line"/>
+      <point x="734" y="160" type="line"/>
+      <point x="1266" y="160" type="line"/>
+    </contour>
+    <contour>
+      <point x="751" y="1060" type="curve" smooth="yes"/>
+      <point x="451" y="1060"/>
+      <point x="248" y="789"/>
+      <point x="248" y="509" type="curve" smooth="yes"/>
+      <point x="248" y="292"/>
+      <point x="387" y="160"/>
+      <point x="592" y="160" type="curve" smooth="yes"/>
+      <point x="892" y="160"/>
+      <point x="1095" y="431"/>
+      <point x="1095" y="711" type="curve" smooth="yes"/>
+      <point x="1095" y="928"/>
+      <point x="956" y="1060"/>
+    </contour>
+    <contour>
+      <point x="67" y="489" type="curve" smooth="yes"/>
+      <point x="67" y="876"/>
+      <point x="385" y="1220"/>
+      <point x="779" y="1220" type="curve" smooth="yes"/>
+      <point x="1069" y="1220"/>
+      <point x="1277" y="1027"/>
+      <point x="1277" y="731" type="curve" smooth="yes"/>
+      <point x="1277" y="344"/>
+      <point x="958" y="0"/>
+      <point x="564" y="0" type="curve" smooth="yes"/>
+      <point x="274" y="0"/>
+      <point x="67" y="193"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni051A_.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051A.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1672"/>
+  <anchor x="671" y="1" name="bottom_center"/>
+  <anchor x="914" y="1381" name="top_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="Q.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni051A_.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051A.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051B.sc.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1438"/>
+  <anchor x="776" y="1201" name="top_center"/>
+  <anchor x="564" y="1" name="bottom_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="q.sc.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051B.sc.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni213A_.cv29.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni213A_.cv29.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni213A.cv29" format="2">
+  <advance width="1700"/>
+  <outline>
+    <contour>
+      <point x="1741" y="1539" type="line"/>
+      <point x="1600" y="740" type="line"/>
+      <point x="1497" y="1107" type="line"/>
+      <point x="1573" y="1539" type="line"/>
+    </contour>
+    <contour>
+      <point x="941" y="1251" type="curve" smooth="yes"/>
+      <point x="534" y="1251"/>
+      <point x="260" y="958"/>
+      <point x="260" y="650" type="curve" smooth="yes"/>
+      <point x="260" y="406"/>
+      <point x="447" y="229"/>
+      <point x="760" y="229" type="curve" smooth="yes"/>
+      <point x="1167" y="229"/>
+      <point x="1441" y="522"/>
+      <point x="1441" y="830" type="curve" smooth="yes"/>
+      <point x="1441" y="1074"/>
+      <point x="1254" y="1251"/>
+    </contour>
+    <contour>
+      <point x="1612" y="866" type="curve" smooth="yes"/>
+      <point x="1612" y="439"/>
+      <point x="1233" y="39"/>
+      <point x="727" y="39" type="curve" smooth="yes"/>
+      <point x="336" y="39"/>
+      <point x="89" y="282"/>
+      <point x="89" y="614" type="curve" smooth="yes"/>
+      <point x="89" y="1041"/>
+      <point x="468" y="1441"/>
+      <point x="974" y="1441" type="curve" smooth="yes"/>
+      <point x="1365" y="1441"/>
+      <point x="1612" y="1198"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Italic.ufo/glyphs/uni24C_6.cv29.glif
+++ b/sources/Giphurs-Italic.ufo/glyphs/uni24C_6.cv29.glif
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni24C6.cv29" format="2">
+  <advance width="1720"/>
+  <outline>
+    <contour>
+      <point x="220" y="740" type="curve" smooth="yes"/>
+      <point x="220" y="380"/>
+      <point x="500" y="100"/>
+      <point x="860" y="100" type="curve" smooth="yes"/>
+      <point x="1220" y="100"/>
+      <point x="1500" y="380"/>
+      <point x="1500" y="740" type="curve" smooth="yes"/>
+      <point x="1500" y="1100"/>
+      <point x="1220" y="1380"/>
+      <point x="860" y="1380" type="curve" smooth="yes"/>
+      <point x="500" y="1380"/>
+      <point x="220" y="1100"/>
+    </contour>
+    <contour>
+      <point x="100" y="740" type="curve" smooth="yes"/>
+      <point x="100" y="1160"/>
+      <point x="440" y="1500"/>
+      <point x="860" y="1500" type="curve" smooth="yes"/>
+      <point x="1280" y="1500"/>
+      <point x="1620" y="1160"/>
+      <point x="1620" y="740" type="curve" smooth="yes"/>
+      <point x="1620" y="320"/>
+      <point x="1280" y="-20"/>
+      <point x="860" y="-20" type="curve" smooth="yes"/>
+      <point x="440" y="-20"/>
+      <point x="100" y="320"/>
+    </contour>
+    <contour>
+      <point x="417" y="660" type="curve" smooth="yes"/>
+      <point x="417" y="936"/>
+      <point x="645" y="1181"/>
+      <point x="934" y="1181" type="curve" smooth="yes"/>
+      <point x="1150" y="1181"/>
+      <point x="1298" y="1040"/>
+      <point x="1298" y="831" type="curve" smooth="yes"/>
+      <point x="1298" y="557"/>
+      <point x="1065" y="299"/>
+      <point x="779" y="299" type="curve" smooth="yes"/>
+      <point x="563" y="299"/>
+      <point x="417" y="449"/>
+    </contour>
+    <contour>
+      <point x="800" y="419" type="curve" smooth="yes"/>
+      <point x="1005" y="419"/>
+      <point x="1162" y="613"/>
+      <point x="1162" y="813" type="curve" smooth="yes"/>
+      <point x="1162" y="965"/>
+      <point x="1061" y="1061"/>
+      <point x="913" y="1061" type="curve" smooth="yes"/>
+      <point x="705" y="1061"/>
+      <point x="553" y="878"/>
+      <point x="553" y="677" type="curve" smooth="yes"/>
+      <point x="553" y="524"/>
+      <point x="652" y="419"/>
+    </contour>
+    <contour>
+      <point x="1272" y="299" type="line"/>
+      <point x="779" y="299" type="line"/>
+      <point x="940" y="419" type="line"/>
+      <point x="1293" y="419" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Regular.ufo/features.fea
+++ b/sources/Giphurs-Regular.ufo/features.fea
@@ -4574,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \uni0456 \acutecomb  by \iacute;
     sub \i \acutecomb  by \iacute;
+    sub \uni0456 \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4631,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4719,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5651,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6785,6 +6785,29 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
+
 feature locl {
 
  script cyrl;
@@ -6871,29 +6894,6 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
-
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
 
 feature ss09 {
   featureNames {
@@ -12996,6 +12996,10 @@ lookup mark_Mark_positioning {
 	<anchor 230 1600> mark @top_center;
   pos base [\uni1E3B.cv28 ] <anchor 230 1380> mark @top_center
 	<anchor 230 -220> mark @bottom_center;
+  pos base [\uni051A.cv29 ] <anchor 801 1> mark @bottom_center
+	<anchor 801 1381> mark @top_center;
+  pos base [\uni051B.sc.cv29 ] <anchor 694 1201> mark @top_center
+	<anchor 694 1> mark @bottom_center;
   pos base [\dotlessuni0268 ] <anchor 335 -20> mark @bottom_cedilla
 	<anchor 335 1040> mark @top_center
 	<anchor 335 0> mark @bottom_center

--- a/sources/Giphurs-Regular.ufo/features.fea
+++ b/sources/Giphurs-Regular.ufo/features.fea
@@ -2261,6 +2261,16 @@ lookup cv28_Alternative_small_letter_l {
     sub \uni24A7 by \uni24A7.cv28 ;
 } cv28_Alternative_small_letter_l;
 
+lookup cv29_Alternative_letter_Q {
+  lookupflag 0;
+    sub \Q by \Q.cv29 ;
+    sub \uni051A by \uni051A.cv29 ;
+    sub \uni213A by \uni213A.cv29 ;
+    sub \uni24C6 by \uni24C6.cv29 ;
+    sub \q.sc by \q.sc.cv29 ;
+    sub \uni051B.sc by \uni051B.sc.cv29 ;
+} cv29_Alternative_letter_Q;
+
 lookup ss01_Alternative_digits_set_A {
   lookupflag 0;
     sub \eight by \eight.cv08 ;
@@ -7743,6 +7753,29 @@ feature cv28 {
       lookup cv28_Alternative_small_letter_l;
 } cv28;
 
+feature cv29 {
+
+ script DFLT;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script copt;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script cyrl;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script grek;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script latn;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+} cv29;
+
 feature ss01 {
   featureNames {
     name 3 1 0x409 "Alternative numbers set 1";
@@ -8264,7 +8297,7 @@ feature calt {
 
 lookup kern_Horizontal_kerning {
   lookupflag 0;
-    @kc88_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
+    @kc89_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
 	\Aogonek \Aring \Aringacute \Atilde \Delta \Lambda \backslash \uni01CD 
 	\uni01DE \uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
@@ -8273,12 +8306,12 @@ lookup kern_Horizontal_kerning {
 	\uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F88 \uni1F89 \uni1F8A \uni1F8B 
 	\uni1F8C \uni1F8D \uni1F8E \uni1F8F \uni1FB8 \uni1FB9 \uni1FBA \uni1FBB 
 	\uni1FBC \uni212B \uniA656 ];
-    @kc88_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
+    @kc89_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
 	\uni0412 \uni0417 \uni0432.loclBGR \uni0498 \uni04DE \uni1E02 \uni1E04 
 	\uni1E06 \uni1E9E \uniA7B4 \uniA7B5 ];
-    @kc88_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
+    @kc89_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
 	\uni03FE \uni0421 \uni0464 \uni0480 \uni04AA \uni1E08 \uni2103 \uni216D ];
-    @kc88_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
+    @kc89_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
 	\Gcommaaccent.cv21 \Gdotaccent.cv21 \O \Oacute \Obreve \Ocircumflex 
 	\Odieresis \Ograve \Ohungarumlaut \Omacron \Omicron \Omicrontonos 
 	\Oslash \Oslashacute \Otilde \Theta \uni0189 \uni018A \uni018F 
@@ -8291,46 +8324,46 @@ lookup kern_Horizontal_kerning {
 	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
 	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
 	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
-    @kc88_first_5 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
+    @kc89_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
+	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
+	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
+	\uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA 
+	\uni1FFB \uni1FFC \uni20B2 \uni20B2.ss05 ];
+    @kc89_first_6 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
 	\uni0422 \uni0490 \uni0492 \uni04A4 \uni04AC \uni1E6A \uni1E6C \uni1E6E 
 	\uni1E70 ];
-    @kc88_first_6 = [\Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
-	\uni01E4 \uni03A9 \uni051A \uni1E20 \uni1F68 \uni1F69 \uni1F6A \uni1F6B 
-	\uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 \uni1FA9 \uni1FAA \uni1FAB 
-	\uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA \uni1FFB \uni1FFC \uni20B2 
-	\uni20B2.ss05 ];
-    @kc88_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+    @kc89_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2165 \uni2166 \uni2167 \uni216A \uni216B 
 	\uniA7AE ];
-    @kc88_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
+    @kc89_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc88_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
+    @kc89_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
 	\uniA7AD ];
-    @kc88_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
-    @kc88_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
-    @kc88_first_12 = [\Psi \uni0470 ];
-    @kc88_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
+    @kc89_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
+    @kc89_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
+    @kc89_first_12 = [\Psi \uni0470 ];
+    @kc89_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc88_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
+    @kc89_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
 	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
 	\uni2107 ];
-    @kc88_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
+    @kc89_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
-    @kc88_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
+    @kc89_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
 	\uni2163 \uni2164 \uni2C6F \universal ];
-    @kc88_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_first_19 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
+    @kc89_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_first_19 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
 	\atilde \uni01DF \uni01E1 \uni0201 \uni0203 \uni0227 \uni0430 \uni04D1 
 	\uni04D3 \uni1E01 \uni1EA1 \uni1EA3 \uni1EA5 \uni1EA7 \uni1EA9 \uni1EAB 
 	\uni1EAD \uni1EAF \uni1EB1 \uni1EB3 \uni1EB5 \uni1EB7 \uniA657 ];
-    @kc88_first_20 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 
+    @kc89_first_20 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 
 	\agrave.cv23 \amacron.cv23 \aogonek.cv23 \aring.cv23 
 	\aringacute.cv23 \atilde.cv23 \u \u.cv25 \uacute \uacute.cv25 \ubreve 
 	\ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
@@ -8351,7 +8384,7 @@ lookup kern_Horizontal_kerning {
 	\uni1EE7 \uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 
 	\uni1EED \uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 
 	\uogonek \uogonek.cv25 \uring \uring.cv25 \utilde \utilde.cv25 ];
-    @kc88_first_21 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
+    @kc89_first_21 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
 	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
 	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
 	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
@@ -8364,7 +8397,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
 	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
 	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
-    @kc88_first_22 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_first_22 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8418,7 +8451,7 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_first_23 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
+    @kc89_first_23 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
 	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
@@ -8431,28 +8464,28 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
-    @kc88_first_24 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
+    @kc89_first_24 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
 	\uni1FB7 \uni2C65 ];
-    @kc88_first_25 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_first_25 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_first_26 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
+    @kc89_first_26 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
 	\uni0253 \uni029A \uni03F1 \uni03F8 \uni0440 \uni0444 \uni1E03 \uni1E05 
 	\uni1E07 \uni1E55 \uni1E57 \uni20AF \uni2114 \uniA64D ];
-    @kc88_first_27 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
+    @kc89_first_27 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
 	\uni1E05.sc \uni1E07.sc \uniA7B5.sc ];
-    @kc88_first_28 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
+    @kc89_first_28 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
 	\uni0188 \uni023C \uni0255 \uni0297 \uni03F2 \uni03F5 \uni0441 \uni0454 
 	\uni0465 \uni04AB \uni1E09 \uni217D ];
-    @kc88_first_29 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
+    @kc89_first_29 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
 	\uni037C.sc \uni03F2.sc \uni0441.sc \uni0454.sc \uni0465.sc 
 	\uni0481.sc \uni1E09.sc ];
-    @kc88_first_30 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+    @kc89_first_30 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8508,14 +8541,14 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_first_31 = [\chi ];
-    @kc88_first_32 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
+    @kc89_first_31 = [\chi ];
+    @kc89_first_32 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
 	\uni0436.sc \uni0445.sc \uni0497.sc \uni049B.sc \uni049D.sc 
 	\uni049F.sc \uni04A1.sc \uni04B3.sc \uni04C2.sc \uni04DD.sc 
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc88_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
+    @kc89_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
 	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
 	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
@@ -8527,7 +8560,7 @@ lookup kern_Horizontal_kerning {
 	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
 	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
 	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
-    @kc88_first_34 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_first_34 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8537,7 +8570,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2175.sc 
 	\uni2176.sc \uni2177.sc \uni217A.sc \uni217B.sc ];
-    @kc88_first_35 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
+    @kc89_first_35 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
 	\eight.cv18.numr \eight.cv18.numr.pnum \eight.cv18.numr.tnum 
 	\eight.numr \eight.numr.pnum \eight.numr.tnum \five.cv05.numr 
 	\five.cv05.numr.pnum \five.cv05.numr.tnum \five.cv15.numr 
@@ -8575,146 +8608,146 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.numr.tnum \zero.numr \zero.numr.pnum 
 	\zero.numr.tnum \zero.zero.numr \zero.zero.numr.pnum 
 	\zero.zero.numr.tnum ];
-    @kc88_first_36 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
+    @kc89_first_36 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
 	\uni1F26 \uni1F27 \uni1F74 \uni1F75 \uni1F90 \uni1F91 \uni1F92 \uni1F93 
 	\uni1F94 \uni1F95 \uni1F96 \uni1F97 \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 
 	\uni1FC7 ];
-    @kc88_first_37 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_first_37 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0437 \uni0455 
 	\uni0479 \uni0499 \uni04DF \uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
-    @kc88_first_38 = [\eth \uni1EFC \uni1EFD ];
-    @kc88_first_39 = [\fraction ];
-    @kc88_first_40 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc88_first_41 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \uni0260.sc \uni051B.sc \uni1F60.sc \uni1F61.sc 
-	\uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc 
-	\uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc \uni1FA1.sc 
-	\uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc 
-	\uni1FF7.sc ];
-    @kc88_first_42 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc89_first_38 = [\eth \uni1EFC \uni1EFD ];
+    @kc89_first_39 = [\fraction ];
+    @kc89_first_40 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
+    @kc89_first_41 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
+	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
+	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
+	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
+    @kc89_first_42 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc88_first_43 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_first_43 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc88_first_44 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc89_first_44 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc88_first_45 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc89_first_45 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc88_first_46 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc89_first_46 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc88_first_47 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
+    @kc89_first_47 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
 	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc88_first_48 = [\lambda \uni019B ];
-    @kc88_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc88_first_50 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc89_first_48 = [\lambda \uni019B ];
+    @kc89_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc89_first_50 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc88_first_51 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc88_first_52 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc88_first_53 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc89_first_51 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc89_first_52 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc89_first_53 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc88_first_54 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc88_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc88_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc89_first_54 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc89_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc89_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc88_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc88_first_59 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+    @kc89_first_59 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
 	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_first_60 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+    @kc89_first_60 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
 	\uni1E71 ];
-    @kc88_first_61 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
-    @kc88_first_62 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc88_first_63 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc88_first_64 = [\uni0196 \uni01AA ];
-    @kc88_first_65 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_first_61 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
+    @kc89_first_62 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
+    @kc89_first_63 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc89_first_64 = [\uni0196 \uni01AA ];
+    @kc89_first_65 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
 	\ygrave ];
-    @kc88_first_66 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_first_66 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_first_67 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
+    @kc89_first_67 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
 	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
 	\zdotaccent ];
-    @kc88_first_68 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
+    @kc89_first_68 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
-    @kc88_first_69 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
+    @kc89_first_69 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
 	\uni052D \uni052F ];
-    @kc88_first_70 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
+    @kc89_first_70 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
 	\uni04B7.sc \uni04C6.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
 	\uni0525.sc \uni052F.sc ];
-    @kc88_first_71 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
-    @kc88_first_72 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
-    @kc88_first_73 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_first_71 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
+    @kc89_first_72 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
+    @kc89_first_73 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
+    @kc89_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
 	\Aring \Aringacute \Atilde \Delta \Lambda \slash \uni01CD \uni01DE 
 	\uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
 	\uni1EA0 \uni1EA2 \uni1EA4 \uni1EA6 \uni1EA8 \uni1EAA \uni1EAC \uni1EAE 
 	\uni1EB0 \uni1EB2 \uni1EB4 \uni1EB6 \uni1FB8 \uni1FB9 \uni1FBC \uni212B ];
-    @kc88_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
-    @kc88_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
+    @kc89_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
+    @kc89_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
 	\Gbreve \Gbreve.cv21 \Gcaron \Gcaron.cv21 \Gcircumflex 
 	\Gcircumflex.cv21 \Gcommaaccent \Gcommaaccent.cv21 \Gdotaccent 
 	\Gdotaccent.cv21 \O \OE \Oacute \Obreve \Ocircumflex \Odieresis \Ograve 
 	\Ohorn \Ohungarumlaut \Omacron \Omicron \Omicrontonos \Oslash 
-	\Oslashacute \Otilde \Q \Theta \colonmonetary \emptyset \uni0187 
-	\uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
+	\Oslashacute \Otilde \Q \Q.cv29 \Theta \colonmonetary \emptyset 
+	\uni0187 \uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
 	\uni01E4.cv21 \uni01EA \uni01EC \uni01F4 \uni01F4.cv21 \uni020C 
 	\uni020E \uni022A \uni022C \uni022E \uni0230 \uni023B \uni024A \uni0298 
 	\uni03D8 \uni03F4 \uni03FE \uni0404 \uni041E \uni0421 \uni0472 \uni047A 
 	\uni0480 \uni04AA \uni04BC \uni04BE \uni04D8 \uni04DA \uni04E6 \uni04E8 
-	\uni04EA \uni050C \uni051A \uni1E08 \uni1E20 \uni1E20.cv21 \uni1E4C 
-	\uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE \uni1ED0 \uni1ED2 \uni1ED4 
-	\uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE \uni1EE0 \uni1EE2 \uni20A2 
-	\uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE \uni216D \uni2180 \uni2182 
-	\uni2185 ];
-    @kc88_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
-    @kc88_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+	\uni04EA \uni050C \uni051A \uni051A.cv29 \uni1E08 \uni1E20 
+	\uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE 
+	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
+	\uni1EE0 \uni1EE2 \uni20A2 \uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE 
+	\uni216D \uni2180 \uni2182 \uni2185 ];
+    @kc89_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
+    @kc89_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
-    @kc88_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc88_second_7 = [\Omega \uni03A9 \uni1FFC ];
-    @kc88_second_8 = [\Phi \uni0424 ];
-    @kc88_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc88_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
+    @kc89_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
+    @kc89_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc89_second_8 = [\Phi \uni0424 ];
+    @kc89_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
+    @kc89_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
 	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc88_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
+    @kc89_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
 	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc88_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
+    @kc89_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
 	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
-    @kc88_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
+    @kc89_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
 	\uni2166 \uni2167 \uni2C6F \universal ];
-    @kc88_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
+    @kc89_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
 	\uni04FE \uni1E8A \uni1E8C \uni2169 \uni216A \uni216B ];
-    @kc88_second_17 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
+    @kc89_second_17 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
 	\atilde \uni01DF \uni01E1 \uni0201 \uni0203 \uni0227 \uni0430 \uni04D1 
 	\uni04D3 \uni1E01 \uni1EA1 \uni1EA3 \uni1EA5 \uni1EA7 \uni1EA9 \uni1EAB 
 	\uni1EAD \uni1EAF \uni1EB1 \uni1EB3 \uni1EB5 \uni1EB7 ];
-    @kc88_second_18 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 \ae.cv23 
+    @kc89_second_18 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 \ae.cv23 
 	\aeacute.cv23 \agrave.cv23 \alpha \alphatonos \amacron.cv23 
 	\aogonek.cv23 \aring.cv23 \aringacute.cv23 \atilde.cv23 \d \dcaron 
 	\dcroat \dong \eth \g.cv24 \gbreve.cv24 \gcaron.cv24 \gcircumflex.cv24 
@@ -8731,7 +8764,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 
 	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 
 	\uni1FB4 \uni1FB6 \uni1FB7 \uni217E \uniA64D \uniA7C8 ];
-    @kc88_second_19 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
+    @kc89_second_19 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
 	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
 	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
 	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
@@ -8744,7 +8777,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
 	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
 	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
-    @kc88_second_20 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_second_20 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8798,16 +8831,16 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_second_21 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
-    @kc88_second_22 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_second_21 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
+    @kc89_second_22 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_second_23 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
+    @kc89_second_23 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
 	\uniA7B4 \uniA7B5 ];
-    @kc88_second_24 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
+    @kc89_second_24 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
@@ -8821,25 +8854,26 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
-    @kc88_second_25 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
+    @kc89_second_25 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
 	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
 	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc 
-	\uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc 
-	\uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc 
-	\uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc 
-	\uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc 
-	\uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc 
-	\uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc 
-	\uni050D.sc \uni051B.sc \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
-	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
-	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc ];
-    @kc88_second_26 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+	\q.sc \q.sc.cv29 \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc 
+	\uni01E5.sc \uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc 
+	\uni020F.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc 
+	\uni023C.sc \uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc 
+	\uni037C.sc \uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc 
+	\uni0444.loclBGR.sc \uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc 
+	\uni04AB.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni050D.sc \uni051B.sc \uni051B.sc.cv29 \uni1E09.sc 
+	\uni1E21.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc 
+	\uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc 
+	\uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc 
+	\uni217D.sc ];
+    @kc89_second_26 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8895,11 +8929,11 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_second_27 = [\chi \gamma \uni04AF \uni04B1 ];
-    @kc88_second_28 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
+    @kc89_second_27 = [\chi \gamma \uni04AF \uni04B1 ];
+    @kc89_second_28 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
 	\uni04DD.sc \uni04FD.sc \uni04FF.sc \uni1E8B.sc \uni1E8D.sc 
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
-    @kc88_second_29 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_second_29 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8909,7 +8943,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
 	\uni2178.sc ];
-    @kc88_second_30 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
+    @kc89_second_30 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
 	\five.cv05.dnom.pnum \five.cv05.dnom.tnum \five.cv15.dnom 
@@ -8945,12 +8979,12 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.dnom.tnum \zero.cv20.zero.dnom 
 	\zero.cv20.zero.dnom.tnum \zero.dnom \zero.dnom.tnum 
 	\zero.zero.dnom \zero.zero.dnom.tnum ];
-    @kc88_second_31 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_second_31 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0437 \uni0455 
 	\uni0479 \uni0499 \uni04DF \uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
-    @kc88_second_32 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
+    @kc89_second_32 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
 	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
 	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
 	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
@@ -8974,1734 +9008,1735 @@ lookup kern_Horizontal_kerning {
 	\uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 \upsilon 
 	\upsilondieresistonos \upsilontonos \uring \uring.cv25 \utilde 
 	\utilde.cv25 ];
-    @kc88_second_33 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
+    @kc89_second_33 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
 	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc88_second_34 = [\fraction ];
-    @kc88_second_35 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \uni01E5 \uni1E21 ];
-    @kc88_second_36 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc88_second_37 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+    @kc89_second_34 = [\fraction ];
+    @kc89_second_35 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \uni01E5 \uni1E21 ];
+    @kc89_second_36 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc89_second_37 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc88_second_38 = [\lambda \uni019B ];
-    @kc88_second_39 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc89_second_38 = [\lambda \uni019B ];
+    @kc89_second_39 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc88_second_40 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+    @kc89_second_40 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
 	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
 	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
 	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
 	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc88_second_41 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_second_42 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
-    @kc88_second_43 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc89_second_41 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_second_42 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
+    @kc89_second_43 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc88_second_44 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_second_44 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc88_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc89_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_second_46 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_second_46 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
 	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
 	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc88_second_47 = [\theta \uni0478 \uniA64C ];
-    @kc88_second_48 = [\tonos2 ];
-    @kc88_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc88_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_second_47 = [\theta \uni0478 \uniA64C ];
+    @kc89_second_48 = [\tonos2 ];
+    @kc89_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc89_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc88_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_second_52 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
+    @kc89_second_52 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
 	\z \zacute \zcaron \zdotaccent ];
-    @kc88_second_53 = [\uni0237 ];
-    @kc88_second_54 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc88_second_55 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc88_second_56 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc88_second_57 = [\uni042F \uni0518 ];
-    @kc88_second_58 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
+    @kc89_second_53 = [\uni0237 ];
+    @kc89_second_54 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc89_second_55 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc89_second_56 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc89_second_57 = [\uni042F \uni0518 ];
+    @kc89_second_58 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
 	\uni052F ];
-    @kc88_second_59 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc89_second_59 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc88_second_60 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc89_second_60 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc88_second_61 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc88_second_62 = [\uni044F.sc \uni0519.sc ];
-    @kc88_second_63 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc89_second_61 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc89_second_62 = [\uni044F.sc \uni0519.sc ];
+    @kc89_second_63 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc88_second_64 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc88_second_65 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_second_64 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc89_second_65 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_66 = [\uni0500 \uni0502 ];
-    @kc88_second_67 = [\uni0501.sc \uni0503.sc ];
-    @kc88_second_68 = [\zero.cv10.zero.dnom.pnum \zero.cv20.zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc88_second_69 = [\zero.cv10.zero.numr.pnum \zero.cv20.zero.numr.pnum \zero.zero.numr.pnum ];
-    pos @kc88_first_1 @kc88_second_3 -70;
-    pos @kc88_first_1 @kc88_second_8 -70;
-    pos @kc88_first_1 @kc88_second_9 -140;
-    pos @kc88_first_1 @kc88_second_10 -35;
-    pos @kc88_first_1 @kc88_second_12 -280;
-    pos @kc88_first_1 @kc88_second_13 -280;
-    pos @kc88_first_1 @kc88_second_14 -280;
-    pos @kc88_first_1 @kc88_second_15 -210;
-    pos @kc88_first_1 @kc88_second_22 -70;
-    pos @kc88_first_1 @kc88_second_25 -35;
-    pos @kc88_first_1 @kc88_second_27 -50;
-    pos @kc88_first_1 @kc88_second_33 -70;
-    pos @kc88_first_1 @kc88_second_41 -35;
-    pos @kc88_first_1 @kc88_second_42 -140;
-    pos @kc88_first_1 @kc88_second_43 -105;
-    pos @kc88_first_1 @kc88_second_46 -210;
-    pos @kc88_first_1 @kc88_second_47 -35;
-    pos @kc88_first_1 @kc88_second_48 1;
-    pos @kc88_first_1 @kc88_second_50 -175;
-    pos @kc88_first_1 @kc88_second_51 -210;
-    pos @kc88_first_1 @kc88_second_61 -140;
-    pos @kc88_first_1 @kc88_second_63 -140;
-    pos @kc88_first_1 @kc88_second_64 -210;
-    pos @kc88_first_1 @kc88_second_65 -140;
-    pos @kc88_first_2 @kc88_second_9 -35;
-    pos @kc88_first_2 @kc88_second_12 -70;
-    pos @kc88_first_2 @kc88_second_13 -70;
-    pos @kc88_first_2 @kc88_second_14 -70;
-    pos @kc88_first_2 @kc88_second_15 -35;
-    pos @kc88_first_2 @kc88_second_16 -35;
-    pos @kc88_first_2 @kc88_second_42 -35;
-    pos @kc88_first_2 @kc88_second_48 1;
-    pos @kc88_first_3 @kc88_second_1 -35;
-    pos @kc88_first_3 @kc88_second_2 -70;
-    pos @kc88_first_3 @kc88_second_5 -35;
-    pos @kc88_first_3 @kc88_second_11 -35;
-    pos @kc88_first_3 @kc88_second_12 -35;
-    pos @kc88_first_3 @kc88_second_13 -70;
-    pos @kc88_first_3 @kc88_second_14 -35;
-    pos @kc88_first_3 @kc88_second_16 -70;
-    pos @kc88_first_3 @kc88_second_19 -35;
-    pos @kc88_first_3 @kc88_second_21 -70;
-    pos @kc88_first_3 @kc88_second_38 -35;
-    pos @kc88_first_3 @kc88_second_48 1;
-    pos @kc88_first_4 @kc88_second_1 -70;
-    pos @kc88_first_4 @kc88_second_2 -140;
-    pos @kc88_first_4 @kc88_second_4 70;
-    pos @kc88_first_4 @kc88_second_5 -70;
-    pos @kc88_first_4 @kc88_second_11 -105;
-    pos @kc88_first_4 @kc88_second_12 -140;
-    pos @kc88_first_4 @kc88_second_13 -140;
-    pos @kc88_first_4 @kc88_second_14 -105;
-    pos @kc88_first_4 @kc88_second_15 -35;
-    pos @kc88_first_4 @kc88_second_16 -140;
-    pos @kc88_first_4 @kc88_second_19 -70;
-    pos @kc88_first_4 @kc88_second_26 -70;
-    pos @kc88_first_4 @kc88_second_28 -70;
-    pos @kc88_first_4 @kc88_second_29 -35;
-    pos @kc88_first_4 @kc88_second_33 35;
-    pos @kc88_first_4 @kc88_second_35 -35;
-    pos @kc88_first_4 @kc88_second_37 -70;
-    pos @kc88_first_4 @kc88_second_38 -70;
-    pos @kc88_first_4 @kc88_second_46 -35;
-    pos @kc88_first_4 @kc88_second_48 1;
-    pos @kc88_first_4 @kc88_second_51 -70;
-    pos @kc88_first_4 @kc88_second_56 -70;
-    pos @kc88_first_4 @kc88_second_58 -70;
-    pos @kc88_first_4 @kc88_second_59 -70;
-    pos @kc88_first_4 @kc88_second_64 -35;
-    pos @kc88_first_5 @kc88_second_1 -280;
-    pos @kc88_first_5 @kc88_second_2 -350;
-    pos @kc88_first_5 @kc88_second_3 -140;
-    pos @kc88_first_5 @kc88_second_4 -70;
-    pos @kc88_first_5 @kc88_second_6 -350;
-    pos @kc88_first_5 @kc88_second_7 -140;
-    pos @kc88_first_5 @kc88_second_8 -210;
-    pos @kc88_first_5 @kc88_second_10 -70;
-    pos @kc88_first_5 @kc88_second_17 -240;
-    pos @kc88_first_5 @kc88_second_18 -240;
-    pos @kc88_first_5 @kc88_second_19 -280;
-    pos @kc88_first_5 @kc88_second_21 -350;
-    pos @kc88_first_5 @kc88_second_22 -280;
-    pos @kc88_first_5 @kc88_second_23 -240;
-    pos @kc88_first_5 @kc88_second_24 -240;
-    pos @kc88_first_5 @kc88_second_25 -210;
-    pos @kc88_first_5 @kc88_second_26 -350;
-    pos @kc88_first_5 @kc88_second_27 -140;
-    pos @kc88_first_5 @kc88_second_29 -140;
-    pos @kc88_first_5 @kc88_second_31 -240;
-    pos @kc88_first_5 @kc88_second_32 -240;
-    pos @kc88_first_5 @kc88_second_33 -175;
-    pos @kc88_first_5 @kc88_second_35 -240;
-    pos @kc88_first_5 @kc88_second_37 -350;
-    pos @kc88_first_5 @kc88_second_38 -105;
-    pos @kc88_first_5 @kc88_second_39 -240;
-    pos @kc88_first_5 @kc88_second_40 -210;
-    pos @kc88_first_5 @kc88_second_41 -240;
-    pos @kc88_first_5 @kc88_second_42 -240;
-    pos @kc88_first_5 @kc88_second_44 -240;
-    pos @kc88_first_5 @kc88_second_47 -140;
-    pos @kc88_first_5 @kc88_second_48 1;
-    pos @kc88_first_5 @kc88_second_49 -35;
-    pos @kc88_first_5 @kc88_second_50 -240;
-    pos @kc88_first_5 @kc88_second_52 -240;
-    pos @kc88_first_5 @kc88_second_53 -240;
-    pos @kc88_first_5 @kc88_second_54 -240;
-    pos @kc88_first_5 @kc88_second_55 -240;
-    pos @kc88_first_5 @kc88_second_56 -280;
-    pos @kc88_first_5 @kc88_second_57 -70;
-    pos @kc88_first_5 @kc88_second_58 -280;
-    pos @kc88_first_5 @kc88_second_59 -240;
-    pos @kc88_first_5 @kc88_second_60 -175;
-    pos @kc88_first_5 @kc88_second_61 -240;
-    pos @kc88_first_5 @kc88_second_62 -210;
-    pos @kc88_first_5 @kc88_second_63 -175;
-    pos @kc88_first_5 @kc88_second_66 -175;
-    pos @kc88_first_5 @kc88_second_67 -175;
-    pos @kc88_first_6 @kc88_second_48 1;
-    pos @kc88_first_7 @kc88_second_3 -70;
-    pos @kc88_first_7 @kc88_second_8 -105;
-    pos @kc88_first_7 @kc88_second_17 -35;
-    pos @kc88_first_7 @kc88_second_18 -70;
-    pos @kc88_first_7 @kc88_second_22 -105;
-    pos @kc88_first_7 @kc88_second_24 -105;
-    pos @kc88_first_7 @kc88_second_25 -70;
-    pos @kc88_first_7 @kc88_second_48 1;
-    pos @kc88_first_7 @kc88_second_49 -35;
-    pos @kc88_first_7 @kc88_second_50 -70;
-    pos @kc88_first_7 @kc88_second_54 -50;
-    pos @kc88_first_7 @kc88_second_63 -35;
-    pos @kc88_first_7 @kc88_second_66 -70;
-    pos @kc88_first_7 @kc88_second_67 -70;
-    pos @kc88_first_8 @kc88_second_3 -140;
-    pos @kc88_first_8 @kc88_second_4 -70;
-    pos @kc88_first_8 @kc88_second_6 -70;
-    pos @kc88_first_8 @kc88_second_8 -140;
-    pos @kc88_first_8 @kc88_second_10 -35;
-    pos @kc88_first_8 @kc88_second_17 -70;
-    pos @kc88_first_8 @kc88_second_18 -70;
-    pos @kc88_first_8 @kc88_second_22 -140;
-    pos @kc88_first_8 @kc88_second_24 -70;
-    pos @kc88_first_8 @kc88_second_25 -105;
-    pos @kc88_first_8 @kc88_second_27 -140;
-    pos @kc88_first_8 @kc88_second_31 -35;
-    pos @kc88_first_8 @kc88_second_33 -105;
-    pos @kc88_first_8 @kc88_second_37 -70;
-    pos @kc88_first_8 @kc88_second_39 -70;
-    pos @kc88_first_8 @kc88_second_41 -105;
-    pos @kc88_first_8 @kc88_second_42 -175;
-    pos @kc88_first_8 @kc88_second_43 -140;
-    pos @kc88_first_8 @kc88_second_44 -35;
-    pos @kc88_first_8 @kc88_second_46 -140;
-    pos @kc88_first_8 @kc88_second_47 -105;
-    pos @kc88_first_8 @kc88_second_48 1;
-    pos @kc88_first_8 @kc88_second_49 -70;
-    pos @kc88_first_8 @kc88_second_50 -140;
-    pos @kc88_first_8 @kc88_second_51 -70;
-    pos @kc88_first_8 @kc88_second_54 -35;
-    pos @kc88_first_8 @kc88_second_55 -35;
-    pos @kc88_first_8 @kc88_second_61 -210;
-    pos @kc88_first_8 @kc88_second_63 -105;
-    pos @kc88_first_8 @kc88_second_64 -70;
-    pos @kc88_first_8 @kc88_second_65 -35;
-    pos @kc88_first_8 @kc88_second_66 -70;
-    pos @kc88_first_8 @kc88_second_67 -35;
-    pos @kc88_first_9 @kc88_second_3 -140;
-    pos @kc88_first_9 @kc88_second_4 -70;
-    pos @kc88_first_9 @kc88_second_6 -70;
-    pos @kc88_first_9 @kc88_second_8 -210;
-    pos @kc88_first_9 @kc88_second_9 -420;
-    pos @kc88_first_9 @kc88_second_10 -70;
-    pos @kc88_first_9 @kc88_second_12 -350;
-    pos @kc88_first_9 @kc88_second_13 -420;
-    pos @kc88_first_9 @kc88_second_14 -350;
-    pos @kc88_first_9 @kc88_second_15 -280;
-    pos @kc88_first_9 @kc88_second_17 -70;
-    pos @kc88_first_9 @kc88_second_18 -70;
-    pos @kc88_first_9 @kc88_second_20 -210;
-    pos @kc88_first_9 @kc88_second_22 -210;
-    pos @kc88_first_9 @kc88_second_24 -70;
-    pos @kc88_first_9 @kc88_second_25 -140;
-    pos @kc88_first_9 @kc88_second_31 -50;
-    pos @kc88_first_9 @kc88_second_33 -140;
-    pos @kc88_first_9 @kc88_second_37 -70;
-    pos @kc88_first_9 @kc88_second_41 -105;
-    pos @kc88_first_9 @kc88_second_42 -280;
-    pos @kc88_first_9 @kc88_second_43 -350;
-    pos @kc88_first_9 @kc88_second_44 -50;
-    pos @kc88_first_9 @kc88_second_46 -350;
-    pos @kc88_first_9 @kc88_second_48 1;
-    pos @kc88_first_9 @kc88_second_49 -35;
-    pos @kc88_first_9 @kc88_second_50 -210;
-    pos @kc88_first_9 @kc88_second_51 -350;
-    pos @kc88_first_9 @kc88_second_54 -35;
-    pos @kc88_first_9 @kc88_second_55 -35;
-    pos @kc88_first_9 @kc88_second_61 -280;
-    pos @kc88_first_9 @kc88_second_63 -175;
-    pos @kc88_first_9 @kc88_second_64 -280;
-    pos @kc88_first_9 @kc88_second_65 -210;
-    pos @kc88_first_9 @kc88_second_66 -70;
-    pos @kc88_first_9 @kc88_second_67 -70;
-    pos @kc88_first_10 @kc88_second_1 -210;
-    pos @kc88_first_10 @kc88_second_2 -350;
-    pos @kc88_first_10 @kc88_second_5 -70;
-    pos @kc88_first_10 @kc88_second_6 -140;
-    pos @kc88_first_10 @kc88_second_11 -35;
-    pos @kc88_first_10 @kc88_second_12 -70;
-    pos @kc88_first_10 @kc88_second_13 -70;
-    pos @kc88_first_10 @kc88_second_14 -35;
-    pos @kc88_first_10 @kc88_second_16 -70;
-    pos @kc88_first_10 @kc88_second_17 -35;
-    pos @kc88_first_10 @kc88_second_18 -70;
-    pos @kc88_first_10 @kc88_second_19 -140;
-    pos @kc88_first_10 @kc88_second_21 -280;
-    pos @kc88_first_10 @kc88_second_24 -70;
-    pos @kc88_first_10 @kc88_second_26 -350;
-    pos @kc88_first_10 @kc88_second_31 -70;
-    pos @kc88_first_10 @kc88_second_34 -140;
-    pos @kc88_first_10 @kc88_second_35 -70;
-    pos @kc88_first_10 @kc88_second_37 -210;
-    pos @kc88_first_10 @kc88_second_38 -105;
-    pos @kc88_first_10 @kc88_second_41 -70;
-    pos @kc88_first_10 @kc88_second_48 1;
-    pos @kc88_first_10 @kc88_second_56 -210;
-    pos @kc88_first_10 @kc88_second_58 -210;
-    pos @kc88_first_10 @kc88_second_59 -210;
-    pos @kc88_first_10 @kc88_second_64 -70;
-    pos @kc88_first_10 @kc88_second_66 -70;
-    pos @kc88_first_10 @kc88_second_67 -105;
-    pos @kc88_first_11 @kc88_second_1 -70;
-    pos @kc88_first_11 @kc88_second_2 -140;
-    pos @kc88_first_11 @kc88_second_5 -105;
-    pos @kc88_first_11 @kc88_second_6 -35;
-    pos @kc88_first_11 @kc88_second_11 -70;
-    pos @kc88_first_11 @kc88_second_12 -210;
-    pos @kc88_first_11 @kc88_second_13 -175;
-    pos @kc88_first_11 @kc88_second_14 -105;
-    pos @kc88_first_11 @kc88_second_15 -70;
-    pos @kc88_first_11 @kc88_second_16 -140;
-    pos @kc88_first_11 @kc88_second_19 -70;
-    pos @kc88_first_11 @kc88_second_21 -140;
-    pos @kc88_first_11 @kc88_second_26 -70;
-    pos @kc88_first_11 @kc88_second_28 -70;
-    pos @kc88_first_11 @kc88_second_29 -70;
-    pos @kc88_first_11 @kc88_second_35 -35;
-    pos @kc88_first_11 @kc88_second_37 -35;
-    pos @kc88_first_11 @kc88_second_38 -140;
-    pos @kc88_first_11 @kc88_second_42 -70;
-    pos @kc88_first_11 @kc88_second_45 -35;
-    pos @kc88_first_11 @kc88_second_46 -35;
-    pos @kc88_first_11 @kc88_second_48 1;
-    pos @kc88_first_11 @kc88_second_51 -70;
-    pos @kc88_first_11 @kc88_second_56 -210;
-    pos @kc88_first_11 @kc88_second_58 -175;
-    pos @kc88_first_11 @kc88_second_59 -175;
-    pos @kc88_first_11 @kc88_second_60 -35;
-    pos @kc88_first_11 @kc88_second_64 -70;
-    pos @kc88_first_11 @kc88_second_65 -35;
-    pos @kc88_first_11 @kc88_second_66 -35;
-    pos @kc88_first_11 @kc88_second_67 -70;
-    pos @kc88_first_12 @kc88_second_1 -140;
-    pos @kc88_first_12 @kc88_second_2 -210;
-    pos @kc88_first_12 @kc88_second_6 -140;
-    pos @kc88_first_12 @kc88_second_17 -70;
-    pos @kc88_first_12 @kc88_second_18 -70;
-    pos @kc88_first_12 @kc88_second_19 -140;
-    pos @kc88_first_12 @kc88_second_21 -210;
-    pos @kc88_first_12 @kc88_second_24 -70;
-    pos @kc88_first_12 @kc88_second_26 -350;
-    pos @kc88_first_12 @kc88_second_31 -35;
-    pos @kc88_first_12 @kc88_second_34 -140;
-    pos @kc88_first_12 @kc88_second_35 -70;
-    pos @kc88_first_12 @kc88_second_37 -140;
-    pos @kc88_first_12 @kc88_second_38 -70;
-    pos @kc88_first_12 @kc88_second_41 -70;
-    pos @kc88_first_12 @kc88_second_48 1;
-    pos @kc88_first_12 @kc88_second_54 -35;
-    pos @kc88_first_12 @kc88_second_56 -210;
-    pos @kc88_first_12 @kc88_second_58 -210;
-    pos @kc88_first_12 @kc88_second_59 -210;
-    pos @kc88_first_12 @kc88_second_66 -70;
-    pos @kc88_first_12 @kc88_second_67 -105;
-    pos @kc88_first_13 @kc88_second_6 -70;
-    pos @kc88_first_13 @kc88_second_12 -70;
-    pos @kc88_first_13 @kc88_second_13 -105;
-    pos @kc88_first_13 @kc88_second_14 -35;
-    pos @kc88_first_13 @kc88_second_18 -35;
-    pos @kc88_first_13 @kc88_second_24 -35;
-    pos @kc88_first_13 @kc88_second_31 -35;
-    pos @kc88_first_13 @kc88_second_37 -70;
-    pos @kc88_first_13 @kc88_second_41 -70;
-    pos @kc88_first_13 @kc88_second_48 1;
-    pos @kc88_first_13 @kc88_second_66 -70;
-    pos @kc88_first_13 @kc88_second_67 -35;
-    pos @kc88_first_14 @kc88_second_2 -35;
-    pos @kc88_first_14 @kc88_second_11 -35;
-    pos @kc88_first_14 @kc88_second_12 -70;
-    pos @kc88_first_14 @kc88_second_13 -70;
-    pos @kc88_first_14 @kc88_second_14 -35;
-    pos @kc88_first_14 @kc88_second_16 -35;
-    pos @kc88_first_14 @kc88_second_21 -35;
-    pos @kc88_first_14 @kc88_second_27 -35;
-    pos @kc88_first_14 @kc88_second_35 -35;
-    pos @kc88_first_14 @kc88_second_42 -70;
-    pos @kc88_first_14 @kc88_second_48 1;
-    pos @kc88_first_14 @kc88_second_50 -70;
-    pos @kc88_first_14 @kc88_second_51 -35;
-    pos @kc88_first_14 @kc88_second_60 -35;
-    pos @kc88_first_14 @kc88_second_61 -35;
-    pos @kc88_first_14 @kc88_second_63 -35;
-    pos @kc88_first_14 @kc88_second_65 -35;
-    pos @kc88_first_15 @kc88_second_3 -70;
-    pos @kc88_first_15 @kc88_second_4 -70;
-    pos @kc88_first_15 @kc88_second_6 -35;
-    pos @kc88_first_15 @kc88_second_8 -70;
-    pos @kc88_first_15 @kc88_second_17 -70;
-    pos @kc88_first_15 @kc88_second_18 -70;
-    pos @kc88_first_15 @kc88_second_22 -140;
-    pos @kc88_first_15 @kc88_second_24 -70;
-    pos @kc88_first_15 @kc88_second_25 -70;
-    pos @kc88_first_15 @kc88_second_27 -70;
-    pos @kc88_first_15 @kc88_second_31 -35;
-    pos @kc88_first_15 @kc88_second_33 -35;
-    pos @kc88_first_15 @kc88_second_39 -35;
-    pos @kc88_first_15 @kc88_second_41 -70;
-    pos @kc88_first_15 @kc88_second_42 -142;
-    pos @kc88_first_15 @kc88_second_43 -35;
-    pos @kc88_first_15 @kc88_second_47 -35;
-    pos @kc88_first_15 @kc88_second_48 1;
-    pos @kc88_first_15 @kc88_second_49 -35;
-    pos @kc88_first_15 @kc88_second_50 -70;
-    pos @kc88_first_15 @kc88_second_54 -35;
-    pos @kc88_first_15 @kc88_second_55 -35;
-    pos @kc88_first_15 @kc88_second_61 -105;
-    pos @kc88_first_15 @kc88_second_63 -35;
-    pos @kc88_first_15 @kc88_second_66 -35;
-    pos @kc88_first_15 @kc88_second_67 -35;
-    pos @kc88_first_16 @kc88_second_1 -280;
-    pos @kc88_first_16 @kc88_second_2 -280;
-    pos @kc88_first_16 @kc88_second_3 -140;
-    pos @kc88_first_16 @kc88_second_4 -70;
-    pos @kc88_first_16 @kc88_second_6 -280;
-    pos @kc88_first_16 @kc88_second_7 -140;
-    pos @kc88_first_16 @kc88_second_8 -175;
-    pos @kc88_first_16 @kc88_second_10 -70;
-    pos @kc88_first_16 @kc88_second_17 -245;
-    pos @kc88_first_16 @kc88_second_18 -280;
-    pos @kc88_first_16 @kc88_second_19 -280;
-    pos @kc88_first_16 @kc88_second_21 -280;
-    pos @kc88_first_16 @kc88_second_22 -210;
-    pos @kc88_first_16 @kc88_second_23 -140;
-    pos @kc88_first_16 @kc88_second_24 -280;
-    pos @kc88_first_16 @kc88_second_25 -210;
-    pos @kc88_first_16 @kc88_second_26 -350;
-    pos @kc88_first_16 @kc88_second_27 -70;
-    pos @kc88_first_16 @kc88_second_29 -140;
-    pos @kc88_first_16 @kc88_second_31 -240;
-    pos @kc88_first_16 @kc88_second_32 -140;
-    pos @kc88_first_16 @kc88_second_33 -140;
-    pos @kc88_first_16 @kc88_second_34 -245;
-    pos @kc88_first_16 @kc88_second_35 -315;
-    pos @kc88_first_16 @kc88_second_37 -315;
-    pos @kc88_first_16 @kc88_second_38 -70;
-    pos @kc88_first_16 @kc88_second_39 -210;
-    pos @kc88_first_16 @kc88_second_40 -210;
-    pos @kc88_first_16 @kc88_second_41 -245;
-    pos @kc88_first_16 @kc88_second_42 -245;
-    pos @kc88_first_16 @kc88_second_43 -70;
-    pos @kc88_first_16 @kc88_second_45 -35;
-    pos @kc88_first_16 @kc88_second_46 -140;
-    pos @kc88_first_16 @kc88_second_47 -140;
-    pos @kc88_first_16 @kc88_second_48 1;
-    pos @kc88_first_16 @kc88_second_49 -70;
-    pos @kc88_first_16 @kc88_second_50 -140;
-    pos @kc88_first_16 @kc88_second_52 -140;
-    pos @kc88_first_16 @kc88_second_53 -140;
-    pos @kc88_first_16 @kc88_second_54 -240;
-    pos @kc88_first_16 @kc88_second_55 -140;
-    pos @kc88_first_16 @kc88_second_56 -280;
-    pos @kc88_first_16 @kc88_second_57 -105;
-    pos @kc88_first_16 @kc88_second_58 -315;
-    pos @kc88_first_16 @kc88_second_59 -280;
-    pos @kc88_first_16 @kc88_second_60 -140;
-    pos @kc88_first_16 @kc88_second_61 -210;
-    pos @kc88_first_16 @kc88_second_62 -210;
-    pos @kc88_first_16 @kc88_second_63 -105;
-    pos @kc88_first_16 @kc88_second_66 -315;
-    pos @kc88_first_16 @kc88_second_67 -350;
-    pos @kc88_first_17 @kc88_second_1 -280;
-    pos @kc88_first_17 @kc88_second_2 -280;
-    pos @kc88_first_17 @kc88_second_3 -105;
-    pos @kc88_first_17 @kc88_second_6 -210;
-    pos @kc88_first_17 @kc88_second_7 -105;
-    pos @kc88_first_17 @kc88_second_8 -105;
-    pos @kc88_first_17 @kc88_second_10 -35;
-    pos @kc88_first_17 @kc88_second_17 -105;
-    pos @kc88_first_17 @kc88_second_18 -175;
-    pos @kc88_first_17 @kc88_second_19 -280;
-    pos @kc88_first_17 @kc88_second_21 -280;
-    pos @kc88_first_17 @kc88_second_22 -70;
-    pos @kc88_first_17 @kc88_second_23 -105;
-    pos @kc88_first_17 @kc88_second_24 -140;
-    pos @kc88_first_17 @kc88_second_25 -140;
-    pos @kc88_first_17 @kc88_second_26 -210;
-    pos @kc88_first_17 @kc88_second_29 -70;
-    pos @kc88_first_17 @kc88_second_31 -140;
-    pos @kc88_first_17 @kc88_second_32 -105;
-    pos @kc88_first_17 @kc88_second_34 -210;
-    pos @kc88_first_17 @kc88_second_35 -175;
-    pos @kc88_first_17 @kc88_second_37 -245;
-    pos @kc88_first_17 @kc88_second_38 -70;
-    pos @kc88_first_17 @kc88_second_39 -140;
-    pos @kc88_first_17 @kc88_second_40 -140;
-    pos @kc88_first_17 @kc88_second_41 -140;
-    pos @kc88_first_17 @kc88_second_42 -105;
-    pos @kc88_first_17 @kc88_second_43 -35;
-    pos @kc88_first_17 @kc88_second_46 -35;
-    pos @kc88_first_17 @kc88_second_47 -70;
-    pos @kc88_first_17 @kc88_second_48 1;
-    pos @kc88_first_17 @kc88_second_49 -35;
-    pos @kc88_first_17 @kc88_second_50 -70;
-    pos @kc88_first_17 @kc88_second_52 -105;
-    pos @kc88_first_17 @kc88_second_53 -70;
-    pos @kc88_first_17 @kc88_second_54 -105;
-    pos @kc88_first_17 @kc88_second_55 -70;
-    pos @kc88_first_17 @kc88_second_56 -210;
-    pos @kc88_first_17 @kc88_second_57 -35;
-    pos @kc88_first_17 @kc88_second_58 -245;
-    pos @kc88_first_17 @kc88_second_59 -210;
-    pos @kc88_first_17 @kc88_second_60 -70;
-    pos @kc88_first_17 @kc88_second_61 -105;
-    pos @kc88_first_17 @kc88_second_62 -105;
-    pos @kc88_first_17 @kc88_second_63 -70;
-    pos @kc88_first_17 @kc88_second_66 -175;
-    pos @kc88_first_17 @kc88_second_67 -245;
-    pos @kc88_first_18 @kc88_second_1 -210;
-    pos @kc88_first_18 @kc88_second_2 -245;
-    pos @kc88_first_18 @kc88_second_3 -35;
-    pos @kc88_first_18 @kc88_second_6 -140;
-    pos @kc88_first_18 @kc88_second_7 -35;
-    pos @kc88_first_18 @kc88_second_8 -70;
-    pos @kc88_first_18 @kc88_second_17 -105;
-    pos @kc88_first_18 @kc88_second_18 -105;
-    pos @kc88_first_18 @kc88_second_19 -175;
-    pos @kc88_first_18 @kc88_second_21 -210;
-    pos @kc88_first_18 @kc88_second_22 -70;
-    pos @kc88_first_18 @kc88_second_24 -105;
-    pos @kc88_first_18 @kc88_second_25 -70;
-    pos @kc88_first_18 @kc88_second_26 -140;
-    pos @kc88_first_18 @kc88_second_29 -35;
-    pos @kc88_first_18 @kc88_second_34 -140;
-    pos @kc88_first_18 @kc88_second_35 -105;
-    pos @kc88_first_18 @kc88_second_37 -140;
-    pos @kc88_first_18 @kc88_second_39 -105;
-    pos @kc88_first_18 @kc88_second_40 -70;
-    pos @kc88_first_18 @kc88_second_41 -105;
-    pos @kc88_first_18 @kc88_second_42 -70;
-    pos @kc88_first_18 @kc88_second_44 -35;
-    pos @kc88_first_18 @kc88_second_48 1;
-    pos @kc88_first_18 @kc88_second_53 -35;
-    pos @kc88_first_18 @kc88_second_54 -70;
-    pos @kc88_first_18 @kc88_second_56 -140;
-    pos @kc88_first_18 @kc88_second_58 -175;
-    pos @kc88_first_18 @kc88_second_59 -140;
-    pos @kc88_first_18 @kc88_second_61 -70;
-    pos @kc88_first_18 @kc88_second_66 -105;
-    pos @kc88_first_18 @kc88_second_67 -140;
-    pos @kc88_first_19 @kc88_second_12 -280;
-    pos @kc88_first_19 @kc88_second_14 -175;
-    pos @kc88_first_19 @kc88_second_15 -140;
-    pos @kc88_first_19 @kc88_second_18 -35;
-    pos @kc88_first_19 @kc88_second_31 -35;
-    pos @kc88_first_19 @kc88_second_33 -50;
-    pos @kc88_first_19 @kc88_second_48 1;
-    pos @kc88_first_19 @kc88_second_50 -70;
-    pos @kc88_first_19 @kc88_second_51 -140;
-    pos @kc88_first_19 @kc88_second_61 -70;
-    pos @kc88_first_19 @kc88_second_63 -35;
-    pos @kc88_first_19 @kc88_second_64 -105;
-    pos @kc88_first_19 @kc88_second_65 -70;
-    pos @kc88_first_20 @kc88_second_12 -240;
-    pos @kc88_first_20 @kc88_second_13 -140;
-    pos @kc88_first_20 @kc88_second_14 -105;
-    pos @kc88_first_20 @kc88_second_15 -35;
-    pos @kc88_first_20 @kc88_second_48 1;
-    pos @kc88_first_21 @kc88_second_8 -35;
-    pos @kc88_first_21 @kc88_second_9 -140;
-    pos @kc88_first_21 @kc88_second_12 -280;
-    pos @kc88_first_21 @kc88_second_13 -280;
-    pos @kc88_first_21 @kc88_second_14 -280;
-    pos @kc88_first_21 @kc88_second_15 -175;
-    pos @kc88_first_21 @kc88_second_20 -140;
-    pos @kc88_first_21 @kc88_second_22 -70;
-    pos @kc88_first_21 @kc88_second_27 -70;
-    pos @kc88_first_21 @kc88_second_33 -50;
-    pos @kc88_first_21 @kc88_second_42 -140;
-    pos @kc88_first_21 @kc88_second_43 -105;
-    pos @kc88_first_21 @kc88_second_46 -210;
-    pos @kc88_first_21 @kc88_second_48 1;
-    pos @kc88_first_21 @kc88_second_49 -35;
-    pos @kc88_first_21 @kc88_second_50 -140;
-    pos @kc88_first_21 @kc88_second_51 -210;
-    pos @kc88_first_21 @kc88_second_55 -35;
-    pos @kc88_first_21 @kc88_second_61 -105;
-    pos @kc88_first_21 @kc88_second_63 -105;
-    pos @kc88_first_21 @kc88_second_64 -210;
-    pos @kc88_first_21 @kc88_second_65 -140;
-    pos @kc88_first_22 @kc88_second_1 -140;
-    pos @kc88_first_22 @kc88_second_2 -350;
-    pos @kc88_first_22 @kc88_second_19 -140;
-    pos @kc88_first_22 @kc88_second_21 -280;
-    pos @kc88_first_22 @kc88_second_41 -70;
-    pos @kc88_first_22 @kc88_second_48 1;
-    pos @kc88_first_22 @kc88_second_67 -210;
-    pos @kc88_first_23 @kc88_second_1 -35;
-    pos @kc88_first_23 @kc88_second_5 -105;
-    pos @kc88_first_23 @kc88_second_9 -70;
-    pos @kc88_first_23 @kc88_second_11 -70;
-    pos @kc88_first_23 @kc88_second_12 -240;
-    pos @kc88_first_23 @kc88_second_13 -280;
-    pos @kc88_first_23 @kc88_second_14 -140;
-    pos @kc88_first_23 @kc88_second_15 -105;
-    pos @kc88_first_23 @kc88_second_16 -70;
-    pos @kc88_first_23 @kc88_second_27 -35;
-    pos @kc88_first_23 @kc88_second_28 -70;
-    pos @kc88_first_23 @kc88_second_29 -105;
-    pos @kc88_first_23 @kc88_second_35 -35;
-    pos @kc88_first_23 @kc88_second_38 -70;
-    pos @kc88_first_23 @kc88_second_42 -70;
-    pos @kc88_first_23 @kc88_second_43 -35;
-    pos @kc88_first_23 @kc88_second_45 -35;
-    pos @kc88_first_23 @kc88_second_46 -140;
-    pos @kc88_first_23 @kc88_second_48 1;
-    pos @kc88_first_23 @kc88_second_50 -70;
-    pos @kc88_first_23 @kc88_second_51 -175;
-    pos @kc88_first_23 @kc88_second_52 -35;
-    pos @kc88_first_23 @kc88_second_60 -105;
-    pos @kc88_first_23 @kc88_second_61 -35;
-    pos @kc88_first_23 @kc88_second_63 -50;
-    pos @kc88_first_23 @kc88_second_64 -105;
-    pos @kc88_first_23 @kc88_second_65 -70;
-    pos @kc88_first_24 @kc88_second_6 -35;
-    pos @kc88_first_24 @kc88_second_12 -240;
-    pos @kc88_first_24 @kc88_second_13 -175;
-    pos @kc88_first_24 @kc88_second_14 -70;
-    pos @kc88_first_24 @kc88_second_15 -70;
-    pos @kc88_first_24 @kc88_second_18 -70;
-    pos @kc88_first_24 @kc88_second_24 -70;
-    pos @kc88_first_24 @kc88_second_25 -35;
-    pos @kc88_first_24 @kc88_second_37 -35;
-    pos @kc88_first_24 @kc88_second_42 -35;
-    pos @kc88_first_24 @kc88_second_43 -35;
-    pos @kc88_first_24 @kc88_second_46 -70;
-    pos @kc88_first_24 @kc88_second_47 -35;
-    pos @kc88_first_24 @kc88_second_48 1;
-    pos @kc88_first_24 @kc88_second_51 -35;
-    pos @kc88_first_24 @kc88_second_61 -35;
-    pos @kc88_first_24 @kc88_second_65 -35;
-    pos @kc88_first_24 @kc88_second_66 -35;
-    pos @kc88_first_24 @kc88_second_67 -35;
-    pos @kc88_first_25 @kc88_second_1 -70;
-    pos @kc88_first_25 @kc88_second_2 -140;
-    pos @kc88_first_25 @kc88_second_5 -105;
-    pos @kc88_first_25 @kc88_second_11 -70;
-    pos @kc88_first_25 @kc88_second_12 -280;
-    pos @kc88_first_25 @kc88_second_13 -210;
-    pos @kc88_first_25 @kc88_second_14 -70;
-    pos @kc88_first_25 @kc88_second_15 -70;
-    pos @kc88_first_25 @kc88_second_16 -140;
-    pos @kc88_first_25 @kc88_second_21 -70;
-    pos @kc88_first_25 @kc88_second_28 -70;
-    pos @kc88_first_25 @kc88_second_29 -70;
-    pos @kc88_first_25 @kc88_second_34 -70;
-    pos @kc88_first_25 @kc88_second_38 -70;
-    pos @kc88_first_25 @kc88_second_45 -35;
-    pos @kc88_first_25 @kc88_second_46 -140;
-    pos @kc88_first_25 @kc88_second_48 1;
-    pos @kc88_first_25 @kc88_second_51 -140;
-    pos @kc88_first_25 @kc88_second_52 -35;
-    pos @kc88_first_25 @kc88_second_56 -140;
-    pos @kc88_first_25 @kc88_second_58 -70;
-    pos @kc88_first_25 @kc88_second_59 -105;
-    pos @kc88_first_25 @kc88_second_60 -70;
-    pos @kc88_first_25 @kc88_second_64 -70;
-    pos @kc88_first_25 @kc88_second_65 -35;
-    pos @kc88_first_26 @kc88_second_5 -70;
-    pos @kc88_first_26 @kc88_second_9 -70;
-    pos @kc88_first_26 @kc88_second_12 -240;
-    pos @kc88_first_26 @kc88_second_13 -280;
-    pos @kc88_first_26 @kc88_second_14 -175;
-    pos @kc88_first_26 @kc88_second_15 -105;
-    pos @kc88_first_26 @kc88_second_16 -70;
-    pos @kc88_first_26 @kc88_second_27 -35;
-    pos @kc88_first_26 @kc88_second_28 -70;
-    pos @kc88_first_26 @kc88_second_29 -70;
-    pos @kc88_first_26 @kc88_second_38 -70;
-    pos @kc88_first_26 @kc88_second_42 -70;
-    pos @kc88_first_26 @kc88_second_43 -35;
-    pos @kc88_first_26 @kc88_second_46 -140;
-    pos @kc88_first_26 @kc88_second_48 1;
-    pos @kc88_first_26 @kc88_second_50 -70;
-    pos @kc88_first_26 @kc88_second_51 -140;
-    pos @kc88_first_26 @kc88_second_52 -35;
-    pos @kc88_first_26 @kc88_second_56 -50;
-    pos @kc88_first_26 @kc88_second_57 -35;
-    pos @kc88_first_26 @kc88_second_58 -50;
-    pos @kc88_first_26 @kc88_second_59 -50;
-    pos @kc88_first_26 @kc88_second_60 -105;
-    pos @kc88_first_26 @kc88_second_61 -50;
-    pos @kc88_first_26 @kc88_second_63 -35;
-    pos @kc88_first_26 @kc88_second_64 -105;
-    pos @kc88_first_26 @kc88_second_65 -70;
-    pos @kc88_first_27 @kc88_second_9 -35;
-    pos @kc88_first_27 @kc88_second_12 -140;
-    pos @kc88_first_27 @kc88_second_28 -70;
-    pos @kc88_first_27 @kc88_second_42 -35;
-    pos @kc88_first_27 @kc88_second_46 -70;
-    pos @kc88_first_27 @kc88_second_48 1;
-    pos @kc88_first_27 @kc88_second_51 -70;
-    pos @kc88_first_27 @kc88_second_64 -70;
-    pos @kc88_first_27 @kc88_second_65 -35;
-    pos @kc88_first_28 @kc88_second_5 -50;
-    pos @kc88_first_28 @kc88_second_9 -35;
-    pos @kc88_first_28 @kc88_second_11 -35;
-    pos @kc88_first_28 @kc88_second_12 -240;
-    pos @kc88_first_28 @kc88_second_13 -240;
-    pos @kc88_first_28 @kc88_second_14 -105;
-    pos @kc88_first_28 @kc88_second_15 -70;
-    pos @kc88_first_28 @kc88_second_16 -35;
-    pos @kc88_first_28 @kc88_second_28 -35;
-    pos @kc88_first_28 @kc88_second_29 -35;
-    pos @kc88_first_28 @kc88_second_35 -35;
-    pos @kc88_first_28 @kc88_second_38 -35;
-    pos @kc88_first_28 @kc88_second_42 -50;
-    pos @kc88_first_28 @kc88_second_43 -35;
-    pos @kc88_first_28 @kc88_second_46 -100;
-    pos @kc88_first_28 @kc88_second_48 1;
-    pos @kc88_first_28 @kc88_second_50 -35;
-    pos @kc88_first_28 @kc88_second_51 -140;
-    pos @kc88_first_28 @kc88_second_60 -35;
-    pos @kc88_first_28 @kc88_second_64 -70;
-    pos @kc88_first_28 @kc88_second_65 -35;
-    pos @kc88_first_29 @kc88_second_48 1;
-    pos @kc88_first_30 @kc88_second_8 -70;
-    pos @kc88_first_30 @kc88_second_9 -210;
-    pos @kc88_first_30 @kc88_second_12 -350;
-    pos @kc88_first_30 @kc88_second_13 -350;
-    pos @kc88_first_30 @kc88_second_14 -210;
-    pos @kc88_first_30 @kc88_second_15 -175;
-    pos @kc88_first_30 @kc88_second_27 -70;
-    pos @kc88_first_30 @kc88_second_41 -35;
-    pos @kc88_first_30 @kc88_second_42 -210;
-    pos @kc88_first_30 @kc88_second_43 -210;
-    pos @kc88_first_30 @kc88_second_46 -210;
-    pos @kc88_first_30 @kc88_second_48 1;
-    pos @kc88_first_30 @kc88_second_50 -140;
-    pos @kc88_first_30 @kc88_second_51 -280;
-    pos @kc88_first_30 @kc88_second_61 -210;
-    pos @kc88_first_30 @kc88_second_63 -105;
-    pos @kc88_first_30 @kc88_second_64 -175;
-    pos @kc88_first_30 @kc88_second_65 -140;
-    pos @kc88_first_31 @kc88_second_1 -175;
-    pos @kc88_first_31 @kc88_second_2 -175;
-    pos @kc88_first_31 @kc88_second_5 -70;
-    pos @kc88_first_31 @kc88_second_6 -105;
-    pos @kc88_first_31 @kc88_second_10 -35;
-    pos @kc88_first_31 @kc88_second_11 -105;
-    pos @kc88_first_31 @kc88_second_12 -175;
-    pos @kc88_first_31 @kc88_second_13 -140;
-    pos @kc88_first_31 @kc88_second_14 -70;
-    pos @kc88_first_31 @kc88_second_15 -35;
-    pos @kc88_first_31 @kc88_second_16 -140;
-    pos @kc88_first_31 @kc88_second_17 -70;
-    pos @kc88_first_31 @kc88_second_18 -70;
-    pos @kc88_first_31 @kc88_second_19 -140;
-    pos @kc88_first_31 @kc88_second_21 -175;
-    pos @kc88_first_31 @kc88_second_24 -70;
-    pos @kc88_first_31 @kc88_second_31 -105;
-    pos @kc88_first_31 @kc88_second_36 105;
-    pos @kc88_first_31 @kc88_second_37 -105;
-    pos @kc88_first_31 @kc88_second_38 -175;
-    pos @kc88_first_31 @kc88_second_39 -35;
-    pos @kc88_first_31 @kc88_second_41 -70;
-    pos @kc88_first_31 @kc88_second_48 1;
-    pos @kc88_first_31 @kc88_second_53 105;
-    pos @kc88_first_31 @kc88_second_54 -35;
-    pos @kc88_first_31 @kc88_second_66 -70;
-    pos @kc88_first_31 @kc88_second_67 -105;
-    pos @kc88_first_32 @kc88_second_3 -70;
-    pos @kc88_first_32 @kc88_second_4 -35;
-    pos @kc88_first_32 @kc88_second_6 -70;
-    pos @kc88_first_32 @kc88_second_8 -105;
-    pos @kc88_first_32 @kc88_second_17 -35;
-    pos @kc88_first_32 @kc88_second_18 -70;
-    pos @kc88_first_32 @kc88_second_22 -70;
-    pos @kc88_first_32 @kc88_second_24 -70;
-    pos @kc88_first_32 @kc88_second_25 -140;
-    pos @kc88_first_32 @kc88_second_31 -35;
-    pos @kc88_first_32 @kc88_second_37 -70;
-    pos @kc88_first_32 @kc88_second_39 -35;
-    pos @kc88_first_32 @kc88_second_41 -140;
-    pos @kc88_first_32 @kc88_second_42 -70;
-    pos @kc88_first_32 @kc88_second_48 1;
-    pos @kc88_first_32 @kc88_second_54 -35;
-    pos @kc88_first_32 @kc88_second_55 -35;
-    pos @kc88_first_32 @kc88_second_61 -140;
-    pos @kc88_first_32 @kc88_second_66 -70;
-    pos @kc88_first_32 @kc88_second_67 -70;
-    pos @kc88_first_33 @kc88_second_1 -35;
-    pos @kc88_first_33 @kc88_second_2 -105;
-    pos @kc88_first_33 @kc88_second_3 -70;
-    pos @kc88_first_33 @kc88_second_4 70;
-    pos @kc88_first_33 @kc88_second_5 -70;
-    pos @kc88_first_33 @kc88_second_11 -35;
-    pos @kc88_first_33 @kc88_second_12 -240;
-    pos @kc88_first_33 @kc88_second_13 -175;
-    pos @kc88_first_33 @kc88_second_14 -105;
-    pos @kc88_first_33 @kc88_second_15 -70;
-    pos @kc88_first_33 @kc88_second_16 -70;
-    pos @kc88_first_33 @kc88_second_19 -70;
-    pos @kc88_first_33 @kc88_second_26 -35;
-    pos @kc88_first_33 @kc88_second_29 -70;
-    pos @kc88_first_33 @kc88_second_35 -35;
-    pos @kc88_first_33 @kc88_second_38 -35;
-    pos @kc88_first_33 @kc88_second_42 -35;
-    pos @kc88_first_33 @kc88_second_43 -35;
-    pos @kc88_first_33 @kc88_second_45 -35;
-    pos @kc88_first_33 @kc88_second_46 -140;
-    pos @kc88_first_33 @kc88_second_48 1;
-    pos @kc88_first_33 @kc88_second_50 -50;
-    pos @kc88_first_33 @kc88_second_51 -140;
-    pos @kc88_first_33 @kc88_second_52 -35;
-    pos @kc88_first_33 @kc88_second_56 -70;
-    pos @kc88_first_33 @kc88_second_58 -70;
-    pos @kc88_first_33 @kc88_second_59 -70;
-    pos @kc88_first_33 @kc88_second_64 -70;
-    pos @kc88_first_33 @kc88_second_65 -35;
-    pos @kc88_first_34 @kc88_second_3 -35;
-    pos @kc88_first_34 @kc88_second_4 -70;
-    pos @kc88_first_34 @kc88_second_6 -70;
-    pos @kc88_first_34 @kc88_second_8 -70;
-    pos @kc88_first_34 @kc88_second_12 -140;
-    pos @kc88_first_34 @kc88_second_13 -105;
-    pos @kc88_first_34 @kc88_second_14 -70;
-    pos @kc88_first_34 @kc88_second_15 -35;
-    pos @kc88_first_34 @kc88_second_18 -70;
-    pos @kc88_first_34 @kc88_second_22 -70;
-    pos @kc88_first_34 @kc88_second_24 -105;
-    pos @kc88_first_34 @kc88_second_25 -70;
-    pos @kc88_first_34 @kc88_second_31 -35;
-    pos @kc88_first_34 @kc88_second_37 -70;
-    pos @kc88_first_34 @kc88_second_39 -70;
-    pos @kc88_first_34 @kc88_second_41 -105;
-    pos @kc88_first_34 @kc88_second_42 -70;
-    pos @kc88_first_34 @kc88_second_47 -70;
-    pos @kc88_first_34 @kc88_second_48 1;
-    pos @kc88_first_34 @kc88_second_54 -35;
-    pos @kc88_first_34 @kc88_second_55 -35;
-    pos @kc88_first_34 @kc88_second_66 -70;
-    pos @kc88_first_34 @kc88_second_67 -70;
-    pos @kc88_first_35 @kc88_second_34 -315;
-    pos @kc88_first_35 @kc88_second_48 1;
-    pos @kc88_first_36 @kc88_second_9 -70;
-    pos @kc88_first_36 @kc88_second_12 -240;
-    pos @kc88_first_36 @kc88_second_13 -210;
-    pos @kc88_first_36 @kc88_second_14 -140;
-    pos @kc88_first_36 @kc88_second_15 -105;
-    pos @kc88_first_36 @kc88_second_36 44;
-    pos @kc88_first_36 @kc88_second_42 -70;
-    pos @kc88_first_36 @kc88_second_43 -35;
-    pos @kc88_first_36 @kc88_second_46 -140;
-    pos @kc88_first_36 @kc88_second_48 1;
-    pos @kc88_first_36 @kc88_second_50 -50;
-    pos @kc88_first_36 @kc88_second_51 -140;
-    pos @kc88_first_36 @kc88_second_53 44;
-    pos @kc88_first_36 @kc88_second_61 -35;
-    pos @kc88_first_36 @kc88_second_63 -35;
-    pos @kc88_first_36 @kc88_second_64 -70;
-    pos @kc88_first_36 @kc88_second_65 -70;
-    pos @kc88_first_37 @kc88_second_9 -35;
-    pos @kc88_first_37 @kc88_second_12 -240;
-    pos @kc88_first_37 @kc88_second_13 -240;
-    pos @kc88_first_37 @kc88_second_14 -140;
-    pos @kc88_first_37 @kc88_second_15 -105;
-    pos @kc88_first_37 @kc88_second_16 -35;
-    pos @kc88_first_37 @kc88_second_28 -35;
-    pos @kc88_first_37 @kc88_second_29 -35;
-    pos @kc88_first_37 @kc88_second_42 -70;
-    pos @kc88_first_37 @kc88_second_43 -35;
-    pos @kc88_first_37 @kc88_second_46 -70;
-    pos @kc88_first_37 @kc88_second_48 1;
-    pos @kc88_first_37 @kc88_second_50 -35;
-    pos @kc88_first_37 @kc88_second_51 -70;
-    pos @kc88_first_37 @kc88_second_63 -35;
-    pos @kc88_first_37 @kc88_second_64 -70;
-    pos @kc88_first_37 @kc88_second_65 -70;
-    pos @kc88_first_38 @kc88_second_5 -70;
-    pos @kc88_first_38 @kc88_second_9 -70;
-    pos @kc88_first_38 @kc88_second_12 -140;
-    pos @kc88_first_38 @kc88_second_13 -210;
-    pos @kc88_first_38 @kc88_second_14 -140;
-    pos @kc88_first_38 @kc88_second_15 -105;
-    pos @kc88_first_38 @kc88_second_16 -70;
-    pos @kc88_first_38 @kc88_second_28 -70;
-    pos @kc88_first_38 @kc88_second_29 -70;
-    pos @kc88_first_38 @kc88_second_38 -50;
-    pos @kc88_first_38 @kc88_second_42 -50;
-    pos @kc88_first_38 @kc88_second_43 -35;
-    pos @kc88_first_38 @kc88_second_48 1;
-    pos @kc88_first_38 @kc88_second_50 -35;
-    pos @kc88_first_38 @kc88_second_51 -140;
-    pos @kc88_first_38 @kc88_second_60 -35;
-    pos @kc88_first_38 @kc88_second_64 -70;
-    pos @kc88_first_38 @kc88_second_65 -35;
-    pos @kc88_first_39 @kc88_second_1 -210;
-    pos @kc88_first_39 @kc88_second_2 -280;
-    pos @kc88_first_39 @kc88_second_6 -280;
-    pos @kc88_first_39 @kc88_second_8 -70;
-    pos @kc88_first_39 @kc88_second_9 3;
-    pos @kc88_first_39 @kc88_second_17 -140;
-    pos @kc88_first_39 @kc88_second_18 -140;
-    pos @kc88_first_39 @kc88_second_19 -245;
-    pos @kc88_first_39 @kc88_second_21 -350;
-    pos @kc88_first_39 @kc88_second_22 -140;
-    pos @kc88_first_39 @kc88_second_24 -140;
-    pos @kc88_first_39 @kc88_second_25 -70;
-    pos @kc88_first_39 @kc88_second_26 -280;
-    pos @kc88_first_39 @kc88_second_30 -315;
-    pos @kc88_first_39 @kc88_second_31 -140;
-    pos @kc88_first_39 @kc88_second_34 -385;
-    pos @kc88_first_39 @kc88_second_35 -140;
-    pos @kc88_first_39 @kc88_second_37 -210;
-    pos @kc88_first_39 @kc88_second_38 -70;
-    pos @kc88_first_39 @kc88_second_39 -140;
-    pos @kc88_first_39 @kc88_second_40 -140;
-    pos @kc88_first_39 @kc88_second_41 -140;
-    pos @kc88_first_39 @kc88_second_42 -70;
-    pos @kc88_first_39 @kc88_second_44 -70;
-    pos @kc88_first_39 @kc88_second_48 1;
-    pos @kc88_first_39 @kc88_second_54 -140;
-    pos @kc88_first_39 @kc88_second_55 -70;
-    pos @kc88_first_39 @kc88_second_56 -140;
-    pos @kc88_first_39 @kc88_second_58 -245;
-    pos @kc88_first_39 @kc88_second_59 -210;
-    pos @kc88_first_39 @kc88_second_60 -70;
-    pos @kc88_first_39 @kc88_second_61 -70;
-    pos @kc88_first_39 @kc88_second_62 -70;
-    pos @kc88_first_39 @kc88_second_63 -70;
-    pos @kc88_first_39 @kc88_second_66 -245;
-    pos @kc88_first_39 @kc88_second_67 -280;
-    pos @kc88_first_39 @kc88_second_68 -315;
-    pos @kc88_first_40 @kc88_second_6 -35;
-    pos @kc88_first_40 @kc88_second_12 -240;
-    pos @kc88_first_40 @kc88_second_13 -140;
-    pos @kc88_first_40 @kc88_second_14 -35;
-    pos @kc88_first_40 @kc88_second_15 -35;
-    pos @kc88_first_40 @kc88_second_35 35;
-    pos @kc88_first_40 @kc88_second_36 100;
-    pos @kc88_first_40 @kc88_second_37 -35;
-    pos @kc88_first_40 @kc88_second_48 1;
-    pos @kc88_first_40 @kc88_second_66 -35;
-    pos @kc88_first_40 @kc88_second_67 -35;
-    pos @kc88_first_41 @kc88_second_12 -210;
-    pos @kc88_first_41 @kc88_second_13 -175;
-    pos @kc88_first_41 @kc88_second_14 -105;
-    pos @kc88_first_41 @kc88_second_15 -70;
-    pos @kc88_first_41 @kc88_second_46 -70;
-    pos @kc88_first_41 @kc88_second_48 1;
-    pos @kc88_first_41 @kc88_second_51 -105;
-    pos @kc88_first_41 @kc88_second_64 -70;
-    pos @kc88_first_42 @kc88_second_1 -140;
-    pos @kc88_first_42 @kc88_second_2 -175;
-    pos @kc88_first_42 @kc88_second_5 -105;
-    pos @kc88_first_42 @kc88_second_6 -70;
-    pos @kc88_first_42 @kc88_second_11 -70;
-    pos @kc88_first_42 @kc88_second_12 -175;
-    pos @kc88_first_42 @kc88_second_13 -105;
-    pos @kc88_first_42 @kc88_second_14 -70;
-    pos @kc88_first_42 @kc88_second_15 -35;
-    pos @kc88_first_42 @kc88_second_16 -105;
-    pos @kc88_first_42 @kc88_second_17 -35;
-    pos @kc88_first_42 @kc88_second_18 -50;
-    pos @kc88_first_42 @kc88_second_19 -140;
-    pos @kc88_first_42 @kc88_second_21 -175;
-    pos @kc88_first_42 @kc88_second_24 -50;
-    pos @kc88_first_42 @kc88_second_26 -105;
-    pos @kc88_first_42 @kc88_second_31 -35;
-    pos @kc88_first_42 @kc88_second_34 -70;
-    pos @kc88_first_42 @kc88_second_35 -50;
-    pos @kc88_first_42 @kc88_second_37 -70;
-    pos @kc88_first_42 @kc88_second_38 -140;
-    pos @kc88_first_42 @kc88_second_39 -35;
-    pos @kc88_first_42 @kc88_second_41 -50;
-    pos @kc88_first_42 @kc88_second_48 1;
-    pos @kc88_first_42 @kc88_second_54 -35;
-    pos @kc88_first_42 @kc88_second_56 -105;
-    pos @kc88_first_42 @kc88_second_58 -105;
-    pos @kc88_first_42 @kc88_second_59 -105;
-    pos @kc88_first_42 @kc88_second_66 -50;
-    pos @kc88_first_42 @kc88_second_67 -70;
-    pos @kc88_first_43 @kc88_second_1 -210;
-    pos @kc88_first_43 @kc88_second_2 -280;
-    pos @kc88_first_43 @kc88_second_3 -70;
-    pos @kc88_first_43 @kc88_second_6 -280;
-    pos @kc88_first_43 @kc88_second_8 -35;
-    pos @kc88_first_43 @kc88_second_11 -70;
-    pos @kc88_first_43 @kc88_second_13 -140;
-    pos @kc88_first_43 @kc88_second_14 -35;
-    pos @kc88_first_43 @kc88_second_15 -35;
-    pos @kc88_first_43 @kc88_second_16 -140;
-    pos @kc88_first_43 @kc88_second_17 -105;
-    pos @kc88_first_43 @kc88_second_18 -140;
-    pos @kc88_first_43 @kc88_second_19 -210;
-    pos @kc88_first_43 @kc88_second_21 -280;
-    pos @kc88_first_43 @kc88_second_22 -140;
-    pos @kc88_first_43 @kc88_second_24 -140;
-    pos @kc88_first_43 @kc88_second_25 -140;
-    pos @kc88_first_43 @kc88_second_26 -210;
-    pos @kc88_first_43 @kc88_second_34 -140;
-    pos @kc88_first_43 @kc88_second_35 -140;
-    pos @kc88_first_43 @kc88_second_37 -280;
-    pos @kc88_first_43 @kc88_second_38 -140;
-    pos @kc88_first_43 @kc88_second_39 -70;
-    pos @kc88_first_43 @kc88_second_40 -140;
-    pos @kc88_first_43 @kc88_second_41 -175;
-    pos @kc88_first_43 @kc88_second_47 -70;
-    pos @kc88_first_43 @kc88_second_48 1;
-    pos @kc88_first_43 @kc88_second_56 -210;
-    pos @kc88_first_43 @kc88_second_58 -210;
-    pos @kc88_first_43 @kc88_second_59 -175;
-    pos @kc88_first_43 @kc88_second_62 -70;
-    pos @kc88_first_43 @kc88_second_66 -175;
-    pos @kc88_first_43 @kc88_second_67 -175;
-    pos @kc88_first_44 @kc88_second_9 -70;
-    pos @kc88_first_44 @kc88_second_12 -240;
-    pos @kc88_first_44 @kc88_second_13 -210;
-    pos @kc88_first_44 @kc88_second_14 -140;
-    pos @kc88_first_44 @kc88_second_15 -105;
-    pos @kc88_first_44 @kc88_second_42 -70;
-    pos @kc88_first_44 @kc88_second_43 -35;
-    pos @kc88_first_44 @kc88_second_46 -140;
-    pos @kc88_first_44 @kc88_second_48 1;
-    pos @kc88_first_44 @kc88_second_50 -50;
-    pos @kc88_first_44 @kc88_second_51 -140;
-    pos @kc88_first_44 @kc88_second_61 -35;
-    pos @kc88_first_44 @kc88_second_63 -35;
-    pos @kc88_first_44 @kc88_second_64 -70;
-    pos @kc88_first_44 @kc88_second_65 -70;
-    pos @kc88_first_45 @kc88_second_8 -35;
-    pos @kc88_first_45 @kc88_second_9 -70;
-    pos @kc88_first_45 @kc88_second_12 -240;
-    pos @kc88_first_45 @kc88_second_13 -210;
-    pos @kc88_first_45 @kc88_second_14 -70;
-    pos @kc88_first_45 @kc88_second_15 -105;
-    pos @kc88_first_45 @kc88_second_18 -35;
-    pos @kc88_first_45 @kc88_second_24 -35;
-    pos @kc88_first_45 @kc88_second_41 -70;
-    pos @kc88_first_45 @kc88_second_42 -105;
-    pos @kc88_first_45 @kc88_second_43 -70;
-    pos @kc88_first_45 @kc88_second_46 -70;
-    pos @kc88_first_45 @kc88_second_47 -35;
-    pos @kc88_first_45 @kc88_second_48 1;
-    pos @kc88_first_45 @kc88_second_50 -70;
-    pos @kc88_first_45 @kc88_second_51 -70;
-    pos @kc88_first_45 @kc88_second_61 -70;
-    pos @kc88_first_45 @kc88_second_63 -50;
-    pos @kc88_first_45 @kc88_second_65 -70;
-    pos @kc88_first_45 @kc88_second_66 -35;
-    pos @kc88_first_45 @kc88_second_67 -35;
-    pos @kc88_first_46 @kc88_second_6 -70;
-    pos @kc88_first_46 @kc88_second_8 -35;
-    pos @kc88_first_46 @kc88_second_12 -175;
-    pos @kc88_first_46 @kc88_second_13 -140;
-    pos @kc88_first_46 @kc88_second_14 -70;
-    pos @kc88_first_46 @kc88_second_15 -35;
-    pos @kc88_first_46 @kc88_second_17 -70;
-    pos @kc88_first_46 @kc88_second_18 -105;
-    pos @kc88_first_46 @kc88_second_22 -70;
-    pos @kc88_first_46 @kc88_second_24 -105;
-    pos @kc88_first_46 @kc88_second_31 -35;
-    pos @kc88_first_46 @kc88_second_37 -70;
-    pos @kc88_first_46 @kc88_second_39 -35;
-    pos @kc88_first_46 @kc88_second_41 -105;
-    pos @kc88_first_46 @kc88_second_48 1;
-    pos @kc88_first_46 @kc88_second_54 -35;
-    pos @kc88_first_46 @kc88_second_66 -70;
-    pos @kc88_first_46 @kc88_second_67 -70;
-    pos @kc88_first_47 @kc88_second_3 -140;
-    pos @kc88_first_47 @kc88_second_4 -70;
-    pos @kc88_first_47 @kc88_second_6 -70;
-    pos @kc88_first_47 @kc88_second_8 -210;
-    pos @kc88_first_47 @kc88_second_9 -420;
-    pos @kc88_first_47 @kc88_second_12 -350;
-    pos @kc88_first_47 @kc88_second_13 -420;
-    pos @kc88_first_47 @kc88_second_14 -350;
-    pos @kc88_first_47 @kc88_second_15 -280;
-    pos @kc88_first_47 @kc88_second_17 -70;
-    pos @kc88_first_47 @kc88_second_18 -70;
-    pos @kc88_first_47 @kc88_second_20 -210;
-    pos @kc88_first_47 @kc88_second_22 -210;
-    pos @kc88_first_47 @kc88_second_24 -70;
-    pos @kc88_first_47 @kc88_second_25 -140;
-    pos @kc88_first_47 @kc88_second_31 -35;
-    pos @kc88_first_47 @kc88_second_33 -140;
-    pos @kc88_first_47 @kc88_second_37 -70;
-    pos @kc88_first_47 @kc88_second_39 -70;
-    pos @kc88_first_47 @kc88_second_41 -210;
-    pos @kc88_first_47 @kc88_second_42 -280;
-    pos @kc88_first_47 @kc88_second_43 -420;
-    pos @kc88_first_47 @kc88_second_46 -350;
-    pos @kc88_first_47 @kc88_second_48 1;
-    pos @kc88_first_47 @kc88_second_49 -35;
-    pos @kc88_first_47 @kc88_second_50 -210;
-    pos @kc88_first_47 @kc88_second_51 -350;
-    pos @kc88_first_47 @kc88_second_54 -35;
-    pos @kc88_first_47 @kc88_second_55 -35;
-    pos @kc88_first_47 @kc88_second_61 -280;
-    pos @kc88_first_47 @kc88_second_63 -175;
-    pos @kc88_first_47 @kc88_second_64 -280;
-    pos @kc88_first_47 @kc88_second_65 -210;
-    pos @kc88_first_47 @kc88_second_66 -70;
-    pos @kc88_first_48 @kc88_second_3 -140;
-    pos @kc88_first_48 @kc88_second_4 -105;
-    pos @kc88_first_48 @kc88_second_6 -70;
-    pos @kc88_first_48 @kc88_second_8 -210;
-    pos @kc88_first_48 @kc88_second_9 -280;
-    pos @kc88_first_48 @kc88_second_12 -350;
-    pos @kc88_first_48 @kc88_second_13 -385;
-    pos @kc88_first_48 @kc88_second_14 -350;
-    pos @kc88_first_48 @kc88_second_15 -280;
-    pos @kc88_first_48 @kc88_second_18 -105;
-    pos @kc88_first_48 @kc88_second_20 -210;
-    pos @kc88_first_48 @kc88_second_22 -140;
-    pos @kc88_first_48 @kc88_second_24 -105;
-    pos @kc88_first_48 @kc88_second_25 -140;
-    pos @kc88_first_48 @kc88_second_31 -70;
-    pos @kc88_first_48 @kc88_second_33 -175;
-    pos @kc88_first_48 @kc88_second_37 -70;
-    pos @kc88_first_48 @kc88_second_39 -35;
-    pos @kc88_first_48 @kc88_second_41 -175;
-    pos @kc88_first_48 @kc88_second_42 -280;
-    pos @kc88_first_48 @kc88_second_43 -280;
-    pos @kc88_first_48 @kc88_second_46 -280;
-    pos @kc88_first_48 @kc88_second_47 -140;
-    pos @kc88_first_48 @kc88_second_48 1;
-    pos @kc88_first_48 @kc88_second_49 -70;
-    pos @kc88_first_48 @kc88_second_50 -280;
-    pos @kc88_first_48 @kc88_second_51 -350;
-    pos @kc88_first_48 @kc88_second_54 -35;
-    pos @kc88_first_48 @kc88_second_55 -70;
-    pos @kc88_first_48 @kc88_second_61 -245;
-    pos @kc88_first_48 @kc88_second_63 -245;
-    pos @kc88_first_48 @kc88_second_64 -280;
-    pos @kc88_first_48 @kc88_second_65 -210;
-    pos @kc88_first_48 @kc88_second_66 -70;
-    pos @kc88_first_48 @kc88_second_67 -70;
-    pos @kc88_first_49 @kc88_second_3 -70;
-    pos @kc88_first_49 @kc88_second_4 -105;
-    pos @kc88_first_49 @kc88_second_6 -210;
-    pos @kc88_first_49 @kc88_second_7 -70;
-    pos @kc88_first_49 @kc88_second_8 -175;
-    pos @kc88_first_49 @kc88_second_17 -210;
-    pos @kc88_first_49 @kc88_second_18 -210;
-    pos @kc88_first_49 @kc88_second_22 -140;
-    pos @kc88_first_49 @kc88_second_23 -210;
-    pos @kc88_first_49 @kc88_second_24 -210;
-    pos @kc88_first_49 @kc88_second_25 -210;
-    pos @kc88_first_49 @kc88_second_26 -140;
-    pos @kc88_first_49 @kc88_second_27 -140;
-    pos @kc88_first_49 @kc88_second_29 -140;
-    pos @kc88_first_49 @kc88_second_31 -210;
-    pos @kc88_first_49 @kc88_second_32 -210;
-    pos @kc88_first_49 @kc88_second_33 -140;
-    pos @kc88_first_49 @kc88_second_35 -210;
-    pos @kc88_first_49 @kc88_second_37 -210;
-    pos @kc88_first_49 @kc88_second_38 -70;
-    pos @kc88_first_49 @kc88_second_39 -175;
-    pos @kc88_first_49 @kc88_second_40 -210;
-    pos @kc88_first_49 @kc88_second_41 -175;
-    pos @kc88_first_49 @kc88_second_42 -210;
-    pos @kc88_first_49 @kc88_second_43 -105;
-    pos @kc88_first_49 @kc88_second_46 -70;
-    pos @kc88_first_49 @kc88_second_47 -105;
-    pos @kc88_first_49 @kc88_second_48 1;
-    pos @kc88_first_49 @kc88_second_49 -35;
-    pos @kc88_first_49 @kc88_second_50 -210;
-    pos @kc88_first_49 @kc88_second_53 -210;
-    pos @kc88_first_49 @kc88_second_54 -210;
-    pos @kc88_first_49 @kc88_second_55 -175;
-    pos @kc88_first_49 @kc88_second_56 -175;
-    pos @kc88_first_49 @kc88_second_58 -210;
-    pos @kc88_first_49 @kc88_second_59 -210;
-    pos @kc88_first_49 @kc88_second_60 -140;
-    pos @kc88_first_49 @kc88_second_61 -210;
-    pos @kc88_first_49 @kc88_second_62 -175;
-    pos @kc88_first_49 @kc88_second_63 -175;
-    pos @kc88_first_49 @kc88_second_66 -210;
-    pos @kc88_first_49 @kc88_second_67 -210;
-    pos @kc88_first_50 @kc88_second_5 -70;
-    pos @kc88_first_50 @kc88_second_11 -35;
-    pos @kc88_first_50 @kc88_second_12 -240;
-    pos @kc88_first_50 @kc88_second_13 -70;
-    pos @kc88_first_50 @kc88_second_14 -140;
-    pos @kc88_first_50 @kc88_second_15 -105;
-    pos @kc88_first_50 @kc88_second_16 -70;
-    pos @kc88_first_50 @kc88_second_28 -70;
-    pos @kc88_first_50 @kc88_second_29 -70;
-    pos @kc88_first_50 @kc88_second_38 -35;
-    pos @kc88_first_50 @kc88_second_42 -70;
-    pos @kc88_first_50 @kc88_second_45 -35;
-    pos @kc88_first_50 @kc88_second_46 -70;
-    pos @kc88_first_50 @kc88_second_48 1;
-    pos @kc88_first_50 @kc88_second_50 -35;
-    pos @kc88_first_50 @kc88_second_51 -140;
-    pos @kc88_first_50 @kc88_second_54 1;
-    pos @kc88_first_50 @kc88_second_60 -35;
-    pos @kc88_first_50 @kc88_second_63 -35;
-    pos @kc88_first_50 @kc88_second_64 -105;
-    pos @kc88_first_50 @kc88_second_65 -70;
-    pos @kc88_first_51 @kc88_second_48 1;
-    pos @kc88_first_51 @kc88_second_68 -140;
-    pos @kc88_first_52 @kc88_second_34 -315;
-    pos @kc88_first_52 @kc88_second_48 1;
-    pos @kc88_first_52 @kc88_second_69 -140;
-    pos @kc88_first_53 @kc88_second_1 -105;
-    pos @kc88_first_53 @kc88_second_2 -210;
-    pos @kc88_first_53 @kc88_second_6 -140;
-    pos @kc88_first_53 @kc88_second_11 -70;
-    pos @kc88_first_53 @kc88_second_12 -210;
-    pos @kc88_first_53 @kc88_second_13 -210;
-    pos @kc88_first_53 @kc88_second_14 -105;
-    pos @kc88_first_53 @kc88_second_15 -70;
-    pos @kc88_first_53 @kc88_second_16 -140;
-    pos @kc88_first_53 @kc88_second_17 -35;
-    pos @kc88_first_53 @kc88_second_18 -35;
-    pos @kc88_first_53 @kc88_second_19 -105;
-    pos @kc88_first_53 @kc88_second_24 -35;
-    pos @kc88_first_53 @kc88_second_26 -210;
-    pos @kc88_first_53 @kc88_second_28 -70;
-    pos @kc88_first_53 @kc88_second_29 -70;
-    pos @kc88_first_53 @kc88_second_31 -35;
-    pos @kc88_first_53 @kc88_second_35 -70;
-    pos @kc88_first_53 @kc88_second_37 -210;
-    pos @kc88_first_53 @kc88_second_38 -140;
-    pos @kc88_first_53 @kc88_second_45 -35;
-    pos @kc88_first_53 @kc88_second_46 -70;
-    pos @kc88_first_53 @kc88_second_48 1;
-    pos @kc88_first_53 @kc88_second_50 -35;
-    pos @kc88_first_53 @kc88_second_51 -105;
-    pos @kc88_first_53 @kc88_second_56 -210;
-    pos @kc88_first_53 @kc88_second_58 -175;
-    pos @kc88_first_53 @kc88_second_59 -140;
-    pos @kc88_first_53 @kc88_second_64 -35;
-    pos @kc88_first_53 @kc88_second_65 -35;
-    pos @kc88_first_53 @kc88_second_66 -35;
-    pos @kc88_first_53 @kc88_second_67 -70;
-    pos @kc88_first_54 @kc88_second_1 -35;
-    pos @kc88_first_54 @kc88_second_2 -70;
-    pos @kc88_first_54 @kc88_second_5 -105;
-    pos @kc88_first_54 @kc88_second_6 -35;
-    pos @kc88_first_54 @kc88_second_9 -70;
-    pos @kc88_first_54 @kc88_second_11 -70;
-    pos @kc88_first_54 @kc88_second_12 -240;
-    pos @kc88_first_54 @kc88_second_13 -245;
-    pos @kc88_first_54 @kc88_second_14 -140;
-    pos @kc88_first_54 @kc88_second_15 -105;
-    pos @kc88_first_54 @kc88_second_16 -105;
-    pos @kc88_first_54 @kc88_second_19 -35;
-    pos @kc88_first_54 @kc88_second_20 -70;
-    pos @kc88_first_54 @kc88_second_21 -70;
-    pos @kc88_first_54 @kc88_second_26 -35;
-    pos @kc88_first_54 @kc88_second_27 -70;
-    pos @kc88_first_54 @kc88_second_28 -140;
-    pos @kc88_first_54 @kc88_second_29 -105;
-    pos @kc88_first_54 @kc88_second_35 -35;
-    pos @kc88_first_54 @kc88_second_37 -35;
-    pos @kc88_first_54 @kc88_second_38 -140;
-    pos @kc88_first_54 @kc88_second_42 -105;
-    pos @kc88_first_54 @kc88_second_43 -70;
-    pos @kc88_first_54 @kc88_second_45 -105;
-    pos @kc88_first_54 @kc88_second_46 -175;
-    pos @kc88_first_54 @kc88_second_48 1;
-    pos @kc88_first_54 @kc88_second_50 -70;
-    pos @kc88_first_54 @kc88_second_51 -140;
-    pos @kc88_first_54 @kc88_second_52 -70;
-    pos @kc88_first_54 @kc88_second_56 -210;
-    pos @kc88_first_54 @kc88_second_57 -70;
-    pos @kc88_first_54 @kc88_second_58 -175;
-    pos @kc88_first_54 @kc88_second_59 -175;
-    pos @kc88_first_54 @kc88_second_60 -105;
-    pos @kc88_first_54 @kc88_second_63 -50;
-    pos @kc88_first_54 @kc88_second_64 -105;
-    pos @kc88_first_54 @kc88_second_65 -70;
-    pos @kc88_first_54 @kc88_second_67 -35;
-    pos @kc88_first_55 @kc88_second_1 -105;
-    pos @kc88_first_55 @kc88_second_2 -210;
-    pos @kc88_first_55 @kc88_second_5 -70;
-    pos @kc88_first_55 @kc88_second_6 -105;
-    pos @kc88_first_55 @kc88_second_13 -70;
-    pos @kc88_first_55 @kc88_second_14 -35;
-    pos @kc88_first_55 @kc88_second_16 -140;
-    pos @kc88_first_55 @kc88_second_17 -70;
-    pos @kc88_first_55 @kc88_second_18 -35;
-    pos @kc88_first_55 @kc88_second_19 -105;
-    pos @kc88_first_55 @kc88_second_21 -210;
-    pos @kc88_first_55 @kc88_second_24 -35;
-    pos @kc88_first_55 @kc88_second_26 -210;
-    pos @kc88_first_55 @kc88_second_31 -35;
-    pos @kc88_first_55 @kc88_second_34 -105;
-    pos @kc88_first_55 @kc88_second_35 -35;
-    pos @kc88_first_55 @kc88_second_37 -105;
-    pos @kc88_first_55 @kc88_second_38 -140;
-    pos @kc88_first_55 @kc88_second_41 -70;
-    pos @kc88_first_55 @kc88_second_48 1;
-    pos @kc88_first_55 @kc88_second_54 -35;
-    pos @kc88_first_55 @kc88_second_56 -245;
-    pos @kc88_first_55 @kc88_second_58 -210;
-    pos @kc88_first_55 @kc88_second_59 -210;
-    pos @kc88_first_55 @kc88_second_66 -70;
-    pos @kc88_first_55 @kc88_second_67 -105;
-    pos @kc88_first_56 @kc88_second_12 -240;
-    pos @kc88_first_56 @kc88_second_13 -140;
-    pos @kc88_first_56 @kc88_second_14 -105;
-    pos @kc88_first_56 @kc88_second_15 -35;
-    pos @kc88_first_56 @kc88_second_35 35;
-    pos @kc88_first_56 @kc88_second_36 44;
-    pos @kc88_first_56 @kc88_second_48 1;
-    pos @kc88_first_56 @kc88_second_53 44;
-    pos @kc88_first_57 @kc88_second_1 -140;
-    pos @kc88_first_57 @kc88_second_2 -210;
-    pos @kc88_first_57 @kc88_second_6 -140;
-    pos @kc88_first_57 @kc88_second_12 -175;
-    pos @kc88_first_57 @kc88_second_13 -140;
-    pos @kc88_first_57 @kc88_second_16 -140;
-    pos @kc88_first_57 @kc88_second_19 -140;
-    pos @kc88_first_57 @kc88_second_21 -210;
-    pos @kc88_first_57 @kc88_second_26 -210;
-    pos @kc88_first_57 @kc88_second_34 -140;
-    pos @kc88_first_57 @kc88_second_35 -50;
-    pos @kc88_first_57 @kc88_second_37 -140;
-    pos @kc88_first_57 @kc88_second_38 -210;
-    pos @kc88_first_57 @kc88_second_39 -35;
-    pos @kc88_first_57 @kc88_second_48 1;
-    pos @kc88_first_57 @kc88_second_56 -210;
-    pos @kc88_first_57 @kc88_second_58 -175;
-    pos @kc88_first_57 @kc88_second_59 -175;
-    pos @kc88_first_57 @kc88_second_66 -105;
-    pos @kc88_first_57 @kc88_second_67 -210;
-    pos @kc88_first_58 @kc88_second_12 -240;
-    pos @kc88_first_58 @kc88_second_13 -175;
-    pos @kc88_first_58 @kc88_second_14 -70;
-    pos @kc88_first_58 @kc88_second_15 -35;
-    pos @kc88_first_58 @kc88_second_21 -35;
-    pos @kc88_first_58 @kc88_second_28 -35;
-    pos @kc88_first_58 @kc88_second_42 -35;
-    pos @kc88_first_58 @kc88_second_43 -35;
-    pos @kc88_first_58 @kc88_second_46 -70;
-    pos @kc88_first_58 @kc88_second_48 1;
-    pos @kc88_first_58 @kc88_second_50 -35;
-    pos @kc88_first_58 @kc88_second_51 -70;
-    pos @kc88_first_58 @kc88_second_61 -35;
-    pos @kc88_first_58 @kc88_second_63 -35;
-    pos @kc88_first_58 @kc88_second_64 -70;
-    pos @kc88_first_58 @kc88_second_65 -35;
-    pos @kc88_first_59 @kc88_second_13 -35;
-    pos @kc88_first_59 @kc88_second_18 -70;
-    pos @kc88_first_59 @kc88_second_61 -35;
-    pos @kc88_first_59 @kc88_second_67 -35;
-    pos @kc88_first_60 @kc88_second_12 -175;
-    pos @kc88_first_60 @kc88_second_13 -140;
-    pos @kc88_first_60 @kc88_second_14 -35;
-    pos @kc88_first_60 @kc88_second_48 1;
-    pos @kc88_first_61 @kc88_second_1 -140;
-    pos @kc88_first_61 @kc88_second_2 -280;
-    pos @kc88_first_61 @kc88_second_5 -140;
-    pos @kc88_first_61 @kc88_second_6 -280;
-    pos @kc88_first_61 @kc88_second_8 -70;
-    pos @kc88_first_61 @kc88_second_10 -70;
-    pos @kc88_first_61 @kc88_second_11 -175;
-    pos @kc88_first_61 @kc88_second_12 -240;
-    pos @kc88_first_61 @kc88_second_13 -140;
-    pos @kc88_first_61 @kc88_second_14 -105;
-    pos @kc88_first_61 @kc88_second_15 -70;
-    pos @kc88_first_61 @kc88_second_16 -175;
-    pos @kc88_first_61 @kc88_second_17 -70;
-    pos @kc88_first_61 @kc88_second_18 -70;
-    pos @kc88_first_61 @kc88_second_19 -140;
-    pos @kc88_first_61 @kc88_second_21 -280;
-    pos @kc88_first_61 @kc88_second_24 -70;
-    pos @kc88_first_61 @kc88_second_25 -70;
-    pos @kc88_first_61 @kc88_second_26 -210;
-    pos @kc88_first_61 @kc88_second_28 -70;
-    pos @kc88_first_61 @kc88_second_29 -70;
-    pos @kc88_first_61 @kc88_second_31 -70;
-    pos @kc88_first_61 @kc88_second_34 -70;
-    pos @kc88_first_61 @kc88_second_35 -70;
-    pos @kc88_first_61 @kc88_second_37 -315;
-    pos @kc88_first_61 @kc88_second_38 -140;
-    pos @kc88_first_61 @kc88_second_39 -70;
-    pos @kc88_first_61 @kc88_second_41 -105;
-    pos @kc88_first_61 @kc88_second_48 1;
-    pos @kc88_first_61 @kc88_second_51 -35;
-    pos @kc88_first_61 @kc88_second_54 -50;
-    pos @kc88_first_61 @kc88_second_56 -210;
-    pos @kc88_first_61 @kc88_second_58 -210;
-    pos @kc88_first_61 @kc88_second_59 -175;
-    pos @kc88_first_61 @kc88_second_62 -35;
-    pos @kc88_first_61 @kc88_second_64 -70;
-    pos @kc88_first_61 @kc88_second_65 -35;
-    pos @kc88_first_61 @kc88_second_66 -140;
-    pos @kc88_first_61 @kc88_second_67 -210;
-    pos @kc88_first_62 @kc88_second_1 -35;
-    pos @kc88_first_62 @kc88_second_2 -70;
-    pos @kc88_first_62 @kc88_second_5 -70;
-    pos @kc88_first_62 @kc88_second_11 -35;
-    pos @kc88_first_62 @kc88_second_12 -140;
-    pos @kc88_first_62 @kc88_second_13 -140;
-    pos @kc88_first_62 @kc88_second_14 -70;
-    pos @kc88_first_62 @kc88_second_15 -35;
-    pos @kc88_first_62 @kc88_second_16 -105;
-    pos @kc88_first_62 @kc88_second_28 -35;
-    pos @kc88_first_62 @kc88_second_29 -70;
-    pos @kc88_first_62 @kc88_second_35 -35;
-    pos @kc88_first_62 @kc88_second_38 -70;
-    pos @kc88_first_62 @kc88_second_46 -70;
-    pos @kc88_first_62 @kc88_second_48 1;
-    pos @kc88_first_62 @kc88_second_56 -175;
-    pos @kc88_first_62 @kc88_second_58 -140;
-    pos @kc88_first_62 @kc88_second_59 -140;
-    pos @kc88_first_62 @kc88_second_64 -35;
-    pos @kc88_first_63 @kc88_second_5 -70;
-    pos @kc88_first_63 @kc88_second_9 -70;
-    pos @kc88_first_63 @kc88_second_11 -35;
-    pos @kc88_first_63 @kc88_second_12 -350;
-    pos @kc88_first_63 @kc88_second_13 -315;
-    pos @kc88_first_63 @kc88_second_14 -175;
-    pos @kc88_first_63 @kc88_second_15 -140;
-    pos @kc88_first_63 @kc88_second_16 -70;
-    pos @kc88_first_63 @kc88_second_20 -70;
-    pos @kc88_first_63 @kc88_second_29 -70;
-    pos @kc88_first_63 @kc88_second_33 -50;
-    pos @kc88_first_63 @kc88_second_42 -140;
-    pos @kc88_first_63 @kc88_second_43 -50;
-    pos @kc88_first_63 @kc88_second_45 -35;
-    pos @kc88_first_63 @kc88_second_46 -175;
-    pos @kc88_first_63 @kc88_second_48 1;
-    pos @kc88_first_63 @kc88_second_50 -70;
-    pos @kc88_first_63 @kc88_second_51 -175;
-    pos @kc88_first_63 @kc88_second_57 -70;
-    pos @kc88_first_63 @kc88_second_61 -70;
-    pos @kc88_first_63 @kc88_second_63 -50;
-    pos @kc88_first_63 @kc88_second_64 -140;
-    pos @kc88_first_63 @kc88_second_65 -105;
-    pos @kc88_first_64 @kc88_second_4 -105;
-    pos @kc88_first_64 @kc88_second_6 -35;
-    pos @kc88_first_64 @kc88_second_8 1;
-    pos @kc88_first_64 @kc88_second_9 -245;
-    pos @kc88_first_64 @kc88_second_12 -210;
-    pos @kc88_first_64 @kc88_second_13 -210;
-    pos @kc88_first_64 @kc88_second_14 -210;
-    pos @kc88_first_64 @kc88_second_15 -175;
-    pos @kc88_first_64 @kc88_second_17 -70;
-    pos @kc88_first_64 @kc88_second_18 -105;
-    pos @kc88_first_64 @kc88_second_20 -180;
-    pos @kc88_first_64 @kc88_second_22 -140;
-    pos @kc88_first_64 @kc88_second_24 -105;
-    pos @kc88_first_64 @kc88_second_27 -140;
-    pos @kc88_first_64 @kc88_second_31 -105;
-    pos @kc88_first_64 @kc88_second_33 -140;
-    pos @kc88_first_64 @kc88_second_37 -35;
-    pos @kc88_first_64 @kc88_second_39 -35;
-    pos @kc88_first_64 @kc88_second_41 -175;
-    pos @kc88_first_64 @kc88_second_42 -142;
-    pos @kc88_first_64 @kc88_second_43 -245;
-    pos @kc88_first_64 @kc88_second_46 -210;
-    pos @kc88_first_64 @kc88_second_47 -105;
-    pos @kc88_first_64 @kc88_second_48 1;
-    pos @kc88_first_64 @kc88_second_49 -35;
-    pos @kc88_first_64 @kc88_second_50 -210;
-    pos @kc88_first_64 @kc88_second_51 -210;
-    pos @kc88_first_64 @kc88_second_54 -35;
-    pos @kc88_first_64 @kc88_second_61 -280;
-    pos @kc88_first_64 @kc88_second_63 -175;
-    pos @kc88_first_64 @kc88_second_64 -140;
-    pos @kc88_first_64 @kc88_second_65 -140;
-    pos @kc88_first_64 @kc88_second_66 -70;
-    pos @kc88_first_64 @kc88_second_67 -70;
-    pos @kc88_first_65 @kc88_second_1 -175;
-    pos @kc88_first_65 @kc88_second_2 -175;
-    pos @kc88_first_65 @kc88_second_5 -70;
-    pos @kc88_first_65 @kc88_second_6 -105;
-    pos @kc88_first_65 @kc88_second_11 -105;
-    pos @kc88_first_65 @kc88_second_12 -175;
-    pos @kc88_first_65 @kc88_second_13 -140;
-    pos @kc88_first_65 @kc88_second_14 -70;
-    pos @kc88_first_65 @kc88_second_15 -35;
-    pos @kc88_first_65 @kc88_second_16 -140;
-    pos @kc88_first_65 @kc88_second_17 -70;
-    pos @kc88_first_65 @kc88_second_18 -70;
-    pos @kc88_first_65 @kc88_second_19 -140;
-    pos @kc88_first_65 @kc88_second_21 -175;
-    pos @kc88_first_65 @kc88_second_24 -70;
-    pos @kc88_first_65 @kc88_second_31 -35;
-    pos @kc88_first_65 @kc88_second_35 -70;
-    pos @kc88_first_65 @kc88_second_37 -105;
-    pos @kc88_first_65 @kc88_second_38 -175;
-    pos @kc88_first_65 @kc88_second_39 -35;
-    pos @kc88_first_65 @kc88_second_41 -70;
-    pos @kc88_first_65 @kc88_second_48 1;
-    pos @kc88_first_65 @kc88_second_54 -35;
-    pos @kc88_first_65 @kc88_second_56 -140;
-    pos @kc88_first_65 @kc88_second_58 -140;
-    pos @kc88_first_65 @kc88_second_59 -140;
-    pos @kc88_first_65 @kc88_second_66 -70;
-    pos @kc88_first_65 @kc88_second_67 -105;
-    pos @kc88_first_66 @kc88_second_1 -210;
-    pos @kc88_first_66 @kc88_second_2 -210;
-    pos @kc88_first_66 @kc88_second_3 -70;
-    pos @kc88_first_66 @kc88_second_4 -35;
-    pos @kc88_first_66 @kc88_second_6 -210;
-    pos @kc88_first_66 @kc88_second_7 -70;
-    pos @kc88_first_66 @kc88_second_8 -70;
-    pos @kc88_first_66 @kc88_second_16 -70;
-    pos @kc88_first_66 @kc88_second_17 -140;
-    pos @kc88_first_66 @kc88_second_18 -175;
-    pos @kc88_first_66 @kc88_second_19 -210;
-    pos @kc88_first_66 @kc88_second_21 -210;
-    pos @kc88_first_66 @kc88_second_22 -140;
-    pos @kc88_first_66 @kc88_second_23 -35;
-    pos @kc88_first_66 @kc88_second_24 -175;
-    pos @kc88_first_66 @kc88_second_25 -140;
-    pos @kc88_first_66 @kc88_second_26 -280;
-    pos @kc88_first_66 @kc88_second_31 -35;
-    pos @kc88_first_66 @kc88_second_32 -35;
-    pos @kc88_first_66 @kc88_second_34 -210;
-    pos @kc88_first_66 @kc88_second_35 -175;
-    pos @kc88_first_66 @kc88_second_37 -245;
-    pos @kc88_first_66 @kc88_second_38 -140;
-    pos @kc88_first_66 @kc88_second_39 -140;
-    pos @kc88_first_66 @kc88_second_40 -140;
-    pos @kc88_first_66 @kc88_second_41 -140;
-    pos @kc88_first_66 @kc88_second_42 -35;
-    pos @kc88_first_66 @kc88_second_47 -35;
-    pos @kc88_first_66 @kc88_second_48 1;
-    pos @kc88_first_66 @kc88_second_52 -35;
-    pos @kc88_first_66 @kc88_second_54 -140;
-    pos @kc88_first_66 @kc88_second_55 -70;
-    pos @kc88_first_66 @kc88_second_56 -210;
-    pos @kc88_first_66 @kc88_second_58 -210;
-    pos @kc88_first_66 @kc88_second_59 -210;
-    pos @kc88_first_66 @kc88_second_61 -35;
-    pos @kc88_first_66 @kc88_second_66 -175;
-    pos @kc88_first_66 @kc88_second_67 -245;
-    pos @kc88_first_67 @kc88_second_6 -35;
-    pos @kc88_first_67 @kc88_second_12 -240;
-    pos @kc88_first_67 @kc88_second_13 -140;
-    pos @kc88_first_67 @kc88_second_14 -70;
-    pos @kc88_first_67 @kc88_second_15 -35;
-    pos @kc88_first_67 @kc88_second_18 -35;
-    pos @kc88_first_67 @kc88_second_22 -35;
-    pos @kc88_first_67 @kc88_second_24 -35;
-    pos @kc88_first_67 @kc88_second_37 -70;
-    pos @kc88_first_67 @kc88_second_41 -70;
-    pos @kc88_first_67 @kc88_second_42 -50;
-    pos @kc88_first_67 @kc88_second_48 1;
-    pos @kc88_first_67 @kc88_second_51 -35;
-    pos @kc88_first_67 @kc88_second_66 -35;
-    pos @kc88_first_67 @kc88_second_67 -35;
-    pos @kc88_first_68 @kc88_second_3 -100;
-    pos @kc88_first_68 @kc88_second_4 -50;
-    pos @kc88_first_68 @kc88_second_6 -50;
-    pos @kc88_first_68 @kc88_second_8 -70;
-    pos @kc88_first_68 @kc88_second_9 -140;
-    pos @kc88_first_68 @kc88_second_10 -50;
-    pos @kc88_first_68 @kc88_second_12 -140;
-    pos @kc88_first_68 @kc88_second_13 -100;
-    pos @kc88_first_68 @kc88_second_14 -70;
-    pos @kc88_first_68 @kc88_second_15 -50;
-    pos @kc88_first_68 @kc88_second_18 -50;
-    pos @kc88_first_68 @kc88_second_20 -70;
-    pos @kc88_first_68 @kc88_second_22 -70;
-    pos @kc88_first_68 @kc88_second_24 -50;
-    pos @kc88_first_68 @kc88_second_25 -70;
-    pos @kc88_first_68 @kc88_second_31 -35;
-    pos @kc88_first_68 @kc88_second_33 -70;
-    pos @kc88_first_68 @kc88_second_36 105;
-    pos @kc88_first_68 @kc88_second_37 -35;
-    pos @kc88_first_68 @kc88_second_41 -70;
-    pos @kc88_first_68 @kc88_second_42 -140;
-    pos @kc88_first_68 @kc88_second_43 -140;
-    pos @kc88_first_68 @kc88_second_46 -140;
-    pos @kc88_first_68 @kc88_second_47 -35;
-    pos @kc88_first_68 @kc88_second_48 1;
-    pos @kc88_first_68 @kc88_second_50 -70;
-    pos @kc88_first_68 @kc88_second_51 -100;
-    pos @kc88_first_68 @kc88_second_53 105;
-    pos @kc88_first_68 @kc88_second_61 -140;
-    pos @kc88_first_68 @kc88_second_63 -70;
-    pos @kc88_first_68 @kc88_second_64 -70;
-    pos @kc88_first_68 @kc88_second_65 -50;
-    pos @kc88_first_68 @kc88_second_66 -35;
-    pos @kc88_first_68 @kc88_second_67 -35;
-    pos @kc88_first_69 @kc88_second_3 -70;
-    pos @kc88_first_69 @kc88_second_4 -50;
-    pos @kc88_first_69 @kc88_second_6 -50;
-    pos @kc88_first_69 @kc88_second_8 -70;
-    pos @kc88_first_69 @kc88_second_9 -140;
-    pos @kc88_first_69 @kc88_second_10 -50;
-    pos @kc88_first_69 @kc88_second_12 -240;
-    pos @kc88_first_69 @kc88_second_13 -240;
-    pos @kc88_first_69 @kc88_second_14 -175;
-    pos @kc88_first_69 @kc88_second_15 -140;
-    pos @kc88_first_69 @kc88_second_18 -50;
-    pos @kc88_first_69 @kc88_second_20 -70;
-    pos @kc88_first_69 @kc88_second_22 -70;
-    pos @kc88_first_69 @kc88_second_24 -50;
-    pos @kc88_first_69 @kc88_second_25 -70;
-    pos @kc88_first_69 @kc88_second_31 -35;
-    pos @kc88_first_69 @kc88_second_33 -70;
-    pos @kc88_first_69 @kc88_second_36 105;
-    pos @kc88_first_69 @kc88_second_37 -35;
-    pos @kc88_first_69 @kc88_second_41 -70;
-    pos @kc88_first_69 @kc88_second_42 -140;
-    pos @kc88_first_69 @kc88_second_43 -140;
-    pos @kc88_first_69 @kc88_second_46 -140;
-    pos @kc88_first_69 @kc88_second_47 -35;
-    pos @kc88_first_69 @kc88_second_48 1;
-    pos @kc88_first_69 @kc88_second_50 -70;
-    pos @kc88_first_69 @kc88_second_51 -140;
-    pos @kc88_first_69 @kc88_second_53 105;
-    pos @kc88_first_69 @kc88_second_61 -140;
-    pos @kc88_first_69 @kc88_second_63 -70;
-    pos @kc88_first_69 @kc88_second_64 -105;
-    pos @kc88_first_69 @kc88_second_65 -70;
-    pos @kc88_first_69 @kc88_second_66 -35;
-    pos @kc88_first_69 @kc88_second_67 -35;
-    pos @kc88_first_70 @kc88_second_3 -70;
-    pos @kc88_first_70 @kc88_second_4 -50;
-    pos @kc88_first_70 @kc88_second_6 -50;
-    pos @kc88_first_70 @kc88_second_8 -70;
-    pos @kc88_first_70 @kc88_second_9 -140;
-    pos @kc88_first_70 @kc88_second_10 -50;
-    pos @kc88_first_70 @kc88_second_12 -140;
-    pos @kc88_first_70 @kc88_second_13 -140;
-    pos @kc88_first_70 @kc88_second_14 -105;
-    pos @kc88_first_70 @kc88_second_15 -70;
-    pos @kc88_first_70 @kc88_second_18 -50;
-    pos @kc88_first_70 @kc88_second_20 -70;
-    pos @kc88_first_70 @kc88_second_22 -70;
-    pos @kc88_first_70 @kc88_second_24 -50;
-    pos @kc88_first_70 @kc88_second_25 -100;
-    pos @kc88_first_70 @kc88_second_31 -35;
-    pos @kc88_first_70 @kc88_second_33 -70;
-    pos @kc88_first_70 @kc88_second_36 105;
-    pos @kc88_first_70 @kc88_second_37 -35;
-    pos @kc88_first_70 @kc88_second_41 -70;
-    pos @kc88_first_70 @kc88_second_42 -140;
-    pos @kc88_first_70 @kc88_second_43 -140;
-    pos @kc88_first_70 @kc88_second_46 -140;
-    pos @kc88_first_70 @kc88_second_47 -35;
-    pos @kc88_first_70 @kc88_second_48 1;
-    pos @kc88_first_70 @kc88_second_50 -70;
-    pos @kc88_first_70 @kc88_second_51 -140;
-    pos @kc88_first_70 @kc88_second_53 105;
-    pos @kc88_first_70 @kc88_second_61 -140;
-    pos @kc88_first_70 @kc88_second_63 -70;
-    pos @kc88_first_70 @kc88_second_64 -70;
-    pos @kc88_first_70 @kc88_second_65 -50;
-    pos @kc88_first_70 @kc88_second_66 -35;
-    pos @kc88_first_70 @kc88_second_67 -35;
-    pos @kc88_first_71 @kc88_second_1 -210;
-    pos @kc88_first_71 @kc88_second_2 -210;
-    pos @kc88_first_71 @kc88_second_3 -35;
-    pos @kc88_first_71 @kc88_second_6 -140;
-    pos @kc88_first_71 @kc88_second_8 -70;
-    pos @kc88_first_71 @kc88_second_10 -35;
-    pos @kc88_first_71 @kc88_second_17 -70;
-    pos @kc88_first_71 @kc88_second_18 -105;
-    pos @kc88_first_71 @kc88_second_19 -210;
-    pos @kc88_first_71 @kc88_second_21 -210;
-    pos @kc88_first_71 @kc88_second_22 -70;
-    pos @kc88_first_71 @kc88_second_24 -105;
-    pos @kc88_first_71 @kc88_second_25 -105;
-    pos @kc88_first_71 @kc88_second_26 -175;
-    pos @kc88_first_71 @kc88_second_31 -105;
-    pos @kc88_first_71 @kc88_second_34 -210;
-    pos @kc88_first_71 @kc88_second_35 -105;
-    pos @kc88_first_71 @kc88_second_37 -175;
-    pos @kc88_first_71 @kc88_second_38 -140;
-    pos @kc88_first_71 @kc88_second_39 -70;
-    pos @kc88_first_71 @kc88_second_40 -105;
-    pos @kc88_first_71 @kc88_second_41 -105;
-    pos @kc88_first_71 @kc88_second_42 -70;
-    pos @kc88_first_71 @kc88_second_47 -35;
-    pos @kc88_first_71 @kc88_second_48 1;
-    pos @kc88_first_71 @kc88_second_53 -35;
-    pos @kc88_first_71 @kc88_second_54 -70;
-    pos @kc88_first_71 @kc88_second_55 -70;
-    pos @kc88_first_71 @kc88_second_56 -175;
-    pos @kc88_first_71 @kc88_second_58 -175;
-    pos @kc88_first_71 @kc88_second_59 -175;
-    pos @kc88_first_71 @kc88_second_61 -35;
-    pos @kc88_first_71 @kc88_second_62 -35;
-    pos @kc88_first_71 @kc88_second_66 -140;
-    pos @kc88_first_71 @kc88_second_67 -175;
-    pos @kc88_first_72 @kc88_second_5 -70;
-    pos @kc88_first_72 @kc88_second_8 -70;
-    pos @kc88_first_72 @kc88_second_9 -105;
-    pos @kc88_first_72 @kc88_second_11 -35;
-    pos @kc88_first_72 @kc88_second_12 -350;
-    pos @kc88_first_72 @kc88_second_13 -350;
-    pos @kc88_first_72 @kc88_second_14 -245;
-    pos @kc88_first_72 @kc88_second_15 -210;
-    pos @kc88_first_72 @kc88_second_16 -70;
-    pos @kc88_first_72 @kc88_second_20 -210;
-    pos @kc88_first_72 @kc88_second_25 -35;
-    pos @kc88_first_72 @kc88_second_28 -35;
-    pos @kc88_first_72 @kc88_second_29 -70;
-    pos @kc88_first_72 @kc88_second_33 -70;
-    pos @kc88_first_72 @kc88_second_41 -35;
-    pos @kc88_first_72 @kc88_second_42 -245;
-    pos @kc88_first_72 @kc88_second_43 -70;
-    pos @kc88_first_72 @kc88_second_45 -35;
-    pos @kc88_first_72 @kc88_second_46 -240;
-    pos @kc88_first_72 @kc88_second_48 1;
-    pos @kc88_first_72 @kc88_second_50 -105;
-    pos @kc88_first_72 @kc88_second_51 -280;
-    pos @kc88_first_72 @kc88_second_52 -35;
-    pos @kc88_first_72 @kc88_second_57 -35;
-    pos @kc88_first_72 @kc88_second_60 -70;
-    pos @kc88_first_72 @kc88_second_61 -105;
-    pos @kc88_first_72 @kc88_second_62 -35;
-    pos @kc88_first_72 @kc88_second_63 -70;
-    pos @kc88_first_72 @kc88_second_64 -175;
-    pos @kc88_first_72 @kc88_second_65 -140;
-    pos @kc88_first_73 @kc88_second_1 -140;
-    pos @kc88_first_73 @kc88_second_2 -140;
-    pos @kc88_first_73 @kc88_second_6 -140;
-    pos @kc88_first_73 @kc88_second_8 -35;
-    pos @kc88_first_73 @kc88_second_10 -35;
-    pos @kc88_first_73 @kc88_second_17 -35;
-    pos @kc88_first_73 @kc88_second_18 -70;
-    pos @kc88_first_73 @kc88_second_19 -140;
-    pos @kc88_first_73 @kc88_second_21 -140;
-    pos @kc88_first_73 @kc88_second_22 -35;
-    pos @kc88_first_73 @kc88_second_24 -70;
-    pos @kc88_first_73 @kc88_second_25 -70;
-    pos @kc88_first_73 @kc88_second_26 -140;
-    pos @kc88_first_73 @kc88_second_31 -70;
-    pos @kc88_first_73 @kc88_second_35 -70;
-    pos @kc88_first_73 @kc88_second_37 -175;
-    pos @kc88_first_73 @kc88_second_38 -105;
-    pos @kc88_first_73 @kc88_second_39 -70;
-    pos @kc88_first_73 @kc88_second_40 -70;
-    pos @kc88_first_73 @kc88_second_41 -70;
-    pos @kc88_first_73 @kc88_second_42 -35;
-    pos @kc88_first_73 @kc88_second_48 1;
-    pos @kc88_first_73 @kc88_second_53 -35;
-    pos @kc88_first_73 @kc88_second_54 -35;
-    pos @kc88_first_73 @kc88_second_56 -140;
-    pos @kc88_first_73 @kc88_second_58 -140;
-    pos @kc88_first_73 @kc88_second_59 -140;
-    pos @kc88_first_73 @kc88_second_66 -105;
-    pos @kc88_first_73 @kc88_second_67 -105;
+    @kc89_second_66 = [\uni0500 \uni0502 ];
+    @kc89_second_67 = [\uni0501.sc \uni0503.sc ];
+    @kc89_second_68 = [\zero.cv10.zero.dnom.pnum \zero.cv20.zero.dnom.pnum \zero.zero.dnom.pnum ];
+    @kc89_second_69 = [\zero.cv10.zero.numr.pnum \zero.cv20.zero.numr.pnum \zero.zero.numr.pnum ];
+    pos @kc89_first_1 @kc89_second_3 -70;
+    pos @kc89_first_1 @kc89_second_8 -70;
+    pos @kc89_first_1 @kc89_second_9 -140;
+    pos @kc89_first_1 @kc89_second_10 -35;
+    pos @kc89_first_1 @kc89_second_12 -280;
+    pos @kc89_first_1 @kc89_second_13 -280;
+    pos @kc89_first_1 @kc89_second_14 -280;
+    pos @kc89_first_1 @kc89_second_15 -210;
+    pos @kc89_first_1 @kc89_second_22 -70;
+    pos @kc89_first_1 @kc89_second_25 -35;
+    pos @kc89_first_1 @kc89_second_27 -50;
+    pos @kc89_first_1 @kc89_second_33 -70;
+    pos @kc89_first_1 @kc89_second_41 -35;
+    pos @kc89_first_1 @kc89_second_42 -140;
+    pos @kc89_first_1 @kc89_second_43 -105;
+    pos @kc89_first_1 @kc89_second_46 -210;
+    pos @kc89_first_1 @kc89_second_47 -35;
+    pos @kc89_first_1 @kc89_second_48 1;
+    pos @kc89_first_1 @kc89_second_50 -175;
+    pos @kc89_first_1 @kc89_second_51 -210;
+    pos @kc89_first_1 @kc89_second_61 -140;
+    pos @kc89_first_1 @kc89_second_63 -140;
+    pos @kc89_first_1 @kc89_second_64 -210;
+    pos @kc89_first_1 @kc89_second_65 -140;
+    pos @kc89_first_2 @kc89_second_9 -35;
+    pos @kc89_first_2 @kc89_second_12 -70;
+    pos @kc89_first_2 @kc89_second_13 -70;
+    pos @kc89_first_2 @kc89_second_14 -70;
+    pos @kc89_first_2 @kc89_second_15 -35;
+    pos @kc89_first_2 @kc89_second_16 -35;
+    pos @kc89_first_2 @kc89_second_42 -35;
+    pos @kc89_first_2 @kc89_second_48 1;
+    pos @kc89_first_3 @kc89_second_1 -35;
+    pos @kc89_first_3 @kc89_second_2 -70;
+    pos @kc89_first_3 @kc89_second_5 -35;
+    pos @kc89_first_3 @kc89_second_11 -35;
+    pos @kc89_first_3 @kc89_second_12 -35;
+    pos @kc89_first_3 @kc89_second_13 -70;
+    pos @kc89_first_3 @kc89_second_14 -35;
+    pos @kc89_first_3 @kc89_second_16 -70;
+    pos @kc89_first_3 @kc89_second_19 -35;
+    pos @kc89_first_3 @kc89_second_21 -70;
+    pos @kc89_first_3 @kc89_second_38 -35;
+    pos @kc89_first_3 @kc89_second_48 1;
+    pos @kc89_first_4 @kc89_second_1 -70;
+    pos @kc89_first_4 @kc89_second_2 -140;
+    pos @kc89_first_4 @kc89_second_4 70;
+    pos @kc89_first_4 @kc89_second_5 -70;
+    pos @kc89_first_4 @kc89_second_11 -105;
+    pos @kc89_first_4 @kc89_second_12 -140;
+    pos @kc89_first_4 @kc89_second_13 -140;
+    pos @kc89_first_4 @kc89_second_14 -105;
+    pos @kc89_first_4 @kc89_second_15 -35;
+    pos @kc89_first_4 @kc89_second_16 -140;
+    pos @kc89_first_4 @kc89_second_19 -70;
+    pos @kc89_first_4 @kc89_second_26 -70;
+    pos @kc89_first_4 @kc89_second_28 -70;
+    pos @kc89_first_4 @kc89_second_29 -35;
+    pos @kc89_first_4 @kc89_second_33 35;
+    pos @kc89_first_4 @kc89_second_35 -35;
+    pos @kc89_first_4 @kc89_second_37 -70;
+    pos @kc89_first_4 @kc89_second_38 -70;
+    pos @kc89_first_4 @kc89_second_46 -35;
+    pos @kc89_first_4 @kc89_second_48 1;
+    pos @kc89_first_4 @kc89_second_51 -70;
+    pos @kc89_first_4 @kc89_second_56 -70;
+    pos @kc89_first_4 @kc89_second_58 -70;
+    pos @kc89_first_4 @kc89_second_59 -70;
+    pos @kc89_first_4 @kc89_second_64 -35;
+    pos @kc89_first_5 @kc89_second_12 -70;
+    pos @kc89_first_5 @kc89_second_48 1;
+    pos @kc89_first_6 @kc89_second_1 -280;
+    pos @kc89_first_6 @kc89_second_2 -350;
+    pos @kc89_first_6 @kc89_second_3 -140;
+    pos @kc89_first_6 @kc89_second_4 -70;
+    pos @kc89_first_6 @kc89_second_6 -350;
+    pos @kc89_first_6 @kc89_second_7 -140;
+    pos @kc89_first_6 @kc89_second_8 -210;
+    pos @kc89_first_6 @kc89_second_10 -70;
+    pos @kc89_first_6 @kc89_second_17 -240;
+    pos @kc89_first_6 @kc89_second_18 -240;
+    pos @kc89_first_6 @kc89_second_19 -280;
+    pos @kc89_first_6 @kc89_second_21 -350;
+    pos @kc89_first_6 @kc89_second_22 -280;
+    pos @kc89_first_6 @kc89_second_23 -240;
+    pos @kc89_first_6 @kc89_second_24 -240;
+    pos @kc89_first_6 @kc89_second_25 -210;
+    pos @kc89_first_6 @kc89_second_26 -350;
+    pos @kc89_first_6 @kc89_second_27 -140;
+    pos @kc89_first_6 @kc89_second_29 -140;
+    pos @kc89_first_6 @kc89_second_31 -240;
+    pos @kc89_first_6 @kc89_second_32 -240;
+    pos @kc89_first_6 @kc89_second_33 -175;
+    pos @kc89_first_6 @kc89_second_35 -240;
+    pos @kc89_first_6 @kc89_second_37 -350;
+    pos @kc89_first_6 @kc89_second_38 -105;
+    pos @kc89_first_6 @kc89_second_39 -240;
+    pos @kc89_first_6 @kc89_second_40 -210;
+    pos @kc89_first_6 @kc89_second_41 -240;
+    pos @kc89_first_6 @kc89_second_42 -240;
+    pos @kc89_first_6 @kc89_second_44 -240;
+    pos @kc89_first_6 @kc89_second_47 -140;
+    pos @kc89_first_6 @kc89_second_48 1;
+    pos @kc89_first_6 @kc89_second_49 -35;
+    pos @kc89_first_6 @kc89_second_50 -240;
+    pos @kc89_first_6 @kc89_second_52 -240;
+    pos @kc89_first_6 @kc89_second_53 -240;
+    pos @kc89_first_6 @kc89_second_54 -240;
+    pos @kc89_first_6 @kc89_second_55 -240;
+    pos @kc89_first_6 @kc89_second_56 -280;
+    pos @kc89_first_6 @kc89_second_57 -70;
+    pos @kc89_first_6 @kc89_second_58 -280;
+    pos @kc89_first_6 @kc89_second_59 -240;
+    pos @kc89_first_6 @kc89_second_60 -175;
+    pos @kc89_first_6 @kc89_second_61 -240;
+    pos @kc89_first_6 @kc89_second_62 -210;
+    pos @kc89_first_6 @kc89_second_63 -175;
+    pos @kc89_first_6 @kc89_second_66 -175;
+    pos @kc89_first_6 @kc89_second_67 -175;
+    pos @kc89_first_7 @kc89_second_3 -70;
+    pos @kc89_first_7 @kc89_second_8 -105;
+    pos @kc89_first_7 @kc89_second_17 -35;
+    pos @kc89_first_7 @kc89_second_18 -70;
+    pos @kc89_first_7 @kc89_second_22 -105;
+    pos @kc89_first_7 @kc89_second_24 -105;
+    pos @kc89_first_7 @kc89_second_25 -70;
+    pos @kc89_first_7 @kc89_second_48 1;
+    pos @kc89_first_7 @kc89_second_49 -35;
+    pos @kc89_first_7 @kc89_second_50 -70;
+    pos @kc89_first_7 @kc89_second_54 -50;
+    pos @kc89_first_7 @kc89_second_63 -35;
+    pos @kc89_first_7 @kc89_second_66 -70;
+    pos @kc89_first_7 @kc89_second_67 -70;
+    pos @kc89_first_8 @kc89_second_3 -140;
+    pos @kc89_first_8 @kc89_second_4 -70;
+    pos @kc89_first_8 @kc89_second_6 -70;
+    pos @kc89_first_8 @kc89_second_8 -140;
+    pos @kc89_first_8 @kc89_second_10 -35;
+    pos @kc89_first_8 @kc89_second_17 -70;
+    pos @kc89_first_8 @kc89_second_18 -70;
+    pos @kc89_first_8 @kc89_second_22 -140;
+    pos @kc89_first_8 @kc89_second_24 -70;
+    pos @kc89_first_8 @kc89_second_25 -105;
+    pos @kc89_first_8 @kc89_second_27 -140;
+    pos @kc89_first_8 @kc89_second_31 -35;
+    pos @kc89_first_8 @kc89_second_33 -105;
+    pos @kc89_first_8 @kc89_second_37 -70;
+    pos @kc89_first_8 @kc89_second_39 -70;
+    pos @kc89_first_8 @kc89_second_41 -105;
+    pos @kc89_first_8 @kc89_second_42 -175;
+    pos @kc89_first_8 @kc89_second_43 -140;
+    pos @kc89_first_8 @kc89_second_44 -35;
+    pos @kc89_first_8 @kc89_second_46 -140;
+    pos @kc89_first_8 @kc89_second_47 -105;
+    pos @kc89_first_8 @kc89_second_48 1;
+    pos @kc89_first_8 @kc89_second_49 -70;
+    pos @kc89_first_8 @kc89_second_50 -140;
+    pos @kc89_first_8 @kc89_second_51 -70;
+    pos @kc89_first_8 @kc89_second_54 -35;
+    pos @kc89_first_8 @kc89_second_55 -35;
+    pos @kc89_first_8 @kc89_second_61 -210;
+    pos @kc89_first_8 @kc89_second_63 -105;
+    pos @kc89_first_8 @kc89_second_64 -70;
+    pos @kc89_first_8 @kc89_second_65 -35;
+    pos @kc89_first_8 @kc89_second_66 -70;
+    pos @kc89_first_8 @kc89_second_67 -35;
+    pos @kc89_first_9 @kc89_second_3 -140;
+    pos @kc89_first_9 @kc89_second_4 -70;
+    pos @kc89_first_9 @kc89_second_6 -70;
+    pos @kc89_first_9 @kc89_second_8 -210;
+    pos @kc89_first_9 @kc89_second_9 -420;
+    pos @kc89_first_9 @kc89_second_10 -70;
+    pos @kc89_first_9 @kc89_second_12 -350;
+    pos @kc89_first_9 @kc89_second_13 -420;
+    pos @kc89_first_9 @kc89_second_14 -350;
+    pos @kc89_first_9 @kc89_second_15 -280;
+    pos @kc89_first_9 @kc89_second_17 -70;
+    pos @kc89_first_9 @kc89_second_18 -70;
+    pos @kc89_first_9 @kc89_second_20 -210;
+    pos @kc89_first_9 @kc89_second_22 -210;
+    pos @kc89_first_9 @kc89_second_24 -70;
+    pos @kc89_first_9 @kc89_second_25 -140;
+    pos @kc89_first_9 @kc89_second_31 -50;
+    pos @kc89_first_9 @kc89_second_33 -140;
+    pos @kc89_first_9 @kc89_second_37 -70;
+    pos @kc89_first_9 @kc89_second_41 -105;
+    pos @kc89_first_9 @kc89_second_42 -280;
+    pos @kc89_first_9 @kc89_second_43 -350;
+    pos @kc89_first_9 @kc89_second_44 -50;
+    pos @kc89_first_9 @kc89_second_46 -350;
+    pos @kc89_first_9 @kc89_second_48 1;
+    pos @kc89_first_9 @kc89_second_49 -35;
+    pos @kc89_first_9 @kc89_second_50 -210;
+    pos @kc89_first_9 @kc89_second_51 -350;
+    pos @kc89_first_9 @kc89_second_54 -35;
+    pos @kc89_first_9 @kc89_second_55 -35;
+    pos @kc89_first_9 @kc89_second_61 -280;
+    pos @kc89_first_9 @kc89_second_63 -175;
+    pos @kc89_first_9 @kc89_second_64 -280;
+    pos @kc89_first_9 @kc89_second_65 -210;
+    pos @kc89_first_9 @kc89_second_66 -70;
+    pos @kc89_first_9 @kc89_second_67 -70;
+    pos @kc89_first_10 @kc89_second_1 -210;
+    pos @kc89_first_10 @kc89_second_2 -350;
+    pos @kc89_first_10 @kc89_second_5 -70;
+    pos @kc89_first_10 @kc89_second_6 -140;
+    pos @kc89_first_10 @kc89_second_11 -35;
+    pos @kc89_first_10 @kc89_second_12 -70;
+    pos @kc89_first_10 @kc89_second_13 -70;
+    pos @kc89_first_10 @kc89_second_14 -35;
+    pos @kc89_first_10 @kc89_second_16 -70;
+    pos @kc89_first_10 @kc89_second_17 -35;
+    pos @kc89_first_10 @kc89_second_18 -70;
+    pos @kc89_first_10 @kc89_second_19 -140;
+    pos @kc89_first_10 @kc89_second_21 -280;
+    pos @kc89_first_10 @kc89_second_24 -70;
+    pos @kc89_first_10 @kc89_second_26 -350;
+    pos @kc89_first_10 @kc89_second_31 -70;
+    pos @kc89_first_10 @kc89_second_34 -140;
+    pos @kc89_first_10 @kc89_second_35 -70;
+    pos @kc89_first_10 @kc89_second_37 -210;
+    pos @kc89_first_10 @kc89_second_38 -105;
+    pos @kc89_first_10 @kc89_second_41 -70;
+    pos @kc89_first_10 @kc89_second_48 1;
+    pos @kc89_first_10 @kc89_second_56 -210;
+    pos @kc89_first_10 @kc89_second_58 -210;
+    pos @kc89_first_10 @kc89_second_59 -210;
+    pos @kc89_first_10 @kc89_second_64 -70;
+    pos @kc89_first_10 @kc89_second_66 -70;
+    pos @kc89_first_10 @kc89_second_67 -105;
+    pos @kc89_first_11 @kc89_second_1 -70;
+    pos @kc89_first_11 @kc89_second_2 -140;
+    pos @kc89_first_11 @kc89_second_5 -105;
+    pos @kc89_first_11 @kc89_second_6 -35;
+    pos @kc89_first_11 @kc89_second_11 -70;
+    pos @kc89_first_11 @kc89_second_12 -210;
+    pos @kc89_first_11 @kc89_second_13 -175;
+    pos @kc89_first_11 @kc89_second_14 -105;
+    pos @kc89_first_11 @kc89_second_15 -70;
+    pos @kc89_first_11 @kc89_second_16 -140;
+    pos @kc89_first_11 @kc89_second_19 -70;
+    pos @kc89_first_11 @kc89_second_21 -140;
+    pos @kc89_first_11 @kc89_second_26 -70;
+    pos @kc89_first_11 @kc89_second_28 -70;
+    pos @kc89_first_11 @kc89_second_29 -70;
+    pos @kc89_first_11 @kc89_second_35 -35;
+    pos @kc89_first_11 @kc89_second_37 -35;
+    pos @kc89_first_11 @kc89_second_38 -140;
+    pos @kc89_first_11 @kc89_second_42 -70;
+    pos @kc89_first_11 @kc89_second_45 -35;
+    pos @kc89_first_11 @kc89_second_46 -35;
+    pos @kc89_first_11 @kc89_second_48 1;
+    pos @kc89_first_11 @kc89_second_51 -70;
+    pos @kc89_first_11 @kc89_second_56 -210;
+    pos @kc89_first_11 @kc89_second_58 -175;
+    pos @kc89_first_11 @kc89_second_59 -175;
+    pos @kc89_first_11 @kc89_second_60 -35;
+    pos @kc89_first_11 @kc89_second_64 -70;
+    pos @kc89_first_11 @kc89_second_65 -35;
+    pos @kc89_first_11 @kc89_second_66 -35;
+    pos @kc89_first_11 @kc89_second_67 -70;
+    pos @kc89_first_12 @kc89_second_1 -140;
+    pos @kc89_first_12 @kc89_second_2 -210;
+    pos @kc89_first_12 @kc89_second_6 -140;
+    pos @kc89_first_12 @kc89_second_17 -70;
+    pos @kc89_first_12 @kc89_second_18 -70;
+    pos @kc89_first_12 @kc89_second_19 -140;
+    pos @kc89_first_12 @kc89_second_21 -210;
+    pos @kc89_first_12 @kc89_second_24 -70;
+    pos @kc89_first_12 @kc89_second_26 -350;
+    pos @kc89_first_12 @kc89_second_31 -35;
+    pos @kc89_first_12 @kc89_second_34 -140;
+    pos @kc89_first_12 @kc89_second_35 -70;
+    pos @kc89_first_12 @kc89_second_37 -140;
+    pos @kc89_first_12 @kc89_second_38 -70;
+    pos @kc89_first_12 @kc89_second_41 -70;
+    pos @kc89_first_12 @kc89_second_48 1;
+    pos @kc89_first_12 @kc89_second_54 -35;
+    pos @kc89_first_12 @kc89_second_56 -210;
+    pos @kc89_first_12 @kc89_second_58 -210;
+    pos @kc89_first_12 @kc89_second_59 -210;
+    pos @kc89_first_12 @kc89_second_66 -70;
+    pos @kc89_first_12 @kc89_second_67 -105;
+    pos @kc89_first_13 @kc89_second_6 -70;
+    pos @kc89_first_13 @kc89_second_12 -70;
+    pos @kc89_first_13 @kc89_second_13 -105;
+    pos @kc89_first_13 @kc89_second_14 -35;
+    pos @kc89_first_13 @kc89_second_18 -35;
+    pos @kc89_first_13 @kc89_second_24 -35;
+    pos @kc89_first_13 @kc89_second_31 -35;
+    pos @kc89_first_13 @kc89_second_37 -70;
+    pos @kc89_first_13 @kc89_second_41 -70;
+    pos @kc89_first_13 @kc89_second_48 1;
+    pos @kc89_first_13 @kc89_second_66 -70;
+    pos @kc89_first_13 @kc89_second_67 -35;
+    pos @kc89_first_14 @kc89_second_2 -35;
+    pos @kc89_first_14 @kc89_second_11 -35;
+    pos @kc89_first_14 @kc89_second_12 -70;
+    pos @kc89_first_14 @kc89_second_13 -70;
+    pos @kc89_first_14 @kc89_second_14 -35;
+    pos @kc89_first_14 @kc89_second_16 -35;
+    pos @kc89_first_14 @kc89_second_21 -35;
+    pos @kc89_first_14 @kc89_second_27 -35;
+    pos @kc89_first_14 @kc89_second_35 -35;
+    pos @kc89_first_14 @kc89_second_42 -70;
+    pos @kc89_first_14 @kc89_second_48 1;
+    pos @kc89_first_14 @kc89_second_50 -70;
+    pos @kc89_first_14 @kc89_second_51 -35;
+    pos @kc89_first_14 @kc89_second_60 -35;
+    pos @kc89_first_14 @kc89_second_61 -35;
+    pos @kc89_first_14 @kc89_second_63 -35;
+    pos @kc89_first_14 @kc89_second_65 -35;
+    pos @kc89_first_15 @kc89_second_3 -70;
+    pos @kc89_first_15 @kc89_second_4 -70;
+    pos @kc89_first_15 @kc89_second_6 -35;
+    pos @kc89_first_15 @kc89_second_8 -70;
+    pos @kc89_first_15 @kc89_second_17 -70;
+    pos @kc89_first_15 @kc89_second_18 -70;
+    pos @kc89_first_15 @kc89_second_22 -140;
+    pos @kc89_first_15 @kc89_second_24 -70;
+    pos @kc89_first_15 @kc89_second_25 -70;
+    pos @kc89_first_15 @kc89_second_27 -70;
+    pos @kc89_first_15 @kc89_second_31 -35;
+    pos @kc89_first_15 @kc89_second_33 -35;
+    pos @kc89_first_15 @kc89_second_39 -35;
+    pos @kc89_first_15 @kc89_second_41 -70;
+    pos @kc89_first_15 @kc89_second_42 -142;
+    pos @kc89_first_15 @kc89_second_43 -35;
+    pos @kc89_first_15 @kc89_second_47 -35;
+    pos @kc89_first_15 @kc89_second_48 1;
+    pos @kc89_first_15 @kc89_second_49 -35;
+    pos @kc89_first_15 @kc89_second_50 -70;
+    pos @kc89_first_15 @kc89_second_54 -35;
+    pos @kc89_first_15 @kc89_second_55 -35;
+    pos @kc89_first_15 @kc89_second_61 -105;
+    pos @kc89_first_15 @kc89_second_63 -35;
+    pos @kc89_first_15 @kc89_second_66 -35;
+    pos @kc89_first_15 @kc89_second_67 -35;
+    pos @kc89_first_16 @kc89_second_1 -280;
+    pos @kc89_first_16 @kc89_second_2 -280;
+    pos @kc89_first_16 @kc89_second_3 -140;
+    pos @kc89_first_16 @kc89_second_4 -70;
+    pos @kc89_first_16 @kc89_second_6 -280;
+    pos @kc89_first_16 @kc89_second_7 -140;
+    pos @kc89_first_16 @kc89_second_8 -175;
+    pos @kc89_first_16 @kc89_second_10 -70;
+    pos @kc89_first_16 @kc89_second_17 -245;
+    pos @kc89_first_16 @kc89_second_18 -280;
+    pos @kc89_first_16 @kc89_second_19 -280;
+    pos @kc89_first_16 @kc89_second_21 -280;
+    pos @kc89_first_16 @kc89_second_22 -210;
+    pos @kc89_first_16 @kc89_second_23 -140;
+    pos @kc89_first_16 @kc89_second_24 -280;
+    pos @kc89_first_16 @kc89_second_25 -210;
+    pos @kc89_first_16 @kc89_second_26 -350;
+    pos @kc89_first_16 @kc89_second_27 -70;
+    pos @kc89_first_16 @kc89_second_29 -140;
+    pos @kc89_first_16 @kc89_second_31 -240;
+    pos @kc89_first_16 @kc89_second_32 -140;
+    pos @kc89_first_16 @kc89_second_33 -140;
+    pos @kc89_first_16 @kc89_second_34 -245;
+    pos @kc89_first_16 @kc89_second_35 -315;
+    pos @kc89_first_16 @kc89_second_37 -315;
+    pos @kc89_first_16 @kc89_second_38 -70;
+    pos @kc89_first_16 @kc89_second_39 -210;
+    pos @kc89_first_16 @kc89_second_40 -210;
+    pos @kc89_first_16 @kc89_second_41 -245;
+    pos @kc89_first_16 @kc89_second_42 -245;
+    pos @kc89_first_16 @kc89_second_43 -70;
+    pos @kc89_first_16 @kc89_second_45 -35;
+    pos @kc89_first_16 @kc89_second_46 -140;
+    pos @kc89_first_16 @kc89_second_47 -140;
+    pos @kc89_first_16 @kc89_second_48 1;
+    pos @kc89_first_16 @kc89_second_49 -70;
+    pos @kc89_first_16 @kc89_second_50 -140;
+    pos @kc89_first_16 @kc89_second_52 -140;
+    pos @kc89_first_16 @kc89_second_53 -140;
+    pos @kc89_first_16 @kc89_second_54 -240;
+    pos @kc89_first_16 @kc89_second_55 -140;
+    pos @kc89_first_16 @kc89_second_56 -280;
+    pos @kc89_first_16 @kc89_second_57 -105;
+    pos @kc89_first_16 @kc89_second_58 -315;
+    pos @kc89_first_16 @kc89_second_59 -280;
+    pos @kc89_first_16 @kc89_second_60 -140;
+    pos @kc89_first_16 @kc89_second_61 -210;
+    pos @kc89_first_16 @kc89_second_62 -210;
+    pos @kc89_first_16 @kc89_second_63 -105;
+    pos @kc89_first_16 @kc89_second_66 -315;
+    pos @kc89_first_16 @kc89_second_67 -350;
+    pos @kc89_first_17 @kc89_second_1 -280;
+    pos @kc89_first_17 @kc89_second_2 -280;
+    pos @kc89_first_17 @kc89_second_3 -105;
+    pos @kc89_first_17 @kc89_second_6 -210;
+    pos @kc89_first_17 @kc89_second_7 -105;
+    pos @kc89_first_17 @kc89_second_8 -105;
+    pos @kc89_first_17 @kc89_second_10 -35;
+    pos @kc89_first_17 @kc89_second_17 -105;
+    pos @kc89_first_17 @kc89_second_18 -175;
+    pos @kc89_first_17 @kc89_second_19 -280;
+    pos @kc89_first_17 @kc89_second_21 -280;
+    pos @kc89_first_17 @kc89_second_22 -70;
+    pos @kc89_first_17 @kc89_second_23 -105;
+    pos @kc89_first_17 @kc89_second_24 -140;
+    pos @kc89_first_17 @kc89_second_25 -140;
+    pos @kc89_first_17 @kc89_second_26 -210;
+    pos @kc89_first_17 @kc89_second_29 -70;
+    pos @kc89_first_17 @kc89_second_31 -140;
+    pos @kc89_first_17 @kc89_second_32 -105;
+    pos @kc89_first_17 @kc89_second_34 -210;
+    pos @kc89_first_17 @kc89_second_35 -175;
+    pos @kc89_first_17 @kc89_second_37 -245;
+    pos @kc89_first_17 @kc89_second_38 -70;
+    pos @kc89_first_17 @kc89_second_39 -140;
+    pos @kc89_first_17 @kc89_second_40 -140;
+    pos @kc89_first_17 @kc89_second_41 -140;
+    pos @kc89_first_17 @kc89_second_42 -105;
+    pos @kc89_first_17 @kc89_second_43 -35;
+    pos @kc89_first_17 @kc89_second_46 -35;
+    pos @kc89_first_17 @kc89_second_47 -70;
+    pos @kc89_first_17 @kc89_second_48 1;
+    pos @kc89_first_17 @kc89_second_49 -35;
+    pos @kc89_first_17 @kc89_second_50 -70;
+    pos @kc89_first_17 @kc89_second_52 -105;
+    pos @kc89_first_17 @kc89_second_53 -70;
+    pos @kc89_first_17 @kc89_second_54 -105;
+    pos @kc89_first_17 @kc89_second_55 -70;
+    pos @kc89_first_17 @kc89_second_56 -210;
+    pos @kc89_first_17 @kc89_second_57 -35;
+    pos @kc89_first_17 @kc89_second_58 -245;
+    pos @kc89_first_17 @kc89_second_59 -210;
+    pos @kc89_first_17 @kc89_second_60 -70;
+    pos @kc89_first_17 @kc89_second_61 -105;
+    pos @kc89_first_17 @kc89_second_62 -105;
+    pos @kc89_first_17 @kc89_second_63 -70;
+    pos @kc89_first_17 @kc89_second_66 -175;
+    pos @kc89_first_17 @kc89_second_67 -245;
+    pos @kc89_first_18 @kc89_second_1 -210;
+    pos @kc89_first_18 @kc89_second_2 -245;
+    pos @kc89_first_18 @kc89_second_3 -35;
+    pos @kc89_first_18 @kc89_second_6 -140;
+    pos @kc89_first_18 @kc89_second_7 -35;
+    pos @kc89_first_18 @kc89_second_8 -70;
+    pos @kc89_first_18 @kc89_second_17 -105;
+    pos @kc89_first_18 @kc89_second_18 -105;
+    pos @kc89_first_18 @kc89_second_19 -175;
+    pos @kc89_first_18 @kc89_second_21 -210;
+    pos @kc89_first_18 @kc89_second_22 -70;
+    pos @kc89_first_18 @kc89_second_24 -105;
+    pos @kc89_first_18 @kc89_second_25 -70;
+    pos @kc89_first_18 @kc89_second_26 -140;
+    pos @kc89_first_18 @kc89_second_29 -35;
+    pos @kc89_first_18 @kc89_second_34 -140;
+    pos @kc89_first_18 @kc89_second_35 -105;
+    pos @kc89_first_18 @kc89_second_37 -140;
+    pos @kc89_first_18 @kc89_second_39 -105;
+    pos @kc89_first_18 @kc89_second_40 -70;
+    pos @kc89_first_18 @kc89_second_41 -105;
+    pos @kc89_first_18 @kc89_second_42 -70;
+    pos @kc89_first_18 @kc89_second_44 -35;
+    pos @kc89_first_18 @kc89_second_48 1;
+    pos @kc89_first_18 @kc89_second_53 -35;
+    pos @kc89_first_18 @kc89_second_54 -70;
+    pos @kc89_first_18 @kc89_second_56 -140;
+    pos @kc89_first_18 @kc89_second_58 -175;
+    pos @kc89_first_18 @kc89_second_59 -140;
+    pos @kc89_first_18 @kc89_second_61 -70;
+    pos @kc89_first_18 @kc89_second_66 -105;
+    pos @kc89_first_18 @kc89_second_67 -140;
+    pos @kc89_first_19 @kc89_second_12 -280;
+    pos @kc89_first_19 @kc89_second_14 -175;
+    pos @kc89_first_19 @kc89_second_15 -140;
+    pos @kc89_first_19 @kc89_second_18 -35;
+    pos @kc89_first_19 @kc89_second_31 -35;
+    pos @kc89_first_19 @kc89_second_33 -50;
+    pos @kc89_first_19 @kc89_second_48 1;
+    pos @kc89_first_19 @kc89_second_50 -70;
+    pos @kc89_first_19 @kc89_second_51 -140;
+    pos @kc89_first_19 @kc89_second_61 -70;
+    pos @kc89_first_19 @kc89_second_63 -35;
+    pos @kc89_first_19 @kc89_second_64 -105;
+    pos @kc89_first_19 @kc89_second_65 -70;
+    pos @kc89_first_20 @kc89_second_12 -240;
+    pos @kc89_first_20 @kc89_second_13 -140;
+    pos @kc89_first_20 @kc89_second_14 -105;
+    pos @kc89_first_20 @kc89_second_15 -35;
+    pos @kc89_first_20 @kc89_second_48 1;
+    pos @kc89_first_21 @kc89_second_8 -35;
+    pos @kc89_first_21 @kc89_second_9 -140;
+    pos @kc89_first_21 @kc89_second_12 -280;
+    pos @kc89_first_21 @kc89_second_13 -280;
+    pos @kc89_first_21 @kc89_second_14 -280;
+    pos @kc89_first_21 @kc89_second_15 -175;
+    pos @kc89_first_21 @kc89_second_20 -140;
+    pos @kc89_first_21 @kc89_second_22 -70;
+    pos @kc89_first_21 @kc89_second_27 -70;
+    pos @kc89_first_21 @kc89_second_33 -50;
+    pos @kc89_first_21 @kc89_second_42 -140;
+    pos @kc89_first_21 @kc89_second_43 -105;
+    pos @kc89_first_21 @kc89_second_46 -210;
+    pos @kc89_first_21 @kc89_second_48 1;
+    pos @kc89_first_21 @kc89_second_49 -35;
+    pos @kc89_first_21 @kc89_second_50 -140;
+    pos @kc89_first_21 @kc89_second_51 -210;
+    pos @kc89_first_21 @kc89_second_55 -35;
+    pos @kc89_first_21 @kc89_second_61 -105;
+    pos @kc89_first_21 @kc89_second_63 -105;
+    pos @kc89_first_21 @kc89_second_64 -210;
+    pos @kc89_first_21 @kc89_second_65 -140;
+    pos @kc89_first_22 @kc89_second_1 -140;
+    pos @kc89_first_22 @kc89_second_2 -350;
+    pos @kc89_first_22 @kc89_second_19 -140;
+    pos @kc89_first_22 @kc89_second_21 -280;
+    pos @kc89_first_22 @kc89_second_41 -70;
+    pos @kc89_first_22 @kc89_second_48 1;
+    pos @kc89_first_22 @kc89_second_67 -210;
+    pos @kc89_first_23 @kc89_second_1 -35;
+    pos @kc89_first_23 @kc89_second_5 -105;
+    pos @kc89_first_23 @kc89_second_9 -70;
+    pos @kc89_first_23 @kc89_second_11 -70;
+    pos @kc89_first_23 @kc89_second_12 -240;
+    pos @kc89_first_23 @kc89_second_13 -280;
+    pos @kc89_first_23 @kc89_second_14 -140;
+    pos @kc89_first_23 @kc89_second_15 -105;
+    pos @kc89_first_23 @kc89_second_16 -70;
+    pos @kc89_first_23 @kc89_second_27 -35;
+    pos @kc89_first_23 @kc89_second_28 -70;
+    pos @kc89_first_23 @kc89_second_29 -105;
+    pos @kc89_first_23 @kc89_second_35 -35;
+    pos @kc89_first_23 @kc89_second_38 -70;
+    pos @kc89_first_23 @kc89_second_42 -70;
+    pos @kc89_first_23 @kc89_second_43 -35;
+    pos @kc89_first_23 @kc89_second_45 -35;
+    pos @kc89_first_23 @kc89_second_46 -140;
+    pos @kc89_first_23 @kc89_second_48 1;
+    pos @kc89_first_23 @kc89_second_50 -70;
+    pos @kc89_first_23 @kc89_second_51 -175;
+    pos @kc89_first_23 @kc89_second_52 -35;
+    pos @kc89_first_23 @kc89_second_60 -105;
+    pos @kc89_first_23 @kc89_second_61 -35;
+    pos @kc89_first_23 @kc89_second_63 -50;
+    pos @kc89_first_23 @kc89_second_64 -105;
+    pos @kc89_first_23 @kc89_second_65 -70;
+    pos @kc89_first_24 @kc89_second_6 -35;
+    pos @kc89_first_24 @kc89_second_12 -240;
+    pos @kc89_first_24 @kc89_second_13 -175;
+    pos @kc89_first_24 @kc89_second_14 -70;
+    pos @kc89_first_24 @kc89_second_15 -70;
+    pos @kc89_first_24 @kc89_second_18 -70;
+    pos @kc89_first_24 @kc89_second_24 -70;
+    pos @kc89_first_24 @kc89_second_25 -35;
+    pos @kc89_first_24 @kc89_second_37 -35;
+    pos @kc89_first_24 @kc89_second_42 -35;
+    pos @kc89_first_24 @kc89_second_43 -35;
+    pos @kc89_first_24 @kc89_second_46 -70;
+    pos @kc89_first_24 @kc89_second_47 -35;
+    pos @kc89_first_24 @kc89_second_48 1;
+    pos @kc89_first_24 @kc89_second_51 -35;
+    pos @kc89_first_24 @kc89_second_61 -35;
+    pos @kc89_first_24 @kc89_second_65 -35;
+    pos @kc89_first_24 @kc89_second_66 -35;
+    pos @kc89_first_24 @kc89_second_67 -35;
+    pos @kc89_first_25 @kc89_second_1 -70;
+    pos @kc89_first_25 @kc89_second_2 -140;
+    pos @kc89_first_25 @kc89_second_5 -105;
+    pos @kc89_first_25 @kc89_second_11 -70;
+    pos @kc89_first_25 @kc89_second_12 -280;
+    pos @kc89_first_25 @kc89_second_13 -210;
+    pos @kc89_first_25 @kc89_second_14 -70;
+    pos @kc89_first_25 @kc89_second_15 -70;
+    pos @kc89_first_25 @kc89_second_16 -140;
+    pos @kc89_first_25 @kc89_second_21 -70;
+    pos @kc89_first_25 @kc89_second_28 -70;
+    pos @kc89_first_25 @kc89_second_29 -70;
+    pos @kc89_first_25 @kc89_second_34 -70;
+    pos @kc89_first_25 @kc89_second_38 -70;
+    pos @kc89_first_25 @kc89_second_45 -35;
+    pos @kc89_first_25 @kc89_second_46 -140;
+    pos @kc89_first_25 @kc89_second_48 1;
+    pos @kc89_first_25 @kc89_second_51 -140;
+    pos @kc89_first_25 @kc89_second_52 -35;
+    pos @kc89_first_25 @kc89_second_56 -140;
+    pos @kc89_first_25 @kc89_second_58 -70;
+    pos @kc89_first_25 @kc89_second_59 -105;
+    pos @kc89_first_25 @kc89_second_60 -70;
+    pos @kc89_first_25 @kc89_second_64 -70;
+    pos @kc89_first_25 @kc89_second_65 -35;
+    pos @kc89_first_26 @kc89_second_5 -70;
+    pos @kc89_first_26 @kc89_second_9 -70;
+    pos @kc89_first_26 @kc89_second_12 -240;
+    pos @kc89_first_26 @kc89_second_13 -280;
+    pos @kc89_first_26 @kc89_second_14 -175;
+    pos @kc89_first_26 @kc89_second_15 -105;
+    pos @kc89_first_26 @kc89_second_16 -70;
+    pos @kc89_first_26 @kc89_second_27 -35;
+    pos @kc89_first_26 @kc89_second_28 -70;
+    pos @kc89_first_26 @kc89_second_29 -70;
+    pos @kc89_first_26 @kc89_second_38 -70;
+    pos @kc89_first_26 @kc89_second_42 -70;
+    pos @kc89_first_26 @kc89_second_43 -35;
+    pos @kc89_first_26 @kc89_second_46 -140;
+    pos @kc89_first_26 @kc89_second_48 1;
+    pos @kc89_first_26 @kc89_second_50 -70;
+    pos @kc89_first_26 @kc89_second_51 -140;
+    pos @kc89_first_26 @kc89_second_52 -35;
+    pos @kc89_first_26 @kc89_second_56 -50;
+    pos @kc89_first_26 @kc89_second_57 -35;
+    pos @kc89_first_26 @kc89_second_58 -50;
+    pos @kc89_first_26 @kc89_second_59 -50;
+    pos @kc89_first_26 @kc89_second_60 -105;
+    pos @kc89_first_26 @kc89_second_61 -50;
+    pos @kc89_first_26 @kc89_second_63 -35;
+    pos @kc89_first_26 @kc89_second_64 -105;
+    pos @kc89_first_26 @kc89_second_65 -70;
+    pos @kc89_first_27 @kc89_second_9 -35;
+    pos @kc89_first_27 @kc89_second_12 -140;
+    pos @kc89_first_27 @kc89_second_28 -70;
+    pos @kc89_first_27 @kc89_second_42 -35;
+    pos @kc89_first_27 @kc89_second_46 -70;
+    pos @kc89_first_27 @kc89_second_48 1;
+    pos @kc89_first_27 @kc89_second_51 -70;
+    pos @kc89_first_27 @kc89_second_64 -70;
+    pos @kc89_first_27 @kc89_second_65 -35;
+    pos @kc89_first_28 @kc89_second_5 -50;
+    pos @kc89_first_28 @kc89_second_9 -35;
+    pos @kc89_first_28 @kc89_second_11 -35;
+    pos @kc89_first_28 @kc89_second_12 -240;
+    pos @kc89_first_28 @kc89_second_13 -240;
+    pos @kc89_first_28 @kc89_second_14 -105;
+    pos @kc89_first_28 @kc89_second_15 -70;
+    pos @kc89_first_28 @kc89_second_16 -35;
+    pos @kc89_first_28 @kc89_second_28 -35;
+    pos @kc89_first_28 @kc89_second_29 -35;
+    pos @kc89_first_28 @kc89_second_35 -35;
+    pos @kc89_first_28 @kc89_second_38 -35;
+    pos @kc89_first_28 @kc89_second_42 -50;
+    pos @kc89_first_28 @kc89_second_43 -35;
+    pos @kc89_first_28 @kc89_second_46 -100;
+    pos @kc89_first_28 @kc89_second_48 1;
+    pos @kc89_first_28 @kc89_second_50 -35;
+    pos @kc89_first_28 @kc89_second_51 -140;
+    pos @kc89_first_28 @kc89_second_60 -35;
+    pos @kc89_first_28 @kc89_second_64 -70;
+    pos @kc89_first_28 @kc89_second_65 -35;
+    pos @kc89_first_29 @kc89_second_48 1;
+    pos @kc89_first_30 @kc89_second_8 -70;
+    pos @kc89_first_30 @kc89_second_9 -210;
+    pos @kc89_first_30 @kc89_second_12 -350;
+    pos @kc89_first_30 @kc89_second_13 -350;
+    pos @kc89_first_30 @kc89_second_14 -210;
+    pos @kc89_first_30 @kc89_second_15 -175;
+    pos @kc89_first_30 @kc89_second_27 -70;
+    pos @kc89_first_30 @kc89_second_41 -35;
+    pos @kc89_first_30 @kc89_second_42 -210;
+    pos @kc89_first_30 @kc89_second_43 -210;
+    pos @kc89_first_30 @kc89_second_46 -210;
+    pos @kc89_first_30 @kc89_second_48 1;
+    pos @kc89_first_30 @kc89_second_50 -140;
+    pos @kc89_first_30 @kc89_second_51 -280;
+    pos @kc89_first_30 @kc89_second_61 -210;
+    pos @kc89_first_30 @kc89_second_63 -105;
+    pos @kc89_first_30 @kc89_second_64 -175;
+    pos @kc89_first_30 @kc89_second_65 -140;
+    pos @kc89_first_31 @kc89_second_1 -175;
+    pos @kc89_first_31 @kc89_second_2 -175;
+    pos @kc89_first_31 @kc89_second_5 -70;
+    pos @kc89_first_31 @kc89_second_6 -105;
+    pos @kc89_first_31 @kc89_second_10 -35;
+    pos @kc89_first_31 @kc89_second_11 -105;
+    pos @kc89_first_31 @kc89_second_12 -175;
+    pos @kc89_first_31 @kc89_second_13 -140;
+    pos @kc89_first_31 @kc89_second_14 -70;
+    pos @kc89_first_31 @kc89_second_15 -35;
+    pos @kc89_first_31 @kc89_second_16 -140;
+    pos @kc89_first_31 @kc89_second_17 -70;
+    pos @kc89_first_31 @kc89_second_18 -70;
+    pos @kc89_first_31 @kc89_second_19 -140;
+    pos @kc89_first_31 @kc89_second_21 -175;
+    pos @kc89_first_31 @kc89_second_24 -70;
+    pos @kc89_first_31 @kc89_second_31 -105;
+    pos @kc89_first_31 @kc89_second_36 105;
+    pos @kc89_first_31 @kc89_second_37 -105;
+    pos @kc89_first_31 @kc89_second_38 -175;
+    pos @kc89_first_31 @kc89_second_39 -35;
+    pos @kc89_first_31 @kc89_second_41 -70;
+    pos @kc89_first_31 @kc89_second_48 1;
+    pos @kc89_first_31 @kc89_second_53 105;
+    pos @kc89_first_31 @kc89_second_54 -35;
+    pos @kc89_first_31 @kc89_second_66 -70;
+    pos @kc89_first_31 @kc89_second_67 -105;
+    pos @kc89_first_32 @kc89_second_3 -70;
+    pos @kc89_first_32 @kc89_second_4 -35;
+    pos @kc89_first_32 @kc89_second_6 -70;
+    pos @kc89_first_32 @kc89_second_8 -105;
+    pos @kc89_first_32 @kc89_second_17 -35;
+    pos @kc89_first_32 @kc89_second_18 -70;
+    pos @kc89_first_32 @kc89_second_22 -70;
+    pos @kc89_first_32 @kc89_second_24 -70;
+    pos @kc89_first_32 @kc89_second_25 -140;
+    pos @kc89_first_32 @kc89_second_31 -35;
+    pos @kc89_first_32 @kc89_second_37 -70;
+    pos @kc89_first_32 @kc89_second_39 -35;
+    pos @kc89_first_32 @kc89_second_41 -140;
+    pos @kc89_first_32 @kc89_second_42 -70;
+    pos @kc89_first_32 @kc89_second_48 1;
+    pos @kc89_first_32 @kc89_second_54 -35;
+    pos @kc89_first_32 @kc89_second_55 -35;
+    pos @kc89_first_32 @kc89_second_61 -140;
+    pos @kc89_first_32 @kc89_second_66 -70;
+    pos @kc89_first_32 @kc89_second_67 -70;
+    pos @kc89_first_33 @kc89_second_1 -35;
+    pos @kc89_first_33 @kc89_second_2 -105;
+    pos @kc89_first_33 @kc89_second_3 -70;
+    pos @kc89_first_33 @kc89_second_4 70;
+    pos @kc89_first_33 @kc89_second_5 -70;
+    pos @kc89_first_33 @kc89_second_11 -35;
+    pos @kc89_first_33 @kc89_second_12 -240;
+    pos @kc89_first_33 @kc89_second_13 -175;
+    pos @kc89_first_33 @kc89_second_14 -105;
+    pos @kc89_first_33 @kc89_second_15 -70;
+    pos @kc89_first_33 @kc89_second_16 -70;
+    pos @kc89_first_33 @kc89_second_19 -70;
+    pos @kc89_first_33 @kc89_second_26 -35;
+    pos @kc89_first_33 @kc89_second_29 -70;
+    pos @kc89_first_33 @kc89_second_35 -35;
+    pos @kc89_first_33 @kc89_second_38 -35;
+    pos @kc89_first_33 @kc89_second_42 -35;
+    pos @kc89_first_33 @kc89_second_43 -35;
+    pos @kc89_first_33 @kc89_second_45 -35;
+    pos @kc89_first_33 @kc89_second_46 -140;
+    pos @kc89_first_33 @kc89_second_48 1;
+    pos @kc89_first_33 @kc89_second_50 -50;
+    pos @kc89_first_33 @kc89_second_51 -140;
+    pos @kc89_first_33 @kc89_second_52 -35;
+    pos @kc89_first_33 @kc89_second_56 -70;
+    pos @kc89_first_33 @kc89_second_58 -70;
+    pos @kc89_first_33 @kc89_second_59 -70;
+    pos @kc89_first_33 @kc89_second_64 -70;
+    pos @kc89_first_33 @kc89_second_65 -35;
+    pos @kc89_first_34 @kc89_second_3 -35;
+    pos @kc89_first_34 @kc89_second_4 -70;
+    pos @kc89_first_34 @kc89_second_6 -70;
+    pos @kc89_first_34 @kc89_second_8 -70;
+    pos @kc89_first_34 @kc89_second_12 -140;
+    pos @kc89_first_34 @kc89_second_13 -105;
+    pos @kc89_first_34 @kc89_second_14 -70;
+    pos @kc89_first_34 @kc89_second_15 -35;
+    pos @kc89_first_34 @kc89_second_18 -70;
+    pos @kc89_first_34 @kc89_second_22 -70;
+    pos @kc89_first_34 @kc89_second_24 -105;
+    pos @kc89_first_34 @kc89_second_25 -70;
+    pos @kc89_first_34 @kc89_second_31 -35;
+    pos @kc89_first_34 @kc89_second_37 -70;
+    pos @kc89_first_34 @kc89_second_39 -70;
+    pos @kc89_first_34 @kc89_second_41 -105;
+    pos @kc89_first_34 @kc89_second_42 -70;
+    pos @kc89_first_34 @kc89_second_47 -70;
+    pos @kc89_first_34 @kc89_second_48 1;
+    pos @kc89_first_34 @kc89_second_54 -35;
+    pos @kc89_first_34 @kc89_second_55 -35;
+    pos @kc89_first_34 @kc89_second_66 -70;
+    pos @kc89_first_34 @kc89_second_67 -70;
+    pos @kc89_first_35 @kc89_second_34 -315;
+    pos @kc89_first_35 @kc89_second_48 1;
+    pos @kc89_first_36 @kc89_second_9 -70;
+    pos @kc89_first_36 @kc89_second_12 -240;
+    pos @kc89_first_36 @kc89_second_13 -210;
+    pos @kc89_first_36 @kc89_second_14 -140;
+    pos @kc89_first_36 @kc89_second_15 -105;
+    pos @kc89_first_36 @kc89_second_36 44;
+    pos @kc89_first_36 @kc89_second_42 -70;
+    pos @kc89_first_36 @kc89_second_43 -35;
+    pos @kc89_first_36 @kc89_second_46 -140;
+    pos @kc89_first_36 @kc89_second_48 1;
+    pos @kc89_first_36 @kc89_second_50 -50;
+    pos @kc89_first_36 @kc89_second_51 -140;
+    pos @kc89_first_36 @kc89_second_53 44;
+    pos @kc89_first_36 @kc89_second_61 -35;
+    pos @kc89_first_36 @kc89_second_63 -35;
+    pos @kc89_first_36 @kc89_second_64 -70;
+    pos @kc89_first_36 @kc89_second_65 -70;
+    pos @kc89_first_37 @kc89_second_9 -35;
+    pos @kc89_first_37 @kc89_second_12 -240;
+    pos @kc89_first_37 @kc89_second_13 -240;
+    pos @kc89_first_37 @kc89_second_14 -140;
+    pos @kc89_first_37 @kc89_second_15 -105;
+    pos @kc89_first_37 @kc89_second_16 -35;
+    pos @kc89_first_37 @kc89_second_28 -35;
+    pos @kc89_first_37 @kc89_second_29 -35;
+    pos @kc89_first_37 @kc89_second_42 -70;
+    pos @kc89_first_37 @kc89_second_43 -35;
+    pos @kc89_first_37 @kc89_second_46 -70;
+    pos @kc89_first_37 @kc89_second_48 1;
+    pos @kc89_first_37 @kc89_second_50 -35;
+    pos @kc89_first_37 @kc89_second_51 -70;
+    pos @kc89_first_37 @kc89_second_63 -35;
+    pos @kc89_first_37 @kc89_second_64 -70;
+    pos @kc89_first_37 @kc89_second_65 -70;
+    pos @kc89_first_38 @kc89_second_5 -70;
+    pos @kc89_first_38 @kc89_second_9 -70;
+    pos @kc89_first_38 @kc89_second_12 -140;
+    pos @kc89_first_38 @kc89_second_13 -210;
+    pos @kc89_first_38 @kc89_second_14 -140;
+    pos @kc89_first_38 @kc89_second_15 -105;
+    pos @kc89_first_38 @kc89_second_16 -70;
+    pos @kc89_first_38 @kc89_second_28 -70;
+    pos @kc89_first_38 @kc89_second_29 -70;
+    pos @kc89_first_38 @kc89_second_38 -50;
+    pos @kc89_first_38 @kc89_second_42 -50;
+    pos @kc89_first_38 @kc89_second_43 -35;
+    pos @kc89_first_38 @kc89_second_48 1;
+    pos @kc89_first_38 @kc89_second_50 -35;
+    pos @kc89_first_38 @kc89_second_51 -140;
+    pos @kc89_first_38 @kc89_second_60 -35;
+    pos @kc89_first_38 @kc89_second_64 -70;
+    pos @kc89_first_38 @kc89_second_65 -35;
+    pos @kc89_first_39 @kc89_second_1 -210;
+    pos @kc89_first_39 @kc89_second_2 -280;
+    pos @kc89_first_39 @kc89_second_6 -280;
+    pos @kc89_first_39 @kc89_second_8 -70;
+    pos @kc89_first_39 @kc89_second_9 3;
+    pos @kc89_first_39 @kc89_second_17 -140;
+    pos @kc89_first_39 @kc89_second_18 -140;
+    pos @kc89_first_39 @kc89_second_19 -245;
+    pos @kc89_first_39 @kc89_second_21 -350;
+    pos @kc89_first_39 @kc89_second_22 -140;
+    pos @kc89_first_39 @kc89_second_24 -140;
+    pos @kc89_first_39 @kc89_second_25 -70;
+    pos @kc89_first_39 @kc89_second_26 -280;
+    pos @kc89_first_39 @kc89_second_30 -315;
+    pos @kc89_first_39 @kc89_second_31 -140;
+    pos @kc89_first_39 @kc89_second_34 -385;
+    pos @kc89_first_39 @kc89_second_35 -140;
+    pos @kc89_first_39 @kc89_second_37 -210;
+    pos @kc89_first_39 @kc89_second_38 -70;
+    pos @kc89_first_39 @kc89_second_39 -140;
+    pos @kc89_first_39 @kc89_second_40 -140;
+    pos @kc89_first_39 @kc89_second_41 -140;
+    pos @kc89_first_39 @kc89_second_42 -70;
+    pos @kc89_first_39 @kc89_second_44 -70;
+    pos @kc89_first_39 @kc89_second_48 1;
+    pos @kc89_first_39 @kc89_second_54 -140;
+    pos @kc89_first_39 @kc89_second_55 -70;
+    pos @kc89_first_39 @kc89_second_56 -140;
+    pos @kc89_first_39 @kc89_second_58 -245;
+    pos @kc89_first_39 @kc89_second_59 -210;
+    pos @kc89_first_39 @kc89_second_60 -70;
+    pos @kc89_first_39 @kc89_second_61 -70;
+    pos @kc89_first_39 @kc89_second_62 -70;
+    pos @kc89_first_39 @kc89_second_63 -70;
+    pos @kc89_first_39 @kc89_second_66 -245;
+    pos @kc89_first_39 @kc89_second_67 -280;
+    pos @kc89_first_39 @kc89_second_68 -315;
+    pos @kc89_first_40 @kc89_second_6 -35;
+    pos @kc89_first_40 @kc89_second_12 -240;
+    pos @kc89_first_40 @kc89_second_13 -140;
+    pos @kc89_first_40 @kc89_second_14 -35;
+    pos @kc89_first_40 @kc89_second_15 -35;
+    pos @kc89_first_40 @kc89_second_35 35;
+    pos @kc89_first_40 @kc89_second_36 100;
+    pos @kc89_first_40 @kc89_second_37 -35;
+    pos @kc89_first_40 @kc89_second_48 1;
+    pos @kc89_first_40 @kc89_second_66 -35;
+    pos @kc89_first_40 @kc89_second_67 -35;
+    pos @kc89_first_41 @kc89_second_12 -210;
+    pos @kc89_first_41 @kc89_second_13 -175;
+    pos @kc89_first_41 @kc89_second_14 -105;
+    pos @kc89_first_41 @kc89_second_15 -70;
+    pos @kc89_first_41 @kc89_second_46 -70;
+    pos @kc89_first_41 @kc89_second_48 1;
+    pos @kc89_first_41 @kc89_second_51 -105;
+    pos @kc89_first_41 @kc89_second_64 -70;
+    pos @kc89_first_42 @kc89_second_1 -140;
+    pos @kc89_first_42 @kc89_second_2 -175;
+    pos @kc89_first_42 @kc89_second_5 -105;
+    pos @kc89_first_42 @kc89_second_6 -70;
+    pos @kc89_first_42 @kc89_second_11 -70;
+    pos @kc89_first_42 @kc89_second_12 -175;
+    pos @kc89_first_42 @kc89_second_13 -105;
+    pos @kc89_first_42 @kc89_second_14 -70;
+    pos @kc89_first_42 @kc89_second_15 -35;
+    pos @kc89_first_42 @kc89_second_16 -105;
+    pos @kc89_first_42 @kc89_second_17 -35;
+    pos @kc89_first_42 @kc89_second_18 -50;
+    pos @kc89_first_42 @kc89_second_19 -140;
+    pos @kc89_first_42 @kc89_second_21 -175;
+    pos @kc89_first_42 @kc89_second_24 -50;
+    pos @kc89_first_42 @kc89_second_26 -105;
+    pos @kc89_first_42 @kc89_second_31 -35;
+    pos @kc89_first_42 @kc89_second_34 -70;
+    pos @kc89_first_42 @kc89_second_35 -50;
+    pos @kc89_first_42 @kc89_second_37 -70;
+    pos @kc89_first_42 @kc89_second_38 -140;
+    pos @kc89_first_42 @kc89_second_39 -35;
+    pos @kc89_first_42 @kc89_second_41 -50;
+    pos @kc89_first_42 @kc89_second_48 1;
+    pos @kc89_first_42 @kc89_second_54 -35;
+    pos @kc89_first_42 @kc89_second_56 -105;
+    pos @kc89_first_42 @kc89_second_58 -105;
+    pos @kc89_first_42 @kc89_second_59 -105;
+    pos @kc89_first_42 @kc89_second_66 -50;
+    pos @kc89_first_42 @kc89_second_67 -70;
+    pos @kc89_first_43 @kc89_second_1 -210;
+    pos @kc89_first_43 @kc89_second_2 -280;
+    pos @kc89_first_43 @kc89_second_3 -70;
+    pos @kc89_first_43 @kc89_second_6 -280;
+    pos @kc89_first_43 @kc89_second_8 -35;
+    pos @kc89_first_43 @kc89_second_11 -70;
+    pos @kc89_first_43 @kc89_second_13 -140;
+    pos @kc89_first_43 @kc89_second_14 -35;
+    pos @kc89_first_43 @kc89_second_15 -35;
+    pos @kc89_first_43 @kc89_second_16 -140;
+    pos @kc89_first_43 @kc89_second_17 -105;
+    pos @kc89_first_43 @kc89_second_18 -140;
+    pos @kc89_first_43 @kc89_second_19 -210;
+    pos @kc89_first_43 @kc89_second_21 -280;
+    pos @kc89_first_43 @kc89_second_22 -140;
+    pos @kc89_first_43 @kc89_second_24 -140;
+    pos @kc89_first_43 @kc89_second_25 -140;
+    pos @kc89_first_43 @kc89_second_26 -210;
+    pos @kc89_first_43 @kc89_second_34 -140;
+    pos @kc89_first_43 @kc89_second_35 -140;
+    pos @kc89_first_43 @kc89_second_37 -280;
+    pos @kc89_first_43 @kc89_second_38 -140;
+    pos @kc89_first_43 @kc89_second_39 -70;
+    pos @kc89_first_43 @kc89_second_40 -140;
+    pos @kc89_first_43 @kc89_second_41 -175;
+    pos @kc89_first_43 @kc89_second_47 -70;
+    pos @kc89_first_43 @kc89_second_48 1;
+    pos @kc89_first_43 @kc89_second_56 -210;
+    pos @kc89_first_43 @kc89_second_58 -210;
+    pos @kc89_first_43 @kc89_second_59 -175;
+    pos @kc89_first_43 @kc89_second_62 -70;
+    pos @kc89_first_43 @kc89_second_66 -175;
+    pos @kc89_first_43 @kc89_second_67 -175;
+    pos @kc89_first_44 @kc89_second_9 -70;
+    pos @kc89_first_44 @kc89_second_12 -240;
+    pos @kc89_first_44 @kc89_second_13 -210;
+    pos @kc89_first_44 @kc89_second_14 -140;
+    pos @kc89_first_44 @kc89_second_15 -105;
+    pos @kc89_first_44 @kc89_second_42 -70;
+    pos @kc89_first_44 @kc89_second_43 -35;
+    pos @kc89_first_44 @kc89_second_46 -140;
+    pos @kc89_first_44 @kc89_second_48 1;
+    pos @kc89_first_44 @kc89_second_50 -50;
+    pos @kc89_first_44 @kc89_second_51 -140;
+    pos @kc89_first_44 @kc89_second_61 -35;
+    pos @kc89_first_44 @kc89_second_63 -35;
+    pos @kc89_first_44 @kc89_second_64 -70;
+    pos @kc89_first_44 @kc89_second_65 -70;
+    pos @kc89_first_45 @kc89_second_8 -35;
+    pos @kc89_first_45 @kc89_second_9 -70;
+    pos @kc89_first_45 @kc89_second_12 -240;
+    pos @kc89_first_45 @kc89_second_13 -210;
+    pos @kc89_first_45 @kc89_second_14 -70;
+    pos @kc89_first_45 @kc89_second_15 -105;
+    pos @kc89_first_45 @kc89_second_18 -35;
+    pos @kc89_first_45 @kc89_second_24 -35;
+    pos @kc89_first_45 @kc89_second_41 -70;
+    pos @kc89_first_45 @kc89_second_42 -105;
+    pos @kc89_first_45 @kc89_second_43 -70;
+    pos @kc89_first_45 @kc89_second_46 -70;
+    pos @kc89_first_45 @kc89_second_47 -35;
+    pos @kc89_first_45 @kc89_second_48 1;
+    pos @kc89_first_45 @kc89_second_50 -70;
+    pos @kc89_first_45 @kc89_second_51 -70;
+    pos @kc89_first_45 @kc89_second_61 -70;
+    pos @kc89_first_45 @kc89_second_63 -50;
+    pos @kc89_first_45 @kc89_second_65 -70;
+    pos @kc89_first_45 @kc89_second_66 -35;
+    pos @kc89_first_45 @kc89_second_67 -35;
+    pos @kc89_first_46 @kc89_second_6 -70;
+    pos @kc89_first_46 @kc89_second_8 -35;
+    pos @kc89_first_46 @kc89_second_12 -175;
+    pos @kc89_first_46 @kc89_second_13 -140;
+    pos @kc89_first_46 @kc89_second_14 -70;
+    pos @kc89_first_46 @kc89_second_15 -35;
+    pos @kc89_first_46 @kc89_second_17 -70;
+    pos @kc89_first_46 @kc89_second_18 -105;
+    pos @kc89_first_46 @kc89_second_22 -70;
+    pos @kc89_first_46 @kc89_second_24 -105;
+    pos @kc89_first_46 @kc89_second_31 -35;
+    pos @kc89_first_46 @kc89_second_37 -70;
+    pos @kc89_first_46 @kc89_second_39 -35;
+    pos @kc89_first_46 @kc89_second_41 -105;
+    pos @kc89_first_46 @kc89_second_48 1;
+    pos @kc89_first_46 @kc89_second_54 -35;
+    pos @kc89_first_46 @kc89_second_66 -70;
+    pos @kc89_first_46 @kc89_second_67 -70;
+    pos @kc89_first_47 @kc89_second_3 -140;
+    pos @kc89_first_47 @kc89_second_4 -70;
+    pos @kc89_first_47 @kc89_second_6 -70;
+    pos @kc89_first_47 @kc89_second_8 -210;
+    pos @kc89_first_47 @kc89_second_9 -420;
+    pos @kc89_first_47 @kc89_second_12 -350;
+    pos @kc89_first_47 @kc89_second_13 -420;
+    pos @kc89_first_47 @kc89_second_14 -350;
+    pos @kc89_first_47 @kc89_second_15 -280;
+    pos @kc89_first_47 @kc89_second_17 -70;
+    pos @kc89_first_47 @kc89_second_18 -70;
+    pos @kc89_first_47 @kc89_second_20 -210;
+    pos @kc89_first_47 @kc89_second_22 -210;
+    pos @kc89_first_47 @kc89_second_24 -70;
+    pos @kc89_first_47 @kc89_second_25 -140;
+    pos @kc89_first_47 @kc89_second_31 -35;
+    pos @kc89_first_47 @kc89_second_33 -140;
+    pos @kc89_first_47 @kc89_second_37 -70;
+    pos @kc89_first_47 @kc89_second_39 -70;
+    pos @kc89_first_47 @kc89_second_41 -210;
+    pos @kc89_first_47 @kc89_second_42 -280;
+    pos @kc89_first_47 @kc89_second_43 -420;
+    pos @kc89_first_47 @kc89_second_46 -350;
+    pos @kc89_first_47 @kc89_second_48 1;
+    pos @kc89_first_47 @kc89_second_49 -35;
+    pos @kc89_first_47 @kc89_second_50 -210;
+    pos @kc89_first_47 @kc89_second_51 -350;
+    pos @kc89_first_47 @kc89_second_54 -35;
+    pos @kc89_first_47 @kc89_second_55 -35;
+    pos @kc89_first_47 @kc89_second_61 -280;
+    pos @kc89_first_47 @kc89_second_63 -175;
+    pos @kc89_first_47 @kc89_second_64 -280;
+    pos @kc89_first_47 @kc89_second_65 -210;
+    pos @kc89_first_47 @kc89_second_66 -70;
+    pos @kc89_first_48 @kc89_second_3 -140;
+    pos @kc89_first_48 @kc89_second_4 -105;
+    pos @kc89_first_48 @kc89_second_6 -70;
+    pos @kc89_first_48 @kc89_second_8 -210;
+    pos @kc89_first_48 @kc89_second_9 -280;
+    pos @kc89_first_48 @kc89_second_12 -350;
+    pos @kc89_first_48 @kc89_second_13 -385;
+    pos @kc89_first_48 @kc89_second_14 -350;
+    pos @kc89_first_48 @kc89_second_15 -280;
+    pos @kc89_first_48 @kc89_second_18 -105;
+    pos @kc89_first_48 @kc89_second_20 -210;
+    pos @kc89_first_48 @kc89_second_22 -140;
+    pos @kc89_first_48 @kc89_second_24 -105;
+    pos @kc89_first_48 @kc89_second_25 -140;
+    pos @kc89_first_48 @kc89_second_31 -70;
+    pos @kc89_first_48 @kc89_second_33 -175;
+    pos @kc89_first_48 @kc89_second_37 -70;
+    pos @kc89_first_48 @kc89_second_39 -35;
+    pos @kc89_first_48 @kc89_second_41 -175;
+    pos @kc89_first_48 @kc89_second_42 -280;
+    pos @kc89_first_48 @kc89_second_43 -280;
+    pos @kc89_first_48 @kc89_second_46 -280;
+    pos @kc89_first_48 @kc89_second_47 -140;
+    pos @kc89_first_48 @kc89_second_48 1;
+    pos @kc89_first_48 @kc89_second_49 -70;
+    pos @kc89_first_48 @kc89_second_50 -280;
+    pos @kc89_first_48 @kc89_second_51 -350;
+    pos @kc89_first_48 @kc89_second_54 -35;
+    pos @kc89_first_48 @kc89_second_55 -70;
+    pos @kc89_first_48 @kc89_second_61 -245;
+    pos @kc89_first_48 @kc89_second_63 -245;
+    pos @kc89_first_48 @kc89_second_64 -280;
+    pos @kc89_first_48 @kc89_second_65 -210;
+    pos @kc89_first_48 @kc89_second_66 -70;
+    pos @kc89_first_48 @kc89_second_67 -70;
+    pos @kc89_first_49 @kc89_second_3 -70;
+    pos @kc89_first_49 @kc89_second_4 -105;
+    pos @kc89_first_49 @kc89_second_6 -210;
+    pos @kc89_first_49 @kc89_second_7 -70;
+    pos @kc89_first_49 @kc89_second_8 -175;
+    pos @kc89_first_49 @kc89_second_17 -210;
+    pos @kc89_first_49 @kc89_second_18 -210;
+    pos @kc89_first_49 @kc89_second_22 -140;
+    pos @kc89_first_49 @kc89_second_23 -210;
+    pos @kc89_first_49 @kc89_second_24 -210;
+    pos @kc89_first_49 @kc89_second_25 -210;
+    pos @kc89_first_49 @kc89_second_26 -140;
+    pos @kc89_first_49 @kc89_second_27 -140;
+    pos @kc89_first_49 @kc89_second_29 -140;
+    pos @kc89_first_49 @kc89_second_31 -210;
+    pos @kc89_first_49 @kc89_second_32 -210;
+    pos @kc89_first_49 @kc89_second_33 -140;
+    pos @kc89_first_49 @kc89_second_35 -210;
+    pos @kc89_first_49 @kc89_second_37 -210;
+    pos @kc89_first_49 @kc89_second_38 -70;
+    pos @kc89_first_49 @kc89_second_39 -175;
+    pos @kc89_first_49 @kc89_second_40 -210;
+    pos @kc89_first_49 @kc89_second_41 -175;
+    pos @kc89_first_49 @kc89_second_42 -210;
+    pos @kc89_first_49 @kc89_second_43 -105;
+    pos @kc89_first_49 @kc89_second_46 -70;
+    pos @kc89_first_49 @kc89_second_47 -105;
+    pos @kc89_first_49 @kc89_second_48 1;
+    pos @kc89_first_49 @kc89_second_49 -35;
+    pos @kc89_first_49 @kc89_second_50 -210;
+    pos @kc89_first_49 @kc89_second_53 -210;
+    pos @kc89_first_49 @kc89_second_54 -210;
+    pos @kc89_first_49 @kc89_second_55 -175;
+    pos @kc89_first_49 @kc89_second_56 -175;
+    pos @kc89_first_49 @kc89_second_58 -210;
+    pos @kc89_first_49 @kc89_second_59 -210;
+    pos @kc89_first_49 @kc89_second_60 -140;
+    pos @kc89_first_49 @kc89_second_61 -210;
+    pos @kc89_first_49 @kc89_second_62 -175;
+    pos @kc89_first_49 @kc89_second_63 -175;
+    pos @kc89_first_49 @kc89_second_66 -210;
+    pos @kc89_first_49 @kc89_second_67 -210;
+    pos @kc89_first_50 @kc89_second_5 -70;
+    pos @kc89_first_50 @kc89_second_11 -35;
+    pos @kc89_first_50 @kc89_second_12 -240;
+    pos @kc89_first_50 @kc89_second_13 -70;
+    pos @kc89_first_50 @kc89_second_14 -140;
+    pos @kc89_first_50 @kc89_second_15 -105;
+    pos @kc89_first_50 @kc89_second_16 -70;
+    pos @kc89_first_50 @kc89_second_28 -70;
+    pos @kc89_first_50 @kc89_second_29 -70;
+    pos @kc89_first_50 @kc89_second_38 -35;
+    pos @kc89_first_50 @kc89_second_42 -70;
+    pos @kc89_first_50 @kc89_second_45 -35;
+    pos @kc89_first_50 @kc89_second_46 -70;
+    pos @kc89_first_50 @kc89_second_48 1;
+    pos @kc89_first_50 @kc89_second_50 -35;
+    pos @kc89_first_50 @kc89_second_51 -140;
+    pos @kc89_first_50 @kc89_second_54 1;
+    pos @kc89_first_50 @kc89_second_60 -35;
+    pos @kc89_first_50 @kc89_second_63 -35;
+    pos @kc89_first_50 @kc89_second_64 -105;
+    pos @kc89_first_50 @kc89_second_65 -70;
+    pos @kc89_first_51 @kc89_second_48 1;
+    pos @kc89_first_51 @kc89_second_68 -140;
+    pos @kc89_first_52 @kc89_second_34 -315;
+    pos @kc89_first_52 @kc89_second_48 1;
+    pos @kc89_first_52 @kc89_second_69 -140;
+    pos @kc89_first_53 @kc89_second_1 -105;
+    pos @kc89_first_53 @kc89_second_2 -210;
+    pos @kc89_first_53 @kc89_second_6 -140;
+    pos @kc89_first_53 @kc89_second_11 -70;
+    pos @kc89_first_53 @kc89_second_12 -210;
+    pos @kc89_first_53 @kc89_second_13 -210;
+    pos @kc89_first_53 @kc89_second_14 -105;
+    pos @kc89_first_53 @kc89_second_15 -70;
+    pos @kc89_first_53 @kc89_second_16 -140;
+    pos @kc89_first_53 @kc89_second_17 -35;
+    pos @kc89_first_53 @kc89_second_18 -35;
+    pos @kc89_first_53 @kc89_second_19 -105;
+    pos @kc89_first_53 @kc89_second_24 -35;
+    pos @kc89_first_53 @kc89_second_26 -210;
+    pos @kc89_first_53 @kc89_second_28 -70;
+    pos @kc89_first_53 @kc89_second_29 -70;
+    pos @kc89_first_53 @kc89_second_31 -35;
+    pos @kc89_first_53 @kc89_second_35 -70;
+    pos @kc89_first_53 @kc89_second_37 -210;
+    pos @kc89_first_53 @kc89_second_38 -140;
+    pos @kc89_first_53 @kc89_second_45 -35;
+    pos @kc89_first_53 @kc89_second_46 -70;
+    pos @kc89_first_53 @kc89_second_48 1;
+    pos @kc89_first_53 @kc89_second_50 -35;
+    pos @kc89_first_53 @kc89_second_51 -105;
+    pos @kc89_first_53 @kc89_second_56 -210;
+    pos @kc89_first_53 @kc89_second_58 -175;
+    pos @kc89_first_53 @kc89_second_59 -140;
+    pos @kc89_first_53 @kc89_second_64 -35;
+    pos @kc89_first_53 @kc89_second_65 -35;
+    pos @kc89_first_53 @kc89_second_66 -35;
+    pos @kc89_first_53 @kc89_second_67 -70;
+    pos @kc89_first_54 @kc89_second_1 -35;
+    pos @kc89_first_54 @kc89_second_2 -70;
+    pos @kc89_first_54 @kc89_second_5 -105;
+    pos @kc89_first_54 @kc89_second_6 -35;
+    pos @kc89_first_54 @kc89_second_9 -70;
+    pos @kc89_first_54 @kc89_second_11 -70;
+    pos @kc89_first_54 @kc89_second_12 -240;
+    pos @kc89_first_54 @kc89_second_13 -245;
+    pos @kc89_first_54 @kc89_second_14 -140;
+    pos @kc89_first_54 @kc89_second_15 -105;
+    pos @kc89_first_54 @kc89_second_16 -105;
+    pos @kc89_first_54 @kc89_second_19 -35;
+    pos @kc89_first_54 @kc89_second_20 -70;
+    pos @kc89_first_54 @kc89_second_21 -70;
+    pos @kc89_first_54 @kc89_second_26 -35;
+    pos @kc89_first_54 @kc89_second_27 -70;
+    pos @kc89_first_54 @kc89_second_28 -140;
+    pos @kc89_first_54 @kc89_second_29 -105;
+    pos @kc89_first_54 @kc89_second_35 -35;
+    pos @kc89_first_54 @kc89_second_37 -35;
+    pos @kc89_first_54 @kc89_second_38 -140;
+    pos @kc89_first_54 @kc89_second_42 -105;
+    pos @kc89_first_54 @kc89_second_43 -70;
+    pos @kc89_first_54 @kc89_second_45 -105;
+    pos @kc89_first_54 @kc89_second_46 -175;
+    pos @kc89_first_54 @kc89_second_48 1;
+    pos @kc89_first_54 @kc89_second_50 -70;
+    pos @kc89_first_54 @kc89_second_51 -140;
+    pos @kc89_first_54 @kc89_second_52 -70;
+    pos @kc89_first_54 @kc89_second_56 -210;
+    pos @kc89_first_54 @kc89_second_57 -70;
+    pos @kc89_first_54 @kc89_second_58 -175;
+    pos @kc89_first_54 @kc89_second_59 -175;
+    pos @kc89_first_54 @kc89_second_60 -105;
+    pos @kc89_first_54 @kc89_second_63 -50;
+    pos @kc89_first_54 @kc89_second_64 -105;
+    pos @kc89_first_54 @kc89_second_65 -70;
+    pos @kc89_first_54 @kc89_second_67 -35;
+    pos @kc89_first_55 @kc89_second_1 -105;
+    pos @kc89_first_55 @kc89_second_2 -210;
+    pos @kc89_first_55 @kc89_second_5 -70;
+    pos @kc89_first_55 @kc89_second_6 -105;
+    pos @kc89_first_55 @kc89_second_13 -70;
+    pos @kc89_first_55 @kc89_second_14 -35;
+    pos @kc89_first_55 @kc89_second_16 -140;
+    pos @kc89_first_55 @kc89_second_17 -70;
+    pos @kc89_first_55 @kc89_second_18 -35;
+    pos @kc89_first_55 @kc89_second_19 -105;
+    pos @kc89_first_55 @kc89_second_21 -210;
+    pos @kc89_first_55 @kc89_second_24 -35;
+    pos @kc89_first_55 @kc89_second_26 -210;
+    pos @kc89_first_55 @kc89_second_31 -35;
+    pos @kc89_first_55 @kc89_second_34 -105;
+    pos @kc89_first_55 @kc89_second_35 -35;
+    pos @kc89_first_55 @kc89_second_37 -105;
+    pos @kc89_first_55 @kc89_second_38 -140;
+    pos @kc89_first_55 @kc89_second_41 -70;
+    pos @kc89_first_55 @kc89_second_48 1;
+    pos @kc89_first_55 @kc89_second_54 -35;
+    pos @kc89_first_55 @kc89_second_56 -245;
+    pos @kc89_first_55 @kc89_second_58 -210;
+    pos @kc89_first_55 @kc89_second_59 -210;
+    pos @kc89_first_55 @kc89_second_66 -70;
+    pos @kc89_first_55 @kc89_second_67 -105;
+    pos @kc89_first_56 @kc89_second_12 -240;
+    pos @kc89_first_56 @kc89_second_13 -140;
+    pos @kc89_first_56 @kc89_second_14 -105;
+    pos @kc89_first_56 @kc89_second_15 -35;
+    pos @kc89_first_56 @kc89_second_35 35;
+    pos @kc89_first_56 @kc89_second_36 44;
+    pos @kc89_first_56 @kc89_second_48 1;
+    pos @kc89_first_56 @kc89_second_53 44;
+    pos @kc89_first_57 @kc89_second_1 -140;
+    pos @kc89_first_57 @kc89_second_2 -210;
+    pos @kc89_first_57 @kc89_second_6 -140;
+    pos @kc89_first_57 @kc89_second_12 -175;
+    pos @kc89_first_57 @kc89_second_13 -140;
+    pos @kc89_first_57 @kc89_second_16 -140;
+    pos @kc89_first_57 @kc89_second_19 -140;
+    pos @kc89_first_57 @kc89_second_21 -210;
+    pos @kc89_first_57 @kc89_second_26 -210;
+    pos @kc89_first_57 @kc89_second_34 -140;
+    pos @kc89_first_57 @kc89_second_35 -50;
+    pos @kc89_first_57 @kc89_second_37 -140;
+    pos @kc89_first_57 @kc89_second_38 -210;
+    pos @kc89_first_57 @kc89_second_39 -35;
+    pos @kc89_first_57 @kc89_second_48 1;
+    pos @kc89_first_57 @kc89_second_56 -210;
+    pos @kc89_first_57 @kc89_second_58 -175;
+    pos @kc89_first_57 @kc89_second_59 -175;
+    pos @kc89_first_57 @kc89_second_66 -105;
+    pos @kc89_first_57 @kc89_second_67 -210;
+    pos @kc89_first_58 @kc89_second_12 -240;
+    pos @kc89_first_58 @kc89_second_13 -175;
+    pos @kc89_first_58 @kc89_second_14 -70;
+    pos @kc89_first_58 @kc89_second_15 -35;
+    pos @kc89_first_58 @kc89_second_21 -35;
+    pos @kc89_first_58 @kc89_second_28 -35;
+    pos @kc89_first_58 @kc89_second_42 -35;
+    pos @kc89_first_58 @kc89_second_43 -35;
+    pos @kc89_first_58 @kc89_second_46 -70;
+    pos @kc89_first_58 @kc89_second_48 1;
+    pos @kc89_first_58 @kc89_second_50 -35;
+    pos @kc89_first_58 @kc89_second_51 -70;
+    pos @kc89_first_58 @kc89_second_61 -35;
+    pos @kc89_first_58 @kc89_second_63 -35;
+    pos @kc89_first_58 @kc89_second_64 -70;
+    pos @kc89_first_58 @kc89_second_65 -35;
+    pos @kc89_first_59 @kc89_second_13 -35;
+    pos @kc89_first_59 @kc89_second_18 -70;
+    pos @kc89_first_59 @kc89_second_61 -35;
+    pos @kc89_first_59 @kc89_second_67 -35;
+    pos @kc89_first_60 @kc89_second_12 -175;
+    pos @kc89_first_60 @kc89_second_13 -140;
+    pos @kc89_first_60 @kc89_second_14 -35;
+    pos @kc89_first_60 @kc89_second_48 1;
+    pos @kc89_first_61 @kc89_second_1 -140;
+    pos @kc89_first_61 @kc89_second_2 -280;
+    pos @kc89_first_61 @kc89_second_5 -140;
+    pos @kc89_first_61 @kc89_second_6 -280;
+    pos @kc89_first_61 @kc89_second_8 -70;
+    pos @kc89_first_61 @kc89_second_10 -70;
+    pos @kc89_first_61 @kc89_second_11 -175;
+    pos @kc89_first_61 @kc89_second_12 -240;
+    pos @kc89_first_61 @kc89_second_13 -140;
+    pos @kc89_first_61 @kc89_second_14 -105;
+    pos @kc89_first_61 @kc89_second_15 -70;
+    pos @kc89_first_61 @kc89_second_16 -175;
+    pos @kc89_first_61 @kc89_second_17 -70;
+    pos @kc89_first_61 @kc89_second_18 -70;
+    pos @kc89_first_61 @kc89_second_19 -140;
+    pos @kc89_first_61 @kc89_second_21 -280;
+    pos @kc89_first_61 @kc89_second_24 -70;
+    pos @kc89_first_61 @kc89_second_25 -70;
+    pos @kc89_first_61 @kc89_second_26 -210;
+    pos @kc89_first_61 @kc89_second_28 -70;
+    pos @kc89_first_61 @kc89_second_29 -70;
+    pos @kc89_first_61 @kc89_second_31 -70;
+    pos @kc89_first_61 @kc89_second_34 -70;
+    pos @kc89_first_61 @kc89_second_35 -70;
+    pos @kc89_first_61 @kc89_second_37 -315;
+    pos @kc89_first_61 @kc89_second_38 -140;
+    pos @kc89_first_61 @kc89_second_39 -70;
+    pos @kc89_first_61 @kc89_second_41 -105;
+    pos @kc89_first_61 @kc89_second_48 1;
+    pos @kc89_first_61 @kc89_second_51 -35;
+    pos @kc89_first_61 @kc89_second_54 -50;
+    pos @kc89_first_61 @kc89_second_56 -210;
+    pos @kc89_first_61 @kc89_second_58 -210;
+    pos @kc89_first_61 @kc89_second_59 -175;
+    pos @kc89_first_61 @kc89_second_62 -35;
+    pos @kc89_first_61 @kc89_second_64 -70;
+    pos @kc89_first_61 @kc89_second_65 -35;
+    pos @kc89_first_61 @kc89_second_66 -140;
+    pos @kc89_first_61 @kc89_second_67 -210;
+    pos @kc89_first_62 @kc89_second_1 -35;
+    pos @kc89_first_62 @kc89_second_2 -70;
+    pos @kc89_first_62 @kc89_second_5 -70;
+    pos @kc89_first_62 @kc89_second_11 -35;
+    pos @kc89_first_62 @kc89_second_12 -140;
+    pos @kc89_first_62 @kc89_second_13 -140;
+    pos @kc89_first_62 @kc89_second_14 -70;
+    pos @kc89_first_62 @kc89_second_15 -35;
+    pos @kc89_first_62 @kc89_second_16 -105;
+    pos @kc89_first_62 @kc89_second_28 -35;
+    pos @kc89_first_62 @kc89_second_29 -70;
+    pos @kc89_first_62 @kc89_second_35 -35;
+    pos @kc89_first_62 @kc89_second_38 -70;
+    pos @kc89_first_62 @kc89_second_46 -70;
+    pos @kc89_first_62 @kc89_second_48 1;
+    pos @kc89_first_62 @kc89_second_56 -175;
+    pos @kc89_first_62 @kc89_second_58 -140;
+    pos @kc89_first_62 @kc89_second_59 -140;
+    pos @kc89_first_62 @kc89_second_64 -35;
+    pos @kc89_first_63 @kc89_second_5 -70;
+    pos @kc89_first_63 @kc89_second_9 -70;
+    pos @kc89_first_63 @kc89_second_11 -35;
+    pos @kc89_first_63 @kc89_second_12 -350;
+    pos @kc89_first_63 @kc89_second_13 -315;
+    pos @kc89_first_63 @kc89_second_14 -175;
+    pos @kc89_first_63 @kc89_second_15 -140;
+    pos @kc89_first_63 @kc89_second_16 -70;
+    pos @kc89_first_63 @kc89_second_20 -70;
+    pos @kc89_first_63 @kc89_second_29 -70;
+    pos @kc89_first_63 @kc89_second_33 -50;
+    pos @kc89_first_63 @kc89_second_42 -140;
+    pos @kc89_first_63 @kc89_second_43 -50;
+    pos @kc89_first_63 @kc89_second_45 -35;
+    pos @kc89_first_63 @kc89_second_46 -175;
+    pos @kc89_first_63 @kc89_second_48 1;
+    pos @kc89_first_63 @kc89_second_50 -70;
+    pos @kc89_first_63 @kc89_second_51 -175;
+    pos @kc89_first_63 @kc89_second_57 -70;
+    pos @kc89_first_63 @kc89_second_61 -70;
+    pos @kc89_first_63 @kc89_second_63 -50;
+    pos @kc89_first_63 @kc89_second_64 -140;
+    pos @kc89_first_63 @kc89_second_65 -105;
+    pos @kc89_first_64 @kc89_second_4 -105;
+    pos @kc89_first_64 @kc89_second_6 -35;
+    pos @kc89_first_64 @kc89_second_8 1;
+    pos @kc89_first_64 @kc89_second_9 -245;
+    pos @kc89_first_64 @kc89_second_12 -210;
+    pos @kc89_first_64 @kc89_second_13 -210;
+    pos @kc89_first_64 @kc89_second_14 -210;
+    pos @kc89_first_64 @kc89_second_15 -175;
+    pos @kc89_first_64 @kc89_second_17 -70;
+    pos @kc89_first_64 @kc89_second_18 -105;
+    pos @kc89_first_64 @kc89_second_20 -180;
+    pos @kc89_first_64 @kc89_second_22 -140;
+    pos @kc89_first_64 @kc89_second_24 -105;
+    pos @kc89_first_64 @kc89_second_27 -140;
+    pos @kc89_first_64 @kc89_second_31 -105;
+    pos @kc89_first_64 @kc89_second_33 -140;
+    pos @kc89_first_64 @kc89_second_37 -35;
+    pos @kc89_first_64 @kc89_second_39 -35;
+    pos @kc89_first_64 @kc89_second_41 -175;
+    pos @kc89_first_64 @kc89_second_42 -142;
+    pos @kc89_first_64 @kc89_second_43 -245;
+    pos @kc89_first_64 @kc89_second_46 -210;
+    pos @kc89_first_64 @kc89_second_47 -105;
+    pos @kc89_first_64 @kc89_second_48 1;
+    pos @kc89_first_64 @kc89_second_49 -35;
+    pos @kc89_first_64 @kc89_second_50 -210;
+    pos @kc89_first_64 @kc89_second_51 -210;
+    pos @kc89_first_64 @kc89_second_54 -35;
+    pos @kc89_first_64 @kc89_second_61 -280;
+    pos @kc89_first_64 @kc89_second_63 -175;
+    pos @kc89_first_64 @kc89_second_64 -140;
+    pos @kc89_first_64 @kc89_second_65 -140;
+    pos @kc89_first_64 @kc89_second_66 -70;
+    pos @kc89_first_64 @kc89_second_67 -70;
+    pos @kc89_first_65 @kc89_second_1 -175;
+    pos @kc89_first_65 @kc89_second_2 -175;
+    pos @kc89_first_65 @kc89_second_5 -70;
+    pos @kc89_first_65 @kc89_second_6 -105;
+    pos @kc89_first_65 @kc89_second_11 -105;
+    pos @kc89_first_65 @kc89_second_12 -175;
+    pos @kc89_first_65 @kc89_second_13 -140;
+    pos @kc89_first_65 @kc89_second_14 -70;
+    pos @kc89_first_65 @kc89_second_15 -35;
+    pos @kc89_first_65 @kc89_second_16 -140;
+    pos @kc89_first_65 @kc89_second_17 -70;
+    pos @kc89_first_65 @kc89_second_18 -70;
+    pos @kc89_first_65 @kc89_second_19 -140;
+    pos @kc89_first_65 @kc89_second_21 -175;
+    pos @kc89_first_65 @kc89_second_24 -70;
+    pos @kc89_first_65 @kc89_second_31 -35;
+    pos @kc89_first_65 @kc89_second_35 -70;
+    pos @kc89_first_65 @kc89_second_37 -105;
+    pos @kc89_first_65 @kc89_second_38 -175;
+    pos @kc89_first_65 @kc89_second_39 -35;
+    pos @kc89_first_65 @kc89_second_41 -70;
+    pos @kc89_first_65 @kc89_second_48 1;
+    pos @kc89_first_65 @kc89_second_54 -35;
+    pos @kc89_first_65 @kc89_second_56 -140;
+    pos @kc89_first_65 @kc89_second_58 -140;
+    pos @kc89_first_65 @kc89_second_59 -140;
+    pos @kc89_first_65 @kc89_second_66 -70;
+    pos @kc89_first_65 @kc89_second_67 -105;
+    pos @kc89_first_66 @kc89_second_1 -210;
+    pos @kc89_first_66 @kc89_second_2 -210;
+    pos @kc89_first_66 @kc89_second_3 -70;
+    pos @kc89_first_66 @kc89_second_4 -35;
+    pos @kc89_first_66 @kc89_second_6 -210;
+    pos @kc89_first_66 @kc89_second_7 -70;
+    pos @kc89_first_66 @kc89_second_8 -70;
+    pos @kc89_first_66 @kc89_second_16 -70;
+    pos @kc89_first_66 @kc89_second_17 -140;
+    pos @kc89_first_66 @kc89_second_18 -175;
+    pos @kc89_first_66 @kc89_second_19 -210;
+    pos @kc89_first_66 @kc89_second_21 -210;
+    pos @kc89_first_66 @kc89_second_22 -140;
+    pos @kc89_first_66 @kc89_second_23 -35;
+    pos @kc89_first_66 @kc89_second_24 -175;
+    pos @kc89_first_66 @kc89_second_25 -140;
+    pos @kc89_first_66 @kc89_second_26 -280;
+    pos @kc89_first_66 @kc89_second_31 -35;
+    pos @kc89_first_66 @kc89_second_32 -35;
+    pos @kc89_first_66 @kc89_second_34 -210;
+    pos @kc89_first_66 @kc89_second_35 -175;
+    pos @kc89_first_66 @kc89_second_37 -245;
+    pos @kc89_first_66 @kc89_second_38 -140;
+    pos @kc89_first_66 @kc89_second_39 -140;
+    pos @kc89_first_66 @kc89_second_40 -140;
+    pos @kc89_first_66 @kc89_second_41 -140;
+    pos @kc89_first_66 @kc89_second_42 -35;
+    pos @kc89_first_66 @kc89_second_47 -35;
+    pos @kc89_first_66 @kc89_second_48 1;
+    pos @kc89_first_66 @kc89_second_52 -35;
+    pos @kc89_first_66 @kc89_second_54 -140;
+    pos @kc89_first_66 @kc89_second_55 -70;
+    pos @kc89_first_66 @kc89_second_56 -210;
+    pos @kc89_first_66 @kc89_second_58 -210;
+    pos @kc89_first_66 @kc89_second_59 -210;
+    pos @kc89_first_66 @kc89_second_61 -35;
+    pos @kc89_first_66 @kc89_second_66 -175;
+    pos @kc89_first_66 @kc89_second_67 -245;
+    pos @kc89_first_67 @kc89_second_6 -35;
+    pos @kc89_first_67 @kc89_second_12 -240;
+    pos @kc89_first_67 @kc89_second_13 -140;
+    pos @kc89_first_67 @kc89_second_14 -70;
+    pos @kc89_first_67 @kc89_second_15 -35;
+    pos @kc89_first_67 @kc89_second_18 -35;
+    pos @kc89_first_67 @kc89_second_22 -35;
+    pos @kc89_first_67 @kc89_second_24 -35;
+    pos @kc89_first_67 @kc89_second_37 -70;
+    pos @kc89_first_67 @kc89_second_41 -70;
+    pos @kc89_first_67 @kc89_second_42 -50;
+    pos @kc89_first_67 @kc89_second_48 1;
+    pos @kc89_first_67 @kc89_second_51 -35;
+    pos @kc89_first_67 @kc89_second_66 -35;
+    pos @kc89_first_67 @kc89_second_67 -35;
+    pos @kc89_first_68 @kc89_second_3 -100;
+    pos @kc89_first_68 @kc89_second_4 -50;
+    pos @kc89_first_68 @kc89_second_6 -50;
+    pos @kc89_first_68 @kc89_second_8 -70;
+    pos @kc89_first_68 @kc89_second_9 -140;
+    pos @kc89_first_68 @kc89_second_10 -50;
+    pos @kc89_first_68 @kc89_second_12 -140;
+    pos @kc89_first_68 @kc89_second_13 -100;
+    pos @kc89_first_68 @kc89_second_14 -70;
+    pos @kc89_first_68 @kc89_second_15 -50;
+    pos @kc89_first_68 @kc89_second_18 -50;
+    pos @kc89_first_68 @kc89_second_20 -70;
+    pos @kc89_first_68 @kc89_second_22 -70;
+    pos @kc89_first_68 @kc89_second_24 -50;
+    pos @kc89_first_68 @kc89_second_25 -70;
+    pos @kc89_first_68 @kc89_second_31 -35;
+    pos @kc89_first_68 @kc89_second_33 -70;
+    pos @kc89_first_68 @kc89_second_36 105;
+    pos @kc89_first_68 @kc89_second_37 -35;
+    pos @kc89_first_68 @kc89_second_41 -70;
+    pos @kc89_first_68 @kc89_second_42 -140;
+    pos @kc89_first_68 @kc89_second_43 -140;
+    pos @kc89_first_68 @kc89_second_46 -140;
+    pos @kc89_first_68 @kc89_second_47 -35;
+    pos @kc89_first_68 @kc89_second_48 1;
+    pos @kc89_first_68 @kc89_second_50 -70;
+    pos @kc89_first_68 @kc89_second_51 -100;
+    pos @kc89_first_68 @kc89_second_53 105;
+    pos @kc89_first_68 @kc89_second_61 -140;
+    pos @kc89_first_68 @kc89_second_63 -70;
+    pos @kc89_first_68 @kc89_second_64 -70;
+    pos @kc89_first_68 @kc89_second_65 -50;
+    pos @kc89_first_68 @kc89_second_66 -35;
+    pos @kc89_first_68 @kc89_second_67 -35;
+    pos @kc89_first_69 @kc89_second_3 -70;
+    pos @kc89_first_69 @kc89_second_4 -50;
+    pos @kc89_first_69 @kc89_second_6 -50;
+    pos @kc89_first_69 @kc89_second_8 -70;
+    pos @kc89_first_69 @kc89_second_9 -140;
+    pos @kc89_first_69 @kc89_second_10 -50;
+    pos @kc89_first_69 @kc89_second_12 -240;
+    pos @kc89_first_69 @kc89_second_13 -240;
+    pos @kc89_first_69 @kc89_second_14 -175;
+    pos @kc89_first_69 @kc89_second_15 -140;
+    pos @kc89_first_69 @kc89_second_18 -50;
+    pos @kc89_first_69 @kc89_second_20 -70;
+    pos @kc89_first_69 @kc89_second_22 -70;
+    pos @kc89_first_69 @kc89_second_24 -50;
+    pos @kc89_first_69 @kc89_second_25 -70;
+    pos @kc89_first_69 @kc89_second_31 -35;
+    pos @kc89_first_69 @kc89_second_33 -70;
+    pos @kc89_first_69 @kc89_second_36 105;
+    pos @kc89_first_69 @kc89_second_37 -35;
+    pos @kc89_first_69 @kc89_second_41 -70;
+    pos @kc89_first_69 @kc89_second_42 -140;
+    pos @kc89_first_69 @kc89_second_43 -140;
+    pos @kc89_first_69 @kc89_second_46 -140;
+    pos @kc89_first_69 @kc89_second_47 -35;
+    pos @kc89_first_69 @kc89_second_48 1;
+    pos @kc89_first_69 @kc89_second_50 -70;
+    pos @kc89_first_69 @kc89_second_51 -140;
+    pos @kc89_first_69 @kc89_second_53 105;
+    pos @kc89_first_69 @kc89_second_61 -140;
+    pos @kc89_first_69 @kc89_second_63 -70;
+    pos @kc89_first_69 @kc89_second_64 -105;
+    pos @kc89_first_69 @kc89_second_65 -70;
+    pos @kc89_first_69 @kc89_second_66 -35;
+    pos @kc89_first_69 @kc89_second_67 -35;
+    pos @kc89_first_70 @kc89_second_3 -70;
+    pos @kc89_first_70 @kc89_second_4 -50;
+    pos @kc89_first_70 @kc89_second_6 -50;
+    pos @kc89_first_70 @kc89_second_8 -70;
+    pos @kc89_first_70 @kc89_second_9 -140;
+    pos @kc89_first_70 @kc89_second_10 -50;
+    pos @kc89_first_70 @kc89_second_12 -140;
+    pos @kc89_first_70 @kc89_second_13 -140;
+    pos @kc89_first_70 @kc89_second_14 -105;
+    pos @kc89_first_70 @kc89_second_15 -70;
+    pos @kc89_first_70 @kc89_second_18 -50;
+    pos @kc89_first_70 @kc89_second_20 -70;
+    pos @kc89_first_70 @kc89_second_22 -70;
+    pos @kc89_first_70 @kc89_second_24 -50;
+    pos @kc89_first_70 @kc89_second_25 -100;
+    pos @kc89_first_70 @kc89_second_31 -35;
+    pos @kc89_first_70 @kc89_second_33 -70;
+    pos @kc89_first_70 @kc89_second_36 105;
+    pos @kc89_first_70 @kc89_second_37 -35;
+    pos @kc89_first_70 @kc89_second_41 -70;
+    pos @kc89_first_70 @kc89_second_42 -140;
+    pos @kc89_first_70 @kc89_second_43 -140;
+    pos @kc89_first_70 @kc89_second_46 -140;
+    pos @kc89_first_70 @kc89_second_47 -35;
+    pos @kc89_first_70 @kc89_second_48 1;
+    pos @kc89_first_70 @kc89_second_50 -70;
+    pos @kc89_first_70 @kc89_second_51 -140;
+    pos @kc89_first_70 @kc89_second_53 105;
+    pos @kc89_first_70 @kc89_second_61 -140;
+    pos @kc89_first_70 @kc89_second_63 -70;
+    pos @kc89_first_70 @kc89_second_64 -70;
+    pos @kc89_first_70 @kc89_second_65 -50;
+    pos @kc89_first_70 @kc89_second_66 -35;
+    pos @kc89_first_70 @kc89_second_67 -35;
+    pos @kc89_first_71 @kc89_second_1 -210;
+    pos @kc89_first_71 @kc89_second_2 -210;
+    pos @kc89_first_71 @kc89_second_3 -35;
+    pos @kc89_first_71 @kc89_second_6 -140;
+    pos @kc89_first_71 @kc89_second_8 -70;
+    pos @kc89_first_71 @kc89_second_10 -35;
+    pos @kc89_first_71 @kc89_second_17 -70;
+    pos @kc89_first_71 @kc89_second_18 -105;
+    pos @kc89_first_71 @kc89_second_19 -210;
+    pos @kc89_first_71 @kc89_second_21 -210;
+    pos @kc89_first_71 @kc89_second_22 -70;
+    pos @kc89_first_71 @kc89_second_24 -105;
+    pos @kc89_first_71 @kc89_second_25 -105;
+    pos @kc89_first_71 @kc89_second_26 -175;
+    pos @kc89_first_71 @kc89_second_31 -105;
+    pos @kc89_first_71 @kc89_second_34 -210;
+    pos @kc89_first_71 @kc89_second_35 -105;
+    pos @kc89_first_71 @kc89_second_37 -175;
+    pos @kc89_first_71 @kc89_second_38 -140;
+    pos @kc89_first_71 @kc89_second_39 -70;
+    pos @kc89_first_71 @kc89_second_40 -105;
+    pos @kc89_first_71 @kc89_second_41 -105;
+    pos @kc89_first_71 @kc89_second_42 -70;
+    pos @kc89_first_71 @kc89_second_47 -35;
+    pos @kc89_first_71 @kc89_second_48 1;
+    pos @kc89_first_71 @kc89_second_53 -35;
+    pos @kc89_first_71 @kc89_second_54 -70;
+    pos @kc89_first_71 @kc89_second_55 -70;
+    pos @kc89_first_71 @kc89_second_56 -175;
+    pos @kc89_first_71 @kc89_second_58 -175;
+    pos @kc89_first_71 @kc89_second_59 -175;
+    pos @kc89_first_71 @kc89_second_61 -35;
+    pos @kc89_first_71 @kc89_second_62 -35;
+    pos @kc89_first_71 @kc89_second_66 -140;
+    pos @kc89_first_71 @kc89_second_67 -175;
+    pos @kc89_first_72 @kc89_second_5 -70;
+    pos @kc89_first_72 @kc89_second_8 -70;
+    pos @kc89_first_72 @kc89_second_9 -105;
+    pos @kc89_first_72 @kc89_second_11 -35;
+    pos @kc89_first_72 @kc89_second_12 -350;
+    pos @kc89_first_72 @kc89_second_13 -350;
+    pos @kc89_first_72 @kc89_second_14 -245;
+    pos @kc89_first_72 @kc89_second_15 -210;
+    pos @kc89_first_72 @kc89_second_16 -70;
+    pos @kc89_first_72 @kc89_second_20 -210;
+    pos @kc89_first_72 @kc89_second_25 -35;
+    pos @kc89_first_72 @kc89_second_28 -35;
+    pos @kc89_first_72 @kc89_second_29 -70;
+    pos @kc89_first_72 @kc89_second_33 -70;
+    pos @kc89_first_72 @kc89_second_41 -35;
+    pos @kc89_first_72 @kc89_second_42 -245;
+    pos @kc89_first_72 @kc89_second_43 -70;
+    pos @kc89_first_72 @kc89_second_45 -35;
+    pos @kc89_first_72 @kc89_second_46 -240;
+    pos @kc89_first_72 @kc89_second_48 1;
+    pos @kc89_first_72 @kc89_second_50 -105;
+    pos @kc89_first_72 @kc89_second_51 -280;
+    pos @kc89_first_72 @kc89_second_52 -35;
+    pos @kc89_first_72 @kc89_second_57 -35;
+    pos @kc89_first_72 @kc89_second_60 -70;
+    pos @kc89_first_72 @kc89_second_61 -105;
+    pos @kc89_first_72 @kc89_second_62 -35;
+    pos @kc89_first_72 @kc89_second_63 -70;
+    pos @kc89_first_72 @kc89_second_64 -175;
+    pos @kc89_first_72 @kc89_second_65 -140;
+    pos @kc89_first_73 @kc89_second_1 -140;
+    pos @kc89_first_73 @kc89_second_2 -140;
+    pos @kc89_first_73 @kc89_second_6 -140;
+    pos @kc89_first_73 @kc89_second_8 -35;
+    pos @kc89_first_73 @kc89_second_10 -35;
+    pos @kc89_first_73 @kc89_second_17 -35;
+    pos @kc89_first_73 @kc89_second_18 -70;
+    pos @kc89_first_73 @kc89_second_19 -140;
+    pos @kc89_first_73 @kc89_second_21 -140;
+    pos @kc89_first_73 @kc89_second_22 -35;
+    pos @kc89_first_73 @kc89_second_24 -70;
+    pos @kc89_first_73 @kc89_second_25 -70;
+    pos @kc89_first_73 @kc89_second_26 -140;
+    pos @kc89_first_73 @kc89_second_31 -70;
+    pos @kc89_first_73 @kc89_second_35 -70;
+    pos @kc89_first_73 @kc89_second_37 -175;
+    pos @kc89_first_73 @kc89_second_38 -105;
+    pos @kc89_first_73 @kc89_second_39 -70;
+    pos @kc89_first_73 @kc89_second_40 -70;
+    pos @kc89_first_73 @kc89_second_41 -70;
+    pos @kc89_first_73 @kc89_second_42 -35;
+    pos @kc89_first_73 @kc89_second_48 1;
+    pos @kc89_first_73 @kc89_second_53 -35;
+    pos @kc89_first_73 @kc89_second_54 -35;
+    pos @kc89_first_73 @kc89_second_56 -140;
+    pos @kc89_first_73 @kc89_second_58 -140;
+    pos @kc89_first_73 @kc89_second_59 -140;
+    pos @kc89_first_73 @kc89_second_66 -105;
+    pos @kc89_first_73 @kc89_second_67 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -10831,7 +10866,7 @@ lookup mark_Mark_positioning {
   pos base [\C \uni0421 \uni216D ] <anchor 801 1380> mark @top_center
 	<anchor 801 0> mark @bottom_center
 	<anchor 801 -20> mark @bottom_cedilla;
-  pos base [\G \Q \Oslash \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \uni1FFC \G.cv21 ] <anchor 801 0> mark @bottom_center
+  pos base [\G \Q \Oslash \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \uni1FFC \G.cv21 \Q.cv29 ] <anchor 801 0> mark @bottom_center
 	<anchor 801 1380> mark @top_center;
   pos base [\U ] <anchor 699 -20> mark @bottom_cedilla
 	<anchor 861 0> mark @bottom_right
@@ -12133,7 +12168,7 @@ lookup mark_Mark_positioning {
 	<anchor 529 0> mark @bottom_center;
   pos base [\f.sc \gamma.sc \uni03DD.sc \uni0433.sc ] <anchor 230 0> mark @bottom_center
 	<anchor 529 1200> mark @top_center;
-  pos base [\g.sc \q.sc \uni028A.sc \theta.sc \uni0473.sc \uni04D9.sc \uni04E9.sc ] <anchor 694 1200> mark @top_center
+  pos base [\g.sc \q.sc \uni028A.sc \theta.sc \uni0473.sc \uni04D9.sc \uni04E9.sc \q.sc.cv29 ] <anchor 694 1200> mark @top_center
 	<anchor 694 0> mark @bottom_center;
   pos base [\h.sc \eta.sc \uni043D.sc ] <anchor 619 -80> mark @bottom_ypogegrammeni
 	<anchor 230 -20> mark @bottom_cedilla
@@ -13981,7 +14016,8 @@ feature mkmk {
 	\lcaron.cv28 \ldot.cv28 \lslash.cv28 \uni019A.cv28 \uni01C9.cv28 
 	\uni0234.cv28 \uni026D.cv28 \uni026E.cv28 \uni02AA.cv28 \uni02AB.cv28 
 	\uni02E1.cv28 \uni1E37.cv28 \uni1E39.cv28 \uni1E3B.cv28 \uni1E3D.cv28 
-	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \dollar.ss05 
+	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \Q.cv29 \uni051A.cv29 
+	\uni213A.cv29 \uni24C6.cv29 \q.sc.cv29 \uni051B.sc.cv29 \dollar.ss05 
 	\cent.ss05 \sterling.ss05 \lira.ss05 \peseta.ss05 \uni20AA.ss05 \Euro.ss05 
 	\uni20B2.ss05 \one.ss06 \one.ss06.pnum \one.ss06.tnum \one.ss06.onum 
 	\one.ss06.onum.tnum \one.ss06.superior \one.ss06.superior.pnum 

--- a/sources/Giphurs-Regular.ufo/fontinfo.plist
+++ b/sources/Giphurs-Regular.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/27 23:37:24</string>
+    <string>2026/07/28 20:52:58</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Regular.ufo/fontinfo.plist
+++ b/sources/Giphurs-Regular.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/28 20:52:58</string>
+    <string>2026/07/28 21:55:55</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Regular.ufo/glyphs/Q_.cv29.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/Q_.cv29.glif
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.cv29" format="2">
+  <advance width="1672"/>
+  <anchor x="801" y="0" name="bottom_center"/>
+  <anchor x="801" y="1380" name="top_center"/>
+  <outline>
+    <contour>
+      <point x="1602" y="0" type="line"/>
+      <point x="801" y="0" type="line"/>
+      <point x="1168" y="168" type="line"/>
+      <point x="1602" y="168" type="line"/>
+    </contour>
+    <contour>
+      <point x="290" y="750" type="curve" smooth="yes"/>
+      <point x="290" y="400"/>
+      <point x="511" y="168"/>
+      <point x="801" y="168" type="curve" smooth="yes"/>
+      <point x="1091" y="168"/>
+      <point x="1312" y="400"/>
+      <point x="1312" y="750" type="curve" smooth="yes"/>
+      <point x="1312" y="1100"/>
+      <point x="1091" y="1332"/>
+      <point x="801" y="1332" type="curve" smooth="yes"/>
+      <point x="511" y="1332"/>
+      <point x="290" y="1100"/>
+    </contour>
+    <contour>
+      <point x="100" y="750" type="curve" smooth="yes"/>
+      <point x="100" y="1189"/>
+      <point x="406" y="1500"/>
+      <point x="801" y="1500" type="curve" smooth="yes"/>
+      <point x="1196" y="1500"/>
+      <point x="1502" y="1189"/>
+      <point x="1502" y="750" type="curve" smooth="yes"/>
+      <point x="1502" y="311"/>
+      <point x="1196" y="0"/>
+      <point x="801" y="0" type="curve" smooth="yes"/>
+      <point x="406" y="0"/>
+      <point x="100" y="311"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict/>
+  </lib>
+</glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-Regular.ufo/glyphs/contents.plist
@@ -9106,6 +9106,18 @@
     <string>uni24A_7.cv28.glif</string>
     <key>uni24DB.cv28</key>
     <string>uni24D_B_.cv28.glif</string>
+    <key>Q.cv29</key>
+    <string>Q_.cv29.glif</string>
+    <key>uni051A.cv29</key>
+    <string>uni051A_.cv29.glif</string>
+    <key>uni213A.cv29</key>
+    <string>uni213A_.cv29.glif</string>
+    <key>uni24C6.cv29</key>
+    <string>uni24C_6.cv29.glif</string>
+    <key>q.sc.cv29</key>
+    <string>q.sc.cv29.glif</string>
+    <key>uni051B.sc.cv29</key>
+    <string>uni051B_.sc.cv29.glif</string>
     <key>dollar.ss05</key>
     <string>dollar.ss05.glif</string>
     <key>cent.ss05</key>

--- a/sources/Giphurs-Regular.ufo/glyphs/q.sc.cv29.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/q.sc.cv29.glif
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="q.sc.cv29" format="2">
+  <advance width="1438"/>
+  <anchor x="694" y="1200" name="top_center"/>
+  <anchor x="694" y="0" name="bottom_center"/>
+  <outline>
+    <contour>
+      <point x="1368" y="0" type="line"/>
+      <point x="694" y="0" type="line"/>
+      <point x="836" y="160" type="line"/>
+      <point x="1368" y="160" type="line"/>
+    </contour>
+    <contour>
+      <point x="694" y="160" type="curve" smooth="yes"/>
+      <point x="929" y="160"/>
+      <point x="1108" y="334"/>
+      <point x="1108" y="610" type="curve" smooth="yes"/>
+      <point x="1108" y="886"/>
+      <point x="929" y="1060"/>
+      <point x="694" y="1060" type="curve" smooth="yes"/>
+      <point x="459" y="1060"/>
+      <point x="280" y="886"/>
+      <point x="280" y="610" type="curve" smooth="yes"/>
+      <point x="280" y="334"/>
+      <point x="459" y="160"/>
+    </contour>
+    <contour>
+      <point x="694" y="1220" type="curve" smooth="yes"/>
+      <point x="1022" y="1220"/>
+      <point x="1288" y="973"/>
+      <point x="1288" y="610" type="curve" smooth="yes"/>
+      <point x="1288" y="247"/>
+      <point x="1022" y="0"/>
+      <point x="694" y="0" type="curve" smooth="yes"/>
+      <point x="366" y="0"/>
+      <point x="100" y="247"/>
+      <point x="100" y="610" type="curve" smooth="yes"/>
+      <point x="100" y="973"/>
+      <point x="366" y="1220"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni051A_.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051A.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1672"/>
+  <anchor x="801" y="1" name="bottom_center"/>
+  <anchor x="801" y="1381" name="top_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="Q.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni051A_.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051A.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051B.sc.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051B.sc.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1438"/>
+  <anchor x="694" y="1201" name="top_center"/>
+  <anchor x="694" y="1" name="bottom_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="q.sc.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni213A_.cv29.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni213A_.cv29.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni213A.cv29" format="2">
+  <advance width="1700"/>
+  <outline>
+    <contour>
+      <point x="1600" y="1539" type="line"/>
+      <point x="1600" y="740" type="line"/>
+      <point x="1432" y="1107" type="line"/>
+      <point x="1432" y="1539" type="line"/>
+    </contour>
+    <contour>
+      <point x="850" y="229" type="curve" smooth="yes"/>
+      <point x="1200" y="229"/>
+      <point x="1432" y="450"/>
+      <point x="1432" y="740" type="curve" smooth="yes"/>
+      <point x="1432" y="1030"/>
+      <point x="1200" y="1251"/>
+      <point x="850" y="1251" type="curve" smooth="yes"/>
+      <point x="500" y="1251"/>
+      <point x="268" y="1030"/>
+      <point x="268" y="740" type="curve" smooth="yes"/>
+      <point x="268" y="450"/>
+      <point x="500" y="229"/>
+    </contour>
+    <contour>
+      <point x="850" y="39" type="curve" smooth="yes"/>
+      <point x="411" y="39"/>
+      <point x="100" y="345"/>
+      <point x="100" y="740" type="curve" smooth="yes"/>
+      <point x="100" y="1135"/>
+      <point x="411" y="1441"/>
+      <point x="850" y="1441" type="curve" smooth="yes"/>
+      <point x="1289" y="1441"/>
+      <point x="1600" y="1135"/>
+      <point x="1600" y="740" type="curve" smooth="yes"/>
+      <point x="1600" y="345"/>
+      <point x="1289" y="39"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Regular.ufo/glyphs/uni24C_6.cv29.glif
+++ b/sources/Giphurs-Regular.ufo/glyphs/uni24C_6.cv29.glif
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni24C6.cv29" format="2">
+  <advance width="1720"/>
+  <outline>
+    <contour>
+      <point x="220" y="740" type="curve" smooth="yes"/>
+      <point x="220" y="380"/>
+      <point x="500" y="100"/>
+      <point x="860" y="100" type="curve" smooth="yes"/>
+      <point x="1220" y="100"/>
+      <point x="1500" y="380"/>
+      <point x="1500" y="740" type="curve" smooth="yes"/>
+      <point x="1500" y="1100"/>
+      <point x="1220" y="1380"/>
+      <point x="860" y="1380" type="curve" smooth="yes"/>
+      <point x="500" y="1380"/>
+      <point x="220" y="1100"/>
+    </contour>
+    <contour>
+      <point x="100" y="740" type="curve" smooth="yes"/>
+      <point x="100" y="1160"/>
+      <point x="440" y="1500"/>
+      <point x="860" y="1500" type="curve" smooth="yes"/>
+      <point x="1280" y="1500"/>
+      <point x="1620" y="1160"/>
+      <point x="1620" y="740" type="curve" smooth="yes"/>
+      <point x="1620" y="320"/>
+      <point x="1280" y="-20"/>
+      <point x="860" y="-20" type="curve" smooth="yes"/>
+      <point x="440" y="-20"/>
+      <point x="100" y="320"/>
+    </contour>
+    <contour>
+      <point x="836" y="1181" type="curve" smooth="yes"/>
+      <point x="1080" y="1181"/>
+      <point x="1269" y="1001"/>
+      <point x="1269" y="746" type="curve" smooth="yes"/>
+      <point x="1269" y="491"/>
+      <point x="1080" y="299"/>
+      <point x="836" y="299" type="curve" smooth="yes"/>
+      <point x="592" y="299"/>
+      <point x="403" y="491"/>
+      <point x="403" y="746" type="curve" smooth="yes"/>
+      <point x="403" y="1001"/>
+      <point x="592" y="1181"/>
+    </contour>
+    <contour>
+      <point x="836" y="1061" type="curve" smooth="yes"/>
+      <point x="667" y="1061"/>
+      <point x="538" y="936"/>
+      <point x="538" y="746" type="curve" smooth="yes"/>
+      <point x="538" y="556"/>
+      <point x="667" y="419"/>
+      <point x="836" y="419" type="curve" smooth="yes"/>
+      <point x="1005" y="419"/>
+      <point x="1134" y="556"/>
+      <point x="1134" y="746" type="curve" smooth="yes"/>
+      <point x="1134" y="936"/>
+      <point x="1005" y="1061"/>
+    </contour>
+    <contour>
+      <point x="1329" y="299" type="line"/>
+      <point x="836" y="299" type="line"/>
+      <point x="976" y="419" type="line"/>
+      <point x="1329" y="419" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Thin.ufo/features.fea
+++ b/sources/Giphurs-Thin.ufo/features.fea
@@ -4574,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \i \acutecomb  by \iacute;
     sub \uni0456 \acutecomb  by \iacute;
+    sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4631,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4719,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5651,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6785,6 +6785,29 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
+
 feature locl {
 
  script cyrl;
@@ -6871,29 +6894,6 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
-
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
 
 feature ss09 {
   featureNames {
@@ -12845,8 +12845,12 @@ lookup mark_Mark_positioning {
 	<anchor 202 1716> mark @top_center;
   pos base [\uni1E3B.cv28 ] <anchor 202 1380> mark @top_center
 	<anchor 202 -201> mark @bottom_center;
+  pos base [\uni051A.cv29 ] <anchor 757 1> mark @bottom_center
+	<anchor 757 1381> mark @top_center;
   pos base [\q.sc.cv29 ] <anchor 664 0> mark @bottom_center
 	<anchor 664 1200> mark @top_center;
+  pos base [\uni051B.sc.cv29 ] <anchor 664 1> mark @bottom_center
+	<anchor 664 1201> mark @top_center;
   pos base [\dotlessuni0268 ] <anchor 268 -20> mark @bottom_cedilla
 	<anchor 290 0> mark @bottom_right
 	<anchor 268 0> mark @bottom_center

--- a/sources/Giphurs-Thin.ufo/features.fea
+++ b/sources/Giphurs-Thin.ufo/features.fea
@@ -2261,6 +2261,16 @@ lookup cv28_Alternative_small_letter_l {
     sub \uni24A7 by \uni24A7.cv28 ;
 } cv28_Alternative_small_letter_l;
 
+lookup cv29_Alternative_letter_Q {
+  lookupflag 0;
+    sub \Q by \Q.cv29 ;
+    sub \uni051A by \uni051A.cv29 ;
+    sub \uni213A by \uni213A.cv29 ;
+    sub \uni24C6 by \uni24C6.cv29 ;
+    sub \q.sc by \q.sc.cv29 ;
+    sub \uni051B.sc by \uni051B.sc.cv29 ;
+} cv29_Alternative_letter_Q;
+
 lookup ss01_Alternative_digits_set_A {
   lookupflag 0;
     sub \eight by \eight.cv08 ;
@@ -4564,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \uni0456 \acutecomb  by \iacute;
     sub \i \acutecomb  by \iacute;
+    sub \uni0456 \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4621,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4709,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5641,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6775,29 +6785,6 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
-
 feature locl {
 
  script cyrl;
@@ -6884,6 +6871,29 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
+
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
 
 feature ss09 {
   featureNames {
@@ -7743,6 +7753,29 @@ feature cv28 {
       lookup cv28_Alternative_small_letter_l;
 } cv28;
 
+feature cv29 {
+
+ script DFLT;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script copt;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script cyrl;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script grek;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script latn;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+} cv29;
+
 feature ss01 {
   featureNames {
     name 3 1 0x409 "Alternative numbers set 1";
@@ -8264,7 +8297,7 @@ feature calt {
 
 lookup kern_Horizontal_kerning {
   lookupflag 0;
-    @kc88_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
+    @kc89_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
 	\Aogonek \Aring \Aringacute \Atilde \Delta \Lambda \backslash \uni01CD 
 	\uni01DE \uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
@@ -8273,12 +8306,12 @@ lookup kern_Horizontal_kerning {
 	\uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F88 \uni1F89 \uni1F8A \uni1F8B 
 	\uni1F8C \uni1F8D \uni1F8E \uni1F8F \uni1FB8 \uni1FB9 \uni1FBA \uni1FBB 
 	\uni1FBC \uni212B \uniA656 ];
-    @kc88_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
+    @kc89_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
 	\uni0412 \uni0417 \uni0432.loclBGR \uni0498 \uni04DE \uni1E02 \uni1E04 
 	\uni1E06 \uni1E9E \uniA7B4 \uniA7B5 ];
-    @kc88_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
+    @kc89_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
 	\uni03FE \uni0421 \uni0464 \uni0480 \uni04AA \uni1E08 \uni2103 \uni216D ];
-    @kc88_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
+    @kc89_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
 	\Gcommaaccent.cv21 \Gdotaccent.cv21 \O \Oacute \Obreve \Ocircumflex 
 	\Odieresis \Ograve \Ohungarumlaut \Omacron \Omicron \Omicrontonos 
 	\Oslash \Oslashacute \Otilde \Theta \uni0189 \uni018A \uni018F 
@@ -8291,46 +8324,46 @@ lookup kern_Horizontal_kerning {
 	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
 	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
 	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
-    @kc88_first_5 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
+    @kc89_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
+	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
+	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
+	\uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA 
+	\uni1FFB \uni1FFC \uni20B2 \uni20B2.ss05 ];
+    @kc89_first_6 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
 	\uni0422 \uni0490 \uni0492 \uni04A4 \uni04AC \uni1E6A \uni1E6C \uni1E6E 
 	\uni1E70 ];
-    @kc88_first_6 = [\Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
-	\uni01E4 \uni03A9 \uni051A \uni1E20 \uni1F68 \uni1F69 \uni1F6A \uni1F6B 
-	\uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 \uni1FA9 \uni1FAA \uni1FAB 
-	\uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA \uni1FFB \uni1FFC \uni20B2 
-	\uni20B2.ss05 ];
-    @kc88_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+    @kc89_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2165 \uni2166 \uni2167 \uni216A \uni216B 
 	\uniA7AE ];
-    @kc88_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
+    @kc89_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc88_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
+    @kc89_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
 	\uniA7AD ];
-    @kc88_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
-    @kc88_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
-    @kc88_first_12 = [\Psi \uni0470 ];
-    @kc88_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
+    @kc89_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
+    @kc89_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
+    @kc89_first_12 = [\Psi \uni0470 ];
+    @kc89_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc88_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
+    @kc89_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
 	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
 	\uni2107 ];
-    @kc88_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
+    @kc89_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
-    @kc88_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
+    @kc89_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
 	\uni2163 \uni2164 \uni2C6F \universal ];
-    @kc88_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_first_19 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
+    @kc89_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_first_19 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
 	\atilde \uni01DF \uni01E1 \uni0201 \uni0203 \uni0227 \uni0430 \uni04D1 
 	\uni04D3 \uni1E01 \uni1EA1 \uni1EA3 \uni1EA5 \uni1EA7 \uni1EA9 \uni1EAB 
 	\uni1EAD \uni1EAF \uni1EB1 \uni1EB3 \uni1EB5 \uni1EB7 \uniA657 ];
-    @kc88_first_20 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 
+    @kc89_first_20 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 
 	\agrave.cv23 \amacron.cv23 \aogonek.cv23 \aring.cv23 
 	\aringacute.cv23 \atilde.cv23 \u \u.cv25 \uacute \uacute.cv25 \ubreve 
 	\ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
@@ -8351,7 +8384,7 @@ lookup kern_Horizontal_kerning {
 	\uni1EE7 \uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 
 	\uni1EED \uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 
 	\uogonek \uogonek.cv25 \uring \uring.cv25 \utilde \utilde.cv25 ];
-    @kc88_first_21 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
+    @kc89_first_21 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
 	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
 	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
 	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
@@ -8364,7 +8397,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
 	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
 	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
-    @kc88_first_22 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_first_22 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8418,7 +8451,7 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_first_23 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
+    @kc89_first_23 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
 	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
@@ -8431,28 +8464,28 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
-    @kc88_first_24 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
+    @kc89_first_24 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
 	\uni1FB7 \uni2C65 ];
-    @kc88_first_25 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_first_25 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_first_26 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
+    @kc89_first_26 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
 	\uni0253 \uni029A \uni03F1 \uni03F8 \uni0440 \uni0444 \uni1E03 \uni1E05 
 	\uni1E07 \uni1E55 \uni1E57 \uni20AF \uni2114 \uniA64D ];
-    @kc88_first_27 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
+    @kc89_first_27 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
 	\uni1E05.sc \uni1E07.sc \uniA7B5.sc ];
-    @kc88_first_28 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
+    @kc89_first_28 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
 	\uni0188 \uni023C \uni0255 \uni0297 \uni03F2 \uni03F5 \uni0441 \uni0454 
 	\uni0465 \uni04AB \uni1E09 \uni217D ];
-    @kc88_first_29 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
+    @kc89_first_29 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
 	\uni037C.sc \uni03F2.sc \uni0441.sc \uni0454.sc \uni0465.sc 
 	\uni0481.sc \uni1E09.sc ];
-    @kc88_first_30 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+    @kc89_first_30 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8508,14 +8541,14 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_first_31 = [\chi ];
-    @kc88_first_32 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
+    @kc89_first_31 = [\chi ];
+    @kc89_first_32 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
 	\uni0436.sc \uni0445.sc \uni0497.sc \uni049B.sc \uni049D.sc 
 	\uni049F.sc \uni04A1.sc \uni04B3.sc \uni04C2.sc \uni04DD.sc 
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc88_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
+    @kc89_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
 	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
 	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
@@ -8527,7 +8560,7 @@ lookup kern_Horizontal_kerning {
 	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
 	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
 	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
-    @kc88_first_34 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_first_34 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8537,7 +8570,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2175.sc 
 	\uni2176.sc \uni2177.sc \uni217A.sc \uni217B.sc ];
-    @kc88_first_35 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
+    @kc89_first_35 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
 	\eight.cv18.numr \eight.cv18.numr.pnum \eight.cv18.numr.tnum 
 	\eight.numr \eight.numr.pnum \eight.numr.tnum \five.cv05.numr 
 	\five.cv05.numr.pnum \five.cv05.numr.tnum \five.cv15.numr 
@@ -8575,146 +8608,146 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.numr.tnum \zero.numr \zero.numr.pnum 
 	\zero.numr.tnum \zero.zero.numr \zero.zero.numr.pnum 
 	\zero.zero.numr.tnum ];
-    @kc88_first_36 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
+    @kc89_first_36 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
 	\uni1F26 \uni1F27 \uni1F74 \uni1F75 \uni1F90 \uni1F91 \uni1F92 \uni1F93 
 	\uni1F94 \uni1F95 \uni1F96 \uni1F97 \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 
 	\uni1FC7 ];
-    @kc88_first_37 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_first_37 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0437 \uni0455 
 	\uni0479 \uni0499 \uni04DF \uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
-    @kc88_first_38 = [\eth \uni1EFC \uni1EFD ];
-    @kc88_first_39 = [\fraction ];
-    @kc88_first_40 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc88_first_41 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \uni0260.sc \uni051B.sc \uni1F60.sc \uni1F61.sc 
-	\uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc 
-	\uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc \uni1FA1.sc 
-	\uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc 
-	\uni1FF7.sc ];
-    @kc88_first_42 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc89_first_38 = [\eth \uni1EFC \uni1EFD ];
+    @kc89_first_39 = [\fraction ];
+    @kc89_first_40 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
+    @kc89_first_41 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
+	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
+	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
+	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
+    @kc89_first_42 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc88_first_43 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_first_43 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc88_first_44 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc89_first_44 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc88_first_45 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc89_first_45 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc88_first_46 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc89_first_46 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc88_first_47 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
+    @kc89_first_47 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
 	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc88_first_48 = [\lambda \uni019B ];
-    @kc88_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc88_first_50 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc89_first_48 = [\lambda \uni019B ];
+    @kc89_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc89_first_50 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc88_first_51 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc88_first_52 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc88_first_53 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc89_first_51 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc89_first_52 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc89_first_53 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc88_first_54 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc88_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc88_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc89_first_54 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc89_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc89_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc88_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc88_first_59 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+    @kc89_first_59 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
 	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_first_60 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+    @kc89_first_60 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
 	\uni1E71 ];
-    @kc88_first_61 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
-    @kc88_first_62 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc88_first_63 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc88_first_64 = [\uni0196 \uni01AA ];
-    @kc88_first_65 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_first_61 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
+    @kc89_first_62 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
+    @kc89_first_63 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc89_first_64 = [\uni0196 \uni01AA ];
+    @kc89_first_65 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
 	\ygrave ];
-    @kc88_first_66 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_first_66 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_first_67 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
+    @kc89_first_67 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
 	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
 	\zdotaccent ];
-    @kc88_first_68 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
+    @kc89_first_68 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
-    @kc88_first_69 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
+    @kc89_first_69 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
 	\uni052D \uni052F ];
-    @kc88_first_70 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
+    @kc89_first_70 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
 	\uni04B7.sc \uni04C6.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
 	\uni0525.sc \uni052F.sc ];
-    @kc88_first_71 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
-    @kc88_first_72 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
-    @kc88_first_73 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_first_71 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
+    @kc89_first_72 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
+    @kc89_first_73 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
+    @kc89_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
 	\Aring \Aringacute \Atilde \Delta \Lambda \slash \uni01CD \uni01DE 
 	\uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
 	\uni1EA0 \uni1EA2 \uni1EA4 \uni1EA6 \uni1EA8 \uni1EAA \uni1EAC \uni1EAE 
 	\uni1EB0 \uni1EB2 \uni1EB4 \uni1EB6 \uni1FB8 \uni1FB9 \uni1FBC \uni212B ];
-    @kc88_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
-    @kc88_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
+    @kc89_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
+    @kc89_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
 	\Gbreve \Gbreve.cv21 \Gcaron \Gcaron.cv21 \Gcircumflex 
 	\Gcircumflex.cv21 \Gcommaaccent \Gcommaaccent.cv21 \Gdotaccent 
 	\Gdotaccent.cv21 \O \OE \Oacute \Obreve \Ocircumflex \Odieresis \Ograve 
 	\Ohorn \Ohungarumlaut \Omacron \Omicron \Omicrontonos \Oslash 
-	\Oslashacute \Otilde \Q \Theta \colonmonetary \emptyset \uni0187 
-	\uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
+	\Oslashacute \Otilde \Q \Q.cv29 \Theta \colonmonetary \emptyset 
+	\uni0187 \uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
 	\uni01E4.cv21 \uni01EA \uni01EC \uni01F4 \uni01F4.cv21 \uni020C 
 	\uni020E \uni022A \uni022C \uni022E \uni0230 \uni023B \uni024A \uni0298 
 	\uni03D8 \uni03F4 \uni03FE \uni0404 \uni041E \uni0421 \uni0472 \uni047A 
 	\uni0480 \uni04AA \uni04BC \uni04BE \uni04D8 \uni04DA \uni04E6 \uni04E8 
-	\uni04EA \uni050C \uni051A \uni1E08 \uni1E20 \uni1E20.cv21 \uni1E4C 
-	\uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE \uni1ED0 \uni1ED2 \uni1ED4 
-	\uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE \uni1EE0 \uni1EE2 \uni20A2 
-	\uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE \uni216D \uni2180 \uni2182 
-	\uni2185 ];
-    @kc88_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
-    @kc88_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+	\uni04EA \uni050C \uni051A \uni051A.cv29 \uni1E08 \uni1E20 
+	\uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE 
+	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
+	\uni1EE0 \uni1EE2 \uni20A2 \uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE 
+	\uni216D \uni2180 \uni2182 \uni2185 ];
+    @kc89_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
+    @kc89_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
-    @kc88_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc88_second_7 = [\Omega \uni03A9 \uni1FFC ];
-    @kc88_second_8 = [\Phi \uni0424 ];
-    @kc88_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc88_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
+    @kc89_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
+    @kc89_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc89_second_8 = [\Phi \uni0424 ];
+    @kc89_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
+    @kc89_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
 	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc88_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
+    @kc89_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
 	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc88_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
+    @kc89_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
 	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
-    @kc88_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
+    @kc89_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
 	\uni2166 \uni2167 \uni2C6F \universal ];
-    @kc88_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
+    @kc89_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
 	\uni04FE \uni1E8A \uni1E8C \uni2169 \uni216A \uni216B ];
-    @kc88_second_17 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
+    @kc89_second_17 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
 	\atilde \uni01DF \uni01E1 \uni0201 \uni0203 \uni0227 \uni0430 \uni04D1 
 	\uni04D3 \uni1E01 \uni1EA1 \uni1EA3 \uni1EA5 \uni1EA7 \uni1EA9 \uni1EAB 
 	\uni1EAD \uni1EAF \uni1EB1 \uni1EB3 \uni1EB5 \uni1EB7 ];
-    @kc88_second_18 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 \ae.cv23 
+    @kc89_second_18 = [\a.cv23 \aacute.cv23 \abreve.cv23 \acircumflex.cv23 \adieresis.cv23 \ae.cv23 
 	\aeacute.cv23 \agrave.cv23 \alpha \alphatonos \amacron.cv23 
 	\aogonek.cv23 \aring.cv23 \aringacute.cv23 \atilde.cv23 \d \dcaron 
 	\dcroat \dong \eth \g.cv24 \gbreve.cv24 \gcaron.cv24 \gcircumflex.cv24 
@@ -8731,7 +8764,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F04 \uni1F05 \uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 
 	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 
 	\uni1FB4 \uni1FB6 \uni1FB7 \uni217E \uniA64D \uniA7C8 ];
-    @kc88_second_19 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
+    @kc89_second_19 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
 	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
 	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
 	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
@@ -8744,7 +8777,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
 	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
 	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
-    @kc88_second_20 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_second_20 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8798,16 +8831,16 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_second_21 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
-    @kc88_second_22 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_second_21 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
+    @kc89_second_22 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_second_23 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
+    @kc89_second_23 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
 	\uniA7B4 \uniA7B5 ];
-    @kc88_second_24 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
+    @kc89_second_24 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
@@ -8821,25 +8854,26 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
-    @kc88_second_25 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
+    @kc89_second_25 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
 	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
 	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc 
-	\uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc 
-	\uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc 
-	\uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc 
-	\uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc 
-	\uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc 
-	\uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc 
-	\uni050D.sc \uni051B.sc \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
-	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
-	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc ];
-    @kc88_second_26 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+	\q.sc \q.sc.cv29 \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc 
+	\uni01E5.sc \uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc 
+	\uni020F.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc 
+	\uni023C.sc \uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc 
+	\uni037C.sc \uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc 
+	\uni0444.loclBGR.sc \uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc 
+	\uni04AB.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni050D.sc \uni051B.sc \uni051B.sc.cv29 \uni1E09.sc 
+	\uni1E21.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc 
+	\uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc 
+	\uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc 
+	\uni217D.sc ];
+    @kc89_second_26 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8895,11 +8929,11 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_second_27 = [\chi \gamma \uni04AF \uni04B1 ];
-    @kc88_second_28 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
+    @kc89_second_27 = [\chi \gamma \uni04AF \uni04B1 ];
+    @kc89_second_28 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
 	\uni04DD.sc \uni04FD.sc \uni04FF.sc \uni1E8B.sc \uni1E8D.sc 
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
-    @kc88_second_29 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_second_29 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8909,7 +8943,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
 	\uni2178.sc ];
-    @kc88_second_30 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
+    @kc89_second_30 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
 	\five.cv05.dnom.pnum \five.cv05.dnom.tnum \five.cv15.dnom 
@@ -8945,12 +8979,12 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.dnom.tnum \zero.cv20.zero.dnom 
 	\zero.cv20.zero.dnom.tnum \zero.dnom \zero.dnom.tnum 
 	\zero.zero.dnom \zero.zero.dnom.tnum ];
-    @kc88_second_31 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_second_31 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0437 \uni0455 
 	\uni0479 \uni0499 \uni04DF \uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
-    @kc88_second_32 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
+    @kc89_second_32 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
 	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
 	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
 	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
@@ -8974,1732 +9008,1733 @@ lookup kern_Horizontal_kerning {
 	\uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 \upsilon 
 	\upsilondieresistonos \upsilontonos \uring \uring.cv25 \utilde 
 	\utilde.cv25 ];
-    @kc88_second_33 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
+    @kc89_second_33 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
 	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc88_second_34 = [\fraction ];
-    @kc88_second_35 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \uni01E5 \uni1E21 ];
-    @kc88_second_36 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc88_second_37 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+    @kc89_second_34 = [\fraction ];
+    @kc89_second_35 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \uni01E5 \uni1E21 ];
+    @kc89_second_36 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc89_second_37 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc88_second_38 = [\lambda \uni019B ];
-    @kc88_second_39 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc89_second_38 = [\lambda \uni019B ];
+    @kc89_second_39 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc88_second_40 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+    @kc89_second_40 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
 	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
 	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
 	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
 	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc88_second_41 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_second_42 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
-    @kc88_second_43 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc89_second_41 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_second_42 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
+    @kc89_second_43 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc88_second_44 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_second_44 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc88_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc89_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_second_46 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_second_46 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
 	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
 	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc88_second_47 = [\theta \uni0478 \uniA64C ];
-    @kc88_second_48 = [\tonos2 ];
-    @kc88_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc88_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_second_47 = [\theta \uni0478 \uniA64C ];
+    @kc89_second_48 = [\tonos2 ];
+    @kc89_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc89_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc88_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_second_52 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
+    @kc89_second_52 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
 	\z \zacute \zcaron \zdotaccent ];
-    @kc88_second_53 = [\uni0237 ];
-    @kc88_second_54 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc88_second_55 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc88_second_56 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc88_second_57 = [\uni042F \uni0518 ];
-    @kc88_second_58 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
+    @kc89_second_53 = [\uni0237 ];
+    @kc89_second_54 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc89_second_55 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc89_second_56 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc89_second_57 = [\uni042F \uni0518 ];
+    @kc89_second_58 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
 	\uni052F ];
-    @kc88_second_59 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc89_second_59 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc88_second_60 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc89_second_60 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc88_second_61 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc88_second_62 = [\uni044F.sc \uni0519.sc ];
-    @kc88_second_63 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc89_second_61 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc89_second_62 = [\uni044F.sc \uni0519.sc ];
+    @kc89_second_63 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc88_second_64 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc88_second_65 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_second_64 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc89_second_65 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_66 = [\uni0500 \uni0502 ];
-    @kc88_second_67 = [\uni0501.sc \uni0503.sc ];
-    @kc88_second_68 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
+    @kc89_second_66 = [\uni0500 \uni0502 ];
+    @kc89_second_67 = [\uni0501.sc \uni0503.sc ];
+    @kc89_second_68 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
 	\zero.cv20.zero.dnom.pnum \zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc88_second_69 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
+    @kc89_second_69 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
 	\zero.cv20.zero.numr.pnum \zero.numr.pnum \zero.zero.numr.pnum ];
-    pos @kc88_first_1 @kc88_second_3 -70;
-    pos @kc88_first_1 @kc88_second_8 -70;
-    pos @kc88_first_1 @kc88_second_9 -140;
-    pos @kc88_first_1 @kc88_second_10 -35;
-    pos @kc88_first_1 @kc88_second_12 -280;
-    pos @kc88_first_1 @kc88_second_13 -280;
-    pos @kc88_first_1 @kc88_second_14 -280;
-    pos @kc88_first_1 @kc88_second_15 -210;
-    pos @kc88_first_1 @kc88_second_22 -70;
-    pos @kc88_first_1 @kc88_second_25 -35;
-    pos @kc88_first_1 @kc88_second_27 -50;
-    pos @kc88_first_1 @kc88_second_33 -70;
-    pos @kc88_first_1 @kc88_second_41 -35;
-    pos @kc88_first_1 @kc88_second_42 -140;
-    pos @kc88_first_1 @kc88_second_43 -105;
-    pos @kc88_first_1 @kc88_second_46 -210;
-    pos @kc88_first_1 @kc88_second_47 -35;
-    pos @kc88_first_1 @kc88_second_48 1;
-    pos @kc88_first_1 @kc88_second_50 -175;
-    pos @kc88_first_1 @kc88_second_51 -210;
-    pos @kc88_first_1 @kc88_second_61 -140;
-    pos @kc88_first_1 @kc88_second_63 -140;
-    pos @kc88_first_1 @kc88_second_64 -210;
-    pos @kc88_first_1 @kc88_second_65 -140;
-    pos @kc88_first_2 @kc88_second_9 -35;
-    pos @kc88_first_2 @kc88_second_12 -70;
-    pos @kc88_first_2 @kc88_second_13 -70;
-    pos @kc88_first_2 @kc88_second_14 -70;
-    pos @kc88_first_2 @kc88_second_15 -35;
-    pos @kc88_first_2 @kc88_second_16 -35;
-    pos @kc88_first_2 @kc88_second_42 -35;
-    pos @kc88_first_2 @kc88_second_48 1;
-    pos @kc88_first_3 @kc88_second_1 -35;
-    pos @kc88_first_3 @kc88_second_2 -70;
-    pos @kc88_first_3 @kc88_second_5 -35;
-    pos @kc88_first_3 @kc88_second_11 -35;
-    pos @kc88_first_3 @kc88_second_12 -35;
-    pos @kc88_first_3 @kc88_second_13 -70;
-    pos @kc88_first_3 @kc88_second_14 -35;
-    pos @kc88_first_3 @kc88_second_16 -70;
-    pos @kc88_first_3 @kc88_second_19 -35;
-    pos @kc88_first_3 @kc88_second_21 -70;
-    pos @kc88_first_3 @kc88_second_38 -35;
-    pos @kc88_first_3 @kc88_second_48 1;
-    pos @kc88_first_4 @kc88_second_1 -70;
-    pos @kc88_first_4 @kc88_second_2 -140;
-    pos @kc88_first_4 @kc88_second_4 70;
-    pos @kc88_first_4 @kc88_second_5 -70;
-    pos @kc88_first_4 @kc88_second_11 -105;
-    pos @kc88_first_4 @kc88_second_12 -140;
-    pos @kc88_first_4 @kc88_second_13 -140;
-    pos @kc88_first_4 @kc88_second_14 -105;
-    pos @kc88_first_4 @kc88_second_15 -35;
-    pos @kc88_first_4 @kc88_second_16 -140;
-    pos @kc88_first_4 @kc88_second_19 -70;
-    pos @kc88_first_4 @kc88_second_26 -70;
-    pos @kc88_first_4 @kc88_second_28 -70;
-    pos @kc88_first_4 @kc88_second_29 -35;
-    pos @kc88_first_4 @kc88_second_33 35;
-    pos @kc88_first_4 @kc88_second_35 -35;
-    pos @kc88_first_4 @kc88_second_37 -70;
-    pos @kc88_first_4 @kc88_second_38 -70;
-    pos @kc88_first_4 @kc88_second_46 -35;
-    pos @kc88_first_4 @kc88_second_48 1;
-    pos @kc88_first_4 @kc88_second_51 -70;
-    pos @kc88_first_4 @kc88_second_56 -70;
-    pos @kc88_first_4 @kc88_second_58 -70;
-    pos @kc88_first_4 @kc88_second_59 -70;
-    pos @kc88_first_4 @kc88_second_64 -35;
-    pos @kc88_first_5 @kc88_second_1 -280;
-    pos @kc88_first_5 @kc88_second_2 -350;
-    pos @kc88_first_5 @kc88_second_3 -140;
-    pos @kc88_first_5 @kc88_second_4 -70;
-    pos @kc88_first_5 @kc88_second_6 -350;
-    pos @kc88_first_5 @kc88_second_7 -140;
-    pos @kc88_first_5 @kc88_second_8 -210;
-    pos @kc88_first_5 @kc88_second_10 -70;
-    pos @kc88_first_5 @kc88_second_17 -240;
-    pos @kc88_first_5 @kc88_second_18 -240;
-    pos @kc88_first_5 @kc88_second_19 -280;
-    pos @kc88_first_5 @kc88_second_21 -350;
-    pos @kc88_first_5 @kc88_second_22 -280;
-    pos @kc88_first_5 @kc88_second_23 -240;
-    pos @kc88_first_5 @kc88_second_24 -240;
-    pos @kc88_first_5 @kc88_second_25 -210;
-    pos @kc88_first_5 @kc88_second_26 -350;
-    pos @kc88_first_5 @kc88_second_27 -140;
-    pos @kc88_first_5 @kc88_second_29 -140;
-    pos @kc88_first_5 @kc88_second_31 -240;
-    pos @kc88_first_5 @kc88_second_32 -240;
-    pos @kc88_first_5 @kc88_second_33 -175;
-    pos @kc88_first_5 @kc88_second_35 -240;
-    pos @kc88_first_5 @kc88_second_37 -350;
-    pos @kc88_first_5 @kc88_second_38 -105;
-    pos @kc88_first_5 @kc88_second_39 -240;
-    pos @kc88_first_5 @kc88_second_40 -210;
-    pos @kc88_first_5 @kc88_second_41 -240;
-    pos @kc88_first_5 @kc88_second_42 -240;
-    pos @kc88_first_5 @kc88_second_44 -240;
-    pos @kc88_first_5 @kc88_second_47 -140;
-    pos @kc88_first_5 @kc88_second_48 1;
-    pos @kc88_first_5 @kc88_second_49 -35;
-    pos @kc88_first_5 @kc88_second_50 -240;
-    pos @kc88_first_5 @kc88_second_52 -240;
-    pos @kc88_first_5 @kc88_second_53 -240;
-    pos @kc88_first_5 @kc88_second_54 -240;
-    pos @kc88_first_5 @kc88_second_55 -240;
-    pos @kc88_first_5 @kc88_second_56 -280;
-    pos @kc88_first_5 @kc88_second_57 -70;
-    pos @kc88_first_5 @kc88_second_58 -280;
-    pos @kc88_first_5 @kc88_second_59 -240;
-    pos @kc88_first_5 @kc88_second_60 -175;
-    pos @kc88_first_5 @kc88_second_61 -240;
-    pos @kc88_first_5 @kc88_second_62 -210;
-    pos @kc88_first_5 @kc88_second_63 -175;
-    pos @kc88_first_5 @kc88_second_66 -175;
-    pos @kc88_first_5 @kc88_second_67 -175;
-    pos @kc88_first_6 @kc88_second_48 1;
-    pos @kc88_first_7 @kc88_second_3 -70;
-    pos @kc88_first_7 @kc88_second_8 -105;
-    pos @kc88_first_7 @kc88_second_17 -35;
-    pos @kc88_first_7 @kc88_second_18 -70;
-    pos @kc88_first_7 @kc88_second_22 -105;
-    pos @kc88_first_7 @kc88_second_24 -105;
-    pos @kc88_first_7 @kc88_second_25 -70;
-    pos @kc88_first_7 @kc88_second_48 1;
-    pos @kc88_first_7 @kc88_second_49 -35;
-    pos @kc88_first_7 @kc88_second_50 -70;
-    pos @kc88_first_7 @kc88_second_54 -50;
-    pos @kc88_first_7 @kc88_second_63 -35;
-    pos @kc88_first_7 @kc88_second_66 -70;
-    pos @kc88_first_7 @kc88_second_67 -70;
-    pos @kc88_first_8 @kc88_second_3 -140;
-    pos @kc88_first_8 @kc88_second_4 -70;
-    pos @kc88_first_8 @kc88_second_6 -70;
-    pos @kc88_first_8 @kc88_second_8 -140;
-    pos @kc88_first_8 @kc88_second_10 -35;
-    pos @kc88_first_8 @kc88_second_17 -70;
-    pos @kc88_first_8 @kc88_second_18 -70;
-    pos @kc88_first_8 @kc88_second_22 -140;
-    pos @kc88_first_8 @kc88_second_24 -70;
-    pos @kc88_first_8 @kc88_second_25 -105;
-    pos @kc88_first_8 @kc88_second_27 -140;
-    pos @kc88_first_8 @kc88_second_31 -35;
-    pos @kc88_first_8 @kc88_second_33 -105;
-    pos @kc88_first_8 @kc88_second_37 -70;
-    pos @kc88_first_8 @kc88_second_39 -70;
-    pos @kc88_first_8 @kc88_second_41 -105;
-    pos @kc88_first_8 @kc88_second_42 -175;
-    pos @kc88_first_8 @kc88_second_43 -140;
-    pos @kc88_first_8 @kc88_second_44 -35;
-    pos @kc88_first_8 @kc88_second_46 -140;
-    pos @kc88_first_8 @kc88_second_47 -105;
-    pos @kc88_first_8 @kc88_second_48 1;
-    pos @kc88_first_8 @kc88_second_49 -70;
-    pos @kc88_first_8 @kc88_second_50 -140;
-    pos @kc88_first_8 @kc88_second_51 -70;
-    pos @kc88_first_8 @kc88_second_54 -35;
-    pos @kc88_first_8 @kc88_second_55 -35;
-    pos @kc88_first_8 @kc88_second_61 -210;
-    pos @kc88_first_8 @kc88_second_63 -105;
-    pos @kc88_first_8 @kc88_second_64 -70;
-    pos @kc88_first_8 @kc88_second_65 -35;
-    pos @kc88_first_8 @kc88_second_66 -70;
-    pos @kc88_first_8 @kc88_second_67 -35;
-    pos @kc88_first_9 @kc88_second_3 -140;
-    pos @kc88_first_9 @kc88_second_4 -70;
-    pos @kc88_first_9 @kc88_second_6 -70;
-    pos @kc88_first_9 @kc88_second_8 -210;
-    pos @kc88_first_9 @kc88_second_9 -420;
-    pos @kc88_first_9 @kc88_second_10 -70;
-    pos @kc88_first_9 @kc88_second_12 -350;
-    pos @kc88_first_9 @kc88_second_13 -420;
-    pos @kc88_first_9 @kc88_second_14 -350;
-    pos @kc88_first_9 @kc88_second_15 -280;
-    pos @kc88_first_9 @kc88_second_17 -70;
-    pos @kc88_first_9 @kc88_second_18 -70;
-    pos @kc88_first_9 @kc88_second_20 -210;
-    pos @kc88_first_9 @kc88_second_22 -210;
-    pos @kc88_first_9 @kc88_second_24 -70;
-    pos @kc88_first_9 @kc88_second_25 -140;
-    pos @kc88_first_9 @kc88_second_31 -50;
-    pos @kc88_first_9 @kc88_second_33 -140;
-    pos @kc88_first_9 @kc88_second_37 -70;
-    pos @kc88_first_9 @kc88_second_41 -105;
-    pos @kc88_first_9 @kc88_second_42 -280;
-    pos @kc88_first_9 @kc88_second_43 -350;
-    pos @kc88_first_9 @kc88_second_44 -50;
-    pos @kc88_first_9 @kc88_second_46 -350;
-    pos @kc88_first_9 @kc88_second_48 1;
-    pos @kc88_first_9 @kc88_second_49 -35;
-    pos @kc88_first_9 @kc88_second_50 -210;
-    pos @kc88_first_9 @kc88_second_51 -350;
-    pos @kc88_first_9 @kc88_second_54 -35;
-    pos @kc88_first_9 @kc88_second_55 -35;
-    pos @kc88_first_9 @kc88_second_61 -280;
-    pos @kc88_first_9 @kc88_second_63 -175;
-    pos @kc88_first_9 @kc88_second_64 -280;
-    pos @kc88_first_9 @kc88_second_65 -210;
-    pos @kc88_first_9 @kc88_second_66 -70;
-    pos @kc88_first_9 @kc88_second_67 -70;
-    pos @kc88_first_10 @kc88_second_1 -210;
-    pos @kc88_first_10 @kc88_second_2 -350;
-    pos @kc88_first_10 @kc88_second_5 -70;
-    pos @kc88_first_10 @kc88_second_6 -140;
-    pos @kc88_first_10 @kc88_second_11 -35;
-    pos @kc88_first_10 @kc88_second_12 -70;
-    pos @kc88_first_10 @kc88_second_13 -70;
-    pos @kc88_first_10 @kc88_second_14 -35;
-    pos @kc88_first_10 @kc88_second_16 -70;
-    pos @kc88_first_10 @kc88_second_17 -35;
-    pos @kc88_first_10 @kc88_second_18 -70;
-    pos @kc88_first_10 @kc88_second_19 -140;
-    pos @kc88_first_10 @kc88_second_21 -280;
-    pos @kc88_first_10 @kc88_second_24 -70;
-    pos @kc88_first_10 @kc88_second_26 -350;
-    pos @kc88_first_10 @kc88_second_31 -70;
-    pos @kc88_first_10 @kc88_second_34 -140;
-    pos @kc88_first_10 @kc88_second_35 -70;
-    pos @kc88_first_10 @kc88_second_37 -210;
-    pos @kc88_first_10 @kc88_second_38 -105;
-    pos @kc88_first_10 @kc88_second_41 -70;
-    pos @kc88_first_10 @kc88_second_48 1;
-    pos @kc88_first_10 @kc88_second_56 -210;
-    pos @kc88_first_10 @kc88_second_58 -210;
-    pos @kc88_first_10 @kc88_second_59 -210;
-    pos @kc88_first_10 @kc88_second_64 -70;
-    pos @kc88_first_10 @kc88_second_66 -70;
-    pos @kc88_first_10 @kc88_second_67 -105;
-    pos @kc88_first_11 @kc88_second_1 -70;
-    pos @kc88_first_11 @kc88_second_2 -140;
-    pos @kc88_first_11 @kc88_second_5 -105;
-    pos @kc88_first_11 @kc88_second_6 -35;
-    pos @kc88_first_11 @kc88_second_11 -70;
-    pos @kc88_first_11 @kc88_second_12 -210;
-    pos @kc88_first_11 @kc88_second_13 -175;
-    pos @kc88_first_11 @kc88_second_14 -105;
-    pos @kc88_first_11 @kc88_second_15 -70;
-    pos @kc88_first_11 @kc88_second_16 -140;
-    pos @kc88_first_11 @kc88_second_19 -70;
-    pos @kc88_first_11 @kc88_second_21 -140;
-    pos @kc88_first_11 @kc88_second_26 -70;
-    pos @kc88_first_11 @kc88_second_28 -70;
-    pos @kc88_first_11 @kc88_second_29 -70;
-    pos @kc88_first_11 @kc88_second_35 -35;
-    pos @kc88_first_11 @kc88_second_37 -35;
-    pos @kc88_first_11 @kc88_second_38 -140;
-    pos @kc88_first_11 @kc88_second_42 -70;
-    pos @kc88_first_11 @kc88_second_45 -35;
-    pos @kc88_first_11 @kc88_second_46 -35;
-    pos @kc88_first_11 @kc88_second_48 1;
-    pos @kc88_first_11 @kc88_second_51 -70;
-    pos @kc88_first_11 @kc88_second_56 -210;
-    pos @kc88_first_11 @kc88_second_58 -175;
-    pos @kc88_first_11 @kc88_second_59 -175;
-    pos @kc88_first_11 @kc88_second_60 -35;
-    pos @kc88_first_11 @kc88_second_64 -70;
-    pos @kc88_first_11 @kc88_second_65 -35;
-    pos @kc88_first_11 @kc88_second_66 -35;
-    pos @kc88_first_11 @kc88_second_67 -70;
-    pos @kc88_first_12 @kc88_second_1 -140;
-    pos @kc88_first_12 @kc88_second_2 -210;
-    pos @kc88_first_12 @kc88_second_6 -140;
-    pos @kc88_first_12 @kc88_second_17 -70;
-    pos @kc88_first_12 @kc88_second_18 -70;
-    pos @kc88_first_12 @kc88_second_19 -140;
-    pos @kc88_first_12 @kc88_second_21 -210;
-    pos @kc88_first_12 @kc88_second_24 -70;
-    pos @kc88_first_12 @kc88_second_26 -350;
-    pos @kc88_first_12 @kc88_second_31 -35;
-    pos @kc88_first_12 @kc88_second_34 -140;
-    pos @kc88_first_12 @kc88_second_35 -70;
-    pos @kc88_first_12 @kc88_second_37 -140;
-    pos @kc88_first_12 @kc88_second_38 -70;
-    pos @kc88_first_12 @kc88_second_41 -70;
-    pos @kc88_first_12 @kc88_second_48 1;
-    pos @kc88_first_12 @kc88_second_54 -35;
-    pos @kc88_first_12 @kc88_second_56 -210;
-    pos @kc88_first_12 @kc88_second_58 -210;
-    pos @kc88_first_12 @kc88_second_59 -210;
-    pos @kc88_first_12 @kc88_second_66 -70;
-    pos @kc88_first_12 @kc88_second_67 -105;
-    pos @kc88_first_13 @kc88_second_6 -70;
-    pos @kc88_first_13 @kc88_second_12 -70;
-    pos @kc88_first_13 @kc88_second_13 -105;
-    pos @kc88_first_13 @kc88_second_14 -35;
-    pos @kc88_first_13 @kc88_second_18 -35;
-    pos @kc88_first_13 @kc88_second_24 -35;
-    pos @kc88_first_13 @kc88_second_31 -35;
-    pos @kc88_first_13 @kc88_second_37 -70;
-    pos @kc88_first_13 @kc88_second_41 -70;
-    pos @kc88_first_13 @kc88_second_48 1;
-    pos @kc88_first_13 @kc88_second_66 -70;
-    pos @kc88_first_13 @kc88_second_67 -35;
-    pos @kc88_first_14 @kc88_second_2 -35;
-    pos @kc88_first_14 @kc88_second_11 -35;
-    pos @kc88_first_14 @kc88_second_12 -70;
-    pos @kc88_first_14 @kc88_second_13 -70;
-    pos @kc88_first_14 @kc88_second_14 -35;
-    pos @kc88_first_14 @kc88_second_16 -35;
-    pos @kc88_first_14 @kc88_second_21 -35;
-    pos @kc88_first_14 @kc88_second_27 -35;
-    pos @kc88_first_14 @kc88_second_35 -35;
-    pos @kc88_first_14 @kc88_second_42 -70;
-    pos @kc88_first_14 @kc88_second_48 1;
-    pos @kc88_first_14 @kc88_second_50 -70;
-    pos @kc88_first_14 @kc88_second_51 -35;
-    pos @kc88_first_14 @kc88_second_60 -35;
-    pos @kc88_first_14 @kc88_second_61 -35;
-    pos @kc88_first_14 @kc88_second_63 -35;
-    pos @kc88_first_14 @kc88_second_65 -35;
-    pos @kc88_first_15 @kc88_second_3 -70;
-    pos @kc88_first_15 @kc88_second_4 -70;
-    pos @kc88_first_15 @kc88_second_6 -35;
-    pos @kc88_first_15 @kc88_second_8 -70;
-    pos @kc88_first_15 @kc88_second_17 -70;
-    pos @kc88_first_15 @kc88_second_18 -70;
-    pos @kc88_first_15 @kc88_second_22 -140;
-    pos @kc88_first_15 @kc88_second_24 -70;
-    pos @kc88_first_15 @kc88_second_25 -70;
-    pos @kc88_first_15 @kc88_second_27 -70;
-    pos @kc88_first_15 @kc88_second_31 -35;
-    pos @kc88_first_15 @kc88_second_33 -35;
-    pos @kc88_first_15 @kc88_second_39 -35;
-    pos @kc88_first_15 @kc88_second_41 -70;
-    pos @kc88_first_15 @kc88_second_42 -142;
-    pos @kc88_first_15 @kc88_second_43 -35;
-    pos @kc88_first_15 @kc88_second_47 -35;
-    pos @kc88_first_15 @kc88_second_48 1;
-    pos @kc88_first_15 @kc88_second_49 -35;
-    pos @kc88_first_15 @kc88_second_50 -70;
-    pos @kc88_first_15 @kc88_second_54 -35;
-    pos @kc88_first_15 @kc88_second_55 -35;
-    pos @kc88_first_15 @kc88_second_61 -105;
-    pos @kc88_first_15 @kc88_second_63 -35;
-    pos @kc88_first_15 @kc88_second_66 -35;
-    pos @kc88_first_15 @kc88_second_67 -35;
-    pos @kc88_first_16 @kc88_second_1 -280;
-    pos @kc88_first_16 @kc88_second_2 -280;
-    pos @kc88_first_16 @kc88_second_3 -140;
-    pos @kc88_first_16 @kc88_second_4 -70;
-    pos @kc88_first_16 @kc88_second_6 -280;
-    pos @kc88_first_16 @kc88_second_7 -140;
-    pos @kc88_first_16 @kc88_second_8 -175;
-    pos @kc88_first_16 @kc88_second_10 -70;
-    pos @kc88_first_16 @kc88_second_17 -245;
-    pos @kc88_first_16 @kc88_second_18 -280;
-    pos @kc88_first_16 @kc88_second_19 -280;
-    pos @kc88_first_16 @kc88_second_21 -280;
-    pos @kc88_first_16 @kc88_second_22 -210;
-    pos @kc88_first_16 @kc88_second_23 -140;
-    pos @kc88_first_16 @kc88_second_24 -280;
-    pos @kc88_first_16 @kc88_second_25 -210;
-    pos @kc88_first_16 @kc88_second_26 -350;
-    pos @kc88_first_16 @kc88_second_27 -70;
-    pos @kc88_first_16 @kc88_second_29 -140;
-    pos @kc88_first_16 @kc88_second_31 -240;
-    pos @kc88_first_16 @kc88_second_32 -140;
-    pos @kc88_first_16 @kc88_second_33 -140;
-    pos @kc88_first_16 @kc88_second_34 -245;
-    pos @kc88_first_16 @kc88_second_35 -315;
-    pos @kc88_first_16 @kc88_second_37 -315;
-    pos @kc88_first_16 @kc88_second_38 -70;
-    pos @kc88_first_16 @kc88_second_39 -210;
-    pos @kc88_first_16 @kc88_second_40 -210;
-    pos @kc88_first_16 @kc88_second_41 -245;
-    pos @kc88_first_16 @kc88_second_42 -245;
-    pos @kc88_first_16 @kc88_second_43 -70;
-    pos @kc88_first_16 @kc88_second_45 -35;
-    pos @kc88_first_16 @kc88_second_46 -140;
-    pos @kc88_first_16 @kc88_second_47 -140;
-    pos @kc88_first_16 @kc88_second_48 1;
-    pos @kc88_first_16 @kc88_second_49 -70;
-    pos @kc88_first_16 @kc88_second_50 -140;
-    pos @kc88_first_16 @kc88_second_52 -140;
-    pos @kc88_first_16 @kc88_second_53 -140;
-    pos @kc88_first_16 @kc88_second_54 -240;
-    pos @kc88_first_16 @kc88_second_55 -140;
-    pos @kc88_first_16 @kc88_second_56 -280;
-    pos @kc88_first_16 @kc88_second_57 -105;
-    pos @kc88_first_16 @kc88_second_58 -315;
-    pos @kc88_first_16 @kc88_second_59 -280;
-    pos @kc88_first_16 @kc88_second_60 -140;
-    pos @kc88_first_16 @kc88_second_61 -210;
-    pos @kc88_first_16 @kc88_second_62 -210;
-    pos @kc88_first_16 @kc88_second_63 -105;
-    pos @kc88_first_16 @kc88_second_66 -315;
-    pos @kc88_first_16 @kc88_second_67 -350;
-    pos @kc88_first_17 @kc88_second_1 -280;
-    pos @kc88_first_17 @kc88_second_2 -280;
-    pos @kc88_first_17 @kc88_second_3 -105;
-    pos @kc88_first_17 @kc88_second_6 -210;
-    pos @kc88_first_17 @kc88_second_7 -105;
-    pos @kc88_first_17 @kc88_second_8 -105;
-    pos @kc88_first_17 @kc88_second_10 -35;
-    pos @kc88_first_17 @kc88_second_17 -105;
-    pos @kc88_first_17 @kc88_second_18 -175;
-    pos @kc88_first_17 @kc88_second_19 -280;
-    pos @kc88_first_17 @kc88_second_21 -280;
-    pos @kc88_first_17 @kc88_second_22 -70;
-    pos @kc88_first_17 @kc88_second_23 -105;
-    pos @kc88_first_17 @kc88_second_24 -140;
-    pos @kc88_first_17 @kc88_second_25 -140;
-    pos @kc88_first_17 @kc88_second_26 -210;
-    pos @kc88_first_17 @kc88_second_29 -70;
-    pos @kc88_first_17 @kc88_second_31 -140;
-    pos @kc88_first_17 @kc88_second_32 -105;
-    pos @kc88_first_17 @kc88_second_34 -210;
-    pos @kc88_first_17 @kc88_second_35 -175;
-    pos @kc88_first_17 @kc88_second_37 -245;
-    pos @kc88_first_17 @kc88_second_38 -70;
-    pos @kc88_first_17 @kc88_second_39 -140;
-    pos @kc88_first_17 @kc88_second_40 -140;
-    pos @kc88_first_17 @kc88_second_41 -140;
-    pos @kc88_first_17 @kc88_second_42 -105;
-    pos @kc88_first_17 @kc88_second_43 -35;
-    pos @kc88_first_17 @kc88_second_46 -35;
-    pos @kc88_first_17 @kc88_second_47 -70;
-    pos @kc88_first_17 @kc88_second_48 1;
-    pos @kc88_first_17 @kc88_second_49 -35;
-    pos @kc88_first_17 @kc88_second_50 -70;
-    pos @kc88_first_17 @kc88_second_52 -105;
-    pos @kc88_first_17 @kc88_second_53 -70;
-    pos @kc88_first_17 @kc88_second_54 -105;
-    pos @kc88_first_17 @kc88_second_55 -70;
-    pos @kc88_first_17 @kc88_second_56 -210;
-    pos @kc88_first_17 @kc88_second_57 -35;
-    pos @kc88_first_17 @kc88_second_58 -245;
-    pos @kc88_first_17 @kc88_second_59 -210;
-    pos @kc88_first_17 @kc88_second_60 -70;
-    pos @kc88_first_17 @kc88_second_61 -105;
-    pos @kc88_first_17 @kc88_second_62 -105;
-    pos @kc88_first_17 @kc88_second_63 -70;
-    pos @kc88_first_17 @kc88_second_66 -175;
-    pos @kc88_first_17 @kc88_second_67 -245;
-    pos @kc88_first_18 @kc88_second_1 -210;
-    pos @kc88_first_18 @kc88_second_2 -245;
-    pos @kc88_first_18 @kc88_second_3 -35;
-    pos @kc88_first_18 @kc88_second_6 -140;
-    pos @kc88_first_18 @kc88_second_7 -35;
-    pos @kc88_first_18 @kc88_second_8 -70;
-    pos @kc88_first_18 @kc88_second_17 -105;
-    pos @kc88_first_18 @kc88_second_18 -105;
-    pos @kc88_first_18 @kc88_second_19 -175;
-    pos @kc88_first_18 @kc88_second_21 -210;
-    pos @kc88_first_18 @kc88_second_22 -70;
-    pos @kc88_first_18 @kc88_second_24 -105;
-    pos @kc88_first_18 @kc88_second_25 -70;
-    pos @kc88_first_18 @kc88_second_26 -140;
-    pos @kc88_first_18 @kc88_second_29 -35;
-    pos @kc88_first_18 @kc88_second_34 -140;
-    pos @kc88_first_18 @kc88_second_35 -105;
-    pos @kc88_first_18 @kc88_second_37 -140;
-    pos @kc88_first_18 @kc88_second_39 -105;
-    pos @kc88_first_18 @kc88_second_40 -70;
-    pos @kc88_first_18 @kc88_second_41 -105;
-    pos @kc88_first_18 @kc88_second_42 -70;
-    pos @kc88_first_18 @kc88_second_44 -35;
-    pos @kc88_first_18 @kc88_second_48 1;
-    pos @kc88_first_18 @kc88_second_53 -35;
-    pos @kc88_first_18 @kc88_second_54 -70;
-    pos @kc88_first_18 @kc88_second_56 -140;
-    pos @kc88_first_18 @kc88_second_58 -175;
-    pos @kc88_first_18 @kc88_second_59 -140;
-    pos @kc88_first_18 @kc88_second_61 -70;
-    pos @kc88_first_18 @kc88_second_66 -105;
-    pos @kc88_first_18 @kc88_second_67 -140;
-    pos @kc88_first_19 @kc88_second_12 -280;
-    pos @kc88_first_19 @kc88_second_14 -175;
-    pos @kc88_first_19 @kc88_second_15 -140;
-    pos @kc88_first_19 @kc88_second_18 -35;
-    pos @kc88_first_19 @kc88_second_31 -35;
-    pos @kc88_first_19 @kc88_second_33 -50;
-    pos @kc88_first_19 @kc88_second_48 1;
-    pos @kc88_first_19 @kc88_second_50 -70;
-    pos @kc88_first_19 @kc88_second_51 -140;
-    pos @kc88_first_19 @kc88_second_61 -70;
-    pos @kc88_first_19 @kc88_second_63 -35;
-    pos @kc88_first_19 @kc88_second_64 -105;
-    pos @kc88_first_19 @kc88_second_65 -70;
-    pos @kc88_first_20 @kc88_second_12 -240;
-    pos @kc88_first_20 @kc88_second_13 -140;
-    pos @kc88_first_20 @kc88_second_14 -105;
-    pos @kc88_first_20 @kc88_second_15 -35;
-    pos @kc88_first_20 @kc88_second_48 1;
-    pos @kc88_first_21 @kc88_second_8 -35;
-    pos @kc88_first_21 @kc88_second_9 -140;
-    pos @kc88_first_21 @kc88_second_12 -280;
-    pos @kc88_first_21 @kc88_second_13 -280;
-    pos @kc88_first_21 @kc88_second_14 -280;
-    pos @kc88_first_21 @kc88_second_15 -175;
-    pos @kc88_first_21 @kc88_second_20 -140;
-    pos @kc88_first_21 @kc88_second_22 -70;
-    pos @kc88_first_21 @kc88_second_27 -70;
-    pos @kc88_first_21 @kc88_second_33 -50;
-    pos @kc88_first_21 @kc88_second_42 -140;
-    pos @kc88_first_21 @kc88_second_43 -105;
-    pos @kc88_first_21 @kc88_second_46 -210;
-    pos @kc88_first_21 @kc88_second_48 1;
-    pos @kc88_first_21 @kc88_second_49 -35;
-    pos @kc88_first_21 @kc88_second_50 -140;
-    pos @kc88_first_21 @kc88_second_51 -210;
-    pos @kc88_first_21 @kc88_second_55 -35;
-    pos @kc88_first_21 @kc88_second_61 -105;
-    pos @kc88_first_21 @kc88_second_63 -105;
-    pos @kc88_first_21 @kc88_second_64 -210;
-    pos @kc88_first_21 @kc88_second_65 -140;
-    pos @kc88_first_22 @kc88_second_1 -140;
-    pos @kc88_first_22 @kc88_second_2 -350;
-    pos @kc88_first_22 @kc88_second_19 -140;
-    pos @kc88_first_22 @kc88_second_21 -280;
-    pos @kc88_first_22 @kc88_second_41 -70;
-    pos @kc88_first_22 @kc88_second_48 1;
-    pos @kc88_first_22 @kc88_second_67 -210;
-    pos @kc88_first_23 @kc88_second_1 -35;
-    pos @kc88_first_23 @kc88_second_5 -105;
-    pos @kc88_first_23 @kc88_second_9 -70;
-    pos @kc88_first_23 @kc88_second_11 -70;
-    pos @kc88_first_23 @kc88_second_12 -240;
-    pos @kc88_first_23 @kc88_second_13 -280;
-    pos @kc88_first_23 @kc88_second_14 -140;
-    pos @kc88_first_23 @kc88_second_15 -105;
-    pos @kc88_first_23 @kc88_second_16 -70;
-    pos @kc88_first_23 @kc88_second_27 -35;
-    pos @kc88_first_23 @kc88_second_28 -70;
-    pos @kc88_first_23 @kc88_second_29 -105;
-    pos @kc88_first_23 @kc88_second_35 -35;
-    pos @kc88_first_23 @kc88_second_38 -70;
-    pos @kc88_first_23 @kc88_second_42 -70;
-    pos @kc88_first_23 @kc88_second_43 -35;
-    pos @kc88_first_23 @kc88_second_45 -35;
-    pos @kc88_first_23 @kc88_second_46 -140;
-    pos @kc88_first_23 @kc88_second_48 1;
-    pos @kc88_first_23 @kc88_second_50 -70;
-    pos @kc88_first_23 @kc88_second_51 -175;
-    pos @kc88_first_23 @kc88_second_52 -35;
-    pos @kc88_first_23 @kc88_second_60 -105;
-    pos @kc88_first_23 @kc88_second_61 -35;
-    pos @kc88_first_23 @kc88_second_63 -50;
-    pos @kc88_first_23 @kc88_second_64 -105;
-    pos @kc88_first_23 @kc88_second_65 -70;
-    pos @kc88_first_24 @kc88_second_6 -35;
-    pos @kc88_first_24 @kc88_second_12 -240;
-    pos @kc88_first_24 @kc88_second_13 -175;
-    pos @kc88_first_24 @kc88_second_14 -70;
-    pos @kc88_first_24 @kc88_second_15 -70;
-    pos @kc88_first_24 @kc88_second_18 -70;
-    pos @kc88_first_24 @kc88_second_24 -70;
-    pos @kc88_first_24 @kc88_second_25 -35;
-    pos @kc88_first_24 @kc88_second_37 -35;
-    pos @kc88_first_24 @kc88_second_42 -35;
-    pos @kc88_first_24 @kc88_second_43 -35;
-    pos @kc88_first_24 @kc88_second_46 -70;
-    pos @kc88_first_24 @kc88_second_47 -35;
-    pos @kc88_first_24 @kc88_second_48 1;
-    pos @kc88_first_24 @kc88_second_51 -35;
-    pos @kc88_first_24 @kc88_second_61 -35;
-    pos @kc88_first_24 @kc88_second_65 -35;
-    pos @kc88_first_24 @kc88_second_66 -35;
-    pos @kc88_first_24 @kc88_second_67 -35;
-    pos @kc88_first_25 @kc88_second_1 -70;
-    pos @kc88_first_25 @kc88_second_2 -140;
-    pos @kc88_first_25 @kc88_second_5 -105;
-    pos @kc88_first_25 @kc88_second_11 -70;
-    pos @kc88_first_25 @kc88_second_12 -280;
-    pos @kc88_first_25 @kc88_second_13 -210;
-    pos @kc88_first_25 @kc88_second_14 -70;
-    pos @kc88_first_25 @kc88_second_15 -70;
-    pos @kc88_first_25 @kc88_second_16 -140;
-    pos @kc88_first_25 @kc88_second_21 -70;
-    pos @kc88_first_25 @kc88_second_28 -70;
-    pos @kc88_first_25 @kc88_second_29 -70;
-    pos @kc88_first_25 @kc88_second_34 -70;
-    pos @kc88_first_25 @kc88_second_38 -70;
-    pos @kc88_first_25 @kc88_second_45 -35;
-    pos @kc88_first_25 @kc88_second_46 -140;
-    pos @kc88_first_25 @kc88_second_48 1;
-    pos @kc88_first_25 @kc88_second_51 -140;
-    pos @kc88_first_25 @kc88_second_52 -35;
-    pos @kc88_first_25 @kc88_second_56 -140;
-    pos @kc88_first_25 @kc88_second_58 -70;
-    pos @kc88_first_25 @kc88_second_59 -105;
-    pos @kc88_first_25 @kc88_second_60 -70;
-    pos @kc88_first_25 @kc88_second_64 -70;
-    pos @kc88_first_25 @kc88_second_65 -35;
-    pos @kc88_first_26 @kc88_second_5 -70;
-    pos @kc88_first_26 @kc88_second_9 -70;
-    pos @kc88_first_26 @kc88_second_12 -240;
-    pos @kc88_first_26 @kc88_second_13 -280;
-    pos @kc88_first_26 @kc88_second_14 -175;
-    pos @kc88_first_26 @kc88_second_15 -105;
-    pos @kc88_first_26 @kc88_second_16 -70;
-    pos @kc88_first_26 @kc88_second_27 -35;
-    pos @kc88_first_26 @kc88_second_28 -70;
-    pos @kc88_first_26 @kc88_second_29 -70;
-    pos @kc88_first_26 @kc88_second_38 -70;
-    pos @kc88_first_26 @kc88_second_42 -70;
-    pos @kc88_first_26 @kc88_second_43 -35;
-    pos @kc88_first_26 @kc88_second_46 -140;
-    pos @kc88_first_26 @kc88_second_48 1;
-    pos @kc88_first_26 @kc88_second_50 -70;
-    pos @kc88_first_26 @kc88_second_51 -140;
-    pos @kc88_first_26 @kc88_second_52 -35;
-    pos @kc88_first_26 @kc88_second_56 -50;
-    pos @kc88_first_26 @kc88_second_57 -35;
-    pos @kc88_first_26 @kc88_second_58 -50;
-    pos @kc88_first_26 @kc88_second_59 -50;
-    pos @kc88_first_26 @kc88_second_60 -105;
-    pos @kc88_first_26 @kc88_second_61 -50;
-    pos @kc88_first_26 @kc88_second_63 -35;
-    pos @kc88_first_26 @kc88_second_64 -105;
-    pos @kc88_first_26 @kc88_second_65 -70;
-    pos @kc88_first_27 @kc88_second_9 -35;
-    pos @kc88_first_27 @kc88_second_12 -140;
-    pos @kc88_first_27 @kc88_second_28 -70;
-    pos @kc88_first_27 @kc88_second_42 -35;
-    pos @kc88_first_27 @kc88_second_46 -70;
-    pos @kc88_first_27 @kc88_second_48 1;
-    pos @kc88_first_27 @kc88_second_51 -70;
-    pos @kc88_first_27 @kc88_second_64 -70;
-    pos @kc88_first_27 @kc88_second_65 -35;
-    pos @kc88_first_28 @kc88_second_5 -50;
-    pos @kc88_first_28 @kc88_second_9 -35;
-    pos @kc88_first_28 @kc88_second_11 -35;
-    pos @kc88_first_28 @kc88_second_12 -240;
-    pos @kc88_first_28 @kc88_second_13 -240;
-    pos @kc88_first_28 @kc88_second_14 -105;
-    pos @kc88_first_28 @kc88_second_15 -70;
-    pos @kc88_first_28 @kc88_second_16 -35;
-    pos @kc88_first_28 @kc88_second_28 -35;
-    pos @kc88_first_28 @kc88_second_29 -35;
-    pos @kc88_first_28 @kc88_second_35 -35;
-    pos @kc88_first_28 @kc88_second_38 -35;
-    pos @kc88_first_28 @kc88_second_42 -50;
-    pos @kc88_first_28 @kc88_second_43 -35;
-    pos @kc88_first_28 @kc88_second_46 -100;
-    pos @kc88_first_28 @kc88_second_48 1;
-    pos @kc88_first_28 @kc88_second_50 -35;
-    pos @kc88_first_28 @kc88_second_51 -140;
-    pos @kc88_first_28 @kc88_second_60 -35;
-    pos @kc88_first_28 @kc88_second_64 -70;
-    pos @kc88_first_28 @kc88_second_65 -35;
-    pos @kc88_first_29 @kc88_second_48 1;
-    pos @kc88_first_30 @kc88_second_8 -70;
-    pos @kc88_first_30 @kc88_second_9 -210;
-    pos @kc88_first_30 @kc88_second_12 -350;
-    pos @kc88_first_30 @kc88_second_13 -350;
-    pos @kc88_first_30 @kc88_second_14 -210;
-    pos @kc88_first_30 @kc88_second_15 -175;
-    pos @kc88_first_30 @kc88_second_27 -70;
-    pos @kc88_first_30 @kc88_second_41 -35;
-    pos @kc88_first_30 @kc88_second_42 -210;
-    pos @kc88_first_30 @kc88_second_43 -210;
-    pos @kc88_first_30 @kc88_second_46 -210;
-    pos @kc88_first_30 @kc88_second_48 1;
-    pos @kc88_first_30 @kc88_second_50 -140;
-    pos @kc88_first_30 @kc88_second_51 -280;
-    pos @kc88_first_30 @kc88_second_61 -210;
-    pos @kc88_first_30 @kc88_second_63 -105;
-    pos @kc88_first_30 @kc88_second_64 -175;
-    pos @kc88_first_30 @kc88_second_65 -140;
-    pos @kc88_first_31 @kc88_second_1 -175;
-    pos @kc88_first_31 @kc88_second_2 -175;
-    pos @kc88_first_31 @kc88_second_5 -70;
-    pos @kc88_first_31 @kc88_second_6 -105;
-    pos @kc88_first_31 @kc88_second_10 -35;
-    pos @kc88_first_31 @kc88_second_11 -105;
-    pos @kc88_first_31 @kc88_second_12 -175;
-    pos @kc88_first_31 @kc88_second_13 -140;
-    pos @kc88_first_31 @kc88_second_14 -70;
-    pos @kc88_first_31 @kc88_second_15 -35;
-    pos @kc88_first_31 @kc88_second_16 -140;
-    pos @kc88_first_31 @kc88_second_17 -70;
-    pos @kc88_first_31 @kc88_second_18 -70;
-    pos @kc88_first_31 @kc88_second_19 -140;
-    pos @kc88_first_31 @kc88_second_21 -175;
-    pos @kc88_first_31 @kc88_second_24 -70;
-    pos @kc88_first_31 @kc88_second_31 -105;
-    pos @kc88_first_31 @kc88_second_36 180;
-    pos @kc88_first_31 @kc88_second_37 -105;
-    pos @kc88_first_31 @kc88_second_38 -175;
-    pos @kc88_first_31 @kc88_second_39 -35;
-    pos @kc88_first_31 @kc88_second_41 -70;
-    pos @kc88_first_31 @kc88_second_48 1;
-    pos @kc88_first_31 @kc88_second_53 180;
-    pos @kc88_first_31 @kc88_second_54 -35;
-    pos @kc88_first_31 @kc88_second_66 -70;
-    pos @kc88_first_31 @kc88_second_67 -105;
-    pos @kc88_first_32 @kc88_second_3 -70;
-    pos @kc88_first_32 @kc88_second_4 -35;
-    pos @kc88_first_32 @kc88_second_6 -70;
-    pos @kc88_first_32 @kc88_second_8 -105;
-    pos @kc88_first_32 @kc88_second_17 -35;
-    pos @kc88_first_32 @kc88_second_18 -70;
-    pos @kc88_first_32 @kc88_second_22 -70;
-    pos @kc88_first_32 @kc88_second_24 -70;
-    pos @kc88_first_32 @kc88_second_25 -140;
-    pos @kc88_first_32 @kc88_second_31 -35;
-    pos @kc88_first_32 @kc88_second_37 -70;
-    pos @kc88_first_32 @kc88_second_39 -35;
-    pos @kc88_first_32 @kc88_second_41 -140;
-    pos @kc88_first_32 @kc88_second_42 -70;
-    pos @kc88_first_32 @kc88_second_48 1;
-    pos @kc88_first_32 @kc88_second_54 -35;
-    pos @kc88_first_32 @kc88_second_55 -35;
-    pos @kc88_first_32 @kc88_second_61 -140;
-    pos @kc88_first_32 @kc88_second_66 -70;
-    pos @kc88_first_32 @kc88_second_67 -70;
-    pos @kc88_first_33 @kc88_second_1 -35;
-    pos @kc88_first_33 @kc88_second_2 -105;
-    pos @kc88_first_33 @kc88_second_3 -70;
-    pos @kc88_first_33 @kc88_second_4 70;
-    pos @kc88_first_33 @kc88_second_5 -70;
-    pos @kc88_first_33 @kc88_second_11 -35;
-    pos @kc88_first_33 @kc88_second_12 -240;
-    pos @kc88_first_33 @kc88_second_13 -175;
-    pos @kc88_first_33 @kc88_second_14 -105;
-    pos @kc88_first_33 @kc88_second_15 -70;
-    pos @kc88_first_33 @kc88_second_16 -70;
-    pos @kc88_first_33 @kc88_second_19 -70;
-    pos @kc88_first_33 @kc88_second_26 -35;
-    pos @kc88_first_33 @kc88_second_29 -70;
-    pos @kc88_first_33 @kc88_second_35 -35;
-    pos @kc88_first_33 @kc88_second_38 -35;
-    pos @kc88_first_33 @kc88_second_42 -35;
-    pos @kc88_first_33 @kc88_second_43 -35;
-    pos @kc88_first_33 @kc88_second_45 -35;
-    pos @kc88_first_33 @kc88_second_46 -140;
-    pos @kc88_first_33 @kc88_second_48 1;
-    pos @kc88_first_33 @kc88_second_50 -50;
-    pos @kc88_first_33 @kc88_second_51 -140;
-    pos @kc88_first_33 @kc88_second_52 -35;
-    pos @kc88_first_33 @kc88_second_56 -70;
-    pos @kc88_first_33 @kc88_second_58 -70;
-    pos @kc88_first_33 @kc88_second_59 -70;
-    pos @kc88_first_33 @kc88_second_64 -70;
-    pos @kc88_first_33 @kc88_second_65 -35;
-    pos @kc88_first_34 @kc88_second_3 -35;
-    pos @kc88_first_34 @kc88_second_4 -70;
-    pos @kc88_first_34 @kc88_second_6 -70;
-    pos @kc88_first_34 @kc88_second_8 -70;
-    pos @kc88_first_34 @kc88_second_12 -140;
-    pos @kc88_first_34 @kc88_second_13 -105;
-    pos @kc88_first_34 @kc88_second_14 -70;
-    pos @kc88_first_34 @kc88_second_15 -35;
-    pos @kc88_first_34 @kc88_second_18 -70;
-    pos @kc88_first_34 @kc88_second_22 -70;
-    pos @kc88_first_34 @kc88_second_24 -105;
-    pos @kc88_first_34 @kc88_second_25 -70;
-    pos @kc88_first_34 @kc88_second_31 -35;
-    pos @kc88_first_34 @kc88_second_37 -70;
-    pos @kc88_first_34 @kc88_second_39 -70;
-    pos @kc88_first_34 @kc88_second_41 -105;
-    pos @kc88_first_34 @kc88_second_42 -70;
-    pos @kc88_first_34 @kc88_second_47 -70;
-    pos @kc88_first_34 @kc88_second_48 1;
-    pos @kc88_first_34 @kc88_second_54 -35;
-    pos @kc88_first_34 @kc88_second_55 -35;
-    pos @kc88_first_34 @kc88_second_66 -70;
-    pos @kc88_first_34 @kc88_second_67 -70;
-    pos @kc88_first_35 @kc88_second_34 -315;
-    pos @kc88_first_35 @kc88_second_48 1;
-    pos @kc88_first_36 @kc88_second_9 -70;
-    pos @kc88_first_36 @kc88_second_12 -240;
-    pos @kc88_first_36 @kc88_second_13 -210;
-    pos @kc88_first_36 @kc88_second_14 -140;
-    pos @kc88_first_36 @kc88_second_15 -105;
-    pos @kc88_first_36 @kc88_second_36 100;
-    pos @kc88_first_36 @kc88_second_42 -70;
-    pos @kc88_first_36 @kc88_second_43 -35;
-    pos @kc88_first_36 @kc88_second_46 -140;
-    pos @kc88_first_36 @kc88_second_48 1;
-    pos @kc88_first_36 @kc88_second_50 -50;
-    pos @kc88_first_36 @kc88_second_51 -140;
-    pos @kc88_first_36 @kc88_second_53 100;
-    pos @kc88_first_36 @kc88_second_61 -35;
-    pos @kc88_first_36 @kc88_second_63 -35;
-    pos @kc88_first_36 @kc88_second_64 -70;
-    pos @kc88_first_36 @kc88_second_65 -70;
-    pos @kc88_first_37 @kc88_second_9 -35;
-    pos @kc88_first_37 @kc88_second_12 -240;
-    pos @kc88_first_37 @kc88_second_13 -240;
-    pos @kc88_first_37 @kc88_second_14 -140;
-    pos @kc88_first_37 @kc88_second_15 -105;
-    pos @kc88_first_37 @kc88_second_16 -35;
-    pos @kc88_first_37 @kc88_second_28 -35;
-    pos @kc88_first_37 @kc88_second_29 -35;
-    pos @kc88_first_37 @kc88_second_42 -70;
-    pos @kc88_first_37 @kc88_second_43 -35;
-    pos @kc88_first_37 @kc88_second_46 -70;
-    pos @kc88_first_37 @kc88_second_48 1;
-    pos @kc88_first_37 @kc88_second_50 -35;
-    pos @kc88_first_37 @kc88_second_51 -70;
-    pos @kc88_first_37 @kc88_second_63 -35;
-    pos @kc88_first_37 @kc88_second_64 -70;
-    pos @kc88_first_37 @kc88_second_65 -70;
-    pos @kc88_first_38 @kc88_second_5 -70;
-    pos @kc88_first_38 @kc88_second_9 -70;
-    pos @kc88_first_38 @kc88_second_12 -140;
-    pos @kc88_first_38 @kc88_second_13 -210;
-    pos @kc88_first_38 @kc88_second_14 -140;
-    pos @kc88_first_38 @kc88_second_15 -105;
-    pos @kc88_first_38 @kc88_second_16 -70;
-    pos @kc88_first_38 @kc88_second_28 -70;
-    pos @kc88_first_38 @kc88_second_29 -70;
-    pos @kc88_first_38 @kc88_second_38 -50;
-    pos @kc88_first_38 @kc88_second_42 -50;
-    pos @kc88_first_38 @kc88_second_43 -35;
-    pos @kc88_first_38 @kc88_second_48 1;
-    pos @kc88_first_38 @kc88_second_50 -35;
-    pos @kc88_first_38 @kc88_second_51 -140;
-    pos @kc88_first_38 @kc88_second_60 -35;
-    pos @kc88_first_38 @kc88_second_64 -70;
-    pos @kc88_first_38 @kc88_second_65 -35;
-    pos @kc88_first_39 @kc88_second_1 -210;
-    pos @kc88_first_39 @kc88_second_2 -280;
-    pos @kc88_first_39 @kc88_second_6 -280;
-    pos @kc88_first_39 @kc88_second_8 -70;
-    pos @kc88_first_39 @kc88_second_17 -140;
-    pos @kc88_first_39 @kc88_second_18 -140;
-    pos @kc88_first_39 @kc88_second_19 -245;
-    pos @kc88_first_39 @kc88_second_21 -350;
-    pos @kc88_first_39 @kc88_second_22 -140;
-    pos @kc88_first_39 @kc88_second_24 -140;
-    pos @kc88_first_39 @kc88_second_25 -70;
-    pos @kc88_first_39 @kc88_second_26 -280;
-    pos @kc88_first_39 @kc88_second_30 -315;
-    pos @kc88_first_39 @kc88_second_31 -140;
-    pos @kc88_first_39 @kc88_second_34 -385;
-    pos @kc88_first_39 @kc88_second_35 -140;
-    pos @kc88_first_39 @kc88_second_37 -210;
-    pos @kc88_first_39 @kc88_second_38 -70;
-    pos @kc88_first_39 @kc88_second_39 -140;
-    pos @kc88_first_39 @kc88_second_40 -140;
-    pos @kc88_first_39 @kc88_second_41 -140;
-    pos @kc88_first_39 @kc88_second_42 -70;
-    pos @kc88_first_39 @kc88_second_44 -70;
-    pos @kc88_first_39 @kc88_second_48 1;
-    pos @kc88_first_39 @kc88_second_54 -140;
-    pos @kc88_first_39 @kc88_second_55 -70;
-    pos @kc88_first_39 @kc88_second_56 -140;
-    pos @kc88_first_39 @kc88_second_58 -245;
-    pos @kc88_first_39 @kc88_second_59 -210;
-    pos @kc88_first_39 @kc88_second_60 -70;
-    pos @kc88_first_39 @kc88_second_61 -70;
-    pos @kc88_first_39 @kc88_second_62 -70;
-    pos @kc88_first_39 @kc88_second_63 -70;
-    pos @kc88_first_39 @kc88_second_66 -245;
-    pos @kc88_first_39 @kc88_second_67 -280;
-    pos @kc88_first_39 @kc88_second_68 -315;
-    pos @kc88_first_40 @kc88_second_6 -35;
-    pos @kc88_first_40 @kc88_second_12 -240;
-    pos @kc88_first_40 @kc88_second_13 -140;
-    pos @kc88_first_40 @kc88_second_14 -35;
-    pos @kc88_first_40 @kc88_second_15 -35;
-    pos @kc88_first_40 @kc88_second_36 100;
-    pos @kc88_first_40 @kc88_second_37 -35;
-    pos @kc88_first_40 @kc88_second_48 1;
-    pos @kc88_first_40 @kc88_second_53 100;
-    pos @kc88_first_40 @kc88_second_66 -35;
-    pos @kc88_first_40 @kc88_second_67 -35;
-    pos @kc88_first_41 @kc88_second_12 -210;
-    pos @kc88_first_41 @kc88_second_13 -175;
-    pos @kc88_first_41 @kc88_second_14 -105;
-    pos @kc88_first_41 @kc88_second_15 -70;
-    pos @kc88_first_41 @kc88_second_46 -70;
-    pos @kc88_first_41 @kc88_second_48 1;
-    pos @kc88_first_41 @kc88_second_51 -105;
-    pos @kc88_first_41 @kc88_second_64 -70;
-    pos @kc88_first_42 @kc88_second_1 -140;
-    pos @kc88_first_42 @kc88_second_2 -175;
-    pos @kc88_first_42 @kc88_second_5 -105;
-    pos @kc88_first_42 @kc88_second_6 -70;
-    pos @kc88_first_42 @kc88_second_11 -70;
-    pos @kc88_first_42 @kc88_second_12 -175;
-    pos @kc88_first_42 @kc88_second_13 -105;
-    pos @kc88_first_42 @kc88_second_14 -70;
-    pos @kc88_first_42 @kc88_second_15 -35;
-    pos @kc88_first_42 @kc88_second_16 -105;
-    pos @kc88_first_42 @kc88_second_17 -35;
-    pos @kc88_first_42 @kc88_second_18 -50;
-    pos @kc88_first_42 @kc88_second_19 -140;
-    pos @kc88_first_42 @kc88_second_21 -175;
-    pos @kc88_first_42 @kc88_second_24 -50;
-    pos @kc88_first_42 @kc88_second_26 -105;
-    pos @kc88_first_42 @kc88_second_31 -35;
-    pos @kc88_first_42 @kc88_second_34 -70;
-    pos @kc88_first_42 @kc88_second_35 -50;
-    pos @kc88_first_42 @kc88_second_37 -70;
-    pos @kc88_first_42 @kc88_second_38 -140;
-    pos @kc88_first_42 @kc88_second_39 -35;
-    pos @kc88_first_42 @kc88_second_41 -50;
-    pos @kc88_first_42 @kc88_second_48 1;
-    pos @kc88_first_42 @kc88_second_54 -35;
-    pos @kc88_first_42 @kc88_second_56 -105;
-    pos @kc88_first_42 @kc88_second_58 -105;
-    pos @kc88_first_42 @kc88_second_59 -105;
-    pos @kc88_first_42 @kc88_second_66 -50;
-    pos @kc88_first_42 @kc88_second_67 -70;
-    pos @kc88_first_43 @kc88_second_1 -210;
-    pos @kc88_first_43 @kc88_second_2 -280;
-    pos @kc88_first_43 @kc88_second_3 -70;
-    pos @kc88_first_43 @kc88_second_6 -280;
-    pos @kc88_first_43 @kc88_second_8 -35;
-    pos @kc88_first_43 @kc88_second_11 -70;
-    pos @kc88_first_43 @kc88_second_13 -140;
-    pos @kc88_first_43 @kc88_second_14 -35;
-    pos @kc88_first_43 @kc88_second_15 -35;
-    pos @kc88_first_43 @kc88_second_16 -140;
-    pos @kc88_first_43 @kc88_second_17 -105;
-    pos @kc88_first_43 @kc88_second_18 -140;
-    pos @kc88_first_43 @kc88_second_19 -210;
-    pos @kc88_first_43 @kc88_second_21 -280;
-    pos @kc88_first_43 @kc88_second_22 -140;
-    pos @kc88_first_43 @kc88_second_24 -140;
-    pos @kc88_first_43 @kc88_second_25 -140;
-    pos @kc88_first_43 @kc88_second_26 -210;
-    pos @kc88_first_43 @kc88_second_34 -140;
-    pos @kc88_first_43 @kc88_second_35 -140;
-    pos @kc88_first_43 @kc88_second_37 -280;
-    pos @kc88_first_43 @kc88_second_38 -140;
-    pos @kc88_first_43 @kc88_second_39 -70;
-    pos @kc88_first_43 @kc88_second_40 -140;
-    pos @kc88_first_43 @kc88_second_41 -175;
-    pos @kc88_first_43 @kc88_second_47 -70;
-    pos @kc88_first_43 @kc88_second_48 1;
-    pos @kc88_first_43 @kc88_second_56 -210;
-    pos @kc88_first_43 @kc88_second_58 -210;
-    pos @kc88_first_43 @kc88_second_59 -175;
-    pos @kc88_first_43 @kc88_second_62 -70;
-    pos @kc88_first_43 @kc88_second_66 -175;
-    pos @kc88_first_43 @kc88_second_67 -175;
-    pos @kc88_first_44 @kc88_second_9 -70;
-    pos @kc88_first_44 @kc88_second_12 -240;
-    pos @kc88_first_44 @kc88_second_13 -210;
-    pos @kc88_first_44 @kc88_second_14 -140;
-    pos @kc88_first_44 @kc88_second_15 -105;
-    pos @kc88_first_44 @kc88_second_42 -70;
-    pos @kc88_first_44 @kc88_second_43 -35;
-    pos @kc88_first_44 @kc88_second_46 -140;
-    pos @kc88_first_44 @kc88_second_48 1;
-    pos @kc88_first_44 @kc88_second_50 -50;
-    pos @kc88_first_44 @kc88_second_51 -140;
-    pos @kc88_first_44 @kc88_second_61 -35;
-    pos @kc88_first_44 @kc88_second_63 -35;
-    pos @kc88_first_44 @kc88_second_64 -70;
-    pos @kc88_first_44 @kc88_second_65 -70;
-    pos @kc88_first_45 @kc88_second_8 -35;
-    pos @kc88_first_45 @kc88_second_9 -70;
-    pos @kc88_first_45 @kc88_second_12 -240;
-    pos @kc88_first_45 @kc88_second_13 -210;
-    pos @kc88_first_45 @kc88_second_14 -70;
-    pos @kc88_first_45 @kc88_second_15 -105;
-    pos @kc88_first_45 @kc88_second_18 -35;
-    pos @kc88_first_45 @kc88_second_24 -35;
-    pos @kc88_first_45 @kc88_second_41 -70;
-    pos @kc88_first_45 @kc88_second_42 -105;
-    pos @kc88_first_45 @kc88_second_43 -70;
-    pos @kc88_first_45 @kc88_second_46 -70;
-    pos @kc88_first_45 @kc88_second_47 -35;
-    pos @kc88_first_45 @kc88_second_48 1;
-    pos @kc88_first_45 @kc88_second_50 -70;
-    pos @kc88_first_45 @kc88_second_51 -70;
-    pos @kc88_first_45 @kc88_second_61 -70;
-    pos @kc88_first_45 @kc88_second_63 -50;
-    pos @kc88_first_45 @kc88_second_65 -70;
-    pos @kc88_first_45 @kc88_second_66 -35;
-    pos @kc88_first_45 @kc88_second_67 -35;
-    pos @kc88_first_46 @kc88_second_6 -70;
-    pos @kc88_first_46 @kc88_second_8 -35;
-    pos @kc88_first_46 @kc88_second_12 -175;
-    pos @kc88_first_46 @kc88_second_13 -140;
-    pos @kc88_first_46 @kc88_second_14 -70;
-    pos @kc88_first_46 @kc88_second_15 -35;
-    pos @kc88_first_46 @kc88_second_17 -70;
-    pos @kc88_first_46 @kc88_second_18 -105;
-    pos @kc88_first_46 @kc88_second_22 -70;
-    pos @kc88_first_46 @kc88_second_24 -105;
-    pos @kc88_first_46 @kc88_second_31 -35;
-    pos @kc88_first_46 @kc88_second_37 -70;
-    pos @kc88_first_46 @kc88_second_39 -35;
-    pos @kc88_first_46 @kc88_second_41 -105;
-    pos @kc88_first_46 @kc88_second_48 1;
-    pos @kc88_first_46 @kc88_second_54 -35;
-    pos @kc88_first_46 @kc88_second_66 -70;
-    pos @kc88_first_46 @kc88_second_67 -70;
-    pos @kc88_first_47 @kc88_second_3 -140;
-    pos @kc88_first_47 @kc88_second_4 -70;
-    pos @kc88_first_47 @kc88_second_6 -70;
-    pos @kc88_first_47 @kc88_second_8 -210;
-    pos @kc88_first_47 @kc88_second_9 -420;
-    pos @kc88_first_47 @kc88_second_12 -350;
-    pos @kc88_first_47 @kc88_second_13 -420;
-    pos @kc88_first_47 @kc88_second_14 -350;
-    pos @kc88_first_47 @kc88_second_15 -280;
-    pos @kc88_first_47 @kc88_second_17 -70;
-    pos @kc88_first_47 @kc88_second_18 -70;
-    pos @kc88_first_47 @kc88_second_20 -210;
-    pos @kc88_first_47 @kc88_second_22 -210;
-    pos @kc88_first_47 @kc88_second_24 -70;
-    pos @kc88_first_47 @kc88_second_25 -140;
-    pos @kc88_first_47 @kc88_second_31 -35;
-    pos @kc88_first_47 @kc88_second_33 -140;
-    pos @kc88_first_47 @kc88_second_37 -70;
-    pos @kc88_first_47 @kc88_second_39 -70;
-    pos @kc88_first_47 @kc88_second_41 -210;
-    pos @kc88_first_47 @kc88_second_42 -280;
-    pos @kc88_first_47 @kc88_second_43 -420;
-    pos @kc88_first_47 @kc88_second_46 -350;
-    pos @kc88_first_47 @kc88_second_48 1;
-    pos @kc88_first_47 @kc88_second_49 -35;
-    pos @kc88_first_47 @kc88_second_50 -210;
-    pos @kc88_first_47 @kc88_second_51 -350;
-    pos @kc88_first_47 @kc88_second_54 -35;
-    pos @kc88_first_47 @kc88_second_55 -35;
-    pos @kc88_first_47 @kc88_second_61 -280;
-    pos @kc88_first_47 @kc88_second_63 -175;
-    pos @kc88_first_47 @kc88_second_64 -280;
-    pos @kc88_first_47 @kc88_second_65 -210;
-    pos @kc88_first_47 @kc88_second_66 -70;
-    pos @kc88_first_48 @kc88_second_3 -140;
-    pos @kc88_first_48 @kc88_second_4 -105;
-    pos @kc88_first_48 @kc88_second_6 -70;
-    pos @kc88_first_48 @kc88_second_8 -210;
-    pos @kc88_first_48 @kc88_second_9 -280;
-    pos @kc88_first_48 @kc88_second_12 -350;
-    pos @kc88_first_48 @kc88_second_13 -385;
-    pos @kc88_first_48 @kc88_second_14 -350;
-    pos @kc88_first_48 @kc88_second_15 -280;
-    pos @kc88_first_48 @kc88_second_18 -105;
-    pos @kc88_first_48 @kc88_second_20 -210;
-    pos @kc88_first_48 @kc88_second_22 -140;
-    pos @kc88_first_48 @kc88_second_24 -105;
-    pos @kc88_first_48 @kc88_second_25 -140;
-    pos @kc88_first_48 @kc88_second_31 -70;
-    pos @kc88_first_48 @kc88_second_33 -175;
-    pos @kc88_first_48 @kc88_second_37 -70;
-    pos @kc88_first_48 @kc88_second_39 -35;
-    pos @kc88_first_48 @kc88_second_41 -175;
-    pos @kc88_first_48 @kc88_second_42 -280;
-    pos @kc88_first_48 @kc88_second_43 -280;
-    pos @kc88_first_48 @kc88_second_46 -280;
-    pos @kc88_first_48 @kc88_second_47 -140;
-    pos @kc88_first_48 @kc88_second_48 1;
-    pos @kc88_first_48 @kc88_second_49 -70;
-    pos @kc88_first_48 @kc88_second_50 -280;
-    pos @kc88_first_48 @kc88_second_51 -350;
-    pos @kc88_first_48 @kc88_second_54 -35;
-    pos @kc88_first_48 @kc88_second_55 -70;
-    pos @kc88_first_48 @kc88_second_61 -245;
-    pos @kc88_first_48 @kc88_second_63 -245;
-    pos @kc88_first_48 @kc88_second_64 -280;
-    pos @kc88_first_48 @kc88_second_65 -210;
-    pos @kc88_first_48 @kc88_second_66 -70;
-    pos @kc88_first_48 @kc88_second_67 -70;
-    pos @kc88_first_49 @kc88_second_3 -70;
-    pos @kc88_first_49 @kc88_second_4 -105;
-    pos @kc88_first_49 @kc88_second_6 -210;
-    pos @kc88_first_49 @kc88_second_7 -70;
-    pos @kc88_first_49 @kc88_second_8 -175;
-    pos @kc88_first_49 @kc88_second_17 -210;
-    pos @kc88_first_49 @kc88_second_18 -210;
-    pos @kc88_first_49 @kc88_second_22 -140;
-    pos @kc88_first_49 @kc88_second_23 -210;
-    pos @kc88_first_49 @kc88_second_24 -210;
-    pos @kc88_first_49 @kc88_second_25 -210;
-    pos @kc88_first_49 @kc88_second_26 -140;
-    pos @kc88_first_49 @kc88_second_27 -140;
-    pos @kc88_first_49 @kc88_second_29 -140;
-    pos @kc88_first_49 @kc88_second_31 -210;
-    pos @kc88_first_49 @kc88_second_32 -210;
-    pos @kc88_first_49 @kc88_second_33 -140;
-    pos @kc88_first_49 @kc88_second_35 -210;
-    pos @kc88_first_49 @kc88_second_37 -210;
-    pos @kc88_first_49 @kc88_second_38 -70;
-    pos @kc88_first_49 @kc88_second_39 -175;
-    pos @kc88_first_49 @kc88_second_40 -210;
-    pos @kc88_first_49 @kc88_second_41 -175;
-    pos @kc88_first_49 @kc88_second_42 -210;
-    pos @kc88_first_49 @kc88_second_43 -105;
-    pos @kc88_first_49 @kc88_second_46 -70;
-    pos @kc88_first_49 @kc88_second_47 -105;
-    pos @kc88_first_49 @kc88_second_48 1;
-    pos @kc88_first_49 @kc88_second_49 -35;
-    pos @kc88_first_49 @kc88_second_50 -210;
-    pos @kc88_first_49 @kc88_second_53 -210;
-    pos @kc88_first_49 @kc88_second_54 -210;
-    pos @kc88_first_49 @kc88_second_55 -175;
-    pos @kc88_first_49 @kc88_second_56 -175;
-    pos @kc88_first_49 @kc88_second_58 -210;
-    pos @kc88_first_49 @kc88_second_59 -210;
-    pos @kc88_first_49 @kc88_second_60 -140;
-    pos @kc88_first_49 @kc88_second_61 -210;
-    pos @kc88_first_49 @kc88_second_62 -175;
-    pos @kc88_first_49 @kc88_second_63 -175;
-    pos @kc88_first_49 @kc88_second_66 -210;
-    pos @kc88_first_49 @kc88_second_67 -210;
-    pos @kc88_first_50 @kc88_second_5 -70;
-    pos @kc88_first_50 @kc88_second_11 -35;
-    pos @kc88_first_50 @kc88_second_12 -240;
-    pos @kc88_first_50 @kc88_second_13 -70;
-    pos @kc88_first_50 @kc88_second_14 -140;
-    pos @kc88_first_50 @kc88_second_15 -105;
-    pos @kc88_first_50 @kc88_second_16 -70;
-    pos @kc88_first_50 @kc88_second_28 -70;
-    pos @kc88_first_50 @kc88_second_29 -70;
-    pos @kc88_first_50 @kc88_second_38 -35;
-    pos @kc88_first_50 @kc88_second_42 -70;
-    pos @kc88_first_50 @kc88_second_45 -35;
-    pos @kc88_first_50 @kc88_second_46 -70;
-    pos @kc88_first_50 @kc88_second_48 1;
-    pos @kc88_first_50 @kc88_second_50 -35;
-    pos @kc88_first_50 @kc88_second_51 -140;
-    pos @kc88_first_50 @kc88_second_54 1;
-    pos @kc88_first_50 @kc88_second_60 -35;
-    pos @kc88_first_50 @kc88_second_63 -35;
-    pos @kc88_first_50 @kc88_second_64 -105;
-    pos @kc88_first_50 @kc88_second_65 -70;
-    pos @kc88_first_51 @kc88_second_68 -210;
-    pos @kc88_first_52 @kc88_second_34 -315;
-    pos @kc88_first_52 @kc88_second_69 -210;
-    pos @kc88_first_53 @kc88_second_1 -105;
-    pos @kc88_first_53 @kc88_second_2 -210;
-    pos @kc88_first_53 @kc88_second_6 -140;
-    pos @kc88_first_53 @kc88_second_11 -70;
-    pos @kc88_first_53 @kc88_second_12 -210;
-    pos @kc88_first_53 @kc88_second_13 -210;
-    pos @kc88_first_53 @kc88_second_14 -105;
-    pos @kc88_first_53 @kc88_second_15 -70;
-    pos @kc88_first_53 @kc88_second_16 -140;
-    pos @kc88_first_53 @kc88_second_17 -35;
-    pos @kc88_first_53 @kc88_second_18 -35;
-    pos @kc88_first_53 @kc88_second_19 -105;
-    pos @kc88_first_53 @kc88_second_24 -35;
-    pos @kc88_first_53 @kc88_second_26 -210;
-    pos @kc88_first_53 @kc88_second_28 -70;
-    pos @kc88_first_53 @kc88_second_29 -70;
-    pos @kc88_first_53 @kc88_second_31 -35;
-    pos @kc88_first_53 @kc88_second_35 -70;
-    pos @kc88_first_53 @kc88_second_37 -210;
-    pos @kc88_first_53 @kc88_second_38 -140;
-    pos @kc88_first_53 @kc88_second_45 -35;
-    pos @kc88_first_53 @kc88_second_46 -70;
-    pos @kc88_first_53 @kc88_second_48 1;
-    pos @kc88_first_53 @kc88_second_50 -35;
-    pos @kc88_first_53 @kc88_second_51 -105;
-    pos @kc88_first_53 @kc88_second_56 -210;
-    pos @kc88_first_53 @kc88_second_58 -175;
-    pos @kc88_first_53 @kc88_second_59 -140;
-    pos @kc88_first_53 @kc88_second_64 -35;
-    pos @kc88_first_53 @kc88_second_65 -35;
-    pos @kc88_first_53 @kc88_second_66 -35;
-    pos @kc88_first_53 @kc88_second_67 -70;
-    pos @kc88_first_54 @kc88_second_1 -35;
-    pos @kc88_first_54 @kc88_second_2 -70;
-    pos @kc88_first_54 @kc88_second_5 -105;
-    pos @kc88_first_54 @kc88_second_6 -35;
-    pos @kc88_first_54 @kc88_second_9 -70;
-    pos @kc88_first_54 @kc88_second_11 -70;
-    pos @kc88_first_54 @kc88_second_12 -240;
-    pos @kc88_first_54 @kc88_second_13 -245;
-    pos @kc88_first_54 @kc88_second_14 -140;
-    pos @kc88_first_54 @kc88_second_15 -105;
-    pos @kc88_first_54 @kc88_second_16 -105;
-    pos @kc88_first_54 @kc88_second_19 -35;
-    pos @kc88_first_54 @kc88_second_20 -70;
-    pos @kc88_first_54 @kc88_second_21 -70;
-    pos @kc88_first_54 @kc88_second_26 -35;
-    pos @kc88_first_54 @kc88_second_27 -70;
-    pos @kc88_first_54 @kc88_second_28 -140;
-    pos @kc88_first_54 @kc88_second_29 -105;
-    pos @kc88_first_54 @kc88_second_35 -35;
-    pos @kc88_first_54 @kc88_second_37 -35;
-    pos @kc88_first_54 @kc88_second_38 -140;
-    pos @kc88_first_54 @kc88_second_42 -105;
-    pos @kc88_first_54 @kc88_second_43 -70;
-    pos @kc88_first_54 @kc88_second_45 -105;
-    pos @kc88_first_54 @kc88_second_46 -175;
-    pos @kc88_first_54 @kc88_second_48 1;
-    pos @kc88_first_54 @kc88_second_50 -70;
-    pos @kc88_first_54 @kc88_second_51 -140;
-    pos @kc88_first_54 @kc88_second_52 -70;
-    pos @kc88_first_54 @kc88_second_56 -210;
-    pos @kc88_first_54 @kc88_second_57 -70;
-    pos @kc88_first_54 @kc88_second_58 -175;
-    pos @kc88_first_54 @kc88_second_59 -175;
-    pos @kc88_first_54 @kc88_second_60 -105;
-    pos @kc88_first_54 @kc88_second_63 -50;
-    pos @kc88_first_54 @kc88_second_64 -105;
-    pos @kc88_first_54 @kc88_second_65 -70;
-    pos @kc88_first_54 @kc88_second_67 -35;
-    pos @kc88_first_55 @kc88_second_1 -105;
-    pos @kc88_first_55 @kc88_second_2 -210;
-    pos @kc88_first_55 @kc88_second_5 -70;
-    pos @kc88_first_55 @kc88_second_6 -105;
-    pos @kc88_first_55 @kc88_second_13 -70;
-    pos @kc88_first_55 @kc88_second_14 -35;
-    pos @kc88_first_55 @kc88_second_16 -140;
-    pos @kc88_first_55 @kc88_second_17 -70;
-    pos @kc88_first_55 @kc88_second_18 -35;
-    pos @kc88_first_55 @kc88_second_19 -105;
-    pos @kc88_first_55 @kc88_second_21 -210;
-    pos @kc88_first_55 @kc88_second_24 -35;
-    pos @kc88_first_55 @kc88_second_26 -210;
-    pos @kc88_first_55 @kc88_second_31 -35;
-    pos @kc88_first_55 @kc88_second_34 -105;
-    pos @kc88_first_55 @kc88_second_35 -35;
-    pos @kc88_first_55 @kc88_second_37 -105;
-    pos @kc88_first_55 @kc88_second_38 -140;
-    pos @kc88_first_55 @kc88_second_41 -70;
-    pos @kc88_first_55 @kc88_second_48 1;
-    pos @kc88_first_55 @kc88_second_54 -35;
-    pos @kc88_first_55 @kc88_second_56 -245;
-    pos @kc88_first_55 @kc88_second_58 -210;
-    pos @kc88_first_55 @kc88_second_59 -210;
-    pos @kc88_first_55 @kc88_second_66 -70;
-    pos @kc88_first_55 @kc88_second_67 -105;
-    pos @kc88_first_56 @kc88_second_12 -240;
-    pos @kc88_first_56 @kc88_second_13 -140;
-    pos @kc88_first_56 @kc88_second_14 -105;
-    pos @kc88_first_56 @kc88_second_15 -35;
-    pos @kc88_first_56 @kc88_second_36 100;
-    pos @kc88_first_56 @kc88_second_48 1;
-    pos @kc88_first_56 @kc88_second_53 100;
-    pos @kc88_first_57 @kc88_second_1 -140;
-    pos @kc88_first_57 @kc88_second_2 -210;
-    pos @kc88_first_57 @kc88_second_6 -140;
-    pos @kc88_first_57 @kc88_second_12 -175;
-    pos @kc88_first_57 @kc88_second_13 -140;
-    pos @kc88_first_57 @kc88_second_16 -140;
-    pos @kc88_first_57 @kc88_second_19 -140;
-    pos @kc88_first_57 @kc88_second_21 -210;
-    pos @kc88_first_57 @kc88_second_26 -210;
-    pos @kc88_first_57 @kc88_second_34 -140;
-    pos @kc88_first_57 @kc88_second_35 -50;
-    pos @kc88_first_57 @kc88_second_37 -140;
-    pos @kc88_first_57 @kc88_second_38 -210;
-    pos @kc88_first_57 @kc88_second_39 -35;
-    pos @kc88_first_57 @kc88_second_48 1;
-    pos @kc88_first_57 @kc88_second_56 -210;
-    pos @kc88_first_57 @kc88_second_58 -175;
-    pos @kc88_first_57 @kc88_second_59 -175;
-    pos @kc88_first_57 @kc88_second_66 -105;
-    pos @kc88_first_57 @kc88_second_67 -210;
-    pos @kc88_first_58 @kc88_second_12 -240;
-    pos @kc88_first_58 @kc88_second_13 -175;
-    pos @kc88_first_58 @kc88_second_14 -70;
-    pos @kc88_first_58 @kc88_second_15 -35;
-    pos @kc88_first_58 @kc88_second_21 -35;
-    pos @kc88_first_58 @kc88_second_28 -35;
-    pos @kc88_first_58 @kc88_second_42 -35;
-    pos @kc88_first_58 @kc88_second_43 -35;
-    pos @kc88_first_58 @kc88_second_46 -70;
-    pos @kc88_first_58 @kc88_second_48 1;
-    pos @kc88_first_58 @kc88_second_50 -35;
-    pos @kc88_first_58 @kc88_second_51 -70;
-    pos @kc88_first_58 @kc88_second_61 -35;
-    pos @kc88_first_58 @kc88_second_63 -35;
-    pos @kc88_first_58 @kc88_second_64 -70;
-    pos @kc88_first_58 @kc88_second_65 -35;
-    pos @kc88_first_59 @kc88_second_13 -35;
-    pos @kc88_first_59 @kc88_second_18 -70;
-    pos @kc88_first_59 @kc88_second_61 -35;
-    pos @kc88_first_59 @kc88_second_67 -35;
-    pos @kc88_first_60 @kc88_second_12 -175;
-    pos @kc88_first_60 @kc88_second_13 -140;
-    pos @kc88_first_60 @kc88_second_14 -35;
-    pos @kc88_first_60 @kc88_second_48 1;
-    pos @kc88_first_61 @kc88_second_1 -140;
-    pos @kc88_first_61 @kc88_second_2 -280;
-    pos @kc88_first_61 @kc88_second_5 -140;
-    pos @kc88_first_61 @kc88_second_6 -280;
-    pos @kc88_first_61 @kc88_second_8 -70;
-    pos @kc88_first_61 @kc88_second_10 -70;
-    pos @kc88_first_61 @kc88_second_11 -175;
-    pos @kc88_first_61 @kc88_second_12 -240;
-    pos @kc88_first_61 @kc88_second_13 -140;
-    pos @kc88_first_61 @kc88_second_14 -105;
-    pos @kc88_first_61 @kc88_second_15 -70;
-    pos @kc88_first_61 @kc88_second_16 -175;
-    pos @kc88_first_61 @kc88_second_17 -70;
-    pos @kc88_first_61 @kc88_second_18 -70;
-    pos @kc88_first_61 @kc88_second_19 -140;
-    pos @kc88_first_61 @kc88_second_21 -280;
-    pos @kc88_first_61 @kc88_second_24 -70;
-    pos @kc88_first_61 @kc88_second_25 -70;
-    pos @kc88_first_61 @kc88_second_26 -210;
-    pos @kc88_first_61 @kc88_second_28 -70;
-    pos @kc88_first_61 @kc88_second_29 -70;
-    pos @kc88_first_61 @kc88_second_31 -70;
-    pos @kc88_first_61 @kc88_second_34 -70;
-    pos @kc88_first_61 @kc88_second_35 -70;
-    pos @kc88_first_61 @kc88_second_37 -315;
-    pos @kc88_first_61 @kc88_second_38 -140;
-    pos @kc88_first_61 @kc88_second_39 -70;
-    pos @kc88_first_61 @kc88_second_41 -105;
-    pos @kc88_first_61 @kc88_second_48 1;
-    pos @kc88_first_61 @kc88_second_51 -35;
-    pos @kc88_first_61 @kc88_second_54 -50;
-    pos @kc88_first_61 @kc88_second_56 -210;
-    pos @kc88_first_61 @kc88_second_58 -210;
-    pos @kc88_first_61 @kc88_second_59 -175;
-    pos @kc88_first_61 @kc88_second_62 -35;
-    pos @kc88_first_61 @kc88_second_64 -70;
-    pos @kc88_first_61 @kc88_second_65 -35;
-    pos @kc88_first_61 @kc88_second_66 -140;
-    pos @kc88_first_61 @kc88_second_67 -210;
-    pos @kc88_first_62 @kc88_second_1 -35;
-    pos @kc88_first_62 @kc88_second_2 -70;
-    pos @kc88_first_62 @kc88_second_5 -70;
-    pos @kc88_first_62 @kc88_second_11 -35;
-    pos @kc88_first_62 @kc88_second_12 -140;
-    pos @kc88_first_62 @kc88_second_13 -140;
-    pos @kc88_first_62 @kc88_second_14 -70;
-    pos @kc88_first_62 @kc88_second_15 -35;
-    pos @kc88_first_62 @kc88_second_16 -105;
-    pos @kc88_first_62 @kc88_second_28 -35;
-    pos @kc88_first_62 @kc88_second_29 -70;
-    pos @kc88_first_62 @kc88_second_35 -35;
-    pos @kc88_first_62 @kc88_second_38 -70;
-    pos @kc88_first_62 @kc88_second_46 -70;
-    pos @kc88_first_62 @kc88_second_48 1;
-    pos @kc88_first_62 @kc88_second_56 -175;
-    pos @kc88_first_62 @kc88_second_58 -140;
-    pos @kc88_first_62 @kc88_second_59 -140;
-    pos @kc88_first_62 @kc88_second_64 -35;
-    pos @kc88_first_63 @kc88_second_5 -70;
-    pos @kc88_first_63 @kc88_second_9 -70;
-    pos @kc88_first_63 @kc88_second_11 -35;
-    pos @kc88_first_63 @kc88_second_12 -350;
-    pos @kc88_first_63 @kc88_second_13 -315;
-    pos @kc88_first_63 @kc88_second_14 -175;
-    pos @kc88_first_63 @kc88_second_15 -140;
-    pos @kc88_first_63 @kc88_second_16 -70;
-    pos @kc88_first_63 @kc88_second_20 -70;
-    pos @kc88_first_63 @kc88_second_29 -70;
-    pos @kc88_first_63 @kc88_second_33 -50;
-    pos @kc88_first_63 @kc88_second_42 -140;
-    pos @kc88_first_63 @kc88_second_43 -50;
-    pos @kc88_first_63 @kc88_second_45 -35;
-    pos @kc88_first_63 @kc88_second_46 -175;
-    pos @kc88_first_63 @kc88_second_48 1;
-    pos @kc88_first_63 @kc88_second_50 -70;
-    pos @kc88_first_63 @kc88_second_51 -175;
-    pos @kc88_first_63 @kc88_second_57 -70;
-    pos @kc88_first_63 @kc88_second_61 -70;
-    pos @kc88_first_63 @kc88_second_63 -50;
-    pos @kc88_first_63 @kc88_second_64 -140;
-    pos @kc88_first_63 @kc88_second_65 -105;
-    pos @kc88_first_64 @kc88_second_4 -105;
-    pos @kc88_first_64 @kc88_second_6 -35;
-    pos @kc88_first_64 @kc88_second_8 1;
-    pos @kc88_first_64 @kc88_second_9 -245;
-    pos @kc88_first_64 @kc88_second_12 -210;
-    pos @kc88_first_64 @kc88_second_13 -210;
-    pos @kc88_first_64 @kc88_second_14 -210;
-    pos @kc88_first_64 @kc88_second_15 -175;
-    pos @kc88_first_64 @kc88_second_17 -70;
-    pos @kc88_first_64 @kc88_second_18 -105;
-    pos @kc88_first_64 @kc88_second_20 -180;
-    pos @kc88_first_64 @kc88_second_22 -140;
-    pos @kc88_first_64 @kc88_second_24 -105;
-    pos @kc88_first_64 @kc88_second_27 -140;
-    pos @kc88_first_64 @kc88_second_31 -105;
-    pos @kc88_first_64 @kc88_second_33 -140;
-    pos @kc88_first_64 @kc88_second_37 -35;
-    pos @kc88_first_64 @kc88_second_39 -35;
-    pos @kc88_first_64 @kc88_second_41 -175;
-    pos @kc88_first_64 @kc88_second_42 -142;
-    pos @kc88_first_64 @kc88_second_43 -245;
-    pos @kc88_first_64 @kc88_second_46 -210;
-    pos @kc88_first_64 @kc88_second_47 -105;
-    pos @kc88_first_64 @kc88_second_48 1;
-    pos @kc88_first_64 @kc88_second_49 -35;
-    pos @kc88_first_64 @kc88_second_50 -210;
-    pos @kc88_first_64 @kc88_second_51 -210;
-    pos @kc88_first_64 @kc88_second_54 -35;
-    pos @kc88_first_64 @kc88_second_61 -280;
-    pos @kc88_first_64 @kc88_second_63 -175;
-    pos @kc88_first_64 @kc88_second_64 -140;
-    pos @kc88_first_64 @kc88_second_65 -140;
-    pos @kc88_first_64 @kc88_second_66 -70;
-    pos @kc88_first_64 @kc88_second_67 -70;
-    pos @kc88_first_65 @kc88_second_1 -175;
-    pos @kc88_first_65 @kc88_second_2 -175;
-    pos @kc88_first_65 @kc88_second_5 -70;
-    pos @kc88_first_65 @kc88_second_6 -105;
-    pos @kc88_first_65 @kc88_second_11 -105;
-    pos @kc88_first_65 @kc88_second_12 -175;
-    pos @kc88_first_65 @kc88_second_13 -140;
-    pos @kc88_first_65 @kc88_second_14 -70;
-    pos @kc88_first_65 @kc88_second_15 -35;
-    pos @kc88_first_65 @kc88_second_16 -140;
-    pos @kc88_first_65 @kc88_second_17 -70;
-    pos @kc88_first_65 @kc88_second_18 -70;
-    pos @kc88_first_65 @kc88_second_19 -140;
-    pos @kc88_first_65 @kc88_second_21 -175;
-    pos @kc88_first_65 @kc88_second_24 -70;
-    pos @kc88_first_65 @kc88_second_31 -35;
-    pos @kc88_first_65 @kc88_second_35 -70;
-    pos @kc88_first_65 @kc88_second_37 -105;
-    pos @kc88_first_65 @kc88_second_38 -175;
-    pos @kc88_first_65 @kc88_second_39 -35;
-    pos @kc88_first_65 @kc88_second_41 -70;
-    pos @kc88_first_65 @kc88_second_48 1;
-    pos @kc88_first_65 @kc88_second_54 -35;
-    pos @kc88_first_65 @kc88_second_56 -140;
-    pos @kc88_first_65 @kc88_second_58 -140;
-    pos @kc88_first_65 @kc88_second_59 -140;
-    pos @kc88_first_65 @kc88_second_66 -70;
-    pos @kc88_first_65 @kc88_second_67 -105;
-    pos @kc88_first_66 @kc88_second_1 -210;
-    pos @kc88_first_66 @kc88_second_2 -210;
-    pos @kc88_first_66 @kc88_second_3 -70;
-    pos @kc88_first_66 @kc88_second_4 -35;
-    pos @kc88_first_66 @kc88_second_6 -210;
-    pos @kc88_first_66 @kc88_second_7 -70;
-    pos @kc88_first_66 @kc88_second_8 -70;
-    pos @kc88_first_66 @kc88_second_16 -70;
-    pos @kc88_first_66 @kc88_second_17 -140;
-    pos @kc88_first_66 @kc88_second_18 -175;
-    pos @kc88_first_66 @kc88_second_19 -210;
-    pos @kc88_first_66 @kc88_second_21 -210;
-    pos @kc88_first_66 @kc88_second_22 -140;
-    pos @kc88_first_66 @kc88_second_23 -35;
-    pos @kc88_first_66 @kc88_second_24 -175;
-    pos @kc88_first_66 @kc88_second_25 -140;
-    pos @kc88_first_66 @kc88_second_26 -280;
-    pos @kc88_first_66 @kc88_second_31 -35;
-    pos @kc88_first_66 @kc88_second_32 -35;
-    pos @kc88_first_66 @kc88_second_34 -210;
-    pos @kc88_first_66 @kc88_second_35 -175;
-    pos @kc88_first_66 @kc88_second_37 -245;
-    pos @kc88_first_66 @kc88_second_38 -140;
-    pos @kc88_first_66 @kc88_second_39 -140;
-    pos @kc88_first_66 @kc88_second_40 -140;
-    pos @kc88_first_66 @kc88_second_41 -140;
-    pos @kc88_first_66 @kc88_second_42 -35;
-    pos @kc88_first_66 @kc88_second_47 -35;
-    pos @kc88_first_66 @kc88_second_48 1;
-    pos @kc88_first_66 @kc88_second_52 -35;
-    pos @kc88_first_66 @kc88_second_54 -140;
-    pos @kc88_first_66 @kc88_second_55 -70;
-    pos @kc88_first_66 @kc88_second_56 -210;
-    pos @kc88_first_66 @kc88_second_58 -210;
-    pos @kc88_first_66 @kc88_second_59 -210;
-    pos @kc88_first_66 @kc88_second_61 -35;
-    pos @kc88_first_66 @kc88_second_66 -175;
-    pos @kc88_first_66 @kc88_second_67 -245;
-    pos @kc88_first_67 @kc88_second_6 -35;
-    pos @kc88_first_67 @kc88_second_12 -240;
-    pos @kc88_first_67 @kc88_second_13 -140;
-    pos @kc88_first_67 @kc88_second_14 -70;
-    pos @kc88_first_67 @kc88_second_15 -35;
-    pos @kc88_first_67 @kc88_second_18 -35;
-    pos @kc88_first_67 @kc88_second_22 -35;
-    pos @kc88_first_67 @kc88_second_24 -35;
-    pos @kc88_first_67 @kc88_second_37 -70;
-    pos @kc88_first_67 @kc88_second_41 -70;
-    pos @kc88_first_67 @kc88_second_42 -50;
-    pos @kc88_first_67 @kc88_second_48 1;
-    pos @kc88_first_67 @kc88_second_51 -35;
-    pos @kc88_first_67 @kc88_second_66 -35;
-    pos @kc88_first_67 @kc88_second_67 -35;
-    pos @kc88_first_68 @kc88_second_3 -100;
-    pos @kc88_first_68 @kc88_second_4 -50;
-    pos @kc88_first_68 @kc88_second_6 -50;
-    pos @kc88_first_68 @kc88_second_8 -70;
-    pos @kc88_first_68 @kc88_second_9 -140;
-    pos @kc88_first_68 @kc88_second_10 -50;
-    pos @kc88_first_68 @kc88_second_12 -140;
-    pos @kc88_first_68 @kc88_second_13 -100;
-    pos @kc88_first_68 @kc88_second_14 -70;
-    pos @kc88_first_68 @kc88_second_15 -50;
-    pos @kc88_first_68 @kc88_second_18 -50;
-    pos @kc88_first_68 @kc88_second_20 -70;
-    pos @kc88_first_68 @kc88_second_22 -70;
-    pos @kc88_first_68 @kc88_second_24 -50;
-    pos @kc88_first_68 @kc88_second_25 -70;
-    pos @kc88_first_68 @kc88_second_31 -35;
-    pos @kc88_first_68 @kc88_second_33 -70;
-    pos @kc88_first_68 @kc88_second_36 105;
-    pos @kc88_first_68 @kc88_second_37 -35;
-    pos @kc88_first_68 @kc88_second_41 -70;
-    pos @kc88_first_68 @kc88_second_42 -140;
-    pos @kc88_first_68 @kc88_second_43 -140;
-    pos @kc88_first_68 @kc88_second_46 -140;
-    pos @kc88_first_68 @kc88_second_47 -35;
-    pos @kc88_first_68 @kc88_second_48 1;
-    pos @kc88_first_68 @kc88_second_50 -70;
-    pos @kc88_first_68 @kc88_second_51 -100;
-    pos @kc88_first_68 @kc88_second_53 105;
-    pos @kc88_first_68 @kc88_second_61 -140;
-    pos @kc88_first_68 @kc88_second_63 -70;
-    pos @kc88_first_68 @kc88_second_64 -70;
-    pos @kc88_first_68 @kc88_second_65 -50;
-    pos @kc88_first_68 @kc88_second_66 -35;
-    pos @kc88_first_68 @kc88_second_67 -35;
-    pos @kc88_first_69 @kc88_second_3 -70;
-    pos @kc88_first_69 @kc88_second_4 -50;
-    pos @kc88_first_69 @kc88_second_6 -50;
-    pos @kc88_first_69 @kc88_second_8 -70;
-    pos @kc88_first_69 @kc88_second_9 -140;
-    pos @kc88_first_69 @kc88_second_10 -50;
-    pos @kc88_first_69 @kc88_second_12 -240;
-    pos @kc88_first_69 @kc88_second_13 -240;
-    pos @kc88_first_69 @kc88_second_14 -175;
-    pos @kc88_first_69 @kc88_second_15 -140;
-    pos @kc88_first_69 @kc88_second_18 -50;
-    pos @kc88_first_69 @kc88_second_20 -70;
-    pos @kc88_first_69 @kc88_second_22 -70;
-    pos @kc88_first_69 @kc88_second_24 -50;
-    pos @kc88_first_69 @kc88_second_25 -70;
-    pos @kc88_first_69 @kc88_second_31 -35;
-    pos @kc88_first_69 @kc88_second_33 -70;
-    pos @kc88_first_69 @kc88_second_36 105;
-    pos @kc88_first_69 @kc88_second_37 -35;
-    pos @kc88_first_69 @kc88_second_41 -70;
-    pos @kc88_first_69 @kc88_second_42 -140;
-    pos @kc88_first_69 @kc88_second_43 -140;
-    pos @kc88_first_69 @kc88_second_46 -140;
-    pos @kc88_first_69 @kc88_second_47 -35;
-    pos @kc88_first_69 @kc88_second_48 1;
-    pos @kc88_first_69 @kc88_second_50 -70;
-    pos @kc88_first_69 @kc88_second_51 -140;
-    pos @kc88_first_69 @kc88_second_53 105;
-    pos @kc88_first_69 @kc88_second_61 -140;
-    pos @kc88_first_69 @kc88_second_63 -70;
-    pos @kc88_first_69 @kc88_second_64 -105;
-    pos @kc88_first_69 @kc88_second_65 -70;
-    pos @kc88_first_69 @kc88_second_66 -35;
-    pos @kc88_first_69 @kc88_second_67 -35;
-    pos @kc88_first_70 @kc88_second_3 -70;
-    pos @kc88_first_70 @kc88_second_4 -50;
-    pos @kc88_first_70 @kc88_second_6 -50;
-    pos @kc88_first_70 @kc88_second_8 -70;
-    pos @kc88_first_70 @kc88_second_9 -140;
-    pos @kc88_first_70 @kc88_second_10 -50;
-    pos @kc88_first_70 @kc88_second_12 -140;
-    pos @kc88_first_70 @kc88_second_13 -140;
-    pos @kc88_first_70 @kc88_second_14 -105;
-    pos @kc88_first_70 @kc88_second_15 -70;
-    pos @kc88_first_70 @kc88_second_18 -50;
-    pos @kc88_first_70 @kc88_second_20 -70;
-    pos @kc88_first_70 @kc88_second_22 -70;
-    pos @kc88_first_70 @kc88_second_24 -50;
-    pos @kc88_first_70 @kc88_second_25 -100;
-    pos @kc88_first_70 @kc88_second_31 -35;
-    pos @kc88_first_70 @kc88_second_33 -70;
-    pos @kc88_first_70 @kc88_second_36 105;
-    pos @kc88_first_70 @kc88_second_37 -35;
-    pos @kc88_first_70 @kc88_second_41 -70;
-    pos @kc88_first_70 @kc88_second_42 -140;
-    pos @kc88_first_70 @kc88_second_43 -140;
-    pos @kc88_first_70 @kc88_second_46 -140;
-    pos @kc88_first_70 @kc88_second_47 -35;
-    pos @kc88_first_70 @kc88_second_48 1;
-    pos @kc88_first_70 @kc88_second_50 -70;
-    pos @kc88_first_70 @kc88_second_51 -140;
-    pos @kc88_first_70 @kc88_second_53 105;
-    pos @kc88_first_70 @kc88_second_61 -140;
-    pos @kc88_first_70 @kc88_second_63 -70;
-    pos @kc88_first_70 @kc88_second_64 -70;
-    pos @kc88_first_70 @kc88_second_65 -50;
-    pos @kc88_first_70 @kc88_second_66 -35;
-    pos @kc88_first_70 @kc88_second_67 -35;
-    pos @kc88_first_71 @kc88_second_1 -210;
-    pos @kc88_first_71 @kc88_second_2 -210;
-    pos @kc88_first_71 @kc88_second_3 -35;
-    pos @kc88_first_71 @kc88_second_6 -140;
-    pos @kc88_first_71 @kc88_second_8 -70;
-    pos @kc88_first_71 @kc88_second_10 -35;
-    pos @kc88_first_71 @kc88_second_17 -70;
-    pos @kc88_first_71 @kc88_second_18 -105;
-    pos @kc88_first_71 @kc88_second_19 -210;
-    pos @kc88_first_71 @kc88_second_21 -210;
-    pos @kc88_first_71 @kc88_second_22 -70;
-    pos @kc88_first_71 @kc88_second_24 -105;
-    pos @kc88_first_71 @kc88_second_25 -105;
-    pos @kc88_first_71 @kc88_second_26 -175;
-    pos @kc88_first_71 @kc88_second_31 -105;
-    pos @kc88_first_71 @kc88_second_34 -210;
-    pos @kc88_first_71 @kc88_second_35 -105;
-    pos @kc88_first_71 @kc88_second_37 -175;
-    pos @kc88_first_71 @kc88_second_38 -140;
-    pos @kc88_first_71 @kc88_second_39 -70;
-    pos @kc88_first_71 @kc88_second_40 -105;
-    pos @kc88_first_71 @kc88_second_41 -105;
-    pos @kc88_first_71 @kc88_second_42 -70;
-    pos @kc88_first_71 @kc88_second_47 -35;
-    pos @kc88_first_71 @kc88_second_48 1;
-    pos @kc88_first_71 @kc88_second_53 -35;
-    pos @kc88_first_71 @kc88_second_54 -70;
-    pos @kc88_first_71 @kc88_second_55 -70;
-    pos @kc88_first_71 @kc88_second_56 -175;
-    pos @kc88_first_71 @kc88_second_58 -175;
-    pos @kc88_first_71 @kc88_second_59 -175;
-    pos @kc88_first_71 @kc88_second_61 -35;
-    pos @kc88_first_71 @kc88_second_62 -35;
-    pos @kc88_first_71 @kc88_second_66 -140;
-    pos @kc88_first_71 @kc88_second_67 -175;
-    pos @kc88_first_72 @kc88_second_5 -70;
-    pos @kc88_first_72 @kc88_second_8 -70;
-    pos @kc88_first_72 @kc88_second_9 -105;
-    pos @kc88_first_72 @kc88_second_11 -35;
-    pos @kc88_first_72 @kc88_second_12 -350;
-    pos @kc88_first_72 @kc88_second_13 -350;
-    pos @kc88_first_72 @kc88_second_14 -245;
-    pos @kc88_first_72 @kc88_second_15 -210;
-    pos @kc88_first_72 @kc88_second_16 -70;
-    pos @kc88_first_72 @kc88_second_20 -210;
-    pos @kc88_first_72 @kc88_second_25 -35;
-    pos @kc88_first_72 @kc88_second_28 -35;
-    pos @kc88_first_72 @kc88_second_29 -70;
-    pos @kc88_first_72 @kc88_second_33 -70;
-    pos @kc88_first_72 @kc88_second_41 -35;
-    pos @kc88_first_72 @kc88_second_42 -245;
-    pos @kc88_first_72 @kc88_second_43 -70;
-    pos @kc88_first_72 @kc88_second_45 -35;
-    pos @kc88_first_72 @kc88_second_46 -240;
-    pos @kc88_first_72 @kc88_second_48 1;
-    pos @kc88_first_72 @kc88_second_50 -105;
-    pos @kc88_first_72 @kc88_second_51 -280;
-    pos @kc88_first_72 @kc88_second_52 -35;
-    pos @kc88_first_72 @kc88_second_57 -35;
-    pos @kc88_first_72 @kc88_second_60 -70;
-    pos @kc88_first_72 @kc88_second_61 -105;
-    pos @kc88_first_72 @kc88_second_62 -35;
-    pos @kc88_first_72 @kc88_second_63 -70;
-    pos @kc88_first_72 @kc88_second_64 -175;
-    pos @kc88_first_72 @kc88_second_65 -140;
-    pos @kc88_first_73 @kc88_second_1 -140;
-    pos @kc88_first_73 @kc88_second_2 -140;
-    pos @kc88_first_73 @kc88_second_6 -140;
-    pos @kc88_first_73 @kc88_second_8 -35;
-    pos @kc88_first_73 @kc88_second_10 -35;
-    pos @kc88_first_73 @kc88_second_17 -35;
-    pos @kc88_first_73 @kc88_second_18 -70;
-    pos @kc88_first_73 @kc88_second_19 -140;
-    pos @kc88_first_73 @kc88_second_21 -140;
-    pos @kc88_first_73 @kc88_second_22 -35;
-    pos @kc88_first_73 @kc88_second_24 -70;
-    pos @kc88_first_73 @kc88_second_25 -70;
-    pos @kc88_first_73 @kc88_second_26 -140;
-    pos @kc88_first_73 @kc88_second_31 -70;
-    pos @kc88_first_73 @kc88_second_35 -70;
-    pos @kc88_first_73 @kc88_second_37 -175;
-    pos @kc88_first_73 @kc88_second_38 -105;
-    pos @kc88_first_73 @kc88_second_39 -70;
-    pos @kc88_first_73 @kc88_second_40 -70;
-    pos @kc88_first_73 @kc88_second_41 -70;
-    pos @kc88_first_73 @kc88_second_42 -35;
-    pos @kc88_first_73 @kc88_second_48 1;
-    pos @kc88_first_73 @kc88_second_53 -35;
-    pos @kc88_first_73 @kc88_second_54 -35;
-    pos @kc88_first_73 @kc88_second_56 -140;
-    pos @kc88_first_73 @kc88_second_58 -140;
-    pos @kc88_first_73 @kc88_second_59 -140;
-    pos @kc88_first_73 @kc88_second_66 -105;
-    pos @kc88_first_73 @kc88_second_67 -105;
+    pos @kc89_first_1 @kc89_second_3 -70;
+    pos @kc89_first_1 @kc89_second_8 -70;
+    pos @kc89_first_1 @kc89_second_9 -140;
+    pos @kc89_first_1 @kc89_second_10 -35;
+    pos @kc89_first_1 @kc89_second_12 -280;
+    pos @kc89_first_1 @kc89_second_13 -280;
+    pos @kc89_first_1 @kc89_second_14 -280;
+    pos @kc89_first_1 @kc89_second_15 -210;
+    pos @kc89_first_1 @kc89_second_22 -70;
+    pos @kc89_first_1 @kc89_second_25 -35;
+    pos @kc89_first_1 @kc89_second_27 -50;
+    pos @kc89_first_1 @kc89_second_33 -70;
+    pos @kc89_first_1 @kc89_second_41 -35;
+    pos @kc89_first_1 @kc89_second_42 -140;
+    pos @kc89_first_1 @kc89_second_43 -105;
+    pos @kc89_first_1 @kc89_second_46 -210;
+    pos @kc89_first_1 @kc89_second_47 -35;
+    pos @kc89_first_1 @kc89_second_48 1;
+    pos @kc89_first_1 @kc89_second_50 -175;
+    pos @kc89_first_1 @kc89_second_51 -210;
+    pos @kc89_first_1 @kc89_second_61 -140;
+    pos @kc89_first_1 @kc89_second_63 -140;
+    pos @kc89_first_1 @kc89_second_64 -210;
+    pos @kc89_first_1 @kc89_second_65 -140;
+    pos @kc89_first_2 @kc89_second_9 -35;
+    pos @kc89_first_2 @kc89_second_12 -70;
+    pos @kc89_first_2 @kc89_second_13 -70;
+    pos @kc89_first_2 @kc89_second_14 -70;
+    pos @kc89_first_2 @kc89_second_15 -35;
+    pos @kc89_first_2 @kc89_second_16 -35;
+    pos @kc89_first_2 @kc89_second_42 -35;
+    pos @kc89_first_2 @kc89_second_48 1;
+    pos @kc89_first_3 @kc89_second_1 -35;
+    pos @kc89_first_3 @kc89_second_2 -70;
+    pos @kc89_first_3 @kc89_second_5 -35;
+    pos @kc89_first_3 @kc89_second_11 -35;
+    pos @kc89_first_3 @kc89_second_12 -35;
+    pos @kc89_first_3 @kc89_second_13 -70;
+    pos @kc89_first_3 @kc89_second_14 -35;
+    pos @kc89_first_3 @kc89_second_16 -70;
+    pos @kc89_first_3 @kc89_second_19 -35;
+    pos @kc89_first_3 @kc89_second_21 -70;
+    pos @kc89_first_3 @kc89_second_38 -35;
+    pos @kc89_first_3 @kc89_second_48 1;
+    pos @kc89_first_4 @kc89_second_1 -70;
+    pos @kc89_first_4 @kc89_second_2 -140;
+    pos @kc89_first_4 @kc89_second_4 70;
+    pos @kc89_first_4 @kc89_second_5 -70;
+    pos @kc89_first_4 @kc89_second_11 -105;
+    pos @kc89_first_4 @kc89_second_12 -140;
+    pos @kc89_first_4 @kc89_second_13 -140;
+    pos @kc89_first_4 @kc89_second_14 -105;
+    pos @kc89_first_4 @kc89_second_15 -35;
+    pos @kc89_first_4 @kc89_second_16 -140;
+    pos @kc89_first_4 @kc89_second_19 -70;
+    pos @kc89_first_4 @kc89_second_26 -70;
+    pos @kc89_first_4 @kc89_second_28 -70;
+    pos @kc89_first_4 @kc89_second_29 -35;
+    pos @kc89_first_4 @kc89_second_33 35;
+    pos @kc89_first_4 @kc89_second_35 -35;
+    pos @kc89_first_4 @kc89_second_37 -70;
+    pos @kc89_first_4 @kc89_second_38 -70;
+    pos @kc89_first_4 @kc89_second_46 -35;
+    pos @kc89_first_4 @kc89_second_48 1;
+    pos @kc89_first_4 @kc89_second_51 -70;
+    pos @kc89_first_4 @kc89_second_56 -70;
+    pos @kc89_first_4 @kc89_second_58 -70;
+    pos @kc89_first_4 @kc89_second_59 -70;
+    pos @kc89_first_4 @kc89_second_64 -35;
+    pos @kc89_first_5 @kc89_second_12 -70;
+    pos @kc89_first_5 @kc89_second_48 1;
+    pos @kc89_first_6 @kc89_second_1 -280;
+    pos @kc89_first_6 @kc89_second_2 -350;
+    pos @kc89_first_6 @kc89_second_3 -140;
+    pos @kc89_first_6 @kc89_second_4 -70;
+    pos @kc89_first_6 @kc89_second_6 -350;
+    pos @kc89_first_6 @kc89_second_7 -140;
+    pos @kc89_first_6 @kc89_second_8 -210;
+    pos @kc89_first_6 @kc89_second_10 -70;
+    pos @kc89_first_6 @kc89_second_17 -240;
+    pos @kc89_first_6 @kc89_second_18 -240;
+    pos @kc89_first_6 @kc89_second_19 -280;
+    pos @kc89_first_6 @kc89_second_21 -350;
+    pos @kc89_first_6 @kc89_second_22 -280;
+    pos @kc89_first_6 @kc89_second_23 -240;
+    pos @kc89_first_6 @kc89_second_24 -240;
+    pos @kc89_first_6 @kc89_second_25 -210;
+    pos @kc89_first_6 @kc89_second_26 -350;
+    pos @kc89_first_6 @kc89_second_27 -140;
+    pos @kc89_first_6 @kc89_second_29 -140;
+    pos @kc89_first_6 @kc89_second_31 -240;
+    pos @kc89_first_6 @kc89_second_32 -240;
+    pos @kc89_first_6 @kc89_second_33 -175;
+    pos @kc89_first_6 @kc89_second_35 -240;
+    pos @kc89_first_6 @kc89_second_37 -350;
+    pos @kc89_first_6 @kc89_second_38 -105;
+    pos @kc89_first_6 @kc89_second_39 -240;
+    pos @kc89_first_6 @kc89_second_40 -210;
+    pos @kc89_first_6 @kc89_second_41 -240;
+    pos @kc89_first_6 @kc89_second_42 -240;
+    pos @kc89_first_6 @kc89_second_44 -240;
+    pos @kc89_first_6 @kc89_second_47 -140;
+    pos @kc89_first_6 @kc89_second_48 1;
+    pos @kc89_first_6 @kc89_second_49 -35;
+    pos @kc89_first_6 @kc89_second_50 -240;
+    pos @kc89_first_6 @kc89_second_52 -240;
+    pos @kc89_first_6 @kc89_second_53 -240;
+    pos @kc89_first_6 @kc89_second_54 -240;
+    pos @kc89_first_6 @kc89_second_55 -240;
+    pos @kc89_first_6 @kc89_second_56 -280;
+    pos @kc89_first_6 @kc89_second_57 -70;
+    pos @kc89_first_6 @kc89_second_58 -280;
+    pos @kc89_first_6 @kc89_second_59 -240;
+    pos @kc89_first_6 @kc89_second_60 -175;
+    pos @kc89_first_6 @kc89_second_61 -240;
+    pos @kc89_first_6 @kc89_second_62 -210;
+    pos @kc89_first_6 @kc89_second_63 -175;
+    pos @kc89_first_6 @kc89_second_66 -175;
+    pos @kc89_first_6 @kc89_second_67 -175;
+    pos @kc89_first_7 @kc89_second_3 -70;
+    pos @kc89_first_7 @kc89_second_8 -105;
+    pos @kc89_first_7 @kc89_second_17 -35;
+    pos @kc89_first_7 @kc89_second_18 -70;
+    pos @kc89_first_7 @kc89_second_22 -105;
+    pos @kc89_first_7 @kc89_second_24 -105;
+    pos @kc89_first_7 @kc89_second_25 -70;
+    pos @kc89_first_7 @kc89_second_48 1;
+    pos @kc89_first_7 @kc89_second_49 -35;
+    pos @kc89_first_7 @kc89_second_50 -70;
+    pos @kc89_first_7 @kc89_second_54 -50;
+    pos @kc89_first_7 @kc89_second_63 -35;
+    pos @kc89_first_7 @kc89_second_66 -70;
+    pos @kc89_first_7 @kc89_second_67 -70;
+    pos @kc89_first_8 @kc89_second_3 -140;
+    pos @kc89_first_8 @kc89_second_4 -70;
+    pos @kc89_first_8 @kc89_second_6 -70;
+    pos @kc89_first_8 @kc89_second_8 -140;
+    pos @kc89_first_8 @kc89_second_10 -35;
+    pos @kc89_first_8 @kc89_second_17 -70;
+    pos @kc89_first_8 @kc89_second_18 -70;
+    pos @kc89_first_8 @kc89_second_22 -140;
+    pos @kc89_first_8 @kc89_second_24 -70;
+    pos @kc89_first_8 @kc89_second_25 -105;
+    pos @kc89_first_8 @kc89_second_27 -140;
+    pos @kc89_first_8 @kc89_second_31 -35;
+    pos @kc89_first_8 @kc89_second_33 -105;
+    pos @kc89_first_8 @kc89_second_37 -70;
+    pos @kc89_first_8 @kc89_second_39 -70;
+    pos @kc89_first_8 @kc89_second_41 -105;
+    pos @kc89_first_8 @kc89_second_42 -175;
+    pos @kc89_first_8 @kc89_second_43 -140;
+    pos @kc89_first_8 @kc89_second_44 -35;
+    pos @kc89_first_8 @kc89_second_46 -140;
+    pos @kc89_first_8 @kc89_second_47 -105;
+    pos @kc89_first_8 @kc89_second_48 1;
+    pos @kc89_first_8 @kc89_second_49 -70;
+    pos @kc89_first_8 @kc89_second_50 -140;
+    pos @kc89_first_8 @kc89_second_51 -70;
+    pos @kc89_first_8 @kc89_second_54 -35;
+    pos @kc89_first_8 @kc89_second_55 -35;
+    pos @kc89_first_8 @kc89_second_61 -210;
+    pos @kc89_first_8 @kc89_second_63 -105;
+    pos @kc89_first_8 @kc89_second_64 -70;
+    pos @kc89_first_8 @kc89_second_65 -35;
+    pos @kc89_first_8 @kc89_second_66 -70;
+    pos @kc89_first_8 @kc89_second_67 -35;
+    pos @kc89_first_9 @kc89_second_3 -140;
+    pos @kc89_first_9 @kc89_second_4 -70;
+    pos @kc89_first_9 @kc89_second_6 -70;
+    pos @kc89_first_9 @kc89_second_8 -210;
+    pos @kc89_first_9 @kc89_second_9 -420;
+    pos @kc89_first_9 @kc89_second_10 -70;
+    pos @kc89_first_9 @kc89_second_12 -350;
+    pos @kc89_first_9 @kc89_second_13 -420;
+    pos @kc89_first_9 @kc89_second_14 -350;
+    pos @kc89_first_9 @kc89_second_15 -280;
+    pos @kc89_first_9 @kc89_second_17 -70;
+    pos @kc89_first_9 @kc89_second_18 -70;
+    pos @kc89_first_9 @kc89_second_20 -210;
+    pos @kc89_first_9 @kc89_second_22 -210;
+    pos @kc89_first_9 @kc89_second_24 -70;
+    pos @kc89_first_9 @kc89_second_25 -140;
+    pos @kc89_first_9 @kc89_second_31 -50;
+    pos @kc89_first_9 @kc89_second_33 -140;
+    pos @kc89_first_9 @kc89_second_37 -70;
+    pos @kc89_first_9 @kc89_second_41 -105;
+    pos @kc89_first_9 @kc89_second_42 -280;
+    pos @kc89_first_9 @kc89_second_43 -350;
+    pos @kc89_first_9 @kc89_second_44 -50;
+    pos @kc89_first_9 @kc89_second_46 -350;
+    pos @kc89_first_9 @kc89_second_48 1;
+    pos @kc89_first_9 @kc89_second_49 -35;
+    pos @kc89_first_9 @kc89_second_50 -210;
+    pos @kc89_first_9 @kc89_second_51 -350;
+    pos @kc89_first_9 @kc89_second_54 -35;
+    pos @kc89_first_9 @kc89_second_55 -35;
+    pos @kc89_first_9 @kc89_second_61 -280;
+    pos @kc89_first_9 @kc89_second_63 -175;
+    pos @kc89_first_9 @kc89_second_64 -280;
+    pos @kc89_first_9 @kc89_second_65 -210;
+    pos @kc89_first_9 @kc89_second_66 -70;
+    pos @kc89_first_9 @kc89_second_67 -70;
+    pos @kc89_first_10 @kc89_second_1 -210;
+    pos @kc89_first_10 @kc89_second_2 -350;
+    pos @kc89_first_10 @kc89_second_5 -70;
+    pos @kc89_first_10 @kc89_second_6 -140;
+    pos @kc89_first_10 @kc89_second_11 -35;
+    pos @kc89_first_10 @kc89_second_12 -70;
+    pos @kc89_first_10 @kc89_second_13 -70;
+    pos @kc89_first_10 @kc89_second_14 -35;
+    pos @kc89_first_10 @kc89_second_16 -70;
+    pos @kc89_first_10 @kc89_second_17 -35;
+    pos @kc89_first_10 @kc89_second_18 -70;
+    pos @kc89_first_10 @kc89_second_19 -140;
+    pos @kc89_first_10 @kc89_second_21 -280;
+    pos @kc89_first_10 @kc89_second_24 -70;
+    pos @kc89_first_10 @kc89_second_26 -350;
+    pos @kc89_first_10 @kc89_second_31 -70;
+    pos @kc89_first_10 @kc89_second_34 -140;
+    pos @kc89_first_10 @kc89_second_35 -70;
+    pos @kc89_first_10 @kc89_second_37 -210;
+    pos @kc89_first_10 @kc89_second_38 -105;
+    pos @kc89_first_10 @kc89_second_41 -70;
+    pos @kc89_first_10 @kc89_second_48 1;
+    pos @kc89_first_10 @kc89_second_56 -210;
+    pos @kc89_first_10 @kc89_second_58 -210;
+    pos @kc89_first_10 @kc89_second_59 -210;
+    pos @kc89_first_10 @kc89_second_64 -70;
+    pos @kc89_first_10 @kc89_second_66 -70;
+    pos @kc89_first_10 @kc89_second_67 -105;
+    pos @kc89_first_11 @kc89_second_1 -70;
+    pos @kc89_first_11 @kc89_second_2 -140;
+    pos @kc89_first_11 @kc89_second_5 -105;
+    pos @kc89_first_11 @kc89_second_6 -35;
+    pos @kc89_first_11 @kc89_second_11 -70;
+    pos @kc89_first_11 @kc89_second_12 -210;
+    pos @kc89_first_11 @kc89_second_13 -175;
+    pos @kc89_first_11 @kc89_second_14 -105;
+    pos @kc89_first_11 @kc89_second_15 -70;
+    pos @kc89_first_11 @kc89_second_16 -140;
+    pos @kc89_first_11 @kc89_second_19 -70;
+    pos @kc89_first_11 @kc89_second_21 -140;
+    pos @kc89_first_11 @kc89_second_26 -70;
+    pos @kc89_first_11 @kc89_second_28 -70;
+    pos @kc89_first_11 @kc89_second_29 -70;
+    pos @kc89_first_11 @kc89_second_35 -35;
+    pos @kc89_first_11 @kc89_second_37 -35;
+    pos @kc89_first_11 @kc89_second_38 -140;
+    pos @kc89_first_11 @kc89_second_42 -70;
+    pos @kc89_first_11 @kc89_second_45 -35;
+    pos @kc89_first_11 @kc89_second_46 -35;
+    pos @kc89_first_11 @kc89_second_48 1;
+    pos @kc89_first_11 @kc89_second_51 -70;
+    pos @kc89_first_11 @kc89_second_56 -210;
+    pos @kc89_first_11 @kc89_second_58 -175;
+    pos @kc89_first_11 @kc89_second_59 -175;
+    pos @kc89_first_11 @kc89_second_60 -35;
+    pos @kc89_first_11 @kc89_second_64 -70;
+    pos @kc89_first_11 @kc89_second_65 -35;
+    pos @kc89_first_11 @kc89_second_66 -35;
+    pos @kc89_first_11 @kc89_second_67 -70;
+    pos @kc89_first_12 @kc89_second_1 -140;
+    pos @kc89_first_12 @kc89_second_2 -210;
+    pos @kc89_first_12 @kc89_second_6 -140;
+    pos @kc89_first_12 @kc89_second_17 -70;
+    pos @kc89_first_12 @kc89_second_18 -70;
+    pos @kc89_first_12 @kc89_second_19 -140;
+    pos @kc89_first_12 @kc89_second_21 -210;
+    pos @kc89_first_12 @kc89_second_24 -70;
+    pos @kc89_first_12 @kc89_second_26 -350;
+    pos @kc89_first_12 @kc89_second_31 -35;
+    pos @kc89_first_12 @kc89_second_34 -140;
+    pos @kc89_first_12 @kc89_second_35 -70;
+    pos @kc89_first_12 @kc89_second_37 -140;
+    pos @kc89_first_12 @kc89_second_38 -70;
+    pos @kc89_first_12 @kc89_second_41 -70;
+    pos @kc89_first_12 @kc89_second_48 1;
+    pos @kc89_first_12 @kc89_second_54 -35;
+    pos @kc89_first_12 @kc89_second_56 -210;
+    pos @kc89_first_12 @kc89_second_58 -210;
+    pos @kc89_first_12 @kc89_second_59 -210;
+    pos @kc89_first_12 @kc89_second_66 -70;
+    pos @kc89_first_12 @kc89_second_67 -105;
+    pos @kc89_first_13 @kc89_second_6 -70;
+    pos @kc89_first_13 @kc89_second_12 -70;
+    pos @kc89_first_13 @kc89_second_13 -105;
+    pos @kc89_first_13 @kc89_second_14 -35;
+    pos @kc89_first_13 @kc89_second_18 -35;
+    pos @kc89_first_13 @kc89_second_24 -35;
+    pos @kc89_first_13 @kc89_second_31 -35;
+    pos @kc89_first_13 @kc89_second_37 -70;
+    pos @kc89_first_13 @kc89_second_41 -70;
+    pos @kc89_first_13 @kc89_second_48 1;
+    pos @kc89_first_13 @kc89_second_66 -70;
+    pos @kc89_first_13 @kc89_second_67 -35;
+    pos @kc89_first_14 @kc89_second_2 -35;
+    pos @kc89_first_14 @kc89_second_11 -35;
+    pos @kc89_first_14 @kc89_second_12 -70;
+    pos @kc89_first_14 @kc89_second_13 -70;
+    pos @kc89_first_14 @kc89_second_14 -35;
+    pos @kc89_first_14 @kc89_second_16 -35;
+    pos @kc89_first_14 @kc89_second_21 -35;
+    pos @kc89_first_14 @kc89_second_27 -35;
+    pos @kc89_first_14 @kc89_second_35 -35;
+    pos @kc89_first_14 @kc89_second_42 -70;
+    pos @kc89_first_14 @kc89_second_48 1;
+    pos @kc89_first_14 @kc89_second_50 -70;
+    pos @kc89_first_14 @kc89_second_51 -35;
+    pos @kc89_first_14 @kc89_second_60 -35;
+    pos @kc89_first_14 @kc89_second_61 -35;
+    pos @kc89_first_14 @kc89_second_63 -35;
+    pos @kc89_first_14 @kc89_second_65 -35;
+    pos @kc89_first_15 @kc89_second_3 -70;
+    pos @kc89_first_15 @kc89_second_4 -70;
+    pos @kc89_first_15 @kc89_second_6 -35;
+    pos @kc89_first_15 @kc89_second_8 -70;
+    pos @kc89_first_15 @kc89_second_17 -70;
+    pos @kc89_first_15 @kc89_second_18 -70;
+    pos @kc89_first_15 @kc89_second_22 -140;
+    pos @kc89_first_15 @kc89_second_24 -70;
+    pos @kc89_first_15 @kc89_second_25 -70;
+    pos @kc89_first_15 @kc89_second_27 -70;
+    pos @kc89_first_15 @kc89_second_31 -35;
+    pos @kc89_first_15 @kc89_second_33 -35;
+    pos @kc89_first_15 @kc89_second_39 -35;
+    pos @kc89_first_15 @kc89_second_41 -70;
+    pos @kc89_first_15 @kc89_second_42 -142;
+    pos @kc89_first_15 @kc89_second_43 -35;
+    pos @kc89_first_15 @kc89_second_47 -35;
+    pos @kc89_first_15 @kc89_second_48 1;
+    pos @kc89_first_15 @kc89_second_49 -35;
+    pos @kc89_first_15 @kc89_second_50 -70;
+    pos @kc89_first_15 @kc89_second_54 -35;
+    pos @kc89_first_15 @kc89_second_55 -35;
+    pos @kc89_first_15 @kc89_second_61 -105;
+    pos @kc89_first_15 @kc89_second_63 -35;
+    pos @kc89_first_15 @kc89_second_66 -35;
+    pos @kc89_first_15 @kc89_second_67 -35;
+    pos @kc89_first_16 @kc89_second_1 -280;
+    pos @kc89_first_16 @kc89_second_2 -280;
+    pos @kc89_first_16 @kc89_second_3 -140;
+    pos @kc89_first_16 @kc89_second_4 -70;
+    pos @kc89_first_16 @kc89_second_6 -280;
+    pos @kc89_first_16 @kc89_second_7 -140;
+    pos @kc89_first_16 @kc89_second_8 -175;
+    pos @kc89_first_16 @kc89_second_10 -70;
+    pos @kc89_first_16 @kc89_second_17 -245;
+    pos @kc89_first_16 @kc89_second_18 -280;
+    pos @kc89_first_16 @kc89_second_19 -280;
+    pos @kc89_first_16 @kc89_second_21 -280;
+    pos @kc89_first_16 @kc89_second_22 -210;
+    pos @kc89_first_16 @kc89_second_23 -140;
+    pos @kc89_first_16 @kc89_second_24 -280;
+    pos @kc89_first_16 @kc89_second_25 -210;
+    pos @kc89_first_16 @kc89_second_26 -350;
+    pos @kc89_first_16 @kc89_second_27 -70;
+    pos @kc89_first_16 @kc89_second_29 -140;
+    pos @kc89_first_16 @kc89_second_31 -240;
+    pos @kc89_first_16 @kc89_second_32 -140;
+    pos @kc89_first_16 @kc89_second_33 -140;
+    pos @kc89_first_16 @kc89_second_34 -245;
+    pos @kc89_first_16 @kc89_second_35 -315;
+    pos @kc89_first_16 @kc89_second_37 -315;
+    pos @kc89_first_16 @kc89_second_38 -70;
+    pos @kc89_first_16 @kc89_second_39 -210;
+    pos @kc89_first_16 @kc89_second_40 -210;
+    pos @kc89_first_16 @kc89_second_41 -245;
+    pos @kc89_first_16 @kc89_second_42 -245;
+    pos @kc89_first_16 @kc89_second_43 -70;
+    pos @kc89_first_16 @kc89_second_45 -35;
+    pos @kc89_first_16 @kc89_second_46 -140;
+    pos @kc89_first_16 @kc89_second_47 -140;
+    pos @kc89_first_16 @kc89_second_48 1;
+    pos @kc89_first_16 @kc89_second_49 -70;
+    pos @kc89_first_16 @kc89_second_50 -140;
+    pos @kc89_first_16 @kc89_second_52 -140;
+    pos @kc89_first_16 @kc89_second_53 -140;
+    pos @kc89_first_16 @kc89_second_54 -240;
+    pos @kc89_first_16 @kc89_second_55 -140;
+    pos @kc89_first_16 @kc89_second_56 -280;
+    pos @kc89_first_16 @kc89_second_57 -105;
+    pos @kc89_first_16 @kc89_second_58 -315;
+    pos @kc89_first_16 @kc89_second_59 -280;
+    pos @kc89_first_16 @kc89_second_60 -140;
+    pos @kc89_first_16 @kc89_second_61 -210;
+    pos @kc89_first_16 @kc89_second_62 -210;
+    pos @kc89_first_16 @kc89_second_63 -105;
+    pos @kc89_first_16 @kc89_second_66 -315;
+    pos @kc89_first_16 @kc89_second_67 -350;
+    pos @kc89_first_17 @kc89_second_1 -280;
+    pos @kc89_first_17 @kc89_second_2 -280;
+    pos @kc89_first_17 @kc89_second_3 -105;
+    pos @kc89_first_17 @kc89_second_6 -210;
+    pos @kc89_first_17 @kc89_second_7 -105;
+    pos @kc89_first_17 @kc89_second_8 -105;
+    pos @kc89_first_17 @kc89_second_10 -35;
+    pos @kc89_first_17 @kc89_second_17 -105;
+    pos @kc89_first_17 @kc89_second_18 -175;
+    pos @kc89_first_17 @kc89_second_19 -280;
+    pos @kc89_first_17 @kc89_second_21 -280;
+    pos @kc89_first_17 @kc89_second_22 -70;
+    pos @kc89_first_17 @kc89_second_23 -105;
+    pos @kc89_first_17 @kc89_second_24 -140;
+    pos @kc89_first_17 @kc89_second_25 -140;
+    pos @kc89_first_17 @kc89_second_26 -210;
+    pos @kc89_first_17 @kc89_second_29 -70;
+    pos @kc89_first_17 @kc89_second_31 -140;
+    pos @kc89_first_17 @kc89_second_32 -105;
+    pos @kc89_first_17 @kc89_second_34 -210;
+    pos @kc89_first_17 @kc89_second_35 -175;
+    pos @kc89_first_17 @kc89_second_37 -245;
+    pos @kc89_first_17 @kc89_second_38 -70;
+    pos @kc89_first_17 @kc89_second_39 -140;
+    pos @kc89_first_17 @kc89_second_40 -140;
+    pos @kc89_first_17 @kc89_second_41 -140;
+    pos @kc89_first_17 @kc89_second_42 -105;
+    pos @kc89_first_17 @kc89_second_43 -35;
+    pos @kc89_first_17 @kc89_second_46 -35;
+    pos @kc89_first_17 @kc89_second_47 -70;
+    pos @kc89_first_17 @kc89_second_48 1;
+    pos @kc89_first_17 @kc89_second_49 -35;
+    pos @kc89_first_17 @kc89_second_50 -70;
+    pos @kc89_first_17 @kc89_second_52 -105;
+    pos @kc89_first_17 @kc89_second_53 -70;
+    pos @kc89_first_17 @kc89_second_54 -105;
+    pos @kc89_first_17 @kc89_second_55 -70;
+    pos @kc89_first_17 @kc89_second_56 -210;
+    pos @kc89_first_17 @kc89_second_57 -35;
+    pos @kc89_first_17 @kc89_second_58 -245;
+    pos @kc89_first_17 @kc89_second_59 -210;
+    pos @kc89_first_17 @kc89_second_60 -70;
+    pos @kc89_first_17 @kc89_second_61 -105;
+    pos @kc89_first_17 @kc89_second_62 -105;
+    pos @kc89_first_17 @kc89_second_63 -70;
+    pos @kc89_first_17 @kc89_second_66 -175;
+    pos @kc89_first_17 @kc89_second_67 -245;
+    pos @kc89_first_18 @kc89_second_1 -210;
+    pos @kc89_first_18 @kc89_second_2 -245;
+    pos @kc89_first_18 @kc89_second_3 -35;
+    pos @kc89_first_18 @kc89_second_6 -140;
+    pos @kc89_first_18 @kc89_second_7 -35;
+    pos @kc89_first_18 @kc89_second_8 -70;
+    pos @kc89_first_18 @kc89_second_17 -105;
+    pos @kc89_first_18 @kc89_second_18 -105;
+    pos @kc89_first_18 @kc89_second_19 -175;
+    pos @kc89_first_18 @kc89_second_21 -210;
+    pos @kc89_first_18 @kc89_second_22 -70;
+    pos @kc89_first_18 @kc89_second_24 -105;
+    pos @kc89_first_18 @kc89_second_25 -70;
+    pos @kc89_first_18 @kc89_second_26 -140;
+    pos @kc89_first_18 @kc89_second_29 -35;
+    pos @kc89_first_18 @kc89_second_34 -140;
+    pos @kc89_first_18 @kc89_second_35 -105;
+    pos @kc89_first_18 @kc89_second_37 -140;
+    pos @kc89_first_18 @kc89_second_39 -105;
+    pos @kc89_first_18 @kc89_second_40 -70;
+    pos @kc89_first_18 @kc89_second_41 -105;
+    pos @kc89_first_18 @kc89_second_42 -70;
+    pos @kc89_first_18 @kc89_second_44 -35;
+    pos @kc89_first_18 @kc89_second_48 1;
+    pos @kc89_first_18 @kc89_second_53 -35;
+    pos @kc89_first_18 @kc89_second_54 -70;
+    pos @kc89_first_18 @kc89_second_56 -140;
+    pos @kc89_first_18 @kc89_second_58 -175;
+    pos @kc89_first_18 @kc89_second_59 -140;
+    pos @kc89_first_18 @kc89_second_61 -70;
+    pos @kc89_first_18 @kc89_second_66 -105;
+    pos @kc89_first_18 @kc89_second_67 -140;
+    pos @kc89_first_19 @kc89_second_12 -280;
+    pos @kc89_first_19 @kc89_second_14 -175;
+    pos @kc89_first_19 @kc89_second_15 -140;
+    pos @kc89_first_19 @kc89_second_18 -35;
+    pos @kc89_first_19 @kc89_second_31 -35;
+    pos @kc89_first_19 @kc89_second_33 -50;
+    pos @kc89_first_19 @kc89_second_48 1;
+    pos @kc89_first_19 @kc89_second_50 -70;
+    pos @kc89_first_19 @kc89_second_51 -140;
+    pos @kc89_first_19 @kc89_second_61 -70;
+    pos @kc89_first_19 @kc89_second_63 -35;
+    pos @kc89_first_19 @kc89_second_64 -105;
+    pos @kc89_first_19 @kc89_second_65 -70;
+    pos @kc89_first_20 @kc89_second_12 -240;
+    pos @kc89_first_20 @kc89_second_13 -140;
+    pos @kc89_first_20 @kc89_second_14 -105;
+    pos @kc89_first_20 @kc89_second_15 -35;
+    pos @kc89_first_20 @kc89_second_48 1;
+    pos @kc89_first_21 @kc89_second_8 -35;
+    pos @kc89_first_21 @kc89_second_9 -140;
+    pos @kc89_first_21 @kc89_second_12 -280;
+    pos @kc89_first_21 @kc89_second_13 -280;
+    pos @kc89_first_21 @kc89_second_14 -280;
+    pos @kc89_first_21 @kc89_second_15 -175;
+    pos @kc89_first_21 @kc89_second_20 -140;
+    pos @kc89_first_21 @kc89_second_22 -70;
+    pos @kc89_first_21 @kc89_second_27 -70;
+    pos @kc89_first_21 @kc89_second_33 -50;
+    pos @kc89_first_21 @kc89_second_42 -140;
+    pos @kc89_first_21 @kc89_second_43 -105;
+    pos @kc89_first_21 @kc89_second_46 -210;
+    pos @kc89_first_21 @kc89_second_48 1;
+    pos @kc89_first_21 @kc89_second_49 -35;
+    pos @kc89_first_21 @kc89_second_50 -140;
+    pos @kc89_first_21 @kc89_second_51 -210;
+    pos @kc89_first_21 @kc89_second_55 -35;
+    pos @kc89_first_21 @kc89_second_61 -105;
+    pos @kc89_first_21 @kc89_second_63 -105;
+    pos @kc89_first_21 @kc89_second_64 -210;
+    pos @kc89_first_21 @kc89_second_65 -140;
+    pos @kc89_first_22 @kc89_second_1 -140;
+    pos @kc89_first_22 @kc89_second_2 -350;
+    pos @kc89_first_22 @kc89_second_19 -140;
+    pos @kc89_first_22 @kc89_second_21 -280;
+    pos @kc89_first_22 @kc89_second_41 -70;
+    pos @kc89_first_22 @kc89_second_48 1;
+    pos @kc89_first_22 @kc89_second_67 -210;
+    pos @kc89_first_23 @kc89_second_1 -35;
+    pos @kc89_first_23 @kc89_second_5 -105;
+    pos @kc89_first_23 @kc89_second_9 -70;
+    pos @kc89_first_23 @kc89_second_11 -70;
+    pos @kc89_first_23 @kc89_second_12 -240;
+    pos @kc89_first_23 @kc89_second_13 -280;
+    pos @kc89_first_23 @kc89_second_14 -140;
+    pos @kc89_first_23 @kc89_second_15 -105;
+    pos @kc89_first_23 @kc89_second_16 -70;
+    pos @kc89_first_23 @kc89_second_27 -35;
+    pos @kc89_first_23 @kc89_second_28 -70;
+    pos @kc89_first_23 @kc89_second_29 -105;
+    pos @kc89_first_23 @kc89_second_35 -35;
+    pos @kc89_first_23 @kc89_second_38 -70;
+    pos @kc89_first_23 @kc89_second_42 -70;
+    pos @kc89_first_23 @kc89_second_43 -35;
+    pos @kc89_first_23 @kc89_second_45 -35;
+    pos @kc89_first_23 @kc89_second_46 -140;
+    pos @kc89_first_23 @kc89_second_48 1;
+    pos @kc89_first_23 @kc89_second_50 -70;
+    pos @kc89_first_23 @kc89_second_51 -175;
+    pos @kc89_first_23 @kc89_second_52 -35;
+    pos @kc89_first_23 @kc89_second_60 -105;
+    pos @kc89_first_23 @kc89_second_61 -35;
+    pos @kc89_first_23 @kc89_second_63 -50;
+    pos @kc89_first_23 @kc89_second_64 -105;
+    pos @kc89_first_23 @kc89_second_65 -70;
+    pos @kc89_first_24 @kc89_second_6 -35;
+    pos @kc89_first_24 @kc89_second_12 -240;
+    pos @kc89_first_24 @kc89_second_13 -175;
+    pos @kc89_first_24 @kc89_second_14 -70;
+    pos @kc89_first_24 @kc89_second_15 -70;
+    pos @kc89_first_24 @kc89_second_18 -70;
+    pos @kc89_first_24 @kc89_second_24 -70;
+    pos @kc89_first_24 @kc89_second_25 -35;
+    pos @kc89_first_24 @kc89_second_37 -35;
+    pos @kc89_first_24 @kc89_second_42 -35;
+    pos @kc89_first_24 @kc89_second_43 -35;
+    pos @kc89_first_24 @kc89_second_46 -70;
+    pos @kc89_first_24 @kc89_second_47 -35;
+    pos @kc89_first_24 @kc89_second_48 1;
+    pos @kc89_first_24 @kc89_second_51 -35;
+    pos @kc89_first_24 @kc89_second_61 -35;
+    pos @kc89_first_24 @kc89_second_65 -35;
+    pos @kc89_first_24 @kc89_second_66 -35;
+    pos @kc89_first_24 @kc89_second_67 -35;
+    pos @kc89_first_25 @kc89_second_1 -70;
+    pos @kc89_first_25 @kc89_second_2 -140;
+    pos @kc89_first_25 @kc89_second_5 -105;
+    pos @kc89_first_25 @kc89_second_11 -70;
+    pos @kc89_first_25 @kc89_second_12 -280;
+    pos @kc89_first_25 @kc89_second_13 -210;
+    pos @kc89_first_25 @kc89_second_14 -70;
+    pos @kc89_first_25 @kc89_second_15 -70;
+    pos @kc89_first_25 @kc89_second_16 -140;
+    pos @kc89_first_25 @kc89_second_21 -70;
+    pos @kc89_first_25 @kc89_second_28 -70;
+    pos @kc89_first_25 @kc89_second_29 -70;
+    pos @kc89_first_25 @kc89_second_34 -70;
+    pos @kc89_first_25 @kc89_second_38 -70;
+    pos @kc89_first_25 @kc89_second_45 -35;
+    pos @kc89_first_25 @kc89_second_46 -140;
+    pos @kc89_first_25 @kc89_second_48 1;
+    pos @kc89_first_25 @kc89_second_51 -140;
+    pos @kc89_first_25 @kc89_second_52 -35;
+    pos @kc89_first_25 @kc89_second_56 -140;
+    pos @kc89_first_25 @kc89_second_58 -70;
+    pos @kc89_first_25 @kc89_second_59 -105;
+    pos @kc89_first_25 @kc89_second_60 -70;
+    pos @kc89_first_25 @kc89_second_64 -70;
+    pos @kc89_first_25 @kc89_second_65 -35;
+    pos @kc89_first_26 @kc89_second_5 -70;
+    pos @kc89_first_26 @kc89_second_9 -70;
+    pos @kc89_first_26 @kc89_second_12 -240;
+    pos @kc89_first_26 @kc89_second_13 -280;
+    pos @kc89_first_26 @kc89_second_14 -175;
+    pos @kc89_first_26 @kc89_second_15 -105;
+    pos @kc89_first_26 @kc89_second_16 -70;
+    pos @kc89_first_26 @kc89_second_27 -35;
+    pos @kc89_first_26 @kc89_second_28 -70;
+    pos @kc89_first_26 @kc89_second_29 -70;
+    pos @kc89_first_26 @kc89_second_38 -70;
+    pos @kc89_first_26 @kc89_second_42 -70;
+    pos @kc89_first_26 @kc89_second_43 -35;
+    pos @kc89_first_26 @kc89_second_46 -140;
+    pos @kc89_first_26 @kc89_second_48 1;
+    pos @kc89_first_26 @kc89_second_50 -70;
+    pos @kc89_first_26 @kc89_second_51 -140;
+    pos @kc89_first_26 @kc89_second_52 -35;
+    pos @kc89_first_26 @kc89_second_56 -50;
+    pos @kc89_first_26 @kc89_second_57 -35;
+    pos @kc89_first_26 @kc89_second_58 -50;
+    pos @kc89_first_26 @kc89_second_59 -50;
+    pos @kc89_first_26 @kc89_second_60 -105;
+    pos @kc89_first_26 @kc89_second_61 -50;
+    pos @kc89_first_26 @kc89_second_63 -35;
+    pos @kc89_first_26 @kc89_second_64 -105;
+    pos @kc89_first_26 @kc89_second_65 -70;
+    pos @kc89_first_27 @kc89_second_9 -35;
+    pos @kc89_first_27 @kc89_second_12 -140;
+    pos @kc89_first_27 @kc89_second_28 -70;
+    pos @kc89_first_27 @kc89_second_42 -35;
+    pos @kc89_first_27 @kc89_second_46 -70;
+    pos @kc89_first_27 @kc89_second_48 1;
+    pos @kc89_first_27 @kc89_second_51 -70;
+    pos @kc89_first_27 @kc89_second_64 -70;
+    pos @kc89_first_27 @kc89_second_65 -35;
+    pos @kc89_first_28 @kc89_second_5 -50;
+    pos @kc89_first_28 @kc89_second_9 -35;
+    pos @kc89_first_28 @kc89_second_11 -35;
+    pos @kc89_first_28 @kc89_second_12 -240;
+    pos @kc89_first_28 @kc89_second_13 -240;
+    pos @kc89_first_28 @kc89_second_14 -105;
+    pos @kc89_first_28 @kc89_second_15 -70;
+    pos @kc89_first_28 @kc89_second_16 -35;
+    pos @kc89_first_28 @kc89_second_28 -35;
+    pos @kc89_first_28 @kc89_second_29 -35;
+    pos @kc89_first_28 @kc89_second_35 -35;
+    pos @kc89_first_28 @kc89_second_38 -35;
+    pos @kc89_first_28 @kc89_second_42 -50;
+    pos @kc89_first_28 @kc89_second_43 -35;
+    pos @kc89_first_28 @kc89_second_46 -100;
+    pos @kc89_first_28 @kc89_second_48 1;
+    pos @kc89_first_28 @kc89_second_50 -35;
+    pos @kc89_first_28 @kc89_second_51 -140;
+    pos @kc89_first_28 @kc89_second_60 -35;
+    pos @kc89_first_28 @kc89_second_64 -70;
+    pos @kc89_first_28 @kc89_second_65 -35;
+    pos @kc89_first_29 @kc89_second_48 1;
+    pos @kc89_first_30 @kc89_second_8 -70;
+    pos @kc89_first_30 @kc89_second_9 -210;
+    pos @kc89_first_30 @kc89_second_12 -350;
+    pos @kc89_first_30 @kc89_second_13 -350;
+    pos @kc89_first_30 @kc89_second_14 -210;
+    pos @kc89_first_30 @kc89_second_15 -175;
+    pos @kc89_first_30 @kc89_second_27 -70;
+    pos @kc89_first_30 @kc89_second_41 -35;
+    pos @kc89_first_30 @kc89_second_42 -210;
+    pos @kc89_first_30 @kc89_second_43 -210;
+    pos @kc89_first_30 @kc89_second_46 -210;
+    pos @kc89_first_30 @kc89_second_48 1;
+    pos @kc89_first_30 @kc89_second_50 -140;
+    pos @kc89_first_30 @kc89_second_51 -280;
+    pos @kc89_first_30 @kc89_second_61 -210;
+    pos @kc89_first_30 @kc89_second_63 -105;
+    pos @kc89_first_30 @kc89_second_64 -175;
+    pos @kc89_first_30 @kc89_second_65 -140;
+    pos @kc89_first_31 @kc89_second_1 -175;
+    pos @kc89_first_31 @kc89_second_2 -175;
+    pos @kc89_first_31 @kc89_second_5 -70;
+    pos @kc89_first_31 @kc89_second_6 -105;
+    pos @kc89_first_31 @kc89_second_10 -35;
+    pos @kc89_first_31 @kc89_second_11 -105;
+    pos @kc89_first_31 @kc89_second_12 -175;
+    pos @kc89_first_31 @kc89_second_13 -140;
+    pos @kc89_first_31 @kc89_second_14 -70;
+    pos @kc89_first_31 @kc89_second_15 -35;
+    pos @kc89_first_31 @kc89_second_16 -140;
+    pos @kc89_first_31 @kc89_second_17 -70;
+    pos @kc89_first_31 @kc89_second_18 -70;
+    pos @kc89_first_31 @kc89_second_19 -140;
+    pos @kc89_first_31 @kc89_second_21 -175;
+    pos @kc89_first_31 @kc89_second_24 -70;
+    pos @kc89_first_31 @kc89_second_31 -105;
+    pos @kc89_first_31 @kc89_second_36 180;
+    pos @kc89_first_31 @kc89_second_37 -105;
+    pos @kc89_first_31 @kc89_second_38 -175;
+    pos @kc89_first_31 @kc89_second_39 -35;
+    pos @kc89_first_31 @kc89_second_41 -70;
+    pos @kc89_first_31 @kc89_second_48 1;
+    pos @kc89_first_31 @kc89_second_53 180;
+    pos @kc89_first_31 @kc89_second_54 -35;
+    pos @kc89_first_31 @kc89_second_66 -70;
+    pos @kc89_first_31 @kc89_second_67 -105;
+    pos @kc89_first_32 @kc89_second_3 -70;
+    pos @kc89_first_32 @kc89_second_4 -35;
+    pos @kc89_first_32 @kc89_second_6 -70;
+    pos @kc89_first_32 @kc89_second_8 -105;
+    pos @kc89_first_32 @kc89_second_17 -35;
+    pos @kc89_first_32 @kc89_second_18 -70;
+    pos @kc89_first_32 @kc89_second_22 -70;
+    pos @kc89_first_32 @kc89_second_24 -70;
+    pos @kc89_first_32 @kc89_second_25 -140;
+    pos @kc89_first_32 @kc89_second_31 -35;
+    pos @kc89_first_32 @kc89_second_37 -70;
+    pos @kc89_first_32 @kc89_second_39 -35;
+    pos @kc89_first_32 @kc89_second_41 -140;
+    pos @kc89_first_32 @kc89_second_42 -70;
+    pos @kc89_first_32 @kc89_second_48 1;
+    pos @kc89_first_32 @kc89_second_54 -35;
+    pos @kc89_first_32 @kc89_second_55 -35;
+    pos @kc89_first_32 @kc89_second_61 -140;
+    pos @kc89_first_32 @kc89_second_66 -70;
+    pos @kc89_first_32 @kc89_second_67 -70;
+    pos @kc89_first_33 @kc89_second_1 -35;
+    pos @kc89_first_33 @kc89_second_2 -105;
+    pos @kc89_first_33 @kc89_second_3 -70;
+    pos @kc89_first_33 @kc89_second_4 70;
+    pos @kc89_first_33 @kc89_second_5 -70;
+    pos @kc89_first_33 @kc89_second_11 -35;
+    pos @kc89_first_33 @kc89_second_12 -240;
+    pos @kc89_first_33 @kc89_second_13 -175;
+    pos @kc89_first_33 @kc89_second_14 -105;
+    pos @kc89_first_33 @kc89_second_15 -70;
+    pos @kc89_first_33 @kc89_second_16 -70;
+    pos @kc89_first_33 @kc89_second_19 -70;
+    pos @kc89_first_33 @kc89_second_26 -35;
+    pos @kc89_first_33 @kc89_second_29 -70;
+    pos @kc89_first_33 @kc89_second_35 -35;
+    pos @kc89_first_33 @kc89_second_38 -35;
+    pos @kc89_first_33 @kc89_second_42 -35;
+    pos @kc89_first_33 @kc89_second_43 -35;
+    pos @kc89_first_33 @kc89_second_45 -35;
+    pos @kc89_first_33 @kc89_second_46 -140;
+    pos @kc89_first_33 @kc89_second_48 1;
+    pos @kc89_first_33 @kc89_second_50 -50;
+    pos @kc89_first_33 @kc89_second_51 -140;
+    pos @kc89_first_33 @kc89_second_52 -35;
+    pos @kc89_first_33 @kc89_second_56 -70;
+    pos @kc89_first_33 @kc89_second_58 -70;
+    pos @kc89_first_33 @kc89_second_59 -70;
+    pos @kc89_first_33 @kc89_second_64 -70;
+    pos @kc89_first_33 @kc89_second_65 -35;
+    pos @kc89_first_34 @kc89_second_3 -35;
+    pos @kc89_first_34 @kc89_second_4 -70;
+    pos @kc89_first_34 @kc89_second_6 -70;
+    pos @kc89_first_34 @kc89_second_8 -70;
+    pos @kc89_first_34 @kc89_second_12 -140;
+    pos @kc89_first_34 @kc89_second_13 -105;
+    pos @kc89_first_34 @kc89_second_14 -70;
+    pos @kc89_first_34 @kc89_second_15 -35;
+    pos @kc89_first_34 @kc89_second_18 -70;
+    pos @kc89_first_34 @kc89_second_22 -70;
+    pos @kc89_first_34 @kc89_second_24 -105;
+    pos @kc89_first_34 @kc89_second_25 -70;
+    pos @kc89_first_34 @kc89_second_31 -35;
+    pos @kc89_first_34 @kc89_second_37 -70;
+    pos @kc89_first_34 @kc89_second_39 -70;
+    pos @kc89_first_34 @kc89_second_41 -105;
+    pos @kc89_first_34 @kc89_second_42 -70;
+    pos @kc89_first_34 @kc89_second_47 -70;
+    pos @kc89_first_34 @kc89_second_48 1;
+    pos @kc89_first_34 @kc89_second_54 -35;
+    pos @kc89_first_34 @kc89_second_55 -35;
+    pos @kc89_first_34 @kc89_second_66 -70;
+    pos @kc89_first_34 @kc89_second_67 -70;
+    pos @kc89_first_35 @kc89_second_34 -315;
+    pos @kc89_first_35 @kc89_second_48 1;
+    pos @kc89_first_36 @kc89_second_9 -70;
+    pos @kc89_first_36 @kc89_second_12 -240;
+    pos @kc89_first_36 @kc89_second_13 -210;
+    pos @kc89_first_36 @kc89_second_14 -140;
+    pos @kc89_first_36 @kc89_second_15 -105;
+    pos @kc89_first_36 @kc89_second_36 100;
+    pos @kc89_first_36 @kc89_second_42 -70;
+    pos @kc89_first_36 @kc89_second_43 -35;
+    pos @kc89_first_36 @kc89_second_46 -140;
+    pos @kc89_first_36 @kc89_second_48 1;
+    pos @kc89_first_36 @kc89_second_50 -50;
+    pos @kc89_first_36 @kc89_second_51 -140;
+    pos @kc89_first_36 @kc89_second_53 100;
+    pos @kc89_first_36 @kc89_second_61 -35;
+    pos @kc89_first_36 @kc89_second_63 -35;
+    pos @kc89_first_36 @kc89_second_64 -70;
+    pos @kc89_first_36 @kc89_second_65 -70;
+    pos @kc89_first_37 @kc89_second_9 -35;
+    pos @kc89_first_37 @kc89_second_12 -240;
+    pos @kc89_first_37 @kc89_second_13 -240;
+    pos @kc89_first_37 @kc89_second_14 -140;
+    pos @kc89_first_37 @kc89_second_15 -105;
+    pos @kc89_first_37 @kc89_second_16 -35;
+    pos @kc89_first_37 @kc89_second_28 -35;
+    pos @kc89_first_37 @kc89_second_29 -35;
+    pos @kc89_first_37 @kc89_second_42 -70;
+    pos @kc89_first_37 @kc89_second_43 -35;
+    pos @kc89_first_37 @kc89_second_46 -70;
+    pos @kc89_first_37 @kc89_second_48 1;
+    pos @kc89_first_37 @kc89_second_50 -35;
+    pos @kc89_first_37 @kc89_second_51 -70;
+    pos @kc89_first_37 @kc89_second_63 -35;
+    pos @kc89_first_37 @kc89_second_64 -70;
+    pos @kc89_first_37 @kc89_second_65 -70;
+    pos @kc89_first_38 @kc89_second_5 -70;
+    pos @kc89_first_38 @kc89_second_9 -70;
+    pos @kc89_first_38 @kc89_second_12 -140;
+    pos @kc89_first_38 @kc89_second_13 -210;
+    pos @kc89_first_38 @kc89_second_14 -140;
+    pos @kc89_first_38 @kc89_second_15 -105;
+    pos @kc89_first_38 @kc89_second_16 -70;
+    pos @kc89_first_38 @kc89_second_28 -70;
+    pos @kc89_first_38 @kc89_second_29 -70;
+    pos @kc89_first_38 @kc89_second_38 -50;
+    pos @kc89_first_38 @kc89_second_42 -50;
+    pos @kc89_first_38 @kc89_second_43 -35;
+    pos @kc89_first_38 @kc89_second_48 1;
+    pos @kc89_first_38 @kc89_second_50 -35;
+    pos @kc89_first_38 @kc89_second_51 -140;
+    pos @kc89_first_38 @kc89_second_60 -35;
+    pos @kc89_first_38 @kc89_second_64 -70;
+    pos @kc89_first_38 @kc89_second_65 -35;
+    pos @kc89_first_39 @kc89_second_1 -210;
+    pos @kc89_first_39 @kc89_second_2 -280;
+    pos @kc89_first_39 @kc89_second_6 -280;
+    pos @kc89_first_39 @kc89_second_8 -70;
+    pos @kc89_first_39 @kc89_second_17 -140;
+    pos @kc89_first_39 @kc89_second_18 -140;
+    pos @kc89_first_39 @kc89_second_19 -245;
+    pos @kc89_first_39 @kc89_second_21 -350;
+    pos @kc89_first_39 @kc89_second_22 -140;
+    pos @kc89_first_39 @kc89_second_24 -140;
+    pos @kc89_first_39 @kc89_second_25 -70;
+    pos @kc89_first_39 @kc89_second_26 -280;
+    pos @kc89_first_39 @kc89_second_30 -315;
+    pos @kc89_first_39 @kc89_second_31 -140;
+    pos @kc89_first_39 @kc89_second_34 -385;
+    pos @kc89_first_39 @kc89_second_35 -140;
+    pos @kc89_first_39 @kc89_second_37 -210;
+    pos @kc89_first_39 @kc89_second_38 -70;
+    pos @kc89_first_39 @kc89_second_39 -140;
+    pos @kc89_first_39 @kc89_second_40 -140;
+    pos @kc89_first_39 @kc89_second_41 -140;
+    pos @kc89_first_39 @kc89_second_42 -70;
+    pos @kc89_first_39 @kc89_second_44 -70;
+    pos @kc89_first_39 @kc89_second_48 1;
+    pos @kc89_first_39 @kc89_second_54 -140;
+    pos @kc89_first_39 @kc89_second_55 -70;
+    pos @kc89_first_39 @kc89_second_56 -140;
+    pos @kc89_first_39 @kc89_second_58 -245;
+    pos @kc89_first_39 @kc89_second_59 -210;
+    pos @kc89_first_39 @kc89_second_60 -70;
+    pos @kc89_first_39 @kc89_second_61 -70;
+    pos @kc89_first_39 @kc89_second_62 -70;
+    pos @kc89_first_39 @kc89_second_63 -70;
+    pos @kc89_first_39 @kc89_second_66 -245;
+    pos @kc89_first_39 @kc89_second_67 -280;
+    pos @kc89_first_39 @kc89_second_68 -315;
+    pos @kc89_first_40 @kc89_second_6 -35;
+    pos @kc89_first_40 @kc89_second_12 -240;
+    pos @kc89_first_40 @kc89_second_13 -140;
+    pos @kc89_first_40 @kc89_second_14 -35;
+    pos @kc89_first_40 @kc89_second_15 -35;
+    pos @kc89_first_40 @kc89_second_36 100;
+    pos @kc89_first_40 @kc89_second_37 -35;
+    pos @kc89_first_40 @kc89_second_48 1;
+    pos @kc89_first_40 @kc89_second_53 100;
+    pos @kc89_first_40 @kc89_second_66 -35;
+    pos @kc89_first_40 @kc89_second_67 -35;
+    pos @kc89_first_41 @kc89_second_12 -210;
+    pos @kc89_first_41 @kc89_second_13 -175;
+    pos @kc89_first_41 @kc89_second_14 -105;
+    pos @kc89_first_41 @kc89_second_15 -70;
+    pos @kc89_first_41 @kc89_second_46 -70;
+    pos @kc89_first_41 @kc89_second_48 1;
+    pos @kc89_first_41 @kc89_second_51 -105;
+    pos @kc89_first_41 @kc89_second_64 -70;
+    pos @kc89_first_42 @kc89_second_1 -140;
+    pos @kc89_first_42 @kc89_second_2 -175;
+    pos @kc89_first_42 @kc89_second_5 -105;
+    pos @kc89_first_42 @kc89_second_6 -70;
+    pos @kc89_first_42 @kc89_second_11 -70;
+    pos @kc89_first_42 @kc89_second_12 -175;
+    pos @kc89_first_42 @kc89_second_13 -105;
+    pos @kc89_first_42 @kc89_second_14 -70;
+    pos @kc89_first_42 @kc89_second_15 -35;
+    pos @kc89_first_42 @kc89_second_16 -105;
+    pos @kc89_first_42 @kc89_second_17 -35;
+    pos @kc89_first_42 @kc89_second_18 -50;
+    pos @kc89_first_42 @kc89_second_19 -140;
+    pos @kc89_first_42 @kc89_second_21 -175;
+    pos @kc89_first_42 @kc89_second_24 -50;
+    pos @kc89_first_42 @kc89_second_26 -105;
+    pos @kc89_first_42 @kc89_second_31 -35;
+    pos @kc89_first_42 @kc89_second_34 -70;
+    pos @kc89_first_42 @kc89_second_35 -50;
+    pos @kc89_first_42 @kc89_second_37 -70;
+    pos @kc89_first_42 @kc89_second_38 -140;
+    pos @kc89_first_42 @kc89_second_39 -35;
+    pos @kc89_first_42 @kc89_second_41 -50;
+    pos @kc89_first_42 @kc89_second_48 1;
+    pos @kc89_first_42 @kc89_second_54 -35;
+    pos @kc89_first_42 @kc89_second_56 -105;
+    pos @kc89_first_42 @kc89_second_58 -105;
+    pos @kc89_first_42 @kc89_second_59 -105;
+    pos @kc89_first_42 @kc89_second_66 -50;
+    pos @kc89_first_42 @kc89_second_67 -70;
+    pos @kc89_first_43 @kc89_second_1 -210;
+    pos @kc89_first_43 @kc89_second_2 -280;
+    pos @kc89_first_43 @kc89_second_3 -70;
+    pos @kc89_first_43 @kc89_second_6 -280;
+    pos @kc89_first_43 @kc89_second_8 -35;
+    pos @kc89_first_43 @kc89_second_11 -70;
+    pos @kc89_first_43 @kc89_second_13 -140;
+    pos @kc89_first_43 @kc89_second_14 -35;
+    pos @kc89_first_43 @kc89_second_15 -35;
+    pos @kc89_first_43 @kc89_second_16 -140;
+    pos @kc89_first_43 @kc89_second_17 -105;
+    pos @kc89_first_43 @kc89_second_18 -140;
+    pos @kc89_first_43 @kc89_second_19 -210;
+    pos @kc89_first_43 @kc89_second_21 -280;
+    pos @kc89_first_43 @kc89_second_22 -140;
+    pos @kc89_first_43 @kc89_second_24 -140;
+    pos @kc89_first_43 @kc89_second_25 -140;
+    pos @kc89_first_43 @kc89_second_26 -210;
+    pos @kc89_first_43 @kc89_second_34 -140;
+    pos @kc89_first_43 @kc89_second_35 -140;
+    pos @kc89_first_43 @kc89_second_37 -280;
+    pos @kc89_first_43 @kc89_second_38 -140;
+    pos @kc89_first_43 @kc89_second_39 -70;
+    pos @kc89_first_43 @kc89_second_40 -140;
+    pos @kc89_first_43 @kc89_second_41 -175;
+    pos @kc89_first_43 @kc89_second_47 -70;
+    pos @kc89_first_43 @kc89_second_48 1;
+    pos @kc89_first_43 @kc89_second_56 -210;
+    pos @kc89_first_43 @kc89_second_58 -210;
+    pos @kc89_first_43 @kc89_second_59 -175;
+    pos @kc89_first_43 @kc89_second_62 -70;
+    pos @kc89_first_43 @kc89_second_66 -175;
+    pos @kc89_first_43 @kc89_second_67 -175;
+    pos @kc89_first_44 @kc89_second_9 -70;
+    pos @kc89_first_44 @kc89_second_12 -240;
+    pos @kc89_first_44 @kc89_second_13 -210;
+    pos @kc89_first_44 @kc89_second_14 -140;
+    pos @kc89_first_44 @kc89_second_15 -105;
+    pos @kc89_first_44 @kc89_second_42 -70;
+    pos @kc89_first_44 @kc89_second_43 -35;
+    pos @kc89_first_44 @kc89_second_46 -140;
+    pos @kc89_first_44 @kc89_second_48 1;
+    pos @kc89_first_44 @kc89_second_50 -50;
+    pos @kc89_first_44 @kc89_second_51 -140;
+    pos @kc89_first_44 @kc89_second_61 -35;
+    pos @kc89_first_44 @kc89_second_63 -35;
+    pos @kc89_first_44 @kc89_second_64 -70;
+    pos @kc89_first_44 @kc89_second_65 -70;
+    pos @kc89_first_45 @kc89_second_8 -35;
+    pos @kc89_first_45 @kc89_second_9 -70;
+    pos @kc89_first_45 @kc89_second_12 -240;
+    pos @kc89_first_45 @kc89_second_13 -210;
+    pos @kc89_first_45 @kc89_second_14 -70;
+    pos @kc89_first_45 @kc89_second_15 -105;
+    pos @kc89_first_45 @kc89_second_18 -35;
+    pos @kc89_first_45 @kc89_second_24 -35;
+    pos @kc89_first_45 @kc89_second_41 -70;
+    pos @kc89_first_45 @kc89_second_42 -105;
+    pos @kc89_first_45 @kc89_second_43 -70;
+    pos @kc89_first_45 @kc89_second_46 -70;
+    pos @kc89_first_45 @kc89_second_47 -35;
+    pos @kc89_first_45 @kc89_second_48 1;
+    pos @kc89_first_45 @kc89_second_50 -70;
+    pos @kc89_first_45 @kc89_second_51 -70;
+    pos @kc89_first_45 @kc89_second_61 -70;
+    pos @kc89_first_45 @kc89_second_63 -50;
+    pos @kc89_first_45 @kc89_second_65 -70;
+    pos @kc89_first_45 @kc89_second_66 -35;
+    pos @kc89_first_45 @kc89_second_67 -35;
+    pos @kc89_first_46 @kc89_second_6 -70;
+    pos @kc89_first_46 @kc89_second_8 -35;
+    pos @kc89_first_46 @kc89_second_12 -175;
+    pos @kc89_first_46 @kc89_second_13 -140;
+    pos @kc89_first_46 @kc89_second_14 -70;
+    pos @kc89_first_46 @kc89_second_15 -35;
+    pos @kc89_first_46 @kc89_second_17 -70;
+    pos @kc89_first_46 @kc89_second_18 -105;
+    pos @kc89_first_46 @kc89_second_22 -70;
+    pos @kc89_first_46 @kc89_second_24 -105;
+    pos @kc89_first_46 @kc89_second_31 -35;
+    pos @kc89_first_46 @kc89_second_37 -70;
+    pos @kc89_first_46 @kc89_second_39 -35;
+    pos @kc89_first_46 @kc89_second_41 -105;
+    pos @kc89_first_46 @kc89_second_48 1;
+    pos @kc89_first_46 @kc89_second_54 -35;
+    pos @kc89_first_46 @kc89_second_66 -70;
+    pos @kc89_first_46 @kc89_second_67 -70;
+    pos @kc89_first_47 @kc89_second_3 -140;
+    pos @kc89_first_47 @kc89_second_4 -70;
+    pos @kc89_first_47 @kc89_second_6 -70;
+    pos @kc89_first_47 @kc89_second_8 -210;
+    pos @kc89_first_47 @kc89_second_9 -420;
+    pos @kc89_first_47 @kc89_second_12 -350;
+    pos @kc89_first_47 @kc89_second_13 -420;
+    pos @kc89_first_47 @kc89_second_14 -350;
+    pos @kc89_first_47 @kc89_second_15 -280;
+    pos @kc89_first_47 @kc89_second_17 -70;
+    pos @kc89_first_47 @kc89_second_18 -70;
+    pos @kc89_first_47 @kc89_second_20 -210;
+    pos @kc89_first_47 @kc89_second_22 -210;
+    pos @kc89_first_47 @kc89_second_24 -70;
+    pos @kc89_first_47 @kc89_second_25 -140;
+    pos @kc89_first_47 @kc89_second_31 -35;
+    pos @kc89_first_47 @kc89_second_33 -140;
+    pos @kc89_first_47 @kc89_second_37 -70;
+    pos @kc89_first_47 @kc89_second_39 -70;
+    pos @kc89_first_47 @kc89_second_41 -210;
+    pos @kc89_first_47 @kc89_second_42 -280;
+    pos @kc89_first_47 @kc89_second_43 -420;
+    pos @kc89_first_47 @kc89_second_46 -350;
+    pos @kc89_first_47 @kc89_second_48 1;
+    pos @kc89_first_47 @kc89_second_49 -35;
+    pos @kc89_first_47 @kc89_second_50 -210;
+    pos @kc89_first_47 @kc89_second_51 -350;
+    pos @kc89_first_47 @kc89_second_54 -35;
+    pos @kc89_first_47 @kc89_second_55 -35;
+    pos @kc89_first_47 @kc89_second_61 -280;
+    pos @kc89_first_47 @kc89_second_63 -175;
+    pos @kc89_first_47 @kc89_second_64 -280;
+    pos @kc89_first_47 @kc89_second_65 -210;
+    pos @kc89_first_47 @kc89_second_66 -70;
+    pos @kc89_first_48 @kc89_second_3 -140;
+    pos @kc89_first_48 @kc89_second_4 -105;
+    pos @kc89_first_48 @kc89_second_6 -70;
+    pos @kc89_first_48 @kc89_second_8 -210;
+    pos @kc89_first_48 @kc89_second_9 -280;
+    pos @kc89_first_48 @kc89_second_12 -350;
+    pos @kc89_first_48 @kc89_second_13 -385;
+    pos @kc89_first_48 @kc89_second_14 -350;
+    pos @kc89_first_48 @kc89_second_15 -280;
+    pos @kc89_first_48 @kc89_second_18 -105;
+    pos @kc89_first_48 @kc89_second_20 -210;
+    pos @kc89_first_48 @kc89_second_22 -140;
+    pos @kc89_first_48 @kc89_second_24 -105;
+    pos @kc89_first_48 @kc89_second_25 -140;
+    pos @kc89_first_48 @kc89_second_31 -70;
+    pos @kc89_first_48 @kc89_second_33 -175;
+    pos @kc89_first_48 @kc89_second_37 -70;
+    pos @kc89_first_48 @kc89_second_39 -35;
+    pos @kc89_first_48 @kc89_second_41 -175;
+    pos @kc89_first_48 @kc89_second_42 -280;
+    pos @kc89_first_48 @kc89_second_43 -280;
+    pos @kc89_first_48 @kc89_second_46 -280;
+    pos @kc89_first_48 @kc89_second_47 -140;
+    pos @kc89_first_48 @kc89_second_48 1;
+    pos @kc89_first_48 @kc89_second_49 -70;
+    pos @kc89_first_48 @kc89_second_50 -280;
+    pos @kc89_first_48 @kc89_second_51 -350;
+    pos @kc89_first_48 @kc89_second_54 -35;
+    pos @kc89_first_48 @kc89_second_55 -70;
+    pos @kc89_first_48 @kc89_second_61 -245;
+    pos @kc89_first_48 @kc89_second_63 -245;
+    pos @kc89_first_48 @kc89_second_64 -280;
+    pos @kc89_first_48 @kc89_second_65 -210;
+    pos @kc89_first_48 @kc89_second_66 -70;
+    pos @kc89_first_48 @kc89_second_67 -70;
+    pos @kc89_first_49 @kc89_second_3 -70;
+    pos @kc89_first_49 @kc89_second_4 -105;
+    pos @kc89_first_49 @kc89_second_6 -210;
+    pos @kc89_first_49 @kc89_second_7 -70;
+    pos @kc89_first_49 @kc89_second_8 -175;
+    pos @kc89_first_49 @kc89_second_17 -210;
+    pos @kc89_first_49 @kc89_second_18 -210;
+    pos @kc89_first_49 @kc89_second_22 -140;
+    pos @kc89_first_49 @kc89_second_23 -210;
+    pos @kc89_first_49 @kc89_second_24 -210;
+    pos @kc89_first_49 @kc89_second_25 -210;
+    pos @kc89_first_49 @kc89_second_26 -140;
+    pos @kc89_first_49 @kc89_second_27 -140;
+    pos @kc89_first_49 @kc89_second_29 -140;
+    pos @kc89_first_49 @kc89_second_31 -210;
+    pos @kc89_first_49 @kc89_second_32 -210;
+    pos @kc89_first_49 @kc89_second_33 -140;
+    pos @kc89_first_49 @kc89_second_35 -210;
+    pos @kc89_first_49 @kc89_second_37 -210;
+    pos @kc89_first_49 @kc89_second_38 -70;
+    pos @kc89_first_49 @kc89_second_39 -175;
+    pos @kc89_first_49 @kc89_second_40 -210;
+    pos @kc89_first_49 @kc89_second_41 -175;
+    pos @kc89_first_49 @kc89_second_42 -210;
+    pos @kc89_first_49 @kc89_second_43 -105;
+    pos @kc89_first_49 @kc89_second_46 -70;
+    pos @kc89_first_49 @kc89_second_47 -105;
+    pos @kc89_first_49 @kc89_second_48 1;
+    pos @kc89_first_49 @kc89_second_49 -35;
+    pos @kc89_first_49 @kc89_second_50 -210;
+    pos @kc89_first_49 @kc89_second_53 -210;
+    pos @kc89_first_49 @kc89_second_54 -210;
+    pos @kc89_first_49 @kc89_second_55 -175;
+    pos @kc89_first_49 @kc89_second_56 -175;
+    pos @kc89_first_49 @kc89_second_58 -210;
+    pos @kc89_first_49 @kc89_second_59 -210;
+    pos @kc89_first_49 @kc89_second_60 -140;
+    pos @kc89_first_49 @kc89_second_61 -210;
+    pos @kc89_first_49 @kc89_second_62 -175;
+    pos @kc89_first_49 @kc89_second_63 -175;
+    pos @kc89_first_49 @kc89_second_66 -210;
+    pos @kc89_first_49 @kc89_second_67 -210;
+    pos @kc89_first_50 @kc89_second_5 -70;
+    pos @kc89_first_50 @kc89_second_11 -35;
+    pos @kc89_first_50 @kc89_second_12 -240;
+    pos @kc89_first_50 @kc89_second_13 -70;
+    pos @kc89_first_50 @kc89_second_14 -140;
+    pos @kc89_first_50 @kc89_second_15 -105;
+    pos @kc89_first_50 @kc89_second_16 -70;
+    pos @kc89_first_50 @kc89_second_28 -70;
+    pos @kc89_first_50 @kc89_second_29 -70;
+    pos @kc89_first_50 @kc89_second_38 -35;
+    pos @kc89_first_50 @kc89_second_42 -70;
+    pos @kc89_first_50 @kc89_second_45 -35;
+    pos @kc89_first_50 @kc89_second_46 -70;
+    pos @kc89_first_50 @kc89_second_48 1;
+    pos @kc89_first_50 @kc89_second_50 -35;
+    pos @kc89_first_50 @kc89_second_51 -140;
+    pos @kc89_first_50 @kc89_second_54 1;
+    pos @kc89_first_50 @kc89_second_60 -35;
+    pos @kc89_first_50 @kc89_second_63 -35;
+    pos @kc89_first_50 @kc89_second_64 -105;
+    pos @kc89_first_50 @kc89_second_65 -70;
+    pos @kc89_first_51 @kc89_second_68 -210;
+    pos @kc89_first_52 @kc89_second_34 -315;
+    pos @kc89_first_52 @kc89_second_69 -210;
+    pos @kc89_first_53 @kc89_second_1 -105;
+    pos @kc89_first_53 @kc89_second_2 -210;
+    pos @kc89_first_53 @kc89_second_6 -140;
+    pos @kc89_first_53 @kc89_second_11 -70;
+    pos @kc89_first_53 @kc89_second_12 -210;
+    pos @kc89_first_53 @kc89_second_13 -210;
+    pos @kc89_first_53 @kc89_second_14 -105;
+    pos @kc89_first_53 @kc89_second_15 -70;
+    pos @kc89_first_53 @kc89_second_16 -140;
+    pos @kc89_first_53 @kc89_second_17 -35;
+    pos @kc89_first_53 @kc89_second_18 -35;
+    pos @kc89_first_53 @kc89_second_19 -105;
+    pos @kc89_first_53 @kc89_second_24 -35;
+    pos @kc89_first_53 @kc89_second_26 -210;
+    pos @kc89_first_53 @kc89_second_28 -70;
+    pos @kc89_first_53 @kc89_second_29 -70;
+    pos @kc89_first_53 @kc89_second_31 -35;
+    pos @kc89_first_53 @kc89_second_35 -70;
+    pos @kc89_first_53 @kc89_second_37 -210;
+    pos @kc89_first_53 @kc89_second_38 -140;
+    pos @kc89_first_53 @kc89_second_45 -35;
+    pos @kc89_first_53 @kc89_second_46 -70;
+    pos @kc89_first_53 @kc89_second_48 1;
+    pos @kc89_first_53 @kc89_second_50 -35;
+    pos @kc89_first_53 @kc89_second_51 -105;
+    pos @kc89_first_53 @kc89_second_56 -210;
+    pos @kc89_first_53 @kc89_second_58 -175;
+    pos @kc89_first_53 @kc89_second_59 -140;
+    pos @kc89_first_53 @kc89_second_64 -35;
+    pos @kc89_first_53 @kc89_second_65 -35;
+    pos @kc89_first_53 @kc89_second_66 -35;
+    pos @kc89_first_53 @kc89_second_67 -70;
+    pos @kc89_first_54 @kc89_second_1 -35;
+    pos @kc89_first_54 @kc89_second_2 -70;
+    pos @kc89_first_54 @kc89_second_5 -105;
+    pos @kc89_first_54 @kc89_second_6 -35;
+    pos @kc89_first_54 @kc89_second_9 -70;
+    pos @kc89_first_54 @kc89_second_11 -70;
+    pos @kc89_first_54 @kc89_second_12 -240;
+    pos @kc89_first_54 @kc89_second_13 -245;
+    pos @kc89_first_54 @kc89_second_14 -140;
+    pos @kc89_first_54 @kc89_second_15 -105;
+    pos @kc89_first_54 @kc89_second_16 -105;
+    pos @kc89_first_54 @kc89_second_19 -35;
+    pos @kc89_first_54 @kc89_second_20 -70;
+    pos @kc89_first_54 @kc89_second_21 -70;
+    pos @kc89_first_54 @kc89_second_26 -35;
+    pos @kc89_first_54 @kc89_second_27 -70;
+    pos @kc89_first_54 @kc89_second_28 -140;
+    pos @kc89_first_54 @kc89_second_29 -105;
+    pos @kc89_first_54 @kc89_second_35 -35;
+    pos @kc89_first_54 @kc89_second_37 -35;
+    pos @kc89_first_54 @kc89_second_38 -140;
+    pos @kc89_first_54 @kc89_second_42 -105;
+    pos @kc89_first_54 @kc89_second_43 -70;
+    pos @kc89_first_54 @kc89_second_45 -105;
+    pos @kc89_first_54 @kc89_second_46 -175;
+    pos @kc89_first_54 @kc89_second_48 1;
+    pos @kc89_first_54 @kc89_second_50 -70;
+    pos @kc89_first_54 @kc89_second_51 -140;
+    pos @kc89_first_54 @kc89_second_52 -70;
+    pos @kc89_first_54 @kc89_second_56 -210;
+    pos @kc89_first_54 @kc89_second_57 -70;
+    pos @kc89_first_54 @kc89_second_58 -175;
+    pos @kc89_first_54 @kc89_second_59 -175;
+    pos @kc89_first_54 @kc89_second_60 -105;
+    pos @kc89_first_54 @kc89_second_63 -50;
+    pos @kc89_first_54 @kc89_second_64 -105;
+    pos @kc89_first_54 @kc89_second_65 -70;
+    pos @kc89_first_54 @kc89_second_67 -35;
+    pos @kc89_first_55 @kc89_second_1 -105;
+    pos @kc89_first_55 @kc89_second_2 -210;
+    pos @kc89_first_55 @kc89_second_5 -70;
+    pos @kc89_first_55 @kc89_second_6 -105;
+    pos @kc89_first_55 @kc89_second_13 -70;
+    pos @kc89_first_55 @kc89_second_14 -35;
+    pos @kc89_first_55 @kc89_second_16 -140;
+    pos @kc89_first_55 @kc89_second_17 -70;
+    pos @kc89_first_55 @kc89_second_18 -35;
+    pos @kc89_first_55 @kc89_second_19 -105;
+    pos @kc89_first_55 @kc89_second_21 -210;
+    pos @kc89_first_55 @kc89_second_24 -35;
+    pos @kc89_first_55 @kc89_second_26 -210;
+    pos @kc89_first_55 @kc89_second_31 -35;
+    pos @kc89_first_55 @kc89_second_34 -105;
+    pos @kc89_first_55 @kc89_second_35 -35;
+    pos @kc89_first_55 @kc89_second_37 -105;
+    pos @kc89_first_55 @kc89_second_38 -140;
+    pos @kc89_first_55 @kc89_second_41 -70;
+    pos @kc89_first_55 @kc89_second_48 1;
+    pos @kc89_first_55 @kc89_second_54 -35;
+    pos @kc89_first_55 @kc89_second_56 -245;
+    pos @kc89_first_55 @kc89_second_58 -210;
+    pos @kc89_first_55 @kc89_second_59 -210;
+    pos @kc89_first_55 @kc89_second_66 -70;
+    pos @kc89_first_55 @kc89_second_67 -105;
+    pos @kc89_first_56 @kc89_second_12 -240;
+    pos @kc89_first_56 @kc89_second_13 -140;
+    pos @kc89_first_56 @kc89_second_14 -105;
+    pos @kc89_first_56 @kc89_second_15 -35;
+    pos @kc89_first_56 @kc89_second_36 100;
+    pos @kc89_first_56 @kc89_second_48 1;
+    pos @kc89_first_56 @kc89_second_53 100;
+    pos @kc89_first_57 @kc89_second_1 -140;
+    pos @kc89_first_57 @kc89_second_2 -210;
+    pos @kc89_first_57 @kc89_second_6 -140;
+    pos @kc89_first_57 @kc89_second_12 -175;
+    pos @kc89_first_57 @kc89_second_13 -140;
+    pos @kc89_first_57 @kc89_second_16 -140;
+    pos @kc89_first_57 @kc89_second_19 -140;
+    pos @kc89_first_57 @kc89_second_21 -210;
+    pos @kc89_first_57 @kc89_second_26 -210;
+    pos @kc89_first_57 @kc89_second_34 -140;
+    pos @kc89_first_57 @kc89_second_35 -50;
+    pos @kc89_first_57 @kc89_second_37 -140;
+    pos @kc89_first_57 @kc89_second_38 -210;
+    pos @kc89_first_57 @kc89_second_39 -35;
+    pos @kc89_first_57 @kc89_second_48 1;
+    pos @kc89_first_57 @kc89_second_56 -210;
+    pos @kc89_first_57 @kc89_second_58 -175;
+    pos @kc89_first_57 @kc89_second_59 -175;
+    pos @kc89_first_57 @kc89_second_66 -105;
+    pos @kc89_first_57 @kc89_second_67 -210;
+    pos @kc89_first_58 @kc89_second_12 -240;
+    pos @kc89_first_58 @kc89_second_13 -175;
+    pos @kc89_first_58 @kc89_second_14 -70;
+    pos @kc89_first_58 @kc89_second_15 -35;
+    pos @kc89_first_58 @kc89_second_21 -35;
+    pos @kc89_first_58 @kc89_second_28 -35;
+    pos @kc89_first_58 @kc89_second_42 -35;
+    pos @kc89_first_58 @kc89_second_43 -35;
+    pos @kc89_first_58 @kc89_second_46 -70;
+    pos @kc89_first_58 @kc89_second_48 1;
+    pos @kc89_first_58 @kc89_second_50 -35;
+    pos @kc89_first_58 @kc89_second_51 -70;
+    pos @kc89_first_58 @kc89_second_61 -35;
+    pos @kc89_first_58 @kc89_second_63 -35;
+    pos @kc89_first_58 @kc89_second_64 -70;
+    pos @kc89_first_58 @kc89_second_65 -35;
+    pos @kc89_first_59 @kc89_second_13 -35;
+    pos @kc89_first_59 @kc89_second_18 -70;
+    pos @kc89_first_59 @kc89_second_61 -35;
+    pos @kc89_first_59 @kc89_second_67 -35;
+    pos @kc89_first_60 @kc89_second_12 -175;
+    pos @kc89_first_60 @kc89_second_13 -140;
+    pos @kc89_first_60 @kc89_second_14 -35;
+    pos @kc89_first_60 @kc89_second_48 1;
+    pos @kc89_first_61 @kc89_second_1 -140;
+    pos @kc89_first_61 @kc89_second_2 -280;
+    pos @kc89_first_61 @kc89_second_5 -140;
+    pos @kc89_first_61 @kc89_second_6 -280;
+    pos @kc89_first_61 @kc89_second_8 -70;
+    pos @kc89_first_61 @kc89_second_10 -70;
+    pos @kc89_first_61 @kc89_second_11 -175;
+    pos @kc89_first_61 @kc89_second_12 -240;
+    pos @kc89_first_61 @kc89_second_13 -140;
+    pos @kc89_first_61 @kc89_second_14 -105;
+    pos @kc89_first_61 @kc89_second_15 -70;
+    pos @kc89_first_61 @kc89_second_16 -175;
+    pos @kc89_first_61 @kc89_second_17 -70;
+    pos @kc89_first_61 @kc89_second_18 -70;
+    pos @kc89_first_61 @kc89_second_19 -140;
+    pos @kc89_first_61 @kc89_second_21 -280;
+    pos @kc89_first_61 @kc89_second_24 -70;
+    pos @kc89_first_61 @kc89_second_25 -70;
+    pos @kc89_first_61 @kc89_second_26 -210;
+    pos @kc89_first_61 @kc89_second_28 -70;
+    pos @kc89_first_61 @kc89_second_29 -70;
+    pos @kc89_first_61 @kc89_second_31 -70;
+    pos @kc89_first_61 @kc89_second_34 -70;
+    pos @kc89_first_61 @kc89_second_35 -70;
+    pos @kc89_first_61 @kc89_second_37 -315;
+    pos @kc89_first_61 @kc89_second_38 -140;
+    pos @kc89_first_61 @kc89_second_39 -70;
+    pos @kc89_first_61 @kc89_second_41 -105;
+    pos @kc89_first_61 @kc89_second_48 1;
+    pos @kc89_first_61 @kc89_second_51 -35;
+    pos @kc89_first_61 @kc89_second_54 -50;
+    pos @kc89_first_61 @kc89_second_56 -210;
+    pos @kc89_first_61 @kc89_second_58 -210;
+    pos @kc89_first_61 @kc89_second_59 -175;
+    pos @kc89_first_61 @kc89_second_62 -35;
+    pos @kc89_first_61 @kc89_second_64 -70;
+    pos @kc89_first_61 @kc89_second_65 -35;
+    pos @kc89_first_61 @kc89_second_66 -140;
+    pos @kc89_first_61 @kc89_second_67 -210;
+    pos @kc89_first_62 @kc89_second_1 -35;
+    pos @kc89_first_62 @kc89_second_2 -70;
+    pos @kc89_first_62 @kc89_second_5 -70;
+    pos @kc89_first_62 @kc89_second_11 -35;
+    pos @kc89_first_62 @kc89_second_12 -140;
+    pos @kc89_first_62 @kc89_second_13 -140;
+    pos @kc89_first_62 @kc89_second_14 -70;
+    pos @kc89_first_62 @kc89_second_15 -35;
+    pos @kc89_first_62 @kc89_second_16 -105;
+    pos @kc89_first_62 @kc89_second_28 -35;
+    pos @kc89_first_62 @kc89_second_29 -70;
+    pos @kc89_first_62 @kc89_second_35 -35;
+    pos @kc89_first_62 @kc89_second_38 -70;
+    pos @kc89_first_62 @kc89_second_46 -70;
+    pos @kc89_first_62 @kc89_second_48 1;
+    pos @kc89_first_62 @kc89_second_56 -175;
+    pos @kc89_first_62 @kc89_second_58 -140;
+    pos @kc89_first_62 @kc89_second_59 -140;
+    pos @kc89_first_62 @kc89_second_64 -35;
+    pos @kc89_first_63 @kc89_second_5 -70;
+    pos @kc89_first_63 @kc89_second_9 -70;
+    pos @kc89_first_63 @kc89_second_11 -35;
+    pos @kc89_first_63 @kc89_second_12 -350;
+    pos @kc89_first_63 @kc89_second_13 -315;
+    pos @kc89_first_63 @kc89_second_14 -175;
+    pos @kc89_first_63 @kc89_second_15 -140;
+    pos @kc89_first_63 @kc89_second_16 -70;
+    pos @kc89_first_63 @kc89_second_20 -70;
+    pos @kc89_first_63 @kc89_second_29 -70;
+    pos @kc89_first_63 @kc89_second_33 -50;
+    pos @kc89_first_63 @kc89_second_42 -140;
+    pos @kc89_first_63 @kc89_second_43 -50;
+    pos @kc89_first_63 @kc89_second_45 -35;
+    pos @kc89_first_63 @kc89_second_46 -175;
+    pos @kc89_first_63 @kc89_second_48 1;
+    pos @kc89_first_63 @kc89_second_50 -70;
+    pos @kc89_first_63 @kc89_second_51 -175;
+    pos @kc89_first_63 @kc89_second_57 -70;
+    pos @kc89_first_63 @kc89_second_61 -70;
+    pos @kc89_first_63 @kc89_second_63 -50;
+    pos @kc89_first_63 @kc89_second_64 -140;
+    pos @kc89_first_63 @kc89_second_65 -105;
+    pos @kc89_first_64 @kc89_second_4 -105;
+    pos @kc89_first_64 @kc89_second_6 -35;
+    pos @kc89_first_64 @kc89_second_8 1;
+    pos @kc89_first_64 @kc89_second_9 -245;
+    pos @kc89_first_64 @kc89_second_12 -210;
+    pos @kc89_first_64 @kc89_second_13 -210;
+    pos @kc89_first_64 @kc89_second_14 -210;
+    pos @kc89_first_64 @kc89_second_15 -175;
+    pos @kc89_first_64 @kc89_second_17 -70;
+    pos @kc89_first_64 @kc89_second_18 -105;
+    pos @kc89_first_64 @kc89_second_20 -180;
+    pos @kc89_first_64 @kc89_second_22 -140;
+    pos @kc89_first_64 @kc89_second_24 -105;
+    pos @kc89_first_64 @kc89_second_27 -140;
+    pos @kc89_first_64 @kc89_second_31 -105;
+    pos @kc89_first_64 @kc89_second_33 -140;
+    pos @kc89_first_64 @kc89_second_37 -35;
+    pos @kc89_first_64 @kc89_second_39 -35;
+    pos @kc89_first_64 @kc89_second_41 -175;
+    pos @kc89_first_64 @kc89_second_42 -142;
+    pos @kc89_first_64 @kc89_second_43 -245;
+    pos @kc89_first_64 @kc89_second_46 -210;
+    pos @kc89_first_64 @kc89_second_47 -105;
+    pos @kc89_first_64 @kc89_second_48 1;
+    pos @kc89_first_64 @kc89_second_49 -35;
+    pos @kc89_first_64 @kc89_second_50 -210;
+    pos @kc89_first_64 @kc89_second_51 -210;
+    pos @kc89_first_64 @kc89_second_54 -35;
+    pos @kc89_first_64 @kc89_second_61 -280;
+    pos @kc89_first_64 @kc89_second_63 -175;
+    pos @kc89_first_64 @kc89_second_64 -140;
+    pos @kc89_first_64 @kc89_second_65 -140;
+    pos @kc89_first_64 @kc89_second_66 -70;
+    pos @kc89_first_64 @kc89_second_67 -70;
+    pos @kc89_first_65 @kc89_second_1 -175;
+    pos @kc89_first_65 @kc89_second_2 -175;
+    pos @kc89_first_65 @kc89_second_5 -70;
+    pos @kc89_first_65 @kc89_second_6 -105;
+    pos @kc89_first_65 @kc89_second_11 -105;
+    pos @kc89_first_65 @kc89_second_12 -175;
+    pos @kc89_first_65 @kc89_second_13 -140;
+    pos @kc89_first_65 @kc89_second_14 -70;
+    pos @kc89_first_65 @kc89_second_15 -35;
+    pos @kc89_first_65 @kc89_second_16 -140;
+    pos @kc89_first_65 @kc89_second_17 -70;
+    pos @kc89_first_65 @kc89_second_18 -70;
+    pos @kc89_first_65 @kc89_second_19 -140;
+    pos @kc89_first_65 @kc89_second_21 -175;
+    pos @kc89_first_65 @kc89_second_24 -70;
+    pos @kc89_first_65 @kc89_second_31 -35;
+    pos @kc89_first_65 @kc89_second_35 -70;
+    pos @kc89_first_65 @kc89_second_37 -105;
+    pos @kc89_first_65 @kc89_second_38 -175;
+    pos @kc89_first_65 @kc89_second_39 -35;
+    pos @kc89_first_65 @kc89_second_41 -70;
+    pos @kc89_first_65 @kc89_second_48 1;
+    pos @kc89_first_65 @kc89_second_54 -35;
+    pos @kc89_first_65 @kc89_second_56 -140;
+    pos @kc89_first_65 @kc89_second_58 -140;
+    pos @kc89_first_65 @kc89_second_59 -140;
+    pos @kc89_first_65 @kc89_second_66 -70;
+    pos @kc89_first_65 @kc89_second_67 -105;
+    pos @kc89_first_66 @kc89_second_1 -210;
+    pos @kc89_first_66 @kc89_second_2 -210;
+    pos @kc89_first_66 @kc89_second_3 -70;
+    pos @kc89_first_66 @kc89_second_4 -35;
+    pos @kc89_first_66 @kc89_second_6 -210;
+    pos @kc89_first_66 @kc89_second_7 -70;
+    pos @kc89_first_66 @kc89_second_8 -70;
+    pos @kc89_first_66 @kc89_second_16 -70;
+    pos @kc89_first_66 @kc89_second_17 -140;
+    pos @kc89_first_66 @kc89_second_18 -175;
+    pos @kc89_first_66 @kc89_second_19 -210;
+    pos @kc89_first_66 @kc89_second_21 -210;
+    pos @kc89_first_66 @kc89_second_22 -140;
+    pos @kc89_first_66 @kc89_second_23 -35;
+    pos @kc89_first_66 @kc89_second_24 -175;
+    pos @kc89_first_66 @kc89_second_25 -140;
+    pos @kc89_first_66 @kc89_second_26 -280;
+    pos @kc89_first_66 @kc89_second_31 -35;
+    pos @kc89_first_66 @kc89_second_32 -35;
+    pos @kc89_first_66 @kc89_second_34 -210;
+    pos @kc89_first_66 @kc89_second_35 -175;
+    pos @kc89_first_66 @kc89_second_37 -245;
+    pos @kc89_first_66 @kc89_second_38 -140;
+    pos @kc89_first_66 @kc89_second_39 -140;
+    pos @kc89_first_66 @kc89_second_40 -140;
+    pos @kc89_first_66 @kc89_second_41 -140;
+    pos @kc89_first_66 @kc89_second_42 -35;
+    pos @kc89_first_66 @kc89_second_47 -35;
+    pos @kc89_first_66 @kc89_second_48 1;
+    pos @kc89_first_66 @kc89_second_52 -35;
+    pos @kc89_first_66 @kc89_second_54 -140;
+    pos @kc89_first_66 @kc89_second_55 -70;
+    pos @kc89_first_66 @kc89_second_56 -210;
+    pos @kc89_first_66 @kc89_second_58 -210;
+    pos @kc89_first_66 @kc89_second_59 -210;
+    pos @kc89_first_66 @kc89_second_61 -35;
+    pos @kc89_first_66 @kc89_second_66 -175;
+    pos @kc89_first_66 @kc89_second_67 -245;
+    pos @kc89_first_67 @kc89_second_6 -35;
+    pos @kc89_first_67 @kc89_second_12 -240;
+    pos @kc89_first_67 @kc89_second_13 -140;
+    pos @kc89_first_67 @kc89_second_14 -70;
+    pos @kc89_first_67 @kc89_second_15 -35;
+    pos @kc89_first_67 @kc89_second_18 -35;
+    pos @kc89_first_67 @kc89_second_22 -35;
+    pos @kc89_first_67 @kc89_second_24 -35;
+    pos @kc89_first_67 @kc89_second_37 -70;
+    pos @kc89_first_67 @kc89_second_41 -70;
+    pos @kc89_first_67 @kc89_second_42 -50;
+    pos @kc89_first_67 @kc89_second_48 1;
+    pos @kc89_first_67 @kc89_second_51 -35;
+    pos @kc89_first_67 @kc89_second_66 -35;
+    pos @kc89_first_67 @kc89_second_67 -35;
+    pos @kc89_first_68 @kc89_second_3 -100;
+    pos @kc89_first_68 @kc89_second_4 -50;
+    pos @kc89_first_68 @kc89_second_6 -50;
+    pos @kc89_first_68 @kc89_second_8 -70;
+    pos @kc89_first_68 @kc89_second_9 -140;
+    pos @kc89_first_68 @kc89_second_10 -50;
+    pos @kc89_first_68 @kc89_second_12 -140;
+    pos @kc89_first_68 @kc89_second_13 -100;
+    pos @kc89_first_68 @kc89_second_14 -70;
+    pos @kc89_first_68 @kc89_second_15 -50;
+    pos @kc89_first_68 @kc89_second_18 -50;
+    pos @kc89_first_68 @kc89_second_20 -70;
+    pos @kc89_first_68 @kc89_second_22 -70;
+    pos @kc89_first_68 @kc89_second_24 -50;
+    pos @kc89_first_68 @kc89_second_25 -70;
+    pos @kc89_first_68 @kc89_second_31 -35;
+    pos @kc89_first_68 @kc89_second_33 -70;
+    pos @kc89_first_68 @kc89_second_36 105;
+    pos @kc89_first_68 @kc89_second_37 -35;
+    pos @kc89_first_68 @kc89_second_41 -70;
+    pos @kc89_first_68 @kc89_second_42 -140;
+    pos @kc89_first_68 @kc89_second_43 -140;
+    pos @kc89_first_68 @kc89_second_46 -140;
+    pos @kc89_first_68 @kc89_second_47 -35;
+    pos @kc89_first_68 @kc89_second_48 1;
+    pos @kc89_first_68 @kc89_second_50 -70;
+    pos @kc89_first_68 @kc89_second_51 -100;
+    pos @kc89_first_68 @kc89_second_53 105;
+    pos @kc89_first_68 @kc89_second_61 -140;
+    pos @kc89_first_68 @kc89_second_63 -70;
+    pos @kc89_first_68 @kc89_second_64 -70;
+    pos @kc89_first_68 @kc89_second_65 -50;
+    pos @kc89_first_68 @kc89_second_66 -35;
+    pos @kc89_first_68 @kc89_second_67 -35;
+    pos @kc89_first_69 @kc89_second_3 -70;
+    pos @kc89_first_69 @kc89_second_4 -50;
+    pos @kc89_first_69 @kc89_second_6 -50;
+    pos @kc89_first_69 @kc89_second_8 -70;
+    pos @kc89_first_69 @kc89_second_9 -140;
+    pos @kc89_first_69 @kc89_second_10 -50;
+    pos @kc89_first_69 @kc89_second_12 -240;
+    pos @kc89_first_69 @kc89_second_13 -240;
+    pos @kc89_first_69 @kc89_second_14 -175;
+    pos @kc89_first_69 @kc89_second_15 -140;
+    pos @kc89_first_69 @kc89_second_18 -50;
+    pos @kc89_first_69 @kc89_second_20 -70;
+    pos @kc89_first_69 @kc89_second_22 -70;
+    pos @kc89_first_69 @kc89_second_24 -50;
+    pos @kc89_first_69 @kc89_second_25 -70;
+    pos @kc89_first_69 @kc89_second_31 -35;
+    pos @kc89_first_69 @kc89_second_33 -70;
+    pos @kc89_first_69 @kc89_second_36 105;
+    pos @kc89_first_69 @kc89_second_37 -35;
+    pos @kc89_first_69 @kc89_second_41 -70;
+    pos @kc89_first_69 @kc89_second_42 -140;
+    pos @kc89_first_69 @kc89_second_43 -140;
+    pos @kc89_first_69 @kc89_second_46 -140;
+    pos @kc89_first_69 @kc89_second_47 -35;
+    pos @kc89_first_69 @kc89_second_48 1;
+    pos @kc89_first_69 @kc89_second_50 -70;
+    pos @kc89_first_69 @kc89_second_51 -140;
+    pos @kc89_first_69 @kc89_second_53 105;
+    pos @kc89_first_69 @kc89_second_61 -140;
+    pos @kc89_first_69 @kc89_second_63 -70;
+    pos @kc89_first_69 @kc89_second_64 -105;
+    pos @kc89_first_69 @kc89_second_65 -70;
+    pos @kc89_first_69 @kc89_second_66 -35;
+    pos @kc89_first_69 @kc89_second_67 -35;
+    pos @kc89_first_70 @kc89_second_3 -70;
+    pos @kc89_first_70 @kc89_second_4 -50;
+    pos @kc89_first_70 @kc89_second_6 -50;
+    pos @kc89_first_70 @kc89_second_8 -70;
+    pos @kc89_first_70 @kc89_second_9 -140;
+    pos @kc89_first_70 @kc89_second_10 -50;
+    pos @kc89_first_70 @kc89_second_12 -140;
+    pos @kc89_first_70 @kc89_second_13 -140;
+    pos @kc89_first_70 @kc89_second_14 -105;
+    pos @kc89_first_70 @kc89_second_15 -70;
+    pos @kc89_first_70 @kc89_second_18 -50;
+    pos @kc89_first_70 @kc89_second_20 -70;
+    pos @kc89_first_70 @kc89_second_22 -70;
+    pos @kc89_first_70 @kc89_second_24 -50;
+    pos @kc89_first_70 @kc89_second_25 -100;
+    pos @kc89_first_70 @kc89_second_31 -35;
+    pos @kc89_first_70 @kc89_second_33 -70;
+    pos @kc89_first_70 @kc89_second_36 105;
+    pos @kc89_first_70 @kc89_second_37 -35;
+    pos @kc89_first_70 @kc89_second_41 -70;
+    pos @kc89_first_70 @kc89_second_42 -140;
+    pos @kc89_first_70 @kc89_second_43 -140;
+    pos @kc89_first_70 @kc89_second_46 -140;
+    pos @kc89_first_70 @kc89_second_47 -35;
+    pos @kc89_first_70 @kc89_second_48 1;
+    pos @kc89_first_70 @kc89_second_50 -70;
+    pos @kc89_first_70 @kc89_second_51 -140;
+    pos @kc89_first_70 @kc89_second_53 105;
+    pos @kc89_first_70 @kc89_second_61 -140;
+    pos @kc89_first_70 @kc89_second_63 -70;
+    pos @kc89_first_70 @kc89_second_64 -70;
+    pos @kc89_first_70 @kc89_second_65 -50;
+    pos @kc89_first_70 @kc89_second_66 -35;
+    pos @kc89_first_70 @kc89_second_67 -35;
+    pos @kc89_first_71 @kc89_second_1 -210;
+    pos @kc89_first_71 @kc89_second_2 -210;
+    pos @kc89_first_71 @kc89_second_3 -35;
+    pos @kc89_first_71 @kc89_second_6 -140;
+    pos @kc89_first_71 @kc89_second_8 -70;
+    pos @kc89_first_71 @kc89_second_10 -35;
+    pos @kc89_first_71 @kc89_second_17 -70;
+    pos @kc89_first_71 @kc89_second_18 -105;
+    pos @kc89_first_71 @kc89_second_19 -210;
+    pos @kc89_first_71 @kc89_second_21 -210;
+    pos @kc89_first_71 @kc89_second_22 -70;
+    pos @kc89_first_71 @kc89_second_24 -105;
+    pos @kc89_first_71 @kc89_second_25 -105;
+    pos @kc89_first_71 @kc89_second_26 -175;
+    pos @kc89_first_71 @kc89_second_31 -105;
+    pos @kc89_first_71 @kc89_second_34 -210;
+    pos @kc89_first_71 @kc89_second_35 -105;
+    pos @kc89_first_71 @kc89_second_37 -175;
+    pos @kc89_first_71 @kc89_second_38 -140;
+    pos @kc89_first_71 @kc89_second_39 -70;
+    pos @kc89_first_71 @kc89_second_40 -105;
+    pos @kc89_first_71 @kc89_second_41 -105;
+    pos @kc89_first_71 @kc89_second_42 -70;
+    pos @kc89_first_71 @kc89_second_47 -35;
+    pos @kc89_first_71 @kc89_second_48 1;
+    pos @kc89_first_71 @kc89_second_53 -35;
+    pos @kc89_first_71 @kc89_second_54 -70;
+    pos @kc89_first_71 @kc89_second_55 -70;
+    pos @kc89_first_71 @kc89_second_56 -175;
+    pos @kc89_first_71 @kc89_second_58 -175;
+    pos @kc89_first_71 @kc89_second_59 -175;
+    pos @kc89_first_71 @kc89_second_61 -35;
+    pos @kc89_first_71 @kc89_second_62 -35;
+    pos @kc89_first_71 @kc89_second_66 -140;
+    pos @kc89_first_71 @kc89_second_67 -175;
+    pos @kc89_first_72 @kc89_second_5 -70;
+    pos @kc89_first_72 @kc89_second_8 -70;
+    pos @kc89_first_72 @kc89_second_9 -105;
+    pos @kc89_first_72 @kc89_second_11 -35;
+    pos @kc89_first_72 @kc89_second_12 -350;
+    pos @kc89_first_72 @kc89_second_13 -350;
+    pos @kc89_first_72 @kc89_second_14 -245;
+    pos @kc89_first_72 @kc89_second_15 -210;
+    pos @kc89_first_72 @kc89_second_16 -70;
+    pos @kc89_first_72 @kc89_second_20 -210;
+    pos @kc89_first_72 @kc89_second_25 -35;
+    pos @kc89_first_72 @kc89_second_28 -35;
+    pos @kc89_first_72 @kc89_second_29 -70;
+    pos @kc89_first_72 @kc89_second_33 -70;
+    pos @kc89_first_72 @kc89_second_41 -35;
+    pos @kc89_first_72 @kc89_second_42 -245;
+    pos @kc89_first_72 @kc89_second_43 -70;
+    pos @kc89_first_72 @kc89_second_45 -35;
+    pos @kc89_first_72 @kc89_second_46 -240;
+    pos @kc89_first_72 @kc89_second_48 1;
+    pos @kc89_first_72 @kc89_second_50 -105;
+    pos @kc89_first_72 @kc89_second_51 -280;
+    pos @kc89_first_72 @kc89_second_52 -35;
+    pos @kc89_first_72 @kc89_second_57 -35;
+    pos @kc89_first_72 @kc89_second_60 -70;
+    pos @kc89_first_72 @kc89_second_61 -105;
+    pos @kc89_first_72 @kc89_second_62 -35;
+    pos @kc89_first_72 @kc89_second_63 -70;
+    pos @kc89_first_72 @kc89_second_64 -175;
+    pos @kc89_first_72 @kc89_second_65 -140;
+    pos @kc89_first_73 @kc89_second_1 -140;
+    pos @kc89_first_73 @kc89_second_2 -140;
+    pos @kc89_first_73 @kc89_second_6 -140;
+    pos @kc89_first_73 @kc89_second_8 -35;
+    pos @kc89_first_73 @kc89_second_10 -35;
+    pos @kc89_first_73 @kc89_second_17 -35;
+    pos @kc89_first_73 @kc89_second_18 -70;
+    pos @kc89_first_73 @kc89_second_19 -140;
+    pos @kc89_first_73 @kc89_second_21 -140;
+    pos @kc89_first_73 @kc89_second_22 -35;
+    pos @kc89_first_73 @kc89_second_24 -70;
+    pos @kc89_first_73 @kc89_second_25 -70;
+    pos @kc89_first_73 @kc89_second_26 -140;
+    pos @kc89_first_73 @kc89_second_31 -70;
+    pos @kc89_first_73 @kc89_second_35 -70;
+    pos @kc89_first_73 @kc89_second_37 -175;
+    pos @kc89_first_73 @kc89_second_38 -105;
+    pos @kc89_first_73 @kc89_second_39 -70;
+    pos @kc89_first_73 @kc89_second_40 -70;
+    pos @kc89_first_73 @kc89_second_41 -70;
+    pos @kc89_first_73 @kc89_second_42 -35;
+    pos @kc89_first_73 @kc89_second_48 1;
+    pos @kc89_first_73 @kc89_second_53 -35;
+    pos @kc89_first_73 @kc89_second_54 -35;
+    pos @kc89_first_73 @kc89_second_56 -140;
+    pos @kc89_first_73 @kc89_second_58 -140;
+    pos @kc89_first_73 @kc89_second_59 -140;
+    pos @kc89_first_73 @kc89_second_66 -105;
+    pos @kc89_first_73 @kc89_second_67 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -10828,7 +10863,7 @@ lookup mark_Mark_positioning {
   pos base [\C \uni0421 \uni216D ] <anchor 757 -20> mark @bottom_cedilla
 	<anchor 757 0> mark @bottom_center
 	<anchor 757 1380> mark @top_center;
-  pos base [\G \Q \Oslash \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \uni1FFC \G.cv21 ] <anchor 757 1380> mark @top_center
+  pos base [\G \Q \Oslash \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \uni1FFC \G.cv21 \Q.cv29 ] <anchor 757 1380> mark @top_center
 	<anchor 757 0> mark @bottom_center;
   pos base [\U ] <anchor 672 -10> mark @bottom_cedilla
 	<anchor 787 0> mark @bottom_right
@@ -12810,6 +12845,8 @@ lookup mark_Mark_positioning {
 	<anchor 202 1716> mark @top_center;
   pos base [\uni1E3B.cv28 ] <anchor 202 1380> mark @top_center
 	<anchor 202 -201> mark @bottom_center;
+  pos base [\q.sc.cv29 ] <anchor 664 0> mark @bottom_center
+	<anchor 664 1200> mark @top_center;
   pos base [\dotlessuni0268 ] <anchor 268 -20> mark @bottom_cedilla
 	<anchor 290 0> mark @bottom_right
 	<anchor 268 0> mark @bottom_center
@@ -13828,7 +13865,8 @@ feature mkmk {
 	\lcaron.cv28 \ldot.cv28 \lslash.cv28 \uni019A.cv28 \uni01C9.cv28 
 	\uni0234.cv28 \uni026D.cv28 \uni026E.cv28 \uni02AA.cv28 \uni02AB.cv28 
 	\uni02E1.cv28 \uni1E37.cv28 \uni1E39.cv28 \uni1E3B.cv28 \uni1E3D.cv28 
-	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \dollar.ss05 
+	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \Q.cv29 \uni051A.cv29 
+	\uni213A.cv29 \uni24C6.cv29 \q.sc.cv29 \uni051B.sc.cv29 \dollar.ss05 
 	\cent.ss05 \sterling.ss05 \lira.ss05 \peseta.ss05 \uni20AA.ss05 \Euro.ss05 
 	\uni20B2.ss05 \one.ss06 \one.ss06.pnum \one.ss06.tnum \one.ss06.onum 
 	\one.ss06.onum.tnum \one.ss06.superior \one.ss06.superior.pnum 
@@ -14130,7 +14168,7 @@ feature mkmk {
 	\uni2152.cv10.cv11.ss06.zero \uni2152.cv11.cv20.ss06.zero \colon.centered 
 	\asterisk.centered \dotlessuni0268 \dotlessuni029D \dotlessuni02B2 
 	\dotlessuni1DA4 \dotlessuni2071 \dotlessuni2148 \dotlessuni2149 
-	\double_circle_empty \uni02E4 \uni02C1 ];
+	\double_circle_empty \uni02C1 \uni02E4 ];
 @GDEF_Ligature = [\i \j \igrave \iacute \icircumflex \idieresis \dotlessi \itilde 
 	\imacron \ibreve \iogonek \jcircumflex \uni01D0 \uni0209 \uni020B \uni0249 
 	\uni0457 \uni1EC9 \arrowright \arrowleft \arrowboth \arrowdblright 

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/28 20:52:46</string>
+    <string>2026/07/28 21:55:46</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/27 23:37:56</string>
+    <string>2026/07/28 20:52:46</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Thin.ufo/glyphs/Q_.cv29.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/Q_.cv29.glif
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.cv29" format="2">
+  <advance width="1582"/>
+  <anchor x="757" y="0" name="bottom_center"/>
+  <anchor x="757" y="1380" name="top_center"/>
+  <outline>
+    <contour>
+      <point x="1462" y="0" type="line"/>
+      <point x="757" y="0" type="line"/>
+      <point x="897" y="42" type="line"/>
+      <point x="1462" y="42" type="line"/>
+    </contour>
+    <contour>
+      <point x="186" y="745" type="curve" smooth="yes"/>
+      <point x="186" y="270"/>
+      <point x="497" y="42"/>
+      <point x="757" y="42" type="curve" smooth="yes"/>
+      <point x="1017" y="42"/>
+      <point x="1328" y="270"/>
+      <point x="1328" y="745" type="curve" smooth="yes"/>
+      <point x="1328" y="1220"/>
+      <point x="1017" y="1448"/>
+      <point x="757" y="1448" type="curve" smooth="yes"/>
+      <point x="497" y="1448"/>
+      <point x="186" y="1220"/>
+    </contour>
+    <contour>
+      <point x="140" y="745" type="curve" smooth="yes"/>
+      <point x="140" y="1184"/>
+      <point x="409" y="1490"/>
+      <point x="757" y="1490" type="curve" smooth="yes"/>
+      <point x="1105" y="1490"/>
+      <point x="1374" y="1184"/>
+      <point x="1374" y="745" type="curve" smooth="yes"/>
+      <point x="1374" y="306"/>
+      <point x="1105" y="0"/>
+      <point x="757" y="0" type="curve" smooth="yes"/>
+      <point x="409" y="0"/>
+      <point x="140" y="306"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict/>
+  </lib>
+</glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-Thin.ufo/glyphs/contents.plist
@@ -9106,6 +9106,18 @@
     <string>uni24A_7.cv28.glif</string>
     <key>uni24DB.cv28</key>
     <string>uni24D_B_.cv28.glif</string>
+    <key>Q.cv29</key>
+    <string>Q_.cv29.glif</string>
+    <key>uni051A.cv29</key>
+    <string>uni051A_.cv29.glif</string>
+    <key>uni213A.cv29</key>
+    <string>uni213A_.cv29.glif</string>
+    <key>uni24C6.cv29</key>
+    <string>uni24C_6.cv29.glif</string>
+    <key>q.sc.cv29</key>
+    <string>q.sc.cv29.glif</string>
+    <key>uni051B.sc.cv29</key>
+    <string>uni051B_.sc.cv29.glif</string>
     <key>dollar.ss05</key>
     <string>dollar.ss05.glif</string>
     <key>cent.ss05</key>
@@ -10970,9 +10982,9 @@
     <string>uni030C__uni0307.case.glif</string>
     <key>tonos2</key>
     <string>tonos2.glif</string>
-    <key>uni02E4</key>
-    <string>uni02E_4.glif</string>
     <key>uni02C1</key>
     <string>uni02C_1.glif</string>
+    <key>uni02E4</key>
+    <string>uni02E_4.glif</string>
   </dict>
 </plist>

--- a/sources/Giphurs-Thin.ufo/glyphs/q.sc.cv29.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/q.sc.cv29.glif
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="q.sc.cv29" format="2">
+  <advance width="1376"/>
+  <anchor x="664" y="0" name="bottom_center"/>
+  <anchor x="664" y="1200" name="top_center"/>
+  <outline>
+    <contour>
+      <point x="1256" y="0" type="line"/>
+      <point x="663" y="0" type="line"/>
+      <point x="783" y="40" type="line"/>
+      <point x="1256" y="40" type="line"/>
+    </contour>
+    <contour>
+      <point x="663" y="40" type="curve" smooth="yes"/>
+      <point x="904" y="40"/>
+      <point x="1141" y="246"/>
+      <point x="1141" y="605" type="curve" smooth="yes"/>
+      <point x="1141" y="964"/>
+      <point x="904" y="1170"/>
+      <point x="663" y="1170" type="curve" smooth="yes"/>
+      <point x="422" y="1170"/>
+      <point x="185" y="964"/>
+      <point x="185" y="605" type="curve" smooth="yes"/>
+      <point x="185" y="246"/>
+      <point x="422" y="40"/>
+    </contour>
+    <contour>
+      <point x="663" y="1210" type="curve" smooth="yes"/>
+      <point x="952" y="1210"/>
+      <point x="1186" y="968"/>
+      <point x="1186" y="605" type="curve" smooth="yes"/>
+      <point x="1186" y="242"/>
+      <point x="952" y="0"/>
+      <point x="663" y="0" type="curve" smooth="yes"/>
+      <point x="374" y="0"/>
+      <point x="140" y="242"/>
+      <point x="140" y="605" type="curve" smooth="yes"/>
+      <point x="140" y="968"/>
+      <point x="374" y="1210"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni051A_.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051A.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1582"/>
+  <anchor x="757" y="1" name="bottom_center"/>
+  <anchor x="757" y="1381" name="top_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="Q.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni051A_.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051A.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051B.sc.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1376"/>
+  <anchor x="664" y="1" name="bottom_center"/>
+  <anchor x="664" y="1201" name="top_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="q.sc.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051B.sc.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni213A_.cv29.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni213A_.cv29.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni213A.cv29" format="2">
+  <advance width="1770"/>
+  <outline>
+    <contour>
+      <point x="1630" y="1445" type="line"/>
+      <point x="1630" y="740" type="line"/>
+      <point x="1588" y="880" type="line"/>
+      <point x="1588" y="1445" type="line"/>
+    </contour>
+    <contour>
+      <point x="885" y="169" type="curve" smooth="yes"/>
+      <point x="1360" y="169"/>
+      <point x="1588" y="480"/>
+      <point x="1588" y="740" type="curve" smooth="yes"/>
+      <point x="1588" y="1000"/>
+      <point x="1360" y="1311"/>
+      <point x="885" y="1311" type="curve" smooth="yes"/>
+      <point x="410" y="1311"/>
+      <point x="182" y="1000"/>
+      <point x="182" y="740" type="curve" smooth="yes"/>
+      <point x="182" y="480"/>
+      <point x="410" y="169"/>
+    </contour>
+    <contour>
+      <point x="885" y="123" type="curve" smooth="yes"/>
+      <point x="446" y="123"/>
+      <point x="140" y="392"/>
+      <point x="140" y="740" type="curve" smooth="yes"/>
+      <point x="140" y="1088"/>
+      <point x="446" y="1357"/>
+      <point x="885" y="1357" type="curve" smooth="yes"/>
+      <point x="1324" y="1357"/>
+      <point x="1630" y="1088"/>
+      <point x="1630" y="740" type="curve" smooth="yes"/>
+      <point x="1630" y="392"/>
+      <point x="1324" y="123"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-Thin.ufo/glyphs/uni24C_6.cv29.glif
+++ b/sources/Giphurs-Thin.ufo/glyphs/uni24C_6.cv29.glif
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni24C6.cv29" format="2">
+  <advance width="1700"/>
+  <outline>
+    <contour>
+      <point x="130" y="740" type="curve" smooth="yes"/>
+      <point x="130" y="342"/>
+      <point x="452" y="20"/>
+      <point x="850" y="20" type="curve" smooth="yes"/>
+      <point x="1248" y="20"/>
+      <point x="1570" y="342"/>
+      <point x="1570" y="740" type="curve" smooth="yes"/>
+      <point x="1570" y="1138"/>
+      <point x="1248" y="1460"/>
+      <point x="850" y="1460" type="curve" smooth="yes"/>
+      <point x="452" y="1460"/>
+      <point x="130" y="1138"/>
+    </contour>
+    <contour>
+      <point x="100" y="740" type="curve" smooth="yes"/>
+      <point x="100" y="1154"/>
+      <point x="436" y="1490"/>
+      <point x="850" y="1490" type="curve" smooth="yes"/>
+      <point x="1264" y="1490"/>
+      <point x="1600" y="1154"/>
+      <point x="1600" y="740" type="curve" smooth="yes"/>
+      <point x="1600" y="326"/>
+      <point x="1264" y="-10"/>
+      <point x="850" y="-10" type="curve" smooth="yes"/>
+      <point x="436" y="-10"/>
+      <point x="100" y="326"/>
+    </contour>
+    <contour>
+      <point x="824" y="1175" type="curve" smooth="yes"/>
+      <point x="1029" y="1175"/>
+      <point x="1188" y="998"/>
+      <point x="1188" y="743" type="curve" smooth="yes"/>
+      <point x="1188" y="488"/>
+      <point x="1029" y="311"/>
+      <point x="824" y="311" type="curve" smooth="yes"/>
+      <point x="619" y="311"/>
+      <point x="460" y="488"/>
+      <point x="460" y="743" type="curve" smooth="yes"/>
+      <point x="460" y="998"/>
+      <point x="619" y="1175"/>
+    </contour>
+    <contour>
+      <point x="824" y="1145" type="curve" smooth="yes"/>
+      <point x="673" y="1145"/>
+      <point x="493" y="1015"/>
+      <point x="493" y="743" type="curve" smooth="yes"/>
+      <point x="493" y="471"/>
+      <point x="673" y="341"/>
+      <point x="824" y="341" type="curve" smooth="yes"/>
+      <point x="975" y="341"/>
+      <point x="1155" y="471"/>
+      <point x="1155" y="743" type="curve" smooth="yes"/>
+      <point x="1155" y="1015"/>
+      <point x="975" y="1145"/>
+    </contour>
+    <contour>
+      <point x="1242" y="311" type="line"/>
+      <point x="824" y="311" type="line"/>
+      <point x="904" y="341" type="line"/>
+      <point x="1242" y="341" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -2261,6 +2261,16 @@ lookup cv28_Alternative_small_letter_l {
     sub \uni24A7 by \uni24A7.cv28 ;
 } cv28_Alternative_small_letter_l;
 
+lookup cv29_Alternative_letter_Q {
+  lookupflag 0;
+    sub \Q by \Q.cv29 ;
+    sub \uni051A by \uni051A.cv29 ;
+    sub \uni213A by \uni213A.cv29 ;
+    sub \uni24C6 by \uni24C6.cv29 ;
+    sub \q.sc by \q.sc.cv29 ;
+    sub \uni051B.sc by \uni051B.sc.cv29 ;
+} cv29_Alternative_letter_Q;
+
 lookup ss01_Alternative_digits_set_A {
   lookupflag 0;
     sub \eight by \eight.cv08 ;
@@ -4564,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \i \acutecomb  by \iacute;
     sub \uni0456 \acutecomb  by \iacute;
+    sub \i \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4621,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \iogonek \gravecomb  by \iogonek;
     sub \i \uni0328  by \iogonek;
+    sub \iogonek \gravecomb  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4709,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \u \uni0308 \gravecomb  by \uni01DC;
-    sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni030A \acutecomb  by \uni01DC;
     sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \AE \acutecomb  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \Oslash \acutecomb  by \uni01E0;
     sub \A \uni0307 \uni0304  by \uni01E0;
+    sub \Oslash \acutecomb  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5641,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0456 \uni0308  by \uni0457;
+    sub \uni0456 \uni0307  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6775,6 +6785,29 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
+
 feature locl {
 
  script cyrl;
@@ -6861,29 +6894,6 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
-
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
 
 feature ss09 {
   featureNames {
@@ -7743,6 +7753,29 @@ feature cv28 {
       lookup cv28_Alternative_small_letter_l;
 } cv28;
 
+feature cv29 {
+
+ script DFLT;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script copt;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script cyrl;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script grek;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+
+ script latn;
+     language dflt ;
+      lookup cv29_Alternative_letter_Q;
+} cv29;
+
 feature ss01 {
   featureNames {
     name 3 1 0x409 "Alternative numbers set 1";
@@ -8264,7 +8297,7 @@ feature calt {
 
 lookup kern_Horizontal_kerning {
   lookupflag 0;
-    @kc88_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
+    @kc89_first_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Alphatonos \Amacron 
 	\Aogonek \Aring \Aringacute \Atilde \Delta \Lambda \backslash \uni01CD 
 	\uni01DE \uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
@@ -8273,12 +8306,12 @@ lookup kern_Horizontal_kerning {
 	\uni1F0C \uni1F0D \uni1F0E \uni1F0F \uni1F88 \uni1F89 \uni1F8A \uni1F8B 
 	\uni1F8C \uni1F8D \uni1F8E \uni1F8F \uni1FB8 \uni1FB9 \uni1FBA \uni1FBB 
 	\uni1FBC \uni212B \uniA656 ];
-    @kc88_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
+    @kc89_first_2 = [\B \Beta \beta \delta \germandbls \uni0181 \uni0182 \uni0243 \uni03D0 \uni0411 
 	\uni0412 \uni0417 \uni0432.loclBGR \uni0498 \uni04DE \uni1E02 \uni1E04 
 	\uni1E06 \uni1E9E \uniA7B4 \uniA7B5 ];
-    @kc88_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
+    @kc89_first_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \uni0187 \uni023B \uni03F9 
 	\uni03FE \uni0421 \uni0464 \uni0480 \uni04AA \uni1E08 \uni2103 \uni216D ];
-    @kc88_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
+    @kc89_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
 	\Gcommaaccent.cv21 \Gdotaccent.cv21 \O \Oacute \Obreve \Ocircumflex 
 	\Odieresis \Ograve \Ohungarumlaut \Omacron \Omicron \Omicrontonos 
 	\Oslash \Oslashacute \Otilde \Theta \uni0189 \uni018A \uni018F 
@@ -8291,42 +8324,42 @@ lookup kern_Horizontal_kerning {
 	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
 	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
 	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
-    @kc88_first_5 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
+    @kc89_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
+	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
+	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
+	\uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA 
+	\uni1FFB \uni1FFC \uni20B2 \uni20B2.ss05 ];
+    @kc89_first_6 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
 	\uni0422 \uni0490 \uni0492 \uni04A4 \uni04AC \uni1E6A \uni1E6C \uni1E6E 
 	\uni1E70 ];
-    @kc88_first_6 = [\Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
-	\uni01E4 \uni03A9 \uni051A \uni1E20 \uni1F68 \uni1F69 \uni1F6A \uni1F6B 
-	\uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 \uni1FA9 \uni1FAA \uni1FAB 
-	\uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA \uni1FFB \uni1FFC \uni20B2 
-	\uni20B2.ss05 ];
-    @kc88_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+    @kc89_first_7 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2165 \uni2166 \uni2167 \uni216A \uni216B 
 	\uniA7AE ];
-    @kc88_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
+    @kc89_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc88_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
+    @kc89_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
 	\uniA7AD ];
-    @kc88_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
-    @kc88_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
-    @kc88_first_12 = [\Psi \uni0470 ];
-    @kc88_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
+    @kc89_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
+    @kc89_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
+    @kc89_first_12 = [\Psi \uni0470 ];
+    @kc89_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc88_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
+    @kc89_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
 	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
 	\uni2107 ];
-    @kc88_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
+    @kc89_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
-    @kc88_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
+    @kc89_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
 	\uni2163 \uni2164 \universal ];
-    @kc88_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_first_19 = [\a \a.cv23 \aacute \aacute.cv23 \abreve \abreve.cv23 \acircumflex 
+    @kc89_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_first_19 = [\a \a.cv23 \aacute \aacute.cv23 \abreve \abreve.cv23 \acircumflex 
 	\acircumflex.cv23 \adieresis \adieresis.cv23 \agrave \agrave.cv23 
 	\amacron \amacron.cv23 \aogonek \aogonek.cv23 \aring \aring.cv23 
 	\aringacute.cv23 \atilde \atilde.cv23 \u \u.cv25 \uacute \uacute.cv25 
@@ -8350,7 +8383,7 @@ lookup kern_Horizontal_kerning {
 	\uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 \uni1EED 
 	\uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 \uniA657 
 	\uogonek \uogonek.cv25 \uring \uring.cv25 \utilde \utilde.cv25 ];
-    @kc88_first_20 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
+    @kc89_first_20 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
 	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
 	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
 	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
@@ -8363,7 +8396,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
 	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
 	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
-    @kc88_first_21 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_first_21 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8417,7 +8450,7 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_first_22 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
+    @kc89_first_22 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
 	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
@@ -8430,28 +8463,28 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
-    @kc88_first_23 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
+    @kc89_first_23 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
 	\uni1FB7 \uni2C65 ];
-    @kc88_first_24 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_first_24 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_first_25 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
+    @kc89_first_25 = [\b \p \rho \thorn \uni0180 \uni0185 \uni01A5 \uni01BF \uni0238 \uni0239 \uni0252 
 	\uni0253 \uni029A \uni03F1 \uni03F8 \uni0440 \uni0444 \uni1E03 \uni1E05 
 	\uni1E07 \uni1E55 \uni1E57 \uni20AF \uni2114 ];
-    @kc88_first_26 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
+    @kc89_first_26 = [\b.sc \beta.sc \uni0180.sc \uni0223.sc \uni0253.sc \uni0432.sc \uni1E03.sc 
 	\uni1E05.sc \uni1E07.sc \uniA7B5.sc ];
-    @kc88_first_27 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
+    @kc89_first_27 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \cent.ss05 \sigma1 
 	\uni0188 \uni023C \uni0255 \uni0297 \uni03F2 \uni03F5 \uni0441 \uni0454 
 	\uni0465 \uni04AB \uni1E09 \uni217D ];
-    @kc88_first_28 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
+    @kc89_first_28 = [\c.sc \cacute.sc \ccaron.sc \ccircumflex.sc \cdotaccent.sc \uni0188.sc 
 	\uni037C.sc \uni03F2.sc \uni0441.sc \uni0454.sc \uni0465.sc 
 	\uni0481.sc \uni1E09.sc ];
-    @kc88_first_29 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+    @kc89_first_29 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8507,14 +8540,14 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_first_30 = [\chi ];
-    @kc88_first_31 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
+    @kc89_first_30 = [\chi ];
+    @kc89_first_31 = [\chi.sc \k.sc \kappa.sc \kcommaaccent.sc \kgreenlandic.sc \uni01E9.sc 
 	\uni0436.sc \uni0445.sc \uni0497.sc \uni049B.sc \uni049D.sc 
 	\uni049F.sc \uni04A1.sc \uni04B3.sc \uni04C2.sc \uni04DD.sc 
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc88_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
+    @kc89_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
 	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
 	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
@@ -8526,7 +8559,7 @@ lookup kern_Horizontal_kerning {
 	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
 	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
 	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
-    @kc88_first_33 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_first_33 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8536,7 +8569,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2175.sc 
 	\uni2176.sc \uni2177.sc \uni217A.sc \uni217B.sc ];
-    @kc88_first_34 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
+    @kc89_first_34 = [\eight.cv08.numr \eight.cv08.numr.pnum \eight.cv08.numr.tnum 
 	\eight.cv18.numr \eight.cv18.numr.pnum \eight.cv18.numr.tnum 
 	\eight.numr \eight.numr.pnum \eight.numr.tnum \five.cv05.numr 
 	\five.cv05.numr.pnum \five.cv05.numr.tnum \five.cv15.numr 
@@ -8574,142 +8607,142 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.numr.tnum \zero.numr \zero.numr.pnum 
 	\zero.numr.tnum \zero.zero.numr \zero.zero.numr.pnum 
 	\zero.zero.numr.tnum ];
-    @kc88_first_35 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
+    @kc89_first_35 = [\eng \eta \uni019E \uni0267 \uni1F20 \uni1F21 \uni1F22 \uni1F23 \uni1F24 \uni1F25 
 	\uni1F26 \uni1F27 \uni1F74 \uni1F75 \uni1F90 \uni1F91 \uni1F92 \uni1F93 
 	\uni1F94 \uni1F95 \uni1F96 \uni1F97 \uni1FC2 \uni1FC3 \uni1FC4 \uni1FC6 
 	\uni1FC7 ];
-    @kc88_first_36 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_first_36 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0433 \uni0437 
 	\uni0453 \uni0455 \uni0479 \uni0493 \uni0499 \uni04DF \uni04F7 \uni04FB 
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
-    @kc88_first_37 = [\eth \uni1EFC \uni1EFD ];
-    @kc88_first_38 = [\fraction ];
-    @kc88_first_39 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc88_first_40 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \uni0260.sc \uni051B.sc \uni1F60.sc \uni1F61.sc 
-	\uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc \uni1F66.sc 
-	\uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc \uni1FA1.sc 
-	\uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc \uni1FA6.sc 
-	\uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc \uni1FF6.sc 
-	\uni1FF7.sc ];
-    @kc88_first_41 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc89_first_37 = [\eth \uni1EFC \uni1EFD ];
+    @kc89_first_38 = [\fraction ];
+    @kc89_first_39 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
+    @kc89_first_40 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
+	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
+	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
+	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
+	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
+    @kc89_first_41 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc88_first_42 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_first_42 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc88_first_43 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc89_first_43 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc88_first_44 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc89_first_44 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc88_first_45 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc89_first_45 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc88_first_46 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
+    @kc89_first_46 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
 	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc88_first_47 = [\lambda \uni019B ];
-    @kc88_first_48 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc88_first_49 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc89_first_47 = [\lambda \uni019B ];
+    @kc89_first_48 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc89_first_49 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc88_first_50 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc88_first_51 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc88_first_52 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc89_first_50 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc89_first_51 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc89_first_52 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc88_first_53 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_first_54 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc88_first_55 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc88_first_56 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc89_first_53 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_first_54 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc89_first_55 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc89_first_56 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc88_first_57 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_first_57 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc88_first_58 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+    @kc89_first_58 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
 	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_first_59 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+    @kc89_first_59 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
 	\uni1E71 ];
-    @kc88_first_60 = [\tau \uni0491 \uni04A5 ];
-    @kc88_first_61 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc88_first_62 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc88_first_63 = [\uni0196 \uni01AA ];
-    @kc88_first_64 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_first_60 = [\tau \uni0491 \uni04A5 ];
+    @kc89_first_61 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
+    @kc89_first_62 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc89_first_63 = [\uni0196 \uni01AA ];
+    @kc89_first_64 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
 	\ygrave ];
-    @kc88_first_65 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_first_65 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_first_66 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
+    @kc89_first_66 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
 	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
 	\zdotaccent ];
-    @kc88_first_67 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
+    @kc89_first_67 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
-    @kc88_first_68 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
+    @kc89_first_68 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
 	\uni052D \uni052F ];
-    @kc88_first_69 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
+    @kc89_first_69 = [\uni0434.sc \uni0446.sc \uni0449.sc \uni048B.sc \uni04A3.sc \uni04B5.sc 
 	\uni04B7.sc \uni04C6.sc \uni04CA.sc \uni04CC.sc \uni04CE.sc 
 	\uni0525.sc \uni052F.sc ];
-    @kc88_first_70 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
-    @kc88_first_71 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
-    @kc88_first_72 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_first_70 = [\uni0443.sc \uni2173.sc \uni2174.sc \v.sc ];
+    @kc89_first_71 = [\uni044A \uni044C \uni0459 \uni045A \uni048D ];
+    @kc89_first_72 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
+    @kc89_second_1 = [\A \Aacute \Abreve \Acircumflex \Adieresis \Agrave \Alpha \Amacron \Aogonek 
 	\Aring \Aringacute \Atilde \Delta \Lambda \slash \uni01CD \uni01DE 
 	\uni01E0 \uni0200 \uni0202 \uni0226 \uni0245 \uni0394 \uni0410 
 	\uni0414.loclBGR \uni041B.loclBGR \uni0466 \uni04D0 \uni04D2 \uni1E00 
 	\uni1EA0 \uni1EA2 \uni1EA4 \uni1EA6 \uni1EA8 \uni1EAA \uni1EAC \uni1EAE 
 	\uni1EB0 \uni1EB2 \uni1EB4 \uni1EB6 \uni1FB8 \uni1FB9 \uni1FBC \uni212B ];
-    @kc88_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
-    @kc88_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
+    @kc89_second_2 = [\AE \AEacute \uni01E2 \uni04D4 ];
+    @kc89_second_3 = [\C \Cacute \Ccaron \Ccedilla \Ccircumflex \Cdotaccent \Euro \Euro.ss05 \G \G.cv21 
 	\Gbreve \Gbreve.cv21 \Gcaron \Gcaron.cv21 \Gcircumflex 
 	\Gcircumflex.cv21 \Gcommaaccent \Gcommaaccent.cv21 \Gdotaccent 
 	\Gdotaccent.cv21 \O \OE \Oacute \Obreve \Ocircumflex \Odieresis \Ograve 
 	\Ohorn \Ohungarumlaut \Omacron \Omicron \Omicrontonos \Oslash 
-	\Oslashacute \Otilde \Q \Theta \colonmonetary \emptyset \uni0187 
-	\uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
+	\Oslashacute \Otilde \Q \Q.cv29 \Theta \colonmonetary \emptyset 
+	\uni0187 \uni0193 \uni0193.cv21 \uni019F \uni01A2 \uni01D1 \uni01E4 
 	\uni01E4.cv21 \uni01EA \uni01EC \uni01F4 \uni01F4.cv21 \uni020C 
 	\uni020E \uni022A \uni022C \uni022E \uni0230 \uni023B \uni024A \uni0298 
 	\uni03D8 \uni03F4 \uni03FE \uni0404 \uni041E \uni0421 \uni0472 \uni047A 
 	\uni0480 \uni04AA \uni04BC \uni04BE \uni04D8 \uni04DA \uni04E6 \uni04E8 
-	\uni04EA \uni050C \uni051A \uni1E08 \uni1E20 \uni1E20.cv21 \uni1E4C 
-	\uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE \uni1ED0 \uni1ED2 \uni1ED4 
-	\uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE \uni1EE0 \uni1EE2 \uni20A2 
-	\uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE \uni216D \uni2180 \uni2182 
-	\uni2185 ];
-    @kc88_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
-    @kc88_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
+	\uni04EA \uni050C \uni051A \uni051A.cv29 \uni1E08 \uni1E20 
+	\uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE 
+	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
+	\uni1EE0 \uni1EE2 \uni20A2 \uni20B2 \uni20B2.ss05 \uni20B5 \uni20BE 
+	\uni216D \uni2180 \uni2182 \uni2185 ];
+    @kc89_second_4 = [\Dcroat \Lslash \lslash \uni0189 \uni0197 \uni019A \uni0244 \uni024C ];
+    @kc89_second_5 = [\I \Iacute \Ibreve \Icircumflex \Idieresis \Idotaccent \Igrave \Imacron \Iogonek 
 	\Iota \Iotadieresis \Itilde \uni01CF \uni0208 \uni020A \uni0406 
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
-    @kc88_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc88_second_7 = [\Omega \uni03A9 \uni1FFC ];
-    @kc88_second_8 = [\Phi \uni0424 ];
-    @kc88_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc88_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
+    @kc89_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
+    @kc89_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc89_second_8 = [\Phi \uni0424 ];
+    @kc89_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
+    @kc89_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
 	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc88_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
+    @kc89_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
 	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc88_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
+    @kc89_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
 	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
-    @kc88_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
+    @kc89_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc88_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
+    @kc89_second_14 = [\V \backslash \gradient \uni0474 \uni0476 \uni1E7C \uni1E7E \uni2164 \uni2165 
 	\uni2166 \uni2167 \universal ];
-    @kc88_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
-    @kc88_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
+    @kc89_second_15 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
+    @kc89_second_16 = [\X \uni0416 \uni0423 \uni0496 \uni049A \uni04B2 \uni04C1 \uni04DC \uni04FC 
 	\uni04FE \uni1E8A \uni1E8C \uni2169 \uni216A \uni216B ];
-    @kc88_second_17 = [\a \a.cv23 \a.sc \aacute \aacute.cv23 \aacute.sc \abreve \abreve.cv23 \abreve.sc 
+    @kc89_second_17 = [\a \a.cv23 \a.sc \aacute \aacute.cv23 \aacute.sc \abreve \abreve.cv23 \abreve.sc 
 	\acircumflex \acircumflex.cv23 \acircumflex.sc \adieresis 
 	\adieresis.cv23 \adieresis.sc \ae.cv23 \aeacute.cv23 \agrave 
 	\agrave.cv23 \agrave.sc \alpha \alpha.sc \alphatonos \amacron 
@@ -8743,7 +8776,7 @@ lookup kern_Horizontal_kerning {
 	\uni1F87 \uni1F87.sc \uni1FB0 \uni1FB0.sc \uni1FB1 \uni1FB1.sc 
 	\uni1FB2 \uni1FB2.sc \uni1FB3 \uni1FB3.sc \uni1FB4 \uni1FB4.sc 
 	\uni1FB6 \uni1FB6.sc \uni1FB7 \uni1FB7.sc \uni217E \uniA7C8 ];
-    @kc88_second_18 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
+    @kc89_second_18 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
 	\eight.cv18.superior \eight.cv18.superior.pnum 
@@ -8797,16 +8830,16 @@ lookup kern_Horizontal_kerning {
 	\zero.cv20.zero.superior.tnum \zero.superior \zero.superior.pnum 
 	\zero.zero.superior \zero.zero.superior.pnum 
 	\zero.zero.superior.tnum ];
-    @kc88_second_19 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
-    @kc88_second_20 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
+    @kc89_second_19 = [\ae.sc \aeacute.sc \uni01E3.sc \uni04D5.sc ];
+    @kc89_second_20 = [\asciitilde \emdash \endash \equal \figuredash \hyphen \logicalnot \notequal 
 	\plus \similar \uni2010 \uni2011 \uni2015 \uni2043 \uni2053 \uni2238 
 	\uni2239 \uni223A \uni223B \uni223D \uni2241 \uni2242 \uni2243 \uni2244 
 	\uni2250 \uni2251 \uni2252 \uni2253 \uni2254 \uni2255 \uni2256 \uni2257 
 	\uni2258 \uni2259 \uni225A \uni225B \uni225C \uni225D \uni225E \uni225F 
 	\uni22A2 \uni22A7 \uni22A8 \uni22A9 \uni22AB ];
-    @kc88_second_21 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
+    @kc89_second_21 = [\beta \mu \p \uni01BF \uni03BC \uni048F \uni0516 \uni1E55 \uni1E57 \uni2C64 
 	\uniA7B4 \uniA7B5 ];
-    @kc88_second_22 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
+    @kc89_second_22 = [\c \cacute \ccaron \ccedilla \ccircumflex \cdotaccent \e \eacute \ebreve \ecaron 
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
@@ -8820,25 +8853,26 @@ lookup kern_Horizontal_kerning {
 	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
 	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
 	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
-    @kc88_second_23 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
+    @kc89_second_23 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
 	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
 	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
 	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc 
-	\uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc 
-	\uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc 
-	\uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc 
-	\uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc 
-	\uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc 
-	\uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc 
-	\uni050D.sc \uni051B.sc \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
-	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
-	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
-	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
-	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc ];
-    @kc88_second_24 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
+	\q.sc \q.sc.cv29 \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc 
+	\uni01E5.sc \uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc 
+	\uni020F.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc 
+	\uni023C.sc \uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc 
+	\uni037C.sc \uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc 
+	\uni0444.loclBGR.sc \uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc 
+	\uni04AB.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni050D.sc \uni051B.sc \uni051B.sc.cv29 \uni1E09.sc 
+	\uni1E21.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
+	\uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc 
+	\uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
+	\uni1EE1.sc \uni1EE3.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc 
+	\uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc 
+	\uni217D.sc ];
+    @kc89_second_24 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
 	\eight.subscript \eight.subscript.pnum \eight.subscript.tnum 
@@ -8894,11 +8928,11 @@ lookup kern_Horizontal_kerning {
 	\zero.subscript \zero.subscript.pnum \zero.subscript.tnum 
 	\zero.zero.subscript \zero.zero.subscript.pnum 
 	\zero.zero.subscript.tnum ];
-    @kc88_second_25 = [\chi \gamma \uni04AF \uni04B1 ];
-    @kc88_second_26 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
+    @kc89_second_25 = [\chi \gamma \uni04AF \uni04B1 ];
+    @kc89_second_26 = [\chi.sc \uni0436.sc \uni0445.sc \uni0497.sc \uni04B3.sc \uni04C2.sc 
 	\uni04DD.sc \uni04FD.sc \uni04FF.sc \uni1E8B.sc \uni1E8D.sc 
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
-    @kc88_second_27 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
+    @kc89_second_27 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
 	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
@@ -8908,7 +8942,7 @@ lookup kern_Horizontal_kerning {
 	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
 	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
 	\uni2178.sc ];
-    @kc88_second_28 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
+    @kc89_second_28 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
 	\five.cv05.dnom.pnum \five.cv05.dnom.tnum \five.cv15.dnom 
@@ -8944,12 +8978,12 @@ lookup kern_Horizontal_kerning {
 	\zero.cv10.zero.dnom.tnum \zero.cv20.dnom \zero.cv20.dnom.tnum 
 	\zero.cv20.zero.dnom \zero.cv20.zero.dnom.tnum \zero.dnom 
 	\zero.dnom.tnum \zero.zero.dnom \zero.zero.dnom.tnum ];
-    @kc88_second_29 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
+    @kc89_second_29 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0433 \uni0437 
 	\uni0453 \uni0455 \uni0479 \uni0493 \uni0499 \uni04DF \uni04F7 \uni04FB 
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
-    @kc88_second_30 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
+    @kc89_second_30 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
 	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
 	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
 	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
@@ -8972,1624 +9006,1625 @@ lookup kern_Horizontal_kerning {
 	\uni1F7B \uni1FE6 \uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 
 	\upsilon \upsilondieresistonos \upsilontonos \uring \uring.cv25 
 	\utilde \utilde.cv25 ];
-    @kc88_second_31 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
+    @kc89_second_31 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
 	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc88_second_32 = [\fraction ];
-    @kc88_second_33 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc88_second_34 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+    @kc89_second_32 = [\fraction ];
+    @kc89_second_33 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc89_second_34 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc88_second_35 = [\lambda \uni019B ];
-    @kc88_second_36 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc89_second_35 = [\lambda \uni019B ];
+    @kc89_second_36 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc88_second_37 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
+    @kc89_second_37 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
 	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
 	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
 	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
 	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc88_second_38 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc88_second_39 = [\pi \tau \uni044A \uni04B5 ];
-    @kc88_second_40 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc89_second_38 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc89_second_39 = [\pi \tau \uni044A \uni04B5 ];
+    @kc89_second_40 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc88_second_41 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc89_second_41 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc88_second_42 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc89_second_42 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc88_second_43 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc89_second_43 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
 	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
 	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc88_second_44 = [\theta \uni0478 \uniA64C ];
-    @kc88_second_45 = [\tonos2 ];
-    @kc88_second_46 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc88_second_47 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc89_second_44 = [\theta \uni0478 \uniA64C ];
+    @kc89_second_45 = [\tonos2 ];
+    @kc89_second_46 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc89_second_47 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc88_second_48 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc89_second_48 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc88_second_49 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
+    @kc89_second_49 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
 	\z \zacute \zcaron \zdotaccent ];
-    @kc88_second_50 = [\uni0237 ];
-    @kc88_second_51 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc88_second_52 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc88_second_53 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc88_second_54 = [\uni042F \uni0518 ];
-    @kc88_second_55 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc89_second_50 = [\uni0237 ];
+    @kc89_second_51 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc89_second_52 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc89_second_53 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc89_second_54 = [\uni042F \uni0518 ];
+    @kc89_second_55 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc88_second_56 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc89_second_56 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc88_second_57 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
-    @kc88_second_58 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc88_second_59 = [\uni044F.sc \uni0519.sc ];
-    @kc88_second_60 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc89_second_57 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
+    @kc89_second_58 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc89_second_59 = [\uni044F.sc \uni0519.sc ];
+    @kc89_second_60 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc88_second_61 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc88_second_62 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc89_second_61 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc89_second_62 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc88_second_63 = [\uni0500 \uni0502 ];
-    @kc88_second_64 = [\uni0501.sc \uni0503.sc ];
-    @kc88_second_65 = [\zero.cv10.dnom \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
+    @kc89_second_63 = [\uni0500 \uni0502 ];
+    @kc89_second_64 = [\uni0501.sc \uni0503.sc ];
+    @kc89_second_65 = [\zero.cv10.dnom \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
 	\zero.cv20.zero.dnom.pnum \zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc88_second_66 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
+    @kc89_second_66 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
 	\zero.cv20.zero.numr.pnum \zero.numr.pnum \zero.zero.numr.pnum ];
-    pos @kc88_first_1 @kc88_second_3 -70;
-    pos @kc88_first_1 @kc88_second_8 -70;
-    pos @kc88_first_1 @kc88_second_9 -140;
-    pos @kc88_first_1 @kc88_second_10 -35;
-    pos @kc88_first_1 @kc88_second_12 -280;
-    pos @kc88_first_1 @kc88_second_13 -280;
-    pos @kc88_first_1 @kc88_second_14 -280;
-    pos @kc88_first_1 @kc88_second_15 -210;
-    pos @kc88_first_1 @kc88_second_20 -70;
-    pos @kc88_first_1 @kc88_second_23 -35;
-    pos @kc88_first_1 @kc88_second_25 -50;
-    pos @kc88_first_1 @kc88_second_31 -70;
-    pos @kc88_first_1 @kc88_second_38 -35;
-    pos @kc88_first_1 @kc88_second_39 -140;
-    pos @kc88_first_1 @kc88_second_40 -105;
-    pos @kc88_first_1 @kc88_second_43 -210;
-    pos @kc88_first_1 @kc88_second_44 -35;
-    pos @kc88_first_1 @kc88_second_45 1;
-    pos @kc88_first_1 @kc88_second_47 -175;
-    pos @kc88_first_1 @kc88_second_48 -210;
-    pos @kc88_first_1 @kc88_second_58 -140;
-    pos @kc88_first_1 @kc88_second_60 -140;
-    pos @kc88_first_1 @kc88_second_61 -210;
-    pos @kc88_first_1 @kc88_second_62 -140;
-    pos @kc88_first_2 @kc88_second_9 -35;
-    pos @kc88_first_2 @kc88_second_12 -70;
-    pos @kc88_first_2 @kc88_second_13 -70;
-    pos @kc88_first_2 @kc88_second_14 -70;
-    pos @kc88_first_2 @kc88_second_15 -35;
-    pos @kc88_first_2 @kc88_second_16 -35;
-    pos @kc88_first_2 @kc88_second_39 -35;
-    pos @kc88_first_2 @kc88_second_45 1;
-    pos @kc88_first_3 @kc88_second_1 -35;
-    pos @kc88_first_3 @kc88_second_2 -70;
-    pos @kc88_first_3 @kc88_second_5 -35;
-    pos @kc88_first_3 @kc88_second_11 -35;
-    pos @kc88_first_3 @kc88_second_12 -35;
-    pos @kc88_first_3 @kc88_second_13 -70;
-    pos @kc88_first_3 @kc88_second_14 -35;
-    pos @kc88_first_3 @kc88_second_16 -70;
-    pos @kc88_first_3 @kc88_second_19 -70;
-    pos @kc88_first_3 @kc88_second_35 -35;
-    pos @kc88_first_3 @kc88_second_45 1;
-    pos @kc88_first_4 @kc88_second_1 -70;
-    pos @kc88_first_4 @kc88_second_2 -140;
-    pos @kc88_first_4 @kc88_second_4 70;
-    pos @kc88_first_4 @kc88_second_5 -70;
-    pos @kc88_first_4 @kc88_second_11 -105;
-    pos @kc88_first_4 @kc88_second_12 -140;
-    pos @kc88_first_4 @kc88_second_13 -140;
-    pos @kc88_first_4 @kc88_second_14 -105;
-    pos @kc88_first_4 @kc88_second_15 -35;
-    pos @kc88_first_4 @kc88_second_16 -140;
-    pos @kc88_first_4 @kc88_second_24 -70;
-    pos @kc88_first_4 @kc88_second_26 -70;
-    pos @kc88_first_4 @kc88_second_27 -35;
-    pos @kc88_first_4 @kc88_second_31 35;
-    pos @kc88_first_4 @kc88_second_34 -70;
-    pos @kc88_first_4 @kc88_second_35 -70;
-    pos @kc88_first_4 @kc88_second_43 -35;
-    pos @kc88_first_4 @kc88_second_45 1;
-    pos @kc88_first_4 @kc88_second_48 -70;
-    pos @kc88_first_4 @kc88_second_53 -70;
-    pos @kc88_first_4 @kc88_second_55 -70;
-    pos @kc88_first_4 @kc88_second_57 -70;
-    pos @kc88_first_4 @kc88_second_61 -35;
-    pos @kc88_first_5 @kc88_second_1 -280;
-    pos @kc88_first_5 @kc88_second_2 -350;
-    pos @kc88_first_5 @kc88_second_3 -140;
-    pos @kc88_first_5 @kc88_second_4 -70;
-    pos @kc88_first_5 @kc88_second_6 -350;
-    pos @kc88_first_5 @kc88_second_7 -140;
-    pos @kc88_first_5 @kc88_second_8 -210;
-    pos @kc88_first_5 @kc88_second_10 -70;
-    pos @kc88_first_5 @kc88_second_17 -240;
-    pos @kc88_first_5 @kc88_second_19 -350;
-    pos @kc88_first_5 @kc88_second_20 -280;
-    pos @kc88_first_5 @kc88_second_21 -240;
-    pos @kc88_first_5 @kc88_second_22 -240;
-    pos @kc88_first_5 @kc88_second_23 -210;
-    pos @kc88_first_5 @kc88_second_24 -350;
-    pos @kc88_first_5 @kc88_second_25 -140;
-    pos @kc88_first_5 @kc88_second_27 -140;
-    pos @kc88_first_5 @kc88_second_29 -240;
-    pos @kc88_first_5 @kc88_second_30 -240;
-    pos @kc88_first_5 @kc88_second_31 -175;
-    pos @kc88_first_5 @kc88_second_34 -350;
-    pos @kc88_first_5 @kc88_second_35 -105;
-    pos @kc88_first_5 @kc88_second_36 -240;
-    pos @kc88_first_5 @kc88_second_37 -210;
-    pos @kc88_first_5 @kc88_second_38 -240;
-    pos @kc88_first_5 @kc88_second_39 -240;
-    pos @kc88_first_5 @kc88_second_41 -240;
-    pos @kc88_first_5 @kc88_second_44 -140;
-    pos @kc88_first_5 @kc88_second_45 1;
-    pos @kc88_first_5 @kc88_second_46 -35;
-    pos @kc88_first_5 @kc88_second_47 -240;
-    pos @kc88_first_5 @kc88_second_49 -240;
-    pos @kc88_first_5 @kc88_second_50 -240;
-    pos @kc88_first_5 @kc88_second_51 -240;
-    pos @kc88_first_5 @kc88_second_52 -240;
-    pos @kc88_first_5 @kc88_second_53 -280;
-    pos @kc88_first_5 @kc88_second_54 -70;
-    pos @kc88_first_5 @kc88_second_55 -240;
-    pos @kc88_first_5 @kc88_second_56 -175;
-    pos @kc88_first_5 @kc88_second_57 -280;
-    pos @kc88_first_5 @kc88_second_58 -240;
-    pos @kc88_first_5 @kc88_second_59 -210;
-    pos @kc88_first_5 @kc88_second_60 -175;
-    pos @kc88_first_5 @kc88_second_63 -175;
-    pos @kc88_first_5 @kc88_second_64 -175;
-    pos @kc88_first_6 @kc88_second_45 1;
-    pos @kc88_first_7 @kc88_second_3 -70;
-    pos @kc88_first_7 @kc88_second_8 -105;
-    pos @kc88_first_7 @kc88_second_17 -35;
-    pos @kc88_first_7 @kc88_second_20 -105;
-    pos @kc88_first_7 @kc88_second_22 -105;
-    pos @kc88_first_7 @kc88_second_23 -70;
-    pos @kc88_first_7 @kc88_second_45 1;
-    pos @kc88_first_7 @kc88_second_46 -35;
-    pos @kc88_first_7 @kc88_second_47 -70;
-    pos @kc88_first_7 @kc88_second_51 -50;
-    pos @kc88_first_7 @kc88_second_60 -35;
-    pos @kc88_first_7 @kc88_second_63 -70;
-    pos @kc88_first_7 @kc88_second_64 -70;
-    pos @kc88_first_8 @kc88_second_3 -140;
-    pos @kc88_first_8 @kc88_second_4 -70;
-    pos @kc88_first_8 @kc88_second_6 -70;
-    pos @kc88_first_8 @kc88_second_8 -140;
-    pos @kc88_first_8 @kc88_second_10 -35;
-    pos @kc88_first_8 @kc88_second_17 -70;
-    pos @kc88_first_8 @kc88_second_20 -140;
-    pos @kc88_first_8 @kc88_second_22 -70;
-    pos @kc88_first_8 @kc88_second_23 -105;
-    pos @kc88_first_8 @kc88_second_25 -140;
-    pos @kc88_first_8 @kc88_second_29 -35;
-    pos @kc88_first_8 @kc88_second_31 -105;
-    pos @kc88_first_8 @kc88_second_34 -70;
-    pos @kc88_first_8 @kc88_second_36 -70;
-    pos @kc88_first_8 @kc88_second_38 -105;
-    pos @kc88_first_8 @kc88_second_39 -175;
-    pos @kc88_first_8 @kc88_second_40 -140;
-    pos @kc88_first_8 @kc88_second_41 -35;
-    pos @kc88_first_8 @kc88_second_43 -140;
-    pos @kc88_first_8 @kc88_second_44 -105;
-    pos @kc88_first_8 @kc88_second_45 1;
-    pos @kc88_first_8 @kc88_second_46 -70;
-    pos @kc88_first_8 @kc88_second_47 -140;
-    pos @kc88_first_8 @kc88_second_48 -70;
-    pos @kc88_first_8 @kc88_second_51 -35;
-    pos @kc88_first_8 @kc88_second_52 -35;
-    pos @kc88_first_8 @kc88_second_58 -210;
-    pos @kc88_first_8 @kc88_second_60 -105;
-    pos @kc88_first_8 @kc88_second_61 -70;
-    pos @kc88_first_8 @kc88_second_62 -35;
-    pos @kc88_first_8 @kc88_second_63 -70;
-    pos @kc88_first_8 @kc88_second_64 -35;
-    pos @kc88_first_9 @kc88_second_3 -140;
-    pos @kc88_first_9 @kc88_second_4 -70;
-    pos @kc88_first_9 @kc88_second_6 -70;
-    pos @kc88_first_9 @kc88_second_8 -210;
-    pos @kc88_first_9 @kc88_second_9 -420;
-    pos @kc88_first_9 @kc88_second_10 -70;
-    pos @kc88_first_9 @kc88_second_12 -350;
-    pos @kc88_first_9 @kc88_second_13 -420;
-    pos @kc88_first_9 @kc88_second_14 -350;
-    pos @kc88_first_9 @kc88_second_15 -280;
-    pos @kc88_first_9 @kc88_second_17 -70;
-    pos @kc88_first_9 @kc88_second_18 -210;
-    pos @kc88_first_9 @kc88_second_20 -210;
-    pos @kc88_first_9 @kc88_second_22 -70;
-    pos @kc88_first_9 @kc88_second_23 -140;
-    pos @kc88_first_9 @kc88_second_29 -50;
-    pos @kc88_first_9 @kc88_second_31 -140;
-    pos @kc88_first_9 @kc88_second_34 -70;
-    pos @kc88_first_9 @kc88_second_38 -105;
-    pos @kc88_first_9 @kc88_second_39 -280;
-    pos @kc88_first_9 @kc88_second_40 -350;
-    pos @kc88_first_9 @kc88_second_41 -50;
-    pos @kc88_first_9 @kc88_second_43 -350;
-    pos @kc88_first_9 @kc88_second_45 1;
-    pos @kc88_first_9 @kc88_second_46 -35;
-    pos @kc88_first_9 @kc88_second_47 -210;
-    pos @kc88_first_9 @kc88_second_48 -350;
-    pos @kc88_first_9 @kc88_second_51 -35;
-    pos @kc88_first_9 @kc88_second_52 -35;
-    pos @kc88_first_9 @kc88_second_58 -280;
-    pos @kc88_first_9 @kc88_second_60 -175;
-    pos @kc88_first_9 @kc88_second_61 -280;
-    pos @kc88_first_9 @kc88_second_62 -210;
-    pos @kc88_first_9 @kc88_second_63 -70;
-    pos @kc88_first_9 @kc88_second_64 -70;
-    pos @kc88_first_10 @kc88_second_1 -210;
-    pos @kc88_first_10 @kc88_second_2 -350;
-    pos @kc88_first_10 @kc88_second_5 -70;
-    pos @kc88_first_10 @kc88_second_6 -140;
-    pos @kc88_first_10 @kc88_second_11 -35;
-    pos @kc88_first_10 @kc88_second_12 -70;
-    pos @kc88_first_10 @kc88_second_13 -70;
-    pos @kc88_first_10 @kc88_second_14 -35;
-    pos @kc88_first_10 @kc88_second_16 -70;
-    pos @kc88_first_10 @kc88_second_17 -35;
-    pos @kc88_first_10 @kc88_second_19 -280;
-    pos @kc88_first_10 @kc88_second_22 -70;
-    pos @kc88_first_10 @kc88_second_24 -350;
-    pos @kc88_first_10 @kc88_second_29 -70;
-    pos @kc88_first_10 @kc88_second_32 -140;
-    pos @kc88_first_10 @kc88_second_34 -210;
-    pos @kc88_first_10 @kc88_second_35 -105;
-    pos @kc88_first_10 @kc88_second_38 -70;
-    pos @kc88_first_10 @kc88_second_45 1;
-    pos @kc88_first_10 @kc88_second_53 -210;
-    pos @kc88_first_10 @kc88_second_55 -210;
-    pos @kc88_first_10 @kc88_second_57 -210;
-    pos @kc88_first_10 @kc88_second_61 -70;
-    pos @kc88_first_10 @kc88_second_63 -70;
-    pos @kc88_first_10 @kc88_second_64 -105;
-    pos @kc88_first_11 @kc88_second_1 -70;
-    pos @kc88_first_11 @kc88_second_2 -140;
-    pos @kc88_first_11 @kc88_second_5 -105;
-    pos @kc88_first_11 @kc88_second_6 -35;
-    pos @kc88_first_11 @kc88_second_11 -70;
-    pos @kc88_first_11 @kc88_second_12 -210;
-    pos @kc88_first_11 @kc88_second_13 -175;
-    pos @kc88_first_11 @kc88_second_14 -105;
-    pos @kc88_first_11 @kc88_second_15 -70;
-    pos @kc88_first_11 @kc88_second_16 -140;
-    pos @kc88_first_11 @kc88_second_19 -140;
-    pos @kc88_first_11 @kc88_second_24 -70;
-    pos @kc88_first_11 @kc88_second_26 -70;
-    pos @kc88_first_11 @kc88_second_27 -70;
-    pos @kc88_first_11 @kc88_second_34 -35;
-    pos @kc88_first_11 @kc88_second_35 -140;
-    pos @kc88_first_11 @kc88_second_39 -70;
-    pos @kc88_first_11 @kc88_second_42 -35;
-    pos @kc88_first_11 @kc88_second_43 -35;
-    pos @kc88_first_11 @kc88_second_45 1;
-    pos @kc88_first_11 @kc88_second_48 -70;
-    pos @kc88_first_11 @kc88_second_53 -210;
-    pos @kc88_first_11 @kc88_second_55 -175;
-    pos @kc88_first_11 @kc88_second_56 -35;
-    pos @kc88_first_11 @kc88_second_57 -175;
-    pos @kc88_first_11 @kc88_second_61 -70;
-    pos @kc88_first_11 @kc88_second_62 -35;
-    pos @kc88_first_11 @kc88_second_63 -35;
-    pos @kc88_first_11 @kc88_second_64 -70;
-    pos @kc88_first_12 @kc88_second_1 -140;
-    pos @kc88_first_12 @kc88_second_2 -210;
-    pos @kc88_first_12 @kc88_second_6 -140;
-    pos @kc88_first_12 @kc88_second_17 -70;
-    pos @kc88_first_12 @kc88_second_19 -210;
-    pos @kc88_first_12 @kc88_second_22 -70;
-    pos @kc88_first_12 @kc88_second_24 -350;
-    pos @kc88_first_12 @kc88_second_29 -35;
-    pos @kc88_first_12 @kc88_second_32 -140;
-    pos @kc88_first_12 @kc88_second_34 -140;
-    pos @kc88_first_12 @kc88_second_35 -70;
-    pos @kc88_first_12 @kc88_second_38 -70;
-    pos @kc88_first_12 @kc88_second_45 1;
-    pos @kc88_first_12 @kc88_second_51 -35;
-    pos @kc88_first_12 @kc88_second_53 -210;
-    pos @kc88_first_12 @kc88_second_55 -210;
-    pos @kc88_first_12 @kc88_second_57 -210;
-    pos @kc88_first_12 @kc88_second_63 -70;
-    pos @kc88_first_12 @kc88_second_64 -105;
-    pos @kc88_first_13 @kc88_second_6 -70;
-    pos @kc88_first_13 @kc88_second_12 -70;
-    pos @kc88_first_13 @kc88_second_13 -105;
-    pos @kc88_first_13 @kc88_second_14 -35;
-    pos @kc88_first_13 @kc88_second_22 -35;
-    pos @kc88_first_13 @kc88_second_29 -35;
-    pos @kc88_first_13 @kc88_second_34 -70;
-    pos @kc88_first_13 @kc88_second_38 -70;
-    pos @kc88_first_13 @kc88_second_45 1;
-    pos @kc88_first_13 @kc88_second_63 -70;
-    pos @kc88_first_13 @kc88_second_64 -35;
-    pos @kc88_first_14 @kc88_second_2 -35;
-    pos @kc88_first_14 @kc88_second_11 -35;
-    pos @kc88_first_14 @kc88_second_12 -70;
-    pos @kc88_first_14 @kc88_second_13 -70;
-    pos @kc88_first_14 @kc88_second_14 -35;
-    pos @kc88_first_14 @kc88_second_16 -35;
-    pos @kc88_first_14 @kc88_second_19 -35;
-    pos @kc88_first_14 @kc88_second_25 -35;
-    pos @kc88_first_14 @kc88_second_39 -70;
-    pos @kc88_first_14 @kc88_second_45 1;
-    pos @kc88_first_14 @kc88_second_47 -70;
-    pos @kc88_first_14 @kc88_second_48 -35;
-    pos @kc88_first_14 @kc88_second_56 -35;
-    pos @kc88_first_14 @kc88_second_58 -35;
-    pos @kc88_first_14 @kc88_second_60 -35;
-    pos @kc88_first_14 @kc88_second_62 -35;
-    pos @kc88_first_15 @kc88_second_3 -70;
-    pos @kc88_first_15 @kc88_second_4 -70;
-    pos @kc88_first_15 @kc88_second_6 -35;
-    pos @kc88_first_15 @kc88_second_8 -70;
-    pos @kc88_first_15 @kc88_second_17 -70;
-    pos @kc88_first_15 @kc88_second_20 -140;
-    pos @kc88_first_15 @kc88_second_22 -70;
-    pos @kc88_first_15 @kc88_second_23 -70;
-    pos @kc88_first_15 @kc88_second_25 -70;
-    pos @kc88_first_15 @kc88_second_29 -35;
-    pos @kc88_first_15 @kc88_second_31 -35;
-    pos @kc88_first_15 @kc88_second_36 -35;
-    pos @kc88_first_15 @kc88_second_38 -70;
-    pos @kc88_first_15 @kc88_second_39 -142;
-    pos @kc88_first_15 @kc88_second_40 -35;
-    pos @kc88_first_15 @kc88_second_44 -35;
-    pos @kc88_first_15 @kc88_second_45 1;
-    pos @kc88_first_15 @kc88_second_46 -35;
-    pos @kc88_first_15 @kc88_second_47 -70;
-    pos @kc88_first_15 @kc88_second_51 -35;
-    pos @kc88_first_15 @kc88_second_52 -35;
-    pos @kc88_first_15 @kc88_second_58 -105;
-    pos @kc88_first_15 @kc88_second_60 -35;
-    pos @kc88_first_15 @kc88_second_63 -35;
-    pos @kc88_first_15 @kc88_second_64 -35;
-    pos @kc88_first_16 @kc88_second_1 -280;
-    pos @kc88_first_16 @kc88_second_2 -280;
-    pos @kc88_first_16 @kc88_second_3 -140;
-    pos @kc88_first_16 @kc88_second_4 -70;
-    pos @kc88_first_16 @kc88_second_6 -280;
-    pos @kc88_first_16 @kc88_second_7 -140;
-    pos @kc88_first_16 @kc88_second_8 -175;
-    pos @kc88_first_16 @kc88_second_10 -70;
-    pos @kc88_first_16 @kc88_second_17 -245;
-    pos @kc88_first_16 @kc88_second_19 -280;
-    pos @kc88_first_16 @kc88_second_20 -210;
-    pos @kc88_first_16 @kc88_second_21 -140;
-    pos @kc88_first_16 @kc88_second_22 -280;
-    pos @kc88_first_16 @kc88_second_23 -210;
-    pos @kc88_first_16 @kc88_second_24 -350;
-    pos @kc88_first_16 @kc88_second_25 -70;
-    pos @kc88_first_16 @kc88_second_27 -140;
-    pos @kc88_first_16 @kc88_second_29 -240;
-    pos @kc88_first_16 @kc88_second_30 -140;
-    pos @kc88_first_16 @kc88_second_31 -140;
-    pos @kc88_first_16 @kc88_second_32 -245;
-    pos @kc88_first_16 @kc88_second_34 -315;
-    pos @kc88_first_16 @kc88_second_35 -70;
-    pos @kc88_first_16 @kc88_second_36 -210;
-    pos @kc88_first_16 @kc88_second_37 -210;
-    pos @kc88_first_16 @kc88_second_38 -245;
-    pos @kc88_first_16 @kc88_second_39 -245;
-    pos @kc88_first_16 @kc88_second_40 -70;
-    pos @kc88_first_16 @kc88_second_42 -35;
-    pos @kc88_first_16 @kc88_second_43 -140;
-    pos @kc88_first_16 @kc88_second_44 -140;
-    pos @kc88_first_16 @kc88_second_45 1;
-    pos @kc88_first_16 @kc88_second_46 -70;
-    pos @kc88_first_16 @kc88_second_47 -140;
-    pos @kc88_first_16 @kc88_second_49 -140;
-    pos @kc88_first_16 @kc88_second_50 -140;
-    pos @kc88_first_16 @kc88_second_51 -240;
-    pos @kc88_first_16 @kc88_second_52 -140;
-    pos @kc88_first_16 @kc88_second_53 -280;
-    pos @kc88_first_16 @kc88_second_54 -105;
-    pos @kc88_first_16 @kc88_second_55 -280;
-    pos @kc88_first_16 @kc88_second_56 -140;
-    pos @kc88_first_16 @kc88_second_57 -315;
-    pos @kc88_first_16 @kc88_second_58 -210;
-    pos @kc88_first_16 @kc88_second_59 -210;
-    pos @kc88_first_16 @kc88_second_60 -105;
-    pos @kc88_first_16 @kc88_second_63 -315;
-    pos @kc88_first_16 @kc88_second_64 -350;
-    pos @kc88_first_17 @kc88_second_1 -280;
-    pos @kc88_first_17 @kc88_second_2 -280;
-    pos @kc88_first_17 @kc88_second_3 -105;
-    pos @kc88_first_17 @kc88_second_6 -210;
-    pos @kc88_first_17 @kc88_second_7 -105;
-    pos @kc88_first_17 @kc88_second_8 -105;
-    pos @kc88_first_17 @kc88_second_10 -35;
-    pos @kc88_first_17 @kc88_second_17 -105;
-    pos @kc88_first_17 @kc88_second_19 -280;
-    pos @kc88_first_17 @kc88_second_20 -70;
-    pos @kc88_first_17 @kc88_second_21 -105;
-    pos @kc88_first_17 @kc88_second_22 -140;
-    pos @kc88_first_17 @kc88_second_23 -140;
-    pos @kc88_first_17 @kc88_second_24 -210;
-    pos @kc88_first_17 @kc88_second_27 -70;
-    pos @kc88_first_17 @kc88_second_29 -140;
-    pos @kc88_first_17 @kc88_second_30 -105;
-    pos @kc88_first_17 @kc88_second_32 -210;
-    pos @kc88_first_17 @kc88_second_34 -245;
-    pos @kc88_first_17 @kc88_second_35 -70;
-    pos @kc88_first_17 @kc88_second_36 -140;
-    pos @kc88_first_17 @kc88_second_37 -140;
-    pos @kc88_first_17 @kc88_second_38 -140;
-    pos @kc88_first_17 @kc88_second_39 -105;
-    pos @kc88_first_17 @kc88_second_40 -35;
-    pos @kc88_first_17 @kc88_second_43 -35;
-    pos @kc88_first_17 @kc88_second_44 -70;
-    pos @kc88_first_17 @kc88_second_45 1;
-    pos @kc88_first_17 @kc88_second_46 -35;
-    pos @kc88_first_17 @kc88_second_47 -70;
-    pos @kc88_first_17 @kc88_second_49 -105;
-    pos @kc88_first_17 @kc88_second_50 -70;
-    pos @kc88_first_17 @kc88_second_51 -105;
-    pos @kc88_first_17 @kc88_second_52 -70;
-    pos @kc88_first_17 @kc88_second_53 -210;
-    pos @kc88_first_17 @kc88_second_54 -35;
-    pos @kc88_first_17 @kc88_second_55 -210;
-    pos @kc88_first_17 @kc88_second_56 -70;
-    pos @kc88_first_17 @kc88_second_57 -245;
-    pos @kc88_first_17 @kc88_second_58 -105;
-    pos @kc88_first_17 @kc88_second_59 -105;
-    pos @kc88_first_17 @kc88_second_60 -70;
-    pos @kc88_first_17 @kc88_second_63 -175;
-    pos @kc88_first_17 @kc88_second_64 -245;
-    pos @kc88_first_18 @kc88_second_1 -210;
-    pos @kc88_first_18 @kc88_second_2 -245;
-    pos @kc88_first_18 @kc88_second_3 -35;
-    pos @kc88_first_18 @kc88_second_6 -140;
-    pos @kc88_first_18 @kc88_second_7 -35;
-    pos @kc88_first_18 @kc88_second_8 -70;
-    pos @kc88_first_18 @kc88_second_17 -105;
-    pos @kc88_first_18 @kc88_second_19 -210;
-    pos @kc88_first_18 @kc88_second_20 -70;
-    pos @kc88_first_18 @kc88_second_22 -105;
-    pos @kc88_first_18 @kc88_second_23 -70;
-    pos @kc88_first_18 @kc88_second_24 -140;
-    pos @kc88_first_18 @kc88_second_27 -35;
-    pos @kc88_first_18 @kc88_second_32 -140;
-    pos @kc88_first_18 @kc88_second_34 -140;
-    pos @kc88_first_18 @kc88_second_36 -105;
-    pos @kc88_first_18 @kc88_second_37 -70;
-    pos @kc88_first_18 @kc88_second_38 -105;
-    pos @kc88_first_18 @kc88_second_39 -70;
-    pos @kc88_first_18 @kc88_second_41 -35;
-    pos @kc88_first_18 @kc88_second_45 1;
-    pos @kc88_first_18 @kc88_second_50 -35;
-    pos @kc88_first_18 @kc88_second_51 -70;
-    pos @kc88_first_18 @kc88_second_53 -140;
-    pos @kc88_first_18 @kc88_second_55 -140;
-    pos @kc88_first_18 @kc88_second_57 -175;
-    pos @kc88_first_18 @kc88_second_58 -70;
-    pos @kc88_first_18 @kc88_second_63 -105;
-    pos @kc88_first_18 @kc88_second_64 -140;
-    pos @kc88_first_19 @kc88_second_12 -280;
-    pos @kc88_first_19 @kc88_second_14 -175;
-    pos @kc88_first_19 @kc88_second_15 -140;
-    pos @kc88_first_19 @kc88_second_29 -35;
-    pos @kc88_first_19 @kc88_second_45 1;
-    pos @kc88_first_19 @kc88_second_47 -70;
-    pos @kc88_first_19 @kc88_second_48 -140;
-    pos @kc88_first_19 @kc88_second_58 -70;
-    pos @kc88_first_19 @kc88_second_60 -35;
-    pos @kc88_first_19 @kc88_second_61 -105;
-    pos @kc88_first_19 @kc88_second_62 -70;
-    pos @kc88_first_20 @kc88_second_8 -35;
-    pos @kc88_first_20 @kc88_second_9 -140;
-    pos @kc88_first_20 @kc88_second_12 -280;
-    pos @kc88_first_20 @kc88_second_13 -280;
-    pos @kc88_first_20 @kc88_second_14 -280;
-    pos @kc88_first_20 @kc88_second_15 -175;
-    pos @kc88_first_20 @kc88_second_18 -140;
-    pos @kc88_first_20 @kc88_second_20 -70;
-    pos @kc88_first_20 @kc88_second_25 -70;
-    pos @kc88_first_20 @kc88_second_31 -50;
-    pos @kc88_first_20 @kc88_second_39 -140;
-    pos @kc88_first_20 @kc88_second_40 -105;
-    pos @kc88_first_20 @kc88_second_43 -210;
-    pos @kc88_first_20 @kc88_second_45 1;
-    pos @kc88_first_20 @kc88_second_46 -35;
-    pos @kc88_first_20 @kc88_second_47 -140;
-    pos @kc88_first_20 @kc88_second_48 -210;
-    pos @kc88_first_20 @kc88_second_52 -35;
-    pos @kc88_first_20 @kc88_second_58 -105;
-    pos @kc88_first_20 @kc88_second_60 -105;
-    pos @kc88_first_20 @kc88_second_61 -210;
-    pos @kc88_first_20 @kc88_second_62 -140;
-    pos @kc88_first_21 @kc88_second_1 -140;
-    pos @kc88_first_21 @kc88_second_2 -350;
-    pos @kc88_first_21 @kc88_second_19 -280;
-    pos @kc88_first_21 @kc88_second_38 -70;
-    pos @kc88_first_21 @kc88_second_45 1;
-    pos @kc88_first_21 @kc88_second_64 -210;
-    pos @kc88_first_22 @kc88_second_1 -35;
-    pos @kc88_first_22 @kc88_second_5 -105;
-    pos @kc88_first_22 @kc88_second_9 -70;
-    pos @kc88_first_22 @kc88_second_11 -70;
-    pos @kc88_first_22 @kc88_second_12 -240;
-    pos @kc88_first_22 @kc88_second_13 -280;
-    pos @kc88_first_22 @kc88_second_14 -140;
-    pos @kc88_first_22 @kc88_second_15 -105;
-    pos @kc88_first_22 @kc88_second_16 -70;
-    pos @kc88_first_22 @kc88_second_25 -35;
-    pos @kc88_first_22 @kc88_second_26 -70;
-    pos @kc88_first_22 @kc88_second_27 -105;
-    pos @kc88_first_22 @kc88_second_35 -70;
-    pos @kc88_first_22 @kc88_second_39 -70;
-    pos @kc88_first_22 @kc88_second_40 -35;
-    pos @kc88_first_22 @kc88_second_42 -35;
-    pos @kc88_first_22 @kc88_second_43 -140;
-    pos @kc88_first_22 @kc88_second_45 1;
-    pos @kc88_first_22 @kc88_second_47 -70;
-    pos @kc88_first_22 @kc88_second_48 -175;
-    pos @kc88_first_22 @kc88_second_49 -35;
-    pos @kc88_first_22 @kc88_second_56 -105;
-    pos @kc88_first_22 @kc88_second_58 -35;
-    pos @kc88_first_22 @kc88_second_60 -50;
-    pos @kc88_first_22 @kc88_second_61 -105;
-    pos @kc88_first_22 @kc88_second_62 -70;
-    pos @kc88_first_23 @kc88_second_6 -35;
-    pos @kc88_first_23 @kc88_second_12 -240;
-    pos @kc88_first_23 @kc88_second_13 -175;
-    pos @kc88_first_23 @kc88_second_14 -70;
-    pos @kc88_first_23 @kc88_second_15 -70;
-    pos @kc88_first_23 @kc88_second_22 -70;
-    pos @kc88_first_23 @kc88_second_23 -35;
-    pos @kc88_first_23 @kc88_second_34 -35;
-    pos @kc88_first_23 @kc88_second_39 -35;
-    pos @kc88_first_23 @kc88_second_40 -35;
-    pos @kc88_first_23 @kc88_second_43 -70;
-    pos @kc88_first_23 @kc88_second_44 -35;
-    pos @kc88_first_23 @kc88_second_45 1;
-    pos @kc88_first_23 @kc88_second_48 -35;
-    pos @kc88_first_23 @kc88_second_58 -35;
-    pos @kc88_first_23 @kc88_second_62 -35;
-    pos @kc88_first_23 @kc88_second_63 -35;
-    pos @kc88_first_23 @kc88_second_64 -35;
-    pos @kc88_first_24 @kc88_second_1 -70;
-    pos @kc88_first_24 @kc88_second_2 -140;
-    pos @kc88_first_24 @kc88_second_5 -105;
-    pos @kc88_first_24 @kc88_second_11 -70;
-    pos @kc88_first_24 @kc88_second_12 -280;
-    pos @kc88_first_24 @kc88_second_13 -210;
-    pos @kc88_first_24 @kc88_second_14 -70;
-    pos @kc88_first_24 @kc88_second_15 -70;
-    pos @kc88_first_24 @kc88_second_16 -140;
-    pos @kc88_first_24 @kc88_second_19 -70;
-    pos @kc88_first_24 @kc88_second_26 -70;
-    pos @kc88_first_24 @kc88_second_27 -70;
-    pos @kc88_first_24 @kc88_second_32 -70;
-    pos @kc88_first_24 @kc88_second_35 -70;
-    pos @kc88_first_24 @kc88_second_42 -35;
-    pos @kc88_first_24 @kc88_second_43 -140;
-    pos @kc88_first_24 @kc88_second_45 1;
-    pos @kc88_first_24 @kc88_second_48 -140;
-    pos @kc88_first_24 @kc88_second_49 -35;
-    pos @kc88_first_24 @kc88_second_53 -140;
-    pos @kc88_first_24 @kc88_second_55 -105;
-    pos @kc88_first_24 @kc88_second_56 -70;
-    pos @kc88_first_24 @kc88_second_57 -70;
-    pos @kc88_first_24 @kc88_second_61 -70;
-    pos @kc88_first_24 @kc88_second_62 -35;
-    pos @kc88_first_25 @kc88_second_5 -70;
-    pos @kc88_first_25 @kc88_second_9 -70;
-    pos @kc88_first_25 @kc88_second_12 -240;
-    pos @kc88_first_25 @kc88_second_13 -280;
-    pos @kc88_first_25 @kc88_second_14 -175;
-    pos @kc88_first_25 @kc88_second_15 -105;
-    pos @kc88_first_25 @kc88_second_16 -70;
-    pos @kc88_first_25 @kc88_second_25 -35;
-    pos @kc88_first_25 @kc88_second_26 -70;
-    pos @kc88_first_25 @kc88_second_27 -70;
-    pos @kc88_first_25 @kc88_second_35 -70;
-    pos @kc88_first_25 @kc88_second_39 -70;
-    pos @kc88_first_25 @kc88_second_40 -35;
-    pos @kc88_first_25 @kc88_second_43 -140;
-    pos @kc88_first_25 @kc88_second_45 1;
-    pos @kc88_first_25 @kc88_second_47 -70;
-    pos @kc88_first_25 @kc88_second_48 -140;
-    pos @kc88_first_25 @kc88_second_49 -35;
-    pos @kc88_first_25 @kc88_second_53 -50;
-    pos @kc88_first_25 @kc88_second_54 -35;
-    pos @kc88_first_25 @kc88_second_55 -50;
-    pos @kc88_first_25 @kc88_second_56 -105;
-    pos @kc88_first_25 @kc88_second_57 -50;
-    pos @kc88_first_25 @kc88_second_58 -50;
-    pos @kc88_first_25 @kc88_second_60 -35;
-    pos @kc88_first_25 @kc88_second_61 -105;
-    pos @kc88_first_25 @kc88_second_62 -70;
-    pos @kc88_first_26 @kc88_second_9 -35;
-    pos @kc88_first_26 @kc88_second_12 -140;
-    pos @kc88_first_26 @kc88_second_26 -70;
-    pos @kc88_first_26 @kc88_second_39 -35;
-    pos @kc88_first_26 @kc88_second_43 -70;
-    pos @kc88_first_26 @kc88_second_45 1;
-    pos @kc88_first_26 @kc88_second_48 -70;
-    pos @kc88_first_26 @kc88_second_61 -70;
-    pos @kc88_first_26 @kc88_second_62 -35;
-    pos @kc88_first_27 @kc88_second_5 -50;
-    pos @kc88_first_27 @kc88_second_9 -35;
-    pos @kc88_first_27 @kc88_second_11 -35;
-    pos @kc88_first_27 @kc88_second_12 -240;
-    pos @kc88_first_27 @kc88_second_13 -240;
-    pos @kc88_first_27 @kc88_second_14 -105;
-    pos @kc88_first_27 @kc88_second_15 -70;
-    pos @kc88_first_27 @kc88_second_16 -35;
-    pos @kc88_first_27 @kc88_second_26 -35;
-    pos @kc88_first_27 @kc88_second_27 -35;
-    pos @kc88_first_27 @kc88_second_35 -35;
-    pos @kc88_first_27 @kc88_second_39 -50;
-    pos @kc88_first_27 @kc88_second_40 -35;
-    pos @kc88_first_27 @kc88_second_43 -100;
-    pos @kc88_first_27 @kc88_second_45 1;
-    pos @kc88_first_27 @kc88_second_47 -35;
-    pos @kc88_first_27 @kc88_second_48 -140;
-    pos @kc88_first_27 @kc88_second_56 -35;
-    pos @kc88_first_27 @kc88_second_61 -70;
-    pos @kc88_first_27 @kc88_second_62 -35;
-    pos @kc88_first_28 @kc88_second_45 1;
-    pos @kc88_first_29 @kc88_second_8 -70;
-    pos @kc88_first_29 @kc88_second_9 -210;
-    pos @kc88_first_29 @kc88_second_12 -350;
-    pos @kc88_first_29 @kc88_second_13 -350;
-    pos @kc88_first_29 @kc88_second_14 -210;
-    pos @kc88_first_29 @kc88_second_15 -175;
-    pos @kc88_first_29 @kc88_second_25 -70;
-    pos @kc88_first_29 @kc88_second_38 -35;
-    pos @kc88_first_29 @kc88_second_39 -210;
-    pos @kc88_first_29 @kc88_second_40 -210;
-    pos @kc88_first_29 @kc88_second_43 -210;
-    pos @kc88_first_29 @kc88_second_45 1;
-    pos @kc88_first_29 @kc88_second_47 -140;
-    pos @kc88_first_29 @kc88_second_48 -280;
-    pos @kc88_first_29 @kc88_second_58 -210;
-    pos @kc88_first_29 @kc88_second_60 -105;
-    pos @kc88_first_29 @kc88_second_61 -175;
-    pos @kc88_first_29 @kc88_second_62 -140;
-    pos @kc88_first_30 @kc88_second_1 -175;
-    pos @kc88_first_30 @kc88_second_2 -175;
-    pos @kc88_first_30 @kc88_second_5 -70;
-    pos @kc88_first_30 @kc88_second_6 -105;
-    pos @kc88_first_30 @kc88_second_10 -35;
-    pos @kc88_first_30 @kc88_second_11 -105;
-    pos @kc88_first_30 @kc88_second_12 -175;
-    pos @kc88_first_30 @kc88_second_13 -140;
-    pos @kc88_first_30 @kc88_second_14 -70;
-    pos @kc88_first_30 @kc88_second_15 -35;
-    pos @kc88_first_30 @kc88_second_16 -140;
-    pos @kc88_first_30 @kc88_second_17 -70;
-    pos @kc88_first_30 @kc88_second_19 -175;
-    pos @kc88_first_30 @kc88_second_22 -70;
-    pos @kc88_first_30 @kc88_second_29 -105;
-    pos @kc88_first_30 @kc88_second_33 180;
-    pos @kc88_first_30 @kc88_second_34 -105;
-    pos @kc88_first_30 @kc88_second_35 -175;
-    pos @kc88_first_30 @kc88_second_36 -35;
-    pos @kc88_first_30 @kc88_second_38 -70;
-    pos @kc88_first_30 @kc88_second_45 1;
-    pos @kc88_first_30 @kc88_second_50 180;
-    pos @kc88_first_30 @kc88_second_51 -35;
-    pos @kc88_first_30 @kc88_second_63 -70;
-    pos @kc88_first_30 @kc88_second_64 -105;
-    pos @kc88_first_31 @kc88_second_3 -70;
-    pos @kc88_first_31 @kc88_second_4 -35;
-    pos @kc88_first_31 @kc88_second_6 -70;
-    pos @kc88_first_31 @kc88_second_8 -105;
-    pos @kc88_first_31 @kc88_second_17 -35;
-    pos @kc88_first_31 @kc88_second_20 -70;
-    pos @kc88_first_31 @kc88_second_22 -70;
-    pos @kc88_first_31 @kc88_second_23 -140;
-    pos @kc88_first_31 @kc88_second_29 -35;
-    pos @kc88_first_31 @kc88_second_34 -70;
-    pos @kc88_first_31 @kc88_second_36 -35;
-    pos @kc88_first_31 @kc88_second_38 -140;
-    pos @kc88_first_31 @kc88_second_39 -70;
-    pos @kc88_first_31 @kc88_second_45 1;
-    pos @kc88_first_31 @kc88_second_51 -35;
-    pos @kc88_first_31 @kc88_second_52 -35;
-    pos @kc88_first_31 @kc88_second_58 -140;
-    pos @kc88_first_31 @kc88_second_63 -70;
-    pos @kc88_first_31 @kc88_second_64 -70;
-    pos @kc88_first_32 @kc88_second_1 -35;
-    pos @kc88_first_32 @kc88_second_2 -105;
-    pos @kc88_first_32 @kc88_second_3 -70;
-    pos @kc88_first_32 @kc88_second_4 70;
-    pos @kc88_first_32 @kc88_second_5 -70;
-    pos @kc88_first_32 @kc88_second_11 -35;
-    pos @kc88_first_32 @kc88_second_12 -240;
-    pos @kc88_first_32 @kc88_second_13 -175;
-    pos @kc88_first_32 @kc88_second_14 -105;
-    pos @kc88_first_32 @kc88_second_15 -70;
-    pos @kc88_first_32 @kc88_second_16 -70;
-    pos @kc88_first_32 @kc88_second_24 -35;
-    pos @kc88_first_32 @kc88_second_27 -70;
-    pos @kc88_first_32 @kc88_second_35 -35;
-    pos @kc88_first_32 @kc88_second_39 -35;
-    pos @kc88_first_32 @kc88_second_40 -35;
-    pos @kc88_first_32 @kc88_second_42 -35;
-    pos @kc88_first_32 @kc88_second_43 -140;
-    pos @kc88_first_32 @kc88_second_45 1;
-    pos @kc88_first_32 @kc88_second_47 -50;
-    pos @kc88_first_32 @kc88_second_48 -140;
-    pos @kc88_first_32 @kc88_second_49 -35;
-    pos @kc88_first_32 @kc88_second_53 -70;
-    pos @kc88_first_32 @kc88_second_55 -70;
-    pos @kc88_first_32 @kc88_second_57 -70;
-    pos @kc88_first_32 @kc88_second_61 -70;
-    pos @kc88_first_32 @kc88_second_62 -35;
-    pos @kc88_first_33 @kc88_second_3 -35;
-    pos @kc88_first_33 @kc88_second_4 -70;
-    pos @kc88_first_33 @kc88_second_6 -70;
-    pos @kc88_first_33 @kc88_second_8 -70;
-    pos @kc88_first_33 @kc88_second_12 -140;
-    pos @kc88_first_33 @kc88_second_13 -105;
-    pos @kc88_first_33 @kc88_second_14 -70;
-    pos @kc88_first_33 @kc88_second_15 -35;
-    pos @kc88_first_33 @kc88_second_20 -70;
-    pos @kc88_first_33 @kc88_second_22 -105;
-    pos @kc88_first_33 @kc88_second_23 -70;
-    pos @kc88_first_33 @kc88_second_29 -35;
-    pos @kc88_first_33 @kc88_second_34 -70;
-    pos @kc88_first_33 @kc88_second_36 -70;
-    pos @kc88_first_33 @kc88_second_38 -105;
-    pos @kc88_first_33 @kc88_second_39 -70;
-    pos @kc88_first_33 @kc88_second_44 -70;
-    pos @kc88_first_33 @kc88_second_45 1;
-    pos @kc88_first_33 @kc88_second_51 -35;
-    pos @kc88_first_33 @kc88_second_52 -35;
-    pos @kc88_first_33 @kc88_second_63 -70;
-    pos @kc88_first_33 @kc88_second_64 -70;
-    pos @kc88_first_34 @kc88_second_32 -315;
-    pos @kc88_first_34 @kc88_second_45 1;
-    pos @kc88_first_35 @kc88_second_9 -70;
-    pos @kc88_first_35 @kc88_second_12 -240;
-    pos @kc88_first_35 @kc88_second_13 -210;
-    pos @kc88_first_35 @kc88_second_14 -140;
-    pos @kc88_first_35 @kc88_second_15 -105;
-    pos @kc88_first_35 @kc88_second_39 -70;
-    pos @kc88_first_35 @kc88_second_40 -35;
-    pos @kc88_first_35 @kc88_second_43 -140;
-    pos @kc88_first_35 @kc88_second_45 1;
-    pos @kc88_first_35 @kc88_second_47 -50;
-    pos @kc88_first_35 @kc88_second_48 -140;
-    pos @kc88_first_35 @kc88_second_58 -35;
-    pos @kc88_first_35 @kc88_second_60 -35;
-    pos @kc88_first_35 @kc88_second_61 -70;
-    pos @kc88_first_35 @kc88_second_62 -70;
-    pos @kc88_first_36 @kc88_second_9 -35;
-    pos @kc88_first_36 @kc88_second_12 -240;
-    pos @kc88_first_36 @kc88_second_13 -240;
-    pos @kc88_first_36 @kc88_second_14 -140;
-    pos @kc88_first_36 @kc88_second_15 -105;
-    pos @kc88_first_36 @kc88_second_16 -35;
-    pos @kc88_first_36 @kc88_second_26 -35;
-    pos @kc88_first_36 @kc88_second_27 -35;
-    pos @kc88_first_36 @kc88_second_39 -70;
-    pos @kc88_first_36 @kc88_second_40 -35;
-    pos @kc88_first_36 @kc88_second_43 -70;
-    pos @kc88_first_36 @kc88_second_45 1;
-    pos @kc88_first_36 @kc88_second_47 -35;
-    pos @kc88_first_36 @kc88_second_48 -70;
-    pos @kc88_first_36 @kc88_second_60 -35;
-    pos @kc88_first_36 @kc88_second_61 -70;
-    pos @kc88_first_36 @kc88_second_62 -70;
-    pos @kc88_first_37 @kc88_second_5 -70;
-    pos @kc88_first_37 @kc88_second_9 -70;
-    pos @kc88_first_37 @kc88_second_12 -140;
-    pos @kc88_first_37 @kc88_second_13 -210;
-    pos @kc88_first_37 @kc88_second_14 -140;
-    pos @kc88_first_37 @kc88_second_15 -105;
-    pos @kc88_first_37 @kc88_second_16 -70;
-    pos @kc88_first_37 @kc88_second_26 -70;
-    pos @kc88_first_37 @kc88_second_27 -70;
-    pos @kc88_first_37 @kc88_second_35 -50;
-    pos @kc88_first_37 @kc88_second_39 -50;
-    pos @kc88_first_37 @kc88_second_40 -35;
-    pos @kc88_first_37 @kc88_second_45 1;
-    pos @kc88_first_37 @kc88_second_47 -35;
-    pos @kc88_first_37 @kc88_second_48 -140;
-    pos @kc88_first_37 @kc88_second_56 -35;
-    pos @kc88_first_37 @kc88_second_61 -70;
-    pos @kc88_first_37 @kc88_second_62 -35;
-    pos @kc88_first_38 @kc88_second_1 -210;
-    pos @kc88_first_38 @kc88_second_2 -280;
-    pos @kc88_first_38 @kc88_second_6 -280;
-    pos @kc88_first_38 @kc88_second_8 -70;
-    pos @kc88_first_38 @kc88_second_17 -140;
-    pos @kc88_first_38 @kc88_second_19 -350;
-    pos @kc88_first_38 @kc88_second_20 -140;
-    pos @kc88_first_38 @kc88_second_22 -140;
-    pos @kc88_first_38 @kc88_second_23 -70;
-    pos @kc88_first_38 @kc88_second_24 -280;
-    pos @kc88_first_38 @kc88_second_28 -315;
-    pos @kc88_first_38 @kc88_second_29 -140;
-    pos @kc88_first_38 @kc88_second_32 -385;
-    pos @kc88_first_38 @kc88_second_34 -210;
-    pos @kc88_first_38 @kc88_second_35 -70;
-    pos @kc88_first_38 @kc88_second_36 -140;
-    pos @kc88_first_38 @kc88_second_37 -140;
-    pos @kc88_first_38 @kc88_second_38 -140;
-    pos @kc88_first_38 @kc88_second_41 -70;
-    pos @kc88_first_38 @kc88_second_45 1;
-    pos @kc88_first_38 @kc88_second_51 -140;
-    pos @kc88_first_38 @kc88_second_52 -70;
-    pos @kc88_first_38 @kc88_second_53 -140;
-    pos @kc88_first_38 @kc88_second_55 -245;
-    pos @kc88_first_38 @kc88_second_58 -70;
-    pos @kc88_first_38 @kc88_second_59 -70;
-    pos @kc88_first_38 @kc88_second_63 -245;
-    pos @kc88_first_38 @kc88_second_64 -280;
-    pos @kc88_first_38 @kc88_second_65 -315;
-    pos @kc88_first_39 @kc88_second_6 -35;
-    pos @kc88_first_39 @kc88_second_12 -240;
-    pos @kc88_first_39 @kc88_second_13 -140;
-    pos @kc88_first_39 @kc88_second_14 -35;
-    pos @kc88_first_39 @kc88_second_15 -35;
-    pos @kc88_first_39 @kc88_second_34 -35;
-    pos @kc88_first_39 @kc88_second_45 1;
-    pos @kc88_first_39 @kc88_second_63 -35;
-    pos @kc88_first_39 @kc88_second_64 -35;
-    pos @kc88_first_40 @kc88_second_12 -210;
-    pos @kc88_first_40 @kc88_second_13 -175;
-    pos @kc88_first_40 @kc88_second_14 -105;
-    pos @kc88_first_40 @kc88_second_15 -70;
-    pos @kc88_first_40 @kc88_second_43 -70;
-    pos @kc88_first_40 @kc88_second_45 1;
-    pos @kc88_first_40 @kc88_second_48 -105;
-    pos @kc88_first_40 @kc88_second_61 -70;
-    pos @kc88_first_41 @kc88_second_1 -140;
-    pos @kc88_first_41 @kc88_second_2 -175;
-    pos @kc88_first_41 @kc88_second_5 -105;
-    pos @kc88_first_41 @kc88_second_6 -70;
-    pos @kc88_first_41 @kc88_second_11 -70;
-    pos @kc88_first_41 @kc88_second_12 -175;
-    pos @kc88_first_41 @kc88_second_13 -105;
-    pos @kc88_first_41 @kc88_second_14 -70;
-    pos @kc88_first_41 @kc88_second_15 -35;
-    pos @kc88_first_41 @kc88_second_16 -105;
-    pos @kc88_first_41 @kc88_second_17 -35;
-    pos @kc88_first_41 @kc88_second_19 -175;
-    pos @kc88_first_41 @kc88_second_22 -50;
-    pos @kc88_first_41 @kc88_second_24 -105;
-    pos @kc88_first_41 @kc88_second_29 -35;
-    pos @kc88_first_41 @kc88_second_34 -70;
-    pos @kc88_first_41 @kc88_second_35 -140;
-    pos @kc88_first_41 @kc88_second_36 -35;
-    pos @kc88_first_41 @kc88_second_38 -50;
-    pos @kc88_first_41 @kc88_second_45 1;
-    pos @kc88_first_41 @kc88_second_51 -35;
-    pos @kc88_first_41 @kc88_second_53 -105;
-    pos @kc88_first_41 @kc88_second_55 -105;
-    pos @kc88_first_41 @kc88_second_57 -105;
-    pos @kc88_first_41 @kc88_second_63 -50;
-    pos @kc88_first_41 @kc88_second_64 -70;
-    pos @kc88_first_42 @kc88_second_1 -210;
-    pos @kc88_first_42 @kc88_second_2 -280;
-    pos @kc88_first_42 @kc88_second_3 -70;
-    pos @kc88_first_42 @kc88_second_6 -280;
-    pos @kc88_first_42 @kc88_second_8 -35;
-    pos @kc88_first_42 @kc88_second_11 -70;
-    pos @kc88_first_42 @kc88_second_13 -140;
-    pos @kc88_first_42 @kc88_second_14 -35;
-    pos @kc88_first_42 @kc88_second_15 -35;
-    pos @kc88_first_42 @kc88_second_16 -140;
-    pos @kc88_first_42 @kc88_second_17 -105;
-    pos @kc88_first_42 @kc88_second_19 -280;
-    pos @kc88_first_42 @kc88_second_20 -140;
-    pos @kc88_first_42 @kc88_second_22 -140;
-    pos @kc88_first_42 @kc88_second_23 -140;
-    pos @kc88_first_42 @kc88_second_24 -210;
-    pos @kc88_first_42 @kc88_second_34 -280;
-    pos @kc88_first_42 @kc88_second_35 -140;
-    pos @kc88_first_42 @kc88_second_36 -70;
-    pos @kc88_first_42 @kc88_second_37 -140;
-    pos @kc88_first_42 @kc88_second_38 -175;
-    pos @kc88_first_42 @kc88_second_44 -70;
-    pos @kc88_first_42 @kc88_second_45 1;
-    pos @kc88_first_42 @kc88_second_53 -210;
-    pos @kc88_first_42 @kc88_second_55 -175;
-    pos @kc88_first_42 @kc88_second_57 -210;
-    pos @kc88_first_42 @kc88_second_59 -70;
-    pos @kc88_first_42 @kc88_second_63 -175;
-    pos @kc88_first_42 @kc88_second_64 -175;
-    pos @kc88_first_43 @kc88_second_9 -70;
-    pos @kc88_first_43 @kc88_second_12 -240;
-    pos @kc88_first_43 @kc88_second_13 -210;
-    pos @kc88_first_43 @kc88_second_14 -140;
-    pos @kc88_first_43 @kc88_second_15 -105;
-    pos @kc88_first_43 @kc88_second_39 -70;
-    pos @kc88_first_43 @kc88_second_40 -35;
-    pos @kc88_first_43 @kc88_second_43 -140;
-    pos @kc88_first_43 @kc88_second_45 1;
-    pos @kc88_first_43 @kc88_second_47 -50;
-    pos @kc88_first_43 @kc88_second_48 -140;
-    pos @kc88_first_43 @kc88_second_58 -35;
-    pos @kc88_first_43 @kc88_second_60 -35;
-    pos @kc88_first_43 @kc88_second_61 -70;
-    pos @kc88_first_43 @kc88_second_62 -70;
-    pos @kc88_first_44 @kc88_second_8 -35;
-    pos @kc88_first_44 @kc88_second_9 -70;
-    pos @kc88_first_44 @kc88_second_12 -240;
-    pos @kc88_first_44 @kc88_second_13 -210;
-    pos @kc88_first_44 @kc88_second_14 -70;
-    pos @kc88_first_44 @kc88_second_15 -105;
-    pos @kc88_first_44 @kc88_second_22 -35;
-    pos @kc88_first_44 @kc88_second_38 -70;
-    pos @kc88_first_44 @kc88_second_39 -105;
-    pos @kc88_first_44 @kc88_second_40 -70;
-    pos @kc88_first_44 @kc88_second_43 -70;
-    pos @kc88_first_44 @kc88_second_44 -35;
-    pos @kc88_first_44 @kc88_second_45 1;
-    pos @kc88_first_44 @kc88_second_47 -70;
-    pos @kc88_first_44 @kc88_second_48 -70;
-    pos @kc88_first_44 @kc88_second_58 -70;
-    pos @kc88_first_44 @kc88_second_60 -50;
-    pos @kc88_first_44 @kc88_second_62 -70;
-    pos @kc88_first_44 @kc88_second_63 -35;
-    pos @kc88_first_44 @kc88_second_64 -35;
-    pos @kc88_first_45 @kc88_second_6 -70;
-    pos @kc88_first_45 @kc88_second_8 -35;
-    pos @kc88_first_45 @kc88_second_12 -175;
-    pos @kc88_first_45 @kc88_second_13 -140;
-    pos @kc88_first_45 @kc88_second_14 -70;
-    pos @kc88_first_45 @kc88_second_15 -35;
-    pos @kc88_first_45 @kc88_second_17 -70;
-    pos @kc88_first_45 @kc88_second_20 -70;
-    pos @kc88_first_45 @kc88_second_22 -105;
-    pos @kc88_first_45 @kc88_second_29 -35;
-    pos @kc88_first_45 @kc88_second_34 -70;
-    pos @kc88_first_45 @kc88_second_36 -35;
-    pos @kc88_first_45 @kc88_second_38 -105;
-    pos @kc88_first_45 @kc88_second_45 1;
-    pos @kc88_first_45 @kc88_second_51 -35;
-    pos @kc88_first_45 @kc88_second_63 -70;
-    pos @kc88_first_45 @kc88_second_64 -70;
-    pos @kc88_first_46 @kc88_second_3 -140;
-    pos @kc88_first_46 @kc88_second_4 -70;
-    pos @kc88_first_46 @kc88_second_6 -70;
-    pos @kc88_first_46 @kc88_second_8 -210;
-    pos @kc88_first_46 @kc88_second_9 -420;
-    pos @kc88_first_46 @kc88_second_12 -350;
-    pos @kc88_first_46 @kc88_second_13 -420;
-    pos @kc88_first_46 @kc88_second_14 -350;
-    pos @kc88_first_46 @kc88_second_15 -280;
-    pos @kc88_first_46 @kc88_second_17 -70;
-    pos @kc88_first_46 @kc88_second_18 -210;
-    pos @kc88_first_46 @kc88_second_20 -210;
-    pos @kc88_first_46 @kc88_second_22 -70;
-    pos @kc88_first_46 @kc88_second_23 -140;
-    pos @kc88_first_46 @kc88_second_29 -35;
-    pos @kc88_first_46 @kc88_second_31 -140;
-    pos @kc88_first_46 @kc88_second_34 -70;
-    pos @kc88_first_46 @kc88_second_36 -70;
-    pos @kc88_first_46 @kc88_second_38 -210;
-    pos @kc88_first_46 @kc88_second_39 -280;
-    pos @kc88_first_46 @kc88_second_40 -420;
-    pos @kc88_first_46 @kc88_second_43 -350;
-    pos @kc88_first_46 @kc88_second_45 1;
-    pos @kc88_first_46 @kc88_second_46 -35;
-    pos @kc88_first_46 @kc88_second_47 -210;
-    pos @kc88_first_46 @kc88_second_48 -350;
-    pos @kc88_first_46 @kc88_second_51 -35;
-    pos @kc88_first_46 @kc88_second_52 -35;
-    pos @kc88_first_46 @kc88_second_58 -280;
-    pos @kc88_first_46 @kc88_second_60 -175;
-    pos @kc88_first_46 @kc88_second_61 -280;
-    pos @kc88_first_46 @kc88_second_62 -210;
-    pos @kc88_first_46 @kc88_second_63 -70;
-    pos @kc88_first_47 @kc88_second_3 -140;
-    pos @kc88_first_47 @kc88_second_4 -105;
-    pos @kc88_first_47 @kc88_second_6 -70;
-    pos @kc88_first_47 @kc88_second_8 -210;
-    pos @kc88_first_47 @kc88_second_9 -280;
-    pos @kc88_first_47 @kc88_second_12 -350;
-    pos @kc88_first_47 @kc88_second_13 -385;
-    pos @kc88_first_47 @kc88_second_14 -350;
-    pos @kc88_first_47 @kc88_second_15 -280;
-    pos @kc88_first_47 @kc88_second_18 -210;
-    pos @kc88_first_47 @kc88_second_20 -140;
-    pos @kc88_first_47 @kc88_second_22 -105;
-    pos @kc88_first_47 @kc88_second_23 -140;
-    pos @kc88_first_47 @kc88_second_29 -70;
-    pos @kc88_first_47 @kc88_second_31 -175;
-    pos @kc88_first_47 @kc88_second_34 -70;
-    pos @kc88_first_47 @kc88_second_36 -35;
-    pos @kc88_first_47 @kc88_second_38 -175;
-    pos @kc88_first_47 @kc88_second_39 -280;
-    pos @kc88_first_47 @kc88_second_40 -280;
-    pos @kc88_first_47 @kc88_second_43 -280;
-    pos @kc88_first_47 @kc88_second_44 -140;
-    pos @kc88_first_47 @kc88_second_45 1;
-    pos @kc88_first_47 @kc88_second_46 -70;
-    pos @kc88_first_47 @kc88_second_47 -280;
-    pos @kc88_first_47 @kc88_second_48 -350;
-    pos @kc88_first_47 @kc88_second_51 -35;
-    pos @kc88_first_47 @kc88_second_52 -70;
-    pos @kc88_first_47 @kc88_second_58 -245;
-    pos @kc88_first_47 @kc88_second_60 -245;
-    pos @kc88_first_47 @kc88_second_61 -280;
-    pos @kc88_first_47 @kc88_second_62 -210;
-    pos @kc88_first_47 @kc88_second_63 -70;
-    pos @kc88_first_47 @kc88_second_64 -70;
-    pos @kc88_first_48 @kc88_second_3 -70;
-    pos @kc88_first_48 @kc88_second_4 -105;
-    pos @kc88_first_48 @kc88_second_6 -210;
-    pos @kc88_first_48 @kc88_second_7 -70;
-    pos @kc88_first_48 @kc88_second_8 -175;
-    pos @kc88_first_48 @kc88_second_17 -210;
-    pos @kc88_first_48 @kc88_second_20 -140;
-    pos @kc88_first_48 @kc88_second_21 -210;
-    pos @kc88_first_48 @kc88_second_22 -210;
-    pos @kc88_first_48 @kc88_second_23 -210;
-    pos @kc88_first_48 @kc88_second_24 -140;
-    pos @kc88_first_48 @kc88_second_25 -140;
-    pos @kc88_first_48 @kc88_second_27 -140;
-    pos @kc88_first_48 @kc88_second_29 -210;
-    pos @kc88_first_48 @kc88_second_30 -210;
-    pos @kc88_first_48 @kc88_second_31 -140;
-    pos @kc88_first_48 @kc88_second_34 -210;
-    pos @kc88_first_48 @kc88_second_35 -70;
-    pos @kc88_first_48 @kc88_second_36 -175;
-    pos @kc88_first_48 @kc88_second_37 -210;
-    pos @kc88_first_48 @kc88_second_38 -175;
-    pos @kc88_first_48 @kc88_second_39 -210;
-    pos @kc88_first_48 @kc88_second_40 -105;
-    pos @kc88_first_48 @kc88_second_43 -70;
-    pos @kc88_first_48 @kc88_second_44 -105;
-    pos @kc88_first_48 @kc88_second_45 1;
-    pos @kc88_first_48 @kc88_second_46 -35;
-    pos @kc88_first_48 @kc88_second_47 -210;
-    pos @kc88_first_48 @kc88_second_50 -210;
-    pos @kc88_first_48 @kc88_second_51 -210;
-    pos @kc88_first_48 @kc88_second_52 -175;
-    pos @kc88_first_48 @kc88_second_53 -175;
-    pos @kc88_first_48 @kc88_second_55 -210;
-    pos @kc88_first_48 @kc88_second_56 -140;
-    pos @kc88_first_48 @kc88_second_57 -210;
-    pos @kc88_first_48 @kc88_second_58 -210;
-    pos @kc88_first_48 @kc88_second_59 -175;
-    pos @kc88_first_48 @kc88_second_60 -175;
-    pos @kc88_first_48 @kc88_second_63 -210;
-    pos @kc88_first_48 @kc88_second_64 -210;
-    pos @kc88_first_49 @kc88_second_5 -70;
-    pos @kc88_first_49 @kc88_second_11 -35;
-    pos @kc88_first_49 @kc88_second_12 -240;
-    pos @kc88_first_49 @kc88_second_13 -70;
-    pos @kc88_first_49 @kc88_second_14 -140;
-    pos @kc88_first_49 @kc88_second_15 -105;
-    pos @kc88_first_49 @kc88_second_16 -70;
-    pos @kc88_first_49 @kc88_second_26 -70;
-    pos @kc88_first_49 @kc88_second_27 -70;
-    pos @kc88_first_49 @kc88_second_35 -35;
-    pos @kc88_first_49 @kc88_second_39 -70;
-    pos @kc88_first_49 @kc88_second_42 -35;
-    pos @kc88_first_49 @kc88_second_43 -70;
-    pos @kc88_first_49 @kc88_second_45 1;
-    pos @kc88_first_49 @kc88_second_47 -35;
-    pos @kc88_first_49 @kc88_second_48 -140;
-    pos @kc88_first_49 @kc88_second_51 1;
-    pos @kc88_first_49 @kc88_second_56 -35;
-    pos @kc88_first_49 @kc88_second_60 -35;
-    pos @kc88_first_49 @kc88_second_61 -105;
-    pos @kc88_first_49 @kc88_second_62 -70;
-    pos @kc88_first_50 @kc88_second_65 -210;
-    pos @kc88_first_51 @kc88_second_32 -315;
-    pos @kc88_first_51 @kc88_second_66 -210;
-    pos @kc88_first_52 @kc88_second_1 -105;
-    pos @kc88_first_52 @kc88_second_2 -210;
-    pos @kc88_first_52 @kc88_second_6 -140;
-    pos @kc88_first_52 @kc88_second_11 -70;
-    pos @kc88_first_52 @kc88_second_12 -210;
-    pos @kc88_first_52 @kc88_second_13 -210;
-    pos @kc88_first_52 @kc88_second_14 -105;
-    pos @kc88_first_52 @kc88_second_15 -70;
-    pos @kc88_first_52 @kc88_second_16 -140;
-    pos @kc88_first_52 @kc88_second_17 -35;
-    pos @kc88_first_52 @kc88_second_22 -35;
-    pos @kc88_first_52 @kc88_second_24 -210;
-    pos @kc88_first_52 @kc88_second_26 -70;
-    pos @kc88_first_52 @kc88_second_27 -70;
-    pos @kc88_first_52 @kc88_second_29 -35;
-    pos @kc88_first_52 @kc88_second_34 -210;
-    pos @kc88_first_52 @kc88_second_35 -140;
-    pos @kc88_first_52 @kc88_second_42 -35;
-    pos @kc88_first_52 @kc88_second_43 -70;
-    pos @kc88_first_52 @kc88_second_45 1;
-    pos @kc88_first_52 @kc88_second_47 -35;
-    pos @kc88_first_52 @kc88_second_48 -105;
-    pos @kc88_first_52 @kc88_second_53 -210;
-    pos @kc88_first_52 @kc88_second_55 -140;
-    pos @kc88_first_52 @kc88_second_57 -175;
-    pos @kc88_first_52 @kc88_second_61 -35;
-    pos @kc88_first_52 @kc88_second_62 -35;
-    pos @kc88_first_52 @kc88_second_63 -35;
-    pos @kc88_first_52 @kc88_second_64 -70;
-    pos @kc88_first_53 @kc88_second_1 -35;
-    pos @kc88_first_53 @kc88_second_2 -70;
-    pos @kc88_first_53 @kc88_second_5 -105;
-    pos @kc88_first_53 @kc88_second_6 -35;
-    pos @kc88_first_53 @kc88_second_9 -70;
-    pos @kc88_first_53 @kc88_second_11 -70;
-    pos @kc88_first_53 @kc88_second_12 -240;
-    pos @kc88_first_53 @kc88_second_13 -245;
-    pos @kc88_first_53 @kc88_second_14 -140;
-    pos @kc88_first_53 @kc88_second_15 -105;
-    pos @kc88_first_53 @kc88_second_16 -105;
-    pos @kc88_first_53 @kc88_second_18 -70;
-    pos @kc88_first_53 @kc88_second_19 -70;
-    pos @kc88_first_53 @kc88_second_24 -35;
-    pos @kc88_first_53 @kc88_second_25 -70;
-    pos @kc88_first_53 @kc88_second_26 -140;
-    pos @kc88_first_53 @kc88_second_27 -105;
-    pos @kc88_first_53 @kc88_second_34 -35;
-    pos @kc88_first_53 @kc88_second_35 -140;
-    pos @kc88_first_53 @kc88_second_39 -105;
-    pos @kc88_first_53 @kc88_second_40 -70;
-    pos @kc88_first_53 @kc88_second_42 -105;
-    pos @kc88_first_53 @kc88_second_43 -175;
-    pos @kc88_first_53 @kc88_second_45 1;
-    pos @kc88_first_53 @kc88_second_47 -70;
-    pos @kc88_first_53 @kc88_second_48 -140;
-    pos @kc88_first_53 @kc88_second_49 -70;
-    pos @kc88_first_53 @kc88_second_53 -210;
-    pos @kc88_first_53 @kc88_second_54 -70;
-    pos @kc88_first_53 @kc88_second_55 -175;
-    pos @kc88_first_53 @kc88_second_56 -105;
-    pos @kc88_first_53 @kc88_second_57 -175;
-    pos @kc88_first_53 @kc88_second_60 -50;
-    pos @kc88_first_53 @kc88_second_61 -105;
-    pos @kc88_first_53 @kc88_second_62 -70;
-    pos @kc88_first_53 @kc88_second_64 -35;
-    pos @kc88_first_54 @kc88_second_1 -105;
-    pos @kc88_first_54 @kc88_second_2 -210;
-    pos @kc88_first_54 @kc88_second_5 -70;
-    pos @kc88_first_54 @kc88_second_6 -105;
-    pos @kc88_first_54 @kc88_second_13 -70;
-    pos @kc88_first_54 @kc88_second_14 -35;
-    pos @kc88_first_54 @kc88_second_16 -140;
-    pos @kc88_first_54 @kc88_second_17 -70;
-    pos @kc88_first_54 @kc88_second_19 -210;
-    pos @kc88_first_54 @kc88_second_22 -35;
-    pos @kc88_first_54 @kc88_second_24 -210;
-    pos @kc88_first_54 @kc88_second_29 -35;
-    pos @kc88_first_54 @kc88_second_32 -105;
-    pos @kc88_first_54 @kc88_second_34 -105;
-    pos @kc88_first_54 @kc88_second_35 -140;
-    pos @kc88_first_54 @kc88_second_38 -70;
-    pos @kc88_first_54 @kc88_second_45 1;
-    pos @kc88_first_54 @kc88_second_51 -35;
-    pos @kc88_first_54 @kc88_second_53 -245;
-    pos @kc88_first_54 @kc88_second_55 -210;
-    pos @kc88_first_54 @kc88_second_57 -210;
-    pos @kc88_first_54 @kc88_second_63 -70;
-    pos @kc88_first_54 @kc88_second_64 -105;
-    pos @kc88_first_55 @kc88_second_12 -240;
-    pos @kc88_first_55 @kc88_second_13 -140;
-    pos @kc88_first_55 @kc88_second_14 -105;
-    pos @kc88_first_55 @kc88_second_15 -35;
-    pos @kc88_first_55 @kc88_second_33 100;
-    pos @kc88_first_55 @kc88_second_45 1;
-    pos @kc88_first_55 @kc88_second_50 100;
-    pos @kc88_first_56 @kc88_second_1 -140;
-    pos @kc88_first_56 @kc88_second_2 -210;
-    pos @kc88_first_56 @kc88_second_6 -140;
-    pos @kc88_first_56 @kc88_second_12 -175;
-    pos @kc88_first_56 @kc88_second_13 -140;
-    pos @kc88_first_56 @kc88_second_16 -140;
-    pos @kc88_first_56 @kc88_second_19 -210;
-    pos @kc88_first_56 @kc88_second_24 -210;
-    pos @kc88_first_56 @kc88_second_32 -140;
-    pos @kc88_first_56 @kc88_second_34 -140;
-    pos @kc88_first_56 @kc88_second_35 -210;
-    pos @kc88_first_56 @kc88_second_36 -35;
-    pos @kc88_first_56 @kc88_second_45 1;
-    pos @kc88_first_56 @kc88_second_53 -210;
-    pos @kc88_first_56 @kc88_second_55 -175;
-    pos @kc88_first_56 @kc88_second_57 -175;
-    pos @kc88_first_56 @kc88_second_63 -105;
-    pos @kc88_first_56 @kc88_second_64 -210;
-    pos @kc88_first_57 @kc88_second_12 -240;
-    pos @kc88_first_57 @kc88_second_13 -175;
-    pos @kc88_first_57 @kc88_second_14 -70;
-    pos @kc88_first_57 @kc88_second_15 -35;
-    pos @kc88_first_57 @kc88_second_19 -35;
-    pos @kc88_first_57 @kc88_second_26 -35;
-    pos @kc88_first_57 @kc88_second_39 -35;
-    pos @kc88_first_57 @kc88_second_40 -35;
-    pos @kc88_first_57 @kc88_second_43 -70;
-    pos @kc88_first_57 @kc88_second_45 1;
-    pos @kc88_first_57 @kc88_second_47 -35;
-    pos @kc88_first_57 @kc88_second_48 -70;
-    pos @kc88_first_57 @kc88_second_58 -35;
-    pos @kc88_first_57 @kc88_second_60 -35;
-    pos @kc88_first_57 @kc88_second_61 -70;
-    pos @kc88_first_57 @kc88_second_62 -35;
-    pos @kc88_first_58 @kc88_second_13 -35;
-    pos @kc88_first_58 @kc88_second_58 -35;
-    pos @kc88_first_58 @kc88_second_64 -35;
-    pos @kc88_first_59 @kc88_second_12 -175;
-    pos @kc88_first_59 @kc88_second_13 -140;
-    pos @kc88_first_59 @kc88_second_14 -35;
-    pos @kc88_first_59 @kc88_second_45 1;
-    pos @kc88_first_60 @kc88_second_1 -140;
-    pos @kc88_first_60 @kc88_second_2 -280;
-    pos @kc88_first_60 @kc88_second_5 -140;
-    pos @kc88_first_60 @kc88_second_6 -280;
-    pos @kc88_first_60 @kc88_second_8 -70;
-    pos @kc88_first_60 @kc88_second_10 -70;
-    pos @kc88_first_60 @kc88_second_11 -175;
-    pos @kc88_first_60 @kc88_second_12 -240;
-    pos @kc88_first_60 @kc88_second_13 -140;
-    pos @kc88_first_60 @kc88_second_14 -105;
-    pos @kc88_first_60 @kc88_second_15 -70;
-    pos @kc88_first_60 @kc88_second_16 -175;
-    pos @kc88_first_60 @kc88_second_17 -70;
-    pos @kc88_first_60 @kc88_second_19 -280;
-    pos @kc88_first_60 @kc88_second_22 -70;
-    pos @kc88_first_60 @kc88_second_23 -70;
-    pos @kc88_first_60 @kc88_second_24 -210;
-    pos @kc88_first_60 @kc88_second_26 -70;
-    pos @kc88_first_60 @kc88_second_27 -70;
-    pos @kc88_first_60 @kc88_second_29 -70;
-    pos @kc88_first_60 @kc88_second_32 -70;
-    pos @kc88_first_60 @kc88_second_34 -315;
-    pos @kc88_first_60 @kc88_second_35 -140;
-    pos @kc88_first_60 @kc88_second_36 -70;
-    pos @kc88_first_60 @kc88_second_38 -105;
-    pos @kc88_first_60 @kc88_second_45 1;
-    pos @kc88_first_60 @kc88_second_48 -35;
-    pos @kc88_first_60 @kc88_second_51 -50;
-    pos @kc88_first_60 @kc88_second_53 -210;
-    pos @kc88_first_60 @kc88_second_55 -175;
-    pos @kc88_first_60 @kc88_second_57 -210;
-    pos @kc88_first_60 @kc88_second_59 -35;
-    pos @kc88_first_60 @kc88_second_61 -70;
-    pos @kc88_first_60 @kc88_second_62 -35;
-    pos @kc88_first_60 @kc88_second_63 -140;
-    pos @kc88_first_60 @kc88_second_64 -210;
-    pos @kc88_first_61 @kc88_second_1 -35;
-    pos @kc88_first_61 @kc88_second_2 -70;
-    pos @kc88_first_61 @kc88_second_5 -70;
-    pos @kc88_first_61 @kc88_second_11 -35;
-    pos @kc88_first_61 @kc88_second_12 -140;
-    pos @kc88_first_61 @kc88_second_13 -140;
-    pos @kc88_first_61 @kc88_second_14 -70;
-    pos @kc88_first_61 @kc88_second_15 -35;
-    pos @kc88_first_61 @kc88_second_16 -105;
-    pos @kc88_first_61 @kc88_second_26 -35;
-    pos @kc88_first_61 @kc88_second_27 -70;
-    pos @kc88_first_61 @kc88_second_35 -70;
-    pos @kc88_first_61 @kc88_second_43 -70;
-    pos @kc88_first_61 @kc88_second_45 1;
-    pos @kc88_first_61 @kc88_second_53 -175;
-    pos @kc88_first_61 @kc88_second_55 -140;
-    pos @kc88_first_61 @kc88_second_57 -140;
-    pos @kc88_first_61 @kc88_second_61 -35;
-    pos @kc88_first_62 @kc88_second_5 -70;
-    pos @kc88_first_62 @kc88_second_9 -70;
-    pos @kc88_first_62 @kc88_second_11 -35;
-    pos @kc88_first_62 @kc88_second_12 -350;
-    pos @kc88_first_62 @kc88_second_13 -315;
-    pos @kc88_first_62 @kc88_second_14 -175;
-    pos @kc88_first_62 @kc88_second_15 -140;
-    pos @kc88_first_62 @kc88_second_16 -70;
-    pos @kc88_first_62 @kc88_second_18 -70;
-    pos @kc88_first_62 @kc88_second_27 -70;
-    pos @kc88_first_62 @kc88_second_31 -50;
-    pos @kc88_first_62 @kc88_second_39 -140;
-    pos @kc88_first_62 @kc88_second_40 -50;
-    pos @kc88_first_62 @kc88_second_42 -35;
-    pos @kc88_first_62 @kc88_second_43 -175;
-    pos @kc88_first_62 @kc88_second_45 1;
-    pos @kc88_first_62 @kc88_second_47 -70;
-    pos @kc88_first_62 @kc88_second_48 -175;
-    pos @kc88_first_62 @kc88_second_54 -70;
-    pos @kc88_first_62 @kc88_second_58 -70;
-    pos @kc88_first_62 @kc88_second_60 -50;
-    pos @kc88_first_62 @kc88_second_61 -140;
-    pos @kc88_first_62 @kc88_second_62 -105;
-    pos @kc88_first_63 @kc88_second_4 -105;
-    pos @kc88_first_63 @kc88_second_6 -35;
-    pos @kc88_first_63 @kc88_second_8 1;
-    pos @kc88_first_63 @kc88_second_9 -245;
-    pos @kc88_first_63 @kc88_second_12 -210;
-    pos @kc88_first_63 @kc88_second_13 -210;
-    pos @kc88_first_63 @kc88_second_14 -210;
-    pos @kc88_first_63 @kc88_second_15 -175;
-    pos @kc88_first_63 @kc88_second_17 -70;
-    pos @kc88_first_63 @kc88_second_18 -180;
-    pos @kc88_first_63 @kc88_second_20 -140;
-    pos @kc88_first_63 @kc88_second_22 -105;
-    pos @kc88_first_63 @kc88_second_25 -140;
-    pos @kc88_first_63 @kc88_second_29 -105;
-    pos @kc88_first_63 @kc88_second_31 -140;
-    pos @kc88_first_63 @kc88_second_34 -35;
-    pos @kc88_first_63 @kc88_second_36 -35;
-    pos @kc88_first_63 @kc88_second_38 -175;
-    pos @kc88_first_63 @kc88_second_39 -142;
-    pos @kc88_first_63 @kc88_second_40 -245;
-    pos @kc88_first_63 @kc88_second_43 -210;
-    pos @kc88_first_63 @kc88_second_44 -105;
-    pos @kc88_first_63 @kc88_second_45 1;
-    pos @kc88_first_63 @kc88_second_46 -35;
-    pos @kc88_first_63 @kc88_second_47 -210;
-    pos @kc88_first_63 @kc88_second_48 -210;
-    pos @kc88_first_63 @kc88_second_51 -35;
-    pos @kc88_first_63 @kc88_second_58 -280;
-    pos @kc88_first_63 @kc88_second_60 -175;
-    pos @kc88_first_63 @kc88_second_61 -140;
-    pos @kc88_first_63 @kc88_second_62 -140;
-    pos @kc88_first_63 @kc88_second_63 -70;
-    pos @kc88_first_63 @kc88_second_64 -70;
-    pos @kc88_first_64 @kc88_second_1 -175;
-    pos @kc88_first_64 @kc88_second_2 -175;
-    pos @kc88_first_64 @kc88_second_5 -70;
-    pos @kc88_first_64 @kc88_second_6 -105;
-    pos @kc88_first_64 @kc88_second_11 -105;
-    pos @kc88_first_64 @kc88_second_12 -175;
-    pos @kc88_first_64 @kc88_second_13 -140;
-    pos @kc88_first_64 @kc88_second_14 -70;
-    pos @kc88_first_64 @kc88_second_15 -35;
-    pos @kc88_first_64 @kc88_second_16 -140;
-    pos @kc88_first_64 @kc88_second_17 -70;
-    pos @kc88_first_64 @kc88_second_19 -175;
-    pos @kc88_first_64 @kc88_second_22 -70;
-    pos @kc88_first_64 @kc88_second_29 -35;
-    pos @kc88_first_64 @kc88_second_34 -105;
-    pos @kc88_first_64 @kc88_second_35 -175;
-    pos @kc88_first_64 @kc88_second_36 -35;
-    pos @kc88_first_64 @kc88_second_38 -70;
-    pos @kc88_first_64 @kc88_second_45 1;
-    pos @kc88_first_64 @kc88_second_51 -35;
-    pos @kc88_first_64 @kc88_second_53 -140;
-    pos @kc88_first_64 @kc88_second_55 -140;
-    pos @kc88_first_64 @kc88_second_57 -140;
-    pos @kc88_first_64 @kc88_second_63 -70;
-    pos @kc88_first_64 @kc88_second_64 -105;
-    pos @kc88_first_65 @kc88_second_1 -210;
-    pos @kc88_first_65 @kc88_second_2 -210;
-    pos @kc88_first_65 @kc88_second_3 -70;
-    pos @kc88_first_65 @kc88_second_4 -35;
-    pos @kc88_first_65 @kc88_second_6 -210;
-    pos @kc88_first_65 @kc88_second_7 -70;
-    pos @kc88_first_65 @kc88_second_8 -70;
-    pos @kc88_first_65 @kc88_second_16 -70;
-    pos @kc88_first_65 @kc88_second_17 -140;
-    pos @kc88_first_65 @kc88_second_19 -210;
-    pos @kc88_first_65 @kc88_second_20 -140;
-    pos @kc88_first_65 @kc88_second_21 -35;
-    pos @kc88_first_65 @kc88_second_22 -175;
-    pos @kc88_first_65 @kc88_second_23 -140;
-    pos @kc88_first_65 @kc88_second_24 -280;
-    pos @kc88_first_65 @kc88_second_29 -35;
-    pos @kc88_first_65 @kc88_second_30 -35;
-    pos @kc88_first_65 @kc88_second_32 -210;
-    pos @kc88_first_65 @kc88_second_34 -245;
-    pos @kc88_first_65 @kc88_second_35 -140;
-    pos @kc88_first_65 @kc88_second_36 -140;
-    pos @kc88_first_65 @kc88_second_37 -140;
-    pos @kc88_first_65 @kc88_second_38 -140;
-    pos @kc88_first_65 @kc88_second_39 -35;
-    pos @kc88_first_65 @kc88_second_44 -35;
-    pos @kc88_first_65 @kc88_second_45 1;
-    pos @kc88_first_65 @kc88_second_49 -35;
-    pos @kc88_first_65 @kc88_second_51 -140;
-    pos @kc88_first_65 @kc88_second_52 -70;
-    pos @kc88_first_65 @kc88_second_53 -210;
-    pos @kc88_first_65 @kc88_second_55 -210;
-    pos @kc88_first_65 @kc88_second_57 -210;
-    pos @kc88_first_65 @kc88_second_58 -35;
-    pos @kc88_first_65 @kc88_second_63 -175;
-    pos @kc88_first_65 @kc88_second_64 -245;
-    pos @kc88_first_66 @kc88_second_6 -35;
-    pos @kc88_first_66 @kc88_second_12 -240;
-    pos @kc88_first_66 @kc88_second_13 -140;
-    pos @kc88_first_66 @kc88_second_14 -70;
-    pos @kc88_first_66 @kc88_second_15 -35;
-    pos @kc88_first_66 @kc88_second_20 -35;
-    pos @kc88_first_66 @kc88_second_22 -35;
-    pos @kc88_first_66 @kc88_second_34 -70;
-    pos @kc88_first_66 @kc88_second_38 -70;
-    pos @kc88_first_66 @kc88_second_39 -50;
-    pos @kc88_first_66 @kc88_second_45 1;
-    pos @kc88_first_66 @kc88_second_48 -35;
-    pos @kc88_first_66 @kc88_second_63 -35;
-    pos @kc88_first_66 @kc88_second_64 -35;
-    pos @kc88_first_67 @kc88_second_3 -100;
-    pos @kc88_first_67 @kc88_second_4 -50;
-    pos @kc88_first_67 @kc88_second_6 -50;
-    pos @kc88_first_67 @kc88_second_8 -70;
-    pos @kc88_first_67 @kc88_second_9 -140;
-    pos @kc88_first_67 @kc88_second_10 -50;
-    pos @kc88_first_67 @kc88_second_12 -140;
-    pos @kc88_first_67 @kc88_second_13 -100;
-    pos @kc88_first_67 @kc88_second_14 -70;
-    pos @kc88_first_67 @kc88_second_15 -50;
-    pos @kc88_first_67 @kc88_second_18 -70;
-    pos @kc88_first_67 @kc88_second_20 -70;
-    pos @kc88_first_67 @kc88_second_22 -50;
-    pos @kc88_first_67 @kc88_second_23 -70;
-    pos @kc88_first_67 @kc88_second_29 -35;
-    pos @kc88_first_67 @kc88_second_31 -70;
-    pos @kc88_first_67 @kc88_second_33 105;
-    pos @kc88_first_67 @kc88_second_34 -35;
-    pos @kc88_first_67 @kc88_second_38 -70;
-    pos @kc88_first_67 @kc88_second_39 -140;
-    pos @kc88_first_67 @kc88_second_40 -140;
-    pos @kc88_first_67 @kc88_second_43 -140;
-    pos @kc88_first_67 @kc88_second_44 -35;
-    pos @kc88_first_67 @kc88_second_45 1;
-    pos @kc88_first_67 @kc88_second_47 -70;
-    pos @kc88_first_67 @kc88_second_48 -100;
-    pos @kc88_first_67 @kc88_second_50 105;
-    pos @kc88_first_67 @kc88_second_58 -140;
-    pos @kc88_first_67 @kc88_second_60 -70;
-    pos @kc88_first_67 @kc88_second_61 -70;
-    pos @kc88_first_67 @kc88_second_62 -50;
-    pos @kc88_first_67 @kc88_second_63 -35;
-    pos @kc88_first_67 @kc88_second_64 -35;
-    pos @kc88_first_68 @kc88_second_3 -70;
-    pos @kc88_first_68 @kc88_second_4 -50;
-    pos @kc88_first_68 @kc88_second_6 -50;
-    pos @kc88_first_68 @kc88_second_8 -70;
-    pos @kc88_first_68 @kc88_second_9 -140;
-    pos @kc88_first_68 @kc88_second_10 -50;
-    pos @kc88_first_68 @kc88_second_12 -240;
-    pos @kc88_first_68 @kc88_second_13 -240;
-    pos @kc88_first_68 @kc88_second_14 -175;
-    pos @kc88_first_68 @kc88_second_15 -140;
-    pos @kc88_first_68 @kc88_second_18 -70;
-    pos @kc88_first_68 @kc88_second_20 -70;
-    pos @kc88_first_68 @kc88_second_22 -50;
-    pos @kc88_first_68 @kc88_second_23 -70;
-    pos @kc88_first_68 @kc88_second_29 -35;
-    pos @kc88_first_68 @kc88_second_31 -70;
-    pos @kc88_first_68 @kc88_second_34 -35;
-    pos @kc88_first_68 @kc88_second_38 -70;
-    pos @kc88_first_68 @kc88_second_39 -140;
-    pos @kc88_first_68 @kc88_second_40 -140;
-    pos @kc88_first_68 @kc88_second_43 -140;
-    pos @kc88_first_68 @kc88_second_44 -35;
-    pos @kc88_first_68 @kc88_second_45 1;
-    pos @kc88_first_68 @kc88_second_47 -70;
-    pos @kc88_first_68 @kc88_second_48 -140;
-    pos @kc88_first_68 @kc88_second_58 -140;
-    pos @kc88_first_68 @kc88_second_60 -70;
-    pos @kc88_first_68 @kc88_second_61 -105;
-    pos @kc88_first_68 @kc88_second_62 -70;
-    pos @kc88_first_68 @kc88_second_63 -35;
-    pos @kc88_first_68 @kc88_second_64 -35;
-    pos @kc88_first_69 @kc88_second_3 -70;
-    pos @kc88_first_69 @kc88_second_4 -50;
-    pos @kc88_first_69 @kc88_second_6 -50;
-    pos @kc88_first_69 @kc88_second_8 -70;
-    pos @kc88_first_69 @kc88_second_9 -140;
-    pos @kc88_first_69 @kc88_second_10 -50;
-    pos @kc88_first_69 @kc88_second_12 -140;
-    pos @kc88_first_69 @kc88_second_13 -140;
-    pos @kc88_first_69 @kc88_second_14 -105;
-    pos @kc88_first_69 @kc88_second_15 -70;
-    pos @kc88_first_69 @kc88_second_18 -70;
-    pos @kc88_first_69 @kc88_second_20 -70;
-    pos @kc88_first_69 @kc88_second_22 -50;
-    pos @kc88_first_69 @kc88_second_23 -100;
-    pos @kc88_first_69 @kc88_second_29 -35;
-    pos @kc88_first_69 @kc88_second_31 -70;
-    pos @kc88_first_69 @kc88_second_33 105;
-    pos @kc88_first_69 @kc88_second_34 -35;
-    pos @kc88_first_69 @kc88_second_38 -70;
-    pos @kc88_first_69 @kc88_second_39 -140;
-    pos @kc88_first_69 @kc88_second_40 -140;
-    pos @kc88_first_69 @kc88_second_43 -140;
-    pos @kc88_first_69 @kc88_second_44 -35;
-    pos @kc88_first_69 @kc88_second_45 1;
-    pos @kc88_first_69 @kc88_second_47 -70;
-    pos @kc88_first_69 @kc88_second_48 -140;
-    pos @kc88_first_69 @kc88_second_50 105;
-    pos @kc88_first_69 @kc88_second_58 -140;
-    pos @kc88_first_69 @kc88_second_60 -70;
-    pos @kc88_first_69 @kc88_second_61 -70;
-    pos @kc88_first_69 @kc88_second_62 -50;
-    pos @kc88_first_69 @kc88_second_63 -35;
-    pos @kc88_first_69 @kc88_second_64 -35;
-    pos @kc88_first_70 @kc88_second_1 -210;
-    pos @kc88_first_70 @kc88_second_2 -210;
-    pos @kc88_first_70 @kc88_second_3 -35;
-    pos @kc88_first_70 @kc88_second_6 -140;
-    pos @kc88_first_70 @kc88_second_8 -70;
-    pos @kc88_first_70 @kc88_second_10 -35;
-    pos @kc88_first_70 @kc88_second_17 -70;
-    pos @kc88_first_70 @kc88_second_19 -210;
-    pos @kc88_first_70 @kc88_second_20 -70;
-    pos @kc88_first_70 @kc88_second_22 -105;
-    pos @kc88_first_70 @kc88_second_23 -105;
-    pos @kc88_first_70 @kc88_second_24 -175;
-    pos @kc88_first_70 @kc88_second_29 -105;
-    pos @kc88_first_70 @kc88_second_34 -175;
-    pos @kc88_first_70 @kc88_second_35 -140;
-    pos @kc88_first_70 @kc88_second_36 -70;
-    pos @kc88_first_70 @kc88_second_37 -105;
-    pos @kc88_first_70 @kc88_second_38 -105;
-    pos @kc88_first_70 @kc88_second_39 -70;
-    pos @kc88_first_70 @kc88_second_44 -35;
-    pos @kc88_first_70 @kc88_second_45 1;
-    pos @kc88_first_70 @kc88_second_50 -35;
-    pos @kc88_first_70 @kc88_second_51 -70;
-    pos @kc88_first_70 @kc88_second_52 -70;
-    pos @kc88_first_70 @kc88_second_53 -175;
-    pos @kc88_first_70 @kc88_second_55 -175;
-    pos @kc88_first_70 @kc88_second_57 -175;
-    pos @kc88_first_70 @kc88_second_58 -35;
-    pos @kc88_first_70 @kc88_second_59 -35;
-    pos @kc88_first_70 @kc88_second_63 -140;
-    pos @kc88_first_70 @kc88_second_64 -175;
-    pos @kc88_first_71 @kc88_second_5 -70;
-    pos @kc88_first_71 @kc88_second_8 -70;
-    pos @kc88_first_71 @kc88_second_9 -105;
-    pos @kc88_first_71 @kc88_second_11 -35;
-    pos @kc88_first_71 @kc88_second_12 -350;
-    pos @kc88_first_71 @kc88_second_13 -350;
-    pos @kc88_first_71 @kc88_second_14 -245;
-    pos @kc88_first_71 @kc88_second_15 -210;
-    pos @kc88_first_71 @kc88_second_16 -70;
-    pos @kc88_first_71 @kc88_second_18 -210;
-    pos @kc88_first_71 @kc88_second_23 -35;
-    pos @kc88_first_71 @kc88_second_26 -35;
-    pos @kc88_first_71 @kc88_second_27 -70;
-    pos @kc88_first_71 @kc88_second_31 -70;
-    pos @kc88_first_71 @kc88_second_38 -35;
-    pos @kc88_first_71 @kc88_second_39 -245;
-    pos @kc88_first_71 @kc88_second_40 -70;
-    pos @kc88_first_71 @kc88_second_42 -35;
-    pos @kc88_first_71 @kc88_second_43 -240;
-    pos @kc88_first_71 @kc88_second_45 1;
-    pos @kc88_first_71 @kc88_second_47 -105;
-    pos @kc88_first_71 @kc88_second_48 -280;
-    pos @kc88_first_71 @kc88_second_49 -35;
-    pos @kc88_first_71 @kc88_second_54 -35;
-    pos @kc88_first_71 @kc88_second_56 -70;
-    pos @kc88_first_71 @kc88_second_58 -105;
-    pos @kc88_first_71 @kc88_second_59 -35;
-    pos @kc88_first_71 @kc88_second_60 -70;
-    pos @kc88_first_71 @kc88_second_61 -175;
-    pos @kc88_first_71 @kc88_second_62 -140;
-    pos @kc88_first_72 @kc88_second_1 -140;
-    pos @kc88_first_72 @kc88_second_2 -140;
-    pos @kc88_first_72 @kc88_second_6 -140;
-    pos @kc88_first_72 @kc88_second_8 -35;
-    pos @kc88_first_72 @kc88_second_10 -35;
-    pos @kc88_first_72 @kc88_second_17 -35;
-    pos @kc88_first_72 @kc88_second_19 -140;
-    pos @kc88_first_72 @kc88_second_20 -35;
-    pos @kc88_first_72 @kc88_second_22 -70;
-    pos @kc88_first_72 @kc88_second_23 -70;
-    pos @kc88_first_72 @kc88_second_24 -140;
-    pos @kc88_first_72 @kc88_second_29 -70;
-    pos @kc88_first_72 @kc88_second_34 -175;
-    pos @kc88_first_72 @kc88_second_35 -105;
-    pos @kc88_first_72 @kc88_second_36 -70;
-    pos @kc88_first_72 @kc88_second_37 -70;
-    pos @kc88_first_72 @kc88_second_38 -70;
-    pos @kc88_first_72 @kc88_second_39 -35;
-    pos @kc88_first_72 @kc88_second_45 1;
-    pos @kc88_first_72 @kc88_second_50 -35;
-    pos @kc88_first_72 @kc88_second_51 -35;
-    pos @kc88_first_72 @kc88_second_53 -140;
-    pos @kc88_first_72 @kc88_second_55 -140;
-    pos @kc88_first_72 @kc88_second_57 -140;
-    pos @kc88_first_72 @kc88_second_63 -105;
-    pos @kc88_first_72 @kc88_second_64 -105;
+    pos @kc89_first_1 @kc89_second_3 -70;
+    pos @kc89_first_1 @kc89_second_8 -70;
+    pos @kc89_first_1 @kc89_second_9 -140;
+    pos @kc89_first_1 @kc89_second_10 -35;
+    pos @kc89_first_1 @kc89_second_12 -280;
+    pos @kc89_first_1 @kc89_second_13 -280;
+    pos @kc89_first_1 @kc89_second_14 -280;
+    pos @kc89_first_1 @kc89_second_15 -210;
+    pos @kc89_first_1 @kc89_second_20 -70;
+    pos @kc89_first_1 @kc89_second_23 -35;
+    pos @kc89_first_1 @kc89_second_25 -50;
+    pos @kc89_first_1 @kc89_second_31 -70;
+    pos @kc89_first_1 @kc89_second_38 -35;
+    pos @kc89_first_1 @kc89_second_39 -140;
+    pos @kc89_first_1 @kc89_second_40 -105;
+    pos @kc89_first_1 @kc89_second_43 -210;
+    pos @kc89_first_1 @kc89_second_44 -35;
+    pos @kc89_first_1 @kc89_second_45 1;
+    pos @kc89_first_1 @kc89_second_47 -175;
+    pos @kc89_first_1 @kc89_second_48 -210;
+    pos @kc89_first_1 @kc89_second_58 -140;
+    pos @kc89_first_1 @kc89_second_60 -140;
+    pos @kc89_first_1 @kc89_second_61 -210;
+    pos @kc89_first_1 @kc89_second_62 -140;
+    pos @kc89_first_2 @kc89_second_9 -35;
+    pos @kc89_first_2 @kc89_second_12 -70;
+    pos @kc89_first_2 @kc89_second_13 -70;
+    pos @kc89_first_2 @kc89_second_14 -70;
+    pos @kc89_first_2 @kc89_second_15 -35;
+    pos @kc89_first_2 @kc89_second_16 -35;
+    pos @kc89_first_2 @kc89_second_39 -35;
+    pos @kc89_first_2 @kc89_second_45 1;
+    pos @kc89_first_3 @kc89_second_1 -35;
+    pos @kc89_first_3 @kc89_second_2 -70;
+    pos @kc89_first_3 @kc89_second_5 -35;
+    pos @kc89_first_3 @kc89_second_11 -35;
+    pos @kc89_first_3 @kc89_second_12 -35;
+    pos @kc89_first_3 @kc89_second_13 -70;
+    pos @kc89_first_3 @kc89_second_14 -35;
+    pos @kc89_first_3 @kc89_second_16 -70;
+    pos @kc89_first_3 @kc89_second_19 -70;
+    pos @kc89_first_3 @kc89_second_35 -35;
+    pos @kc89_first_3 @kc89_second_45 1;
+    pos @kc89_first_4 @kc89_second_1 -70;
+    pos @kc89_first_4 @kc89_second_2 -140;
+    pos @kc89_first_4 @kc89_second_4 70;
+    pos @kc89_first_4 @kc89_second_5 -70;
+    pos @kc89_first_4 @kc89_second_11 -105;
+    pos @kc89_first_4 @kc89_second_12 -140;
+    pos @kc89_first_4 @kc89_second_13 -140;
+    pos @kc89_first_4 @kc89_second_14 -105;
+    pos @kc89_first_4 @kc89_second_15 -35;
+    pos @kc89_first_4 @kc89_second_16 -140;
+    pos @kc89_first_4 @kc89_second_24 -70;
+    pos @kc89_first_4 @kc89_second_26 -70;
+    pos @kc89_first_4 @kc89_second_27 -35;
+    pos @kc89_first_4 @kc89_second_31 35;
+    pos @kc89_first_4 @kc89_second_34 -70;
+    pos @kc89_first_4 @kc89_second_35 -70;
+    pos @kc89_first_4 @kc89_second_43 -35;
+    pos @kc89_first_4 @kc89_second_45 1;
+    pos @kc89_first_4 @kc89_second_48 -70;
+    pos @kc89_first_4 @kc89_second_53 -70;
+    pos @kc89_first_4 @kc89_second_55 -70;
+    pos @kc89_first_4 @kc89_second_57 -70;
+    pos @kc89_first_4 @kc89_second_61 -35;
+    pos @kc89_first_5 @kc89_second_12 -70;
+    pos @kc89_first_5 @kc89_second_45 1;
+    pos @kc89_first_6 @kc89_second_1 -280;
+    pos @kc89_first_6 @kc89_second_2 -350;
+    pos @kc89_first_6 @kc89_second_3 -140;
+    pos @kc89_first_6 @kc89_second_4 -70;
+    pos @kc89_first_6 @kc89_second_6 -350;
+    pos @kc89_first_6 @kc89_second_7 -140;
+    pos @kc89_first_6 @kc89_second_8 -210;
+    pos @kc89_first_6 @kc89_second_10 -70;
+    pos @kc89_first_6 @kc89_second_17 -240;
+    pos @kc89_first_6 @kc89_second_19 -350;
+    pos @kc89_first_6 @kc89_second_20 -280;
+    pos @kc89_first_6 @kc89_second_21 -240;
+    pos @kc89_first_6 @kc89_second_22 -240;
+    pos @kc89_first_6 @kc89_second_23 -210;
+    pos @kc89_first_6 @kc89_second_24 -350;
+    pos @kc89_first_6 @kc89_second_25 -140;
+    pos @kc89_first_6 @kc89_second_27 -140;
+    pos @kc89_first_6 @kc89_second_29 -240;
+    pos @kc89_first_6 @kc89_second_30 -240;
+    pos @kc89_first_6 @kc89_second_31 -175;
+    pos @kc89_first_6 @kc89_second_34 -350;
+    pos @kc89_first_6 @kc89_second_35 -105;
+    pos @kc89_first_6 @kc89_second_36 -240;
+    pos @kc89_first_6 @kc89_second_37 -210;
+    pos @kc89_first_6 @kc89_second_38 -240;
+    pos @kc89_first_6 @kc89_second_39 -240;
+    pos @kc89_first_6 @kc89_second_41 -240;
+    pos @kc89_first_6 @kc89_second_44 -140;
+    pos @kc89_first_6 @kc89_second_45 1;
+    pos @kc89_first_6 @kc89_second_46 -35;
+    pos @kc89_first_6 @kc89_second_47 -240;
+    pos @kc89_first_6 @kc89_second_49 -240;
+    pos @kc89_first_6 @kc89_second_50 -240;
+    pos @kc89_first_6 @kc89_second_51 -240;
+    pos @kc89_first_6 @kc89_second_52 -240;
+    pos @kc89_first_6 @kc89_second_53 -280;
+    pos @kc89_first_6 @kc89_second_54 -70;
+    pos @kc89_first_6 @kc89_second_55 -240;
+    pos @kc89_first_6 @kc89_second_56 -175;
+    pos @kc89_first_6 @kc89_second_57 -280;
+    pos @kc89_first_6 @kc89_second_58 -240;
+    pos @kc89_first_6 @kc89_second_59 -210;
+    pos @kc89_first_6 @kc89_second_60 -175;
+    pos @kc89_first_6 @kc89_second_63 -175;
+    pos @kc89_first_6 @kc89_second_64 -175;
+    pos @kc89_first_7 @kc89_second_3 -70;
+    pos @kc89_first_7 @kc89_second_8 -105;
+    pos @kc89_first_7 @kc89_second_17 -35;
+    pos @kc89_first_7 @kc89_second_20 -105;
+    pos @kc89_first_7 @kc89_second_22 -105;
+    pos @kc89_first_7 @kc89_second_23 -70;
+    pos @kc89_first_7 @kc89_second_45 1;
+    pos @kc89_first_7 @kc89_second_46 -35;
+    pos @kc89_first_7 @kc89_second_47 -70;
+    pos @kc89_first_7 @kc89_second_51 -50;
+    pos @kc89_first_7 @kc89_second_60 -35;
+    pos @kc89_first_7 @kc89_second_63 -70;
+    pos @kc89_first_7 @kc89_second_64 -70;
+    pos @kc89_first_8 @kc89_second_3 -140;
+    pos @kc89_first_8 @kc89_second_4 -70;
+    pos @kc89_first_8 @kc89_second_6 -70;
+    pos @kc89_first_8 @kc89_second_8 -140;
+    pos @kc89_first_8 @kc89_second_10 -35;
+    pos @kc89_first_8 @kc89_second_17 -70;
+    pos @kc89_first_8 @kc89_second_20 -140;
+    pos @kc89_first_8 @kc89_second_22 -70;
+    pos @kc89_first_8 @kc89_second_23 -105;
+    pos @kc89_first_8 @kc89_second_25 -140;
+    pos @kc89_first_8 @kc89_second_29 -35;
+    pos @kc89_first_8 @kc89_second_31 -105;
+    pos @kc89_first_8 @kc89_second_34 -70;
+    pos @kc89_first_8 @kc89_second_36 -70;
+    pos @kc89_first_8 @kc89_second_38 -105;
+    pos @kc89_first_8 @kc89_second_39 -175;
+    pos @kc89_first_8 @kc89_second_40 -140;
+    pos @kc89_first_8 @kc89_second_41 -35;
+    pos @kc89_first_8 @kc89_second_43 -140;
+    pos @kc89_first_8 @kc89_second_44 -105;
+    pos @kc89_first_8 @kc89_second_45 1;
+    pos @kc89_first_8 @kc89_second_46 -70;
+    pos @kc89_first_8 @kc89_second_47 -140;
+    pos @kc89_first_8 @kc89_second_48 -70;
+    pos @kc89_first_8 @kc89_second_51 -35;
+    pos @kc89_first_8 @kc89_second_52 -35;
+    pos @kc89_first_8 @kc89_second_58 -210;
+    pos @kc89_first_8 @kc89_second_60 -105;
+    pos @kc89_first_8 @kc89_second_61 -70;
+    pos @kc89_first_8 @kc89_second_62 -35;
+    pos @kc89_first_8 @kc89_second_63 -70;
+    pos @kc89_first_8 @kc89_second_64 -35;
+    pos @kc89_first_9 @kc89_second_3 -140;
+    pos @kc89_first_9 @kc89_second_4 -70;
+    pos @kc89_first_9 @kc89_second_6 -70;
+    pos @kc89_first_9 @kc89_second_8 -210;
+    pos @kc89_first_9 @kc89_second_9 -420;
+    pos @kc89_first_9 @kc89_second_10 -70;
+    pos @kc89_first_9 @kc89_second_12 -350;
+    pos @kc89_first_9 @kc89_second_13 -420;
+    pos @kc89_first_9 @kc89_second_14 -350;
+    pos @kc89_first_9 @kc89_second_15 -280;
+    pos @kc89_first_9 @kc89_second_17 -70;
+    pos @kc89_first_9 @kc89_second_18 -210;
+    pos @kc89_first_9 @kc89_second_20 -210;
+    pos @kc89_first_9 @kc89_second_22 -70;
+    pos @kc89_first_9 @kc89_second_23 -140;
+    pos @kc89_first_9 @kc89_second_29 -50;
+    pos @kc89_first_9 @kc89_second_31 -140;
+    pos @kc89_first_9 @kc89_second_34 -70;
+    pos @kc89_first_9 @kc89_second_38 -105;
+    pos @kc89_first_9 @kc89_second_39 -280;
+    pos @kc89_first_9 @kc89_second_40 -350;
+    pos @kc89_first_9 @kc89_second_41 -50;
+    pos @kc89_first_9 @kc89_second_43 -350;
+    pos @kc89_first_9 @kc89_second_45 1;
+    pos @kc89_first_9 @kc89_second_46 -35;
+    pos @kc89_first_9 @kc89_second_47 -210;
+    pos @kc89_first_9 @kc89_second_48 -350;
+    pos @kc89_first_9 @kc89_second_51 -35;
+    pos @kc89_first_9 @kc89_second_52 -35;
+    pos @kc89_first_9 @kc89_second_58 -280;
+    pos @kc89_first_9 @kc89_second_60 -175;
+    pos @kc89_first_9 @kc89_second_61 -280;
+    pos @kc89_first_9 @kc89_second_62 -210;
+    pos @kc89_first_9 @kc89_second_63 -70;
+    pos @kc89_first_9 @kc89_second_64 -70;
+    pos @kc89_first_10 @kc89_second_1 -210;
+    pos @kc89_first_10 @kc89_second_2 -350;
+    pos @kc89_first_10 @kc89_second_5 -70;
+    pos @kc89_first_10 @kc89_second_6 -140;
+    pos @kc89_first_10 @kc89_second_11 -35;
+    pos @kc89_first_10 @kc89_second_12 -70;
+    pos @kc89_first_10 @kc89_second_13 -70;
+    pos @kc89_first_10 @kc89_second_14 -35;
+    pos @kc89_first_10 @kc89_second_16 -70;
+    pos @kc89_first_10 @kc89_second_17 -35;
+    pos @kc89_first_10 @kc89_second_19 -280;
+    pos @kc89_first_10 @kc89_second_22 -70;
+    pos @kc89_first_10 @kc89_second_24 -350;
+    pos @kc89_first_10 @kc89_second_29 -70;
+    pos @kc89_first_10 @kc89_second_32 -140;
+    pos @kc89_first_10 @kc89_second_34 -210;
+    pos @kc89_first_10 @kc89_second_35 -105;
+    pos @kc89_first_10 @kc89_second_38 -70;
+    pos @kc89_first_10 @kc89_second_45 1;
+    pos @kc89_first_10 @kc89_second_53 -210;
+    pos @kc89_first_10 @kc89_second_55 -210;
+    pos @kc89_first_10 @kc89_second_57 -210;
+    pos @kc89_first_10 @kc89_second_61 -70;
+    pos @kc89_first_10 @kc89_second_63 -70;
+    pos @kc89_first_10 @kc89_second_64 -105;
+    pos @kc89_first_11 @kc89_second_1 -70;
+    pos @kc89_first_11 @kc89_second_2 -140;
+    pos @kc89_first_11 @kc89_second_5 -105;
+    pos @kc89_first_11 @kc89_second_6 -35;
+    pos @kc89_first_11 @kc89_second_11 -70;
+    pos @kc89_first_11 @kc89_second_12 -210;
+    pos @kc89_first_11 @kc89_second_13 -175;
+    pos @kc89_first_11 @kc89_second_14 -105;
+    pos @kc89_first_11 @kc89_second_15 -70;
+    pos @kc89_first_11 @kc89_second_16 -140;
+    pos @kc89_first_11 @kc89_second_19 -140;
+    pos @kc89_first_11 @kc89_second_24 -70;
+    pos @kc89_first_11 @kc89_second_26 -70;
+    pos @kc89_first_11 @kc89_second_27 -70;
+    pos @kc89_first_11 @kc89_second_34 -35;
+    pos @kc89_first_11 @kc89_second_35 -140;
+    pos @kc89_first_11 @kc89_second_39 -70;
+    pos @kc89_first_11 @kc89_second_42 -35;
+    pos @kc89_first_11 @kc89_second_43 -35;
+    pos @kc89_first_11 @kc89_second_45 1;
+    pos @kc89_first_11 @kc89_second_48 -70;
+    pos @kc89_first_11 @kc89_second_53 -210;
+    pos @kc89_first_11 @kc89_second_55 -175;
+    pos @kc89_first_11 @kc89_second_56 -35;
+    pos @kc89_first_11 @kc89_second_57 -175;
+    pos @kc89_first_11 @kc89_second_61 -70;
+    pos @kc89_first_11 @kc89_second_62 -35;
+    pos @kc89_first_11 @kc89_second_63 -35;
+    pos @kc89_first_11 @kc89_second_64 -70;
+    pos @kc89_first_12 @kc89_second_1 -140;
+    pos @kc89_first_12 @kc89_second_2 -210;
+    pos @kc89_first_12 @kc89_second_6 -140;
+    pos @kc89_first_12 @kc89_second_17 -70;
+    pos @kc89_first_12 @kc89_second_19 -210;
+    pos @kc89_first_12 @kc89_second_22 -70;
+    pos @kc89_first_12 @kc89_second_24 -350;
+    pos @kc89_first_12 @kc89_second_29 -35;
+    pos @kc89_first_12 @kc89_second_32 -140;
+    pos @kc89_first_12 @kc89_second_34 -140;
+    pos @kc89_first_12 @kc89_second_35 -70;
+    pos @kc89_first_12 @kc89_second_38 -70;
+    pos @kc89_first_12 @kc89_second_45 1;
+    pos @kc89_first_12 @kc89_second_51 -35;
+    pos @kc89_first_12 @kc89_second_53 -210;
+    pos @kc89_first_12 @kc89_second_55 -210;
+    pos @kc89_first_12 @kc89_second_57 -210;
+    pos @kc89_first_12 @kc89_second_63 -70;
+    pos @kc89_first_12 @kc89_second_64 -105;
+    pos @kc89_first_13 @kc89_second_6 -70;
+    pos @kc89_first_13 @kc89_second_12 -70;
+    pos @kc89_first_13 @kc89_second_13 -105;
+    pos @kc89_first_13 @kc89_second_14 -35;
+    pos @kc89_first_13 @kc89_second_22 -35;
+    pos @kc89_first_13 @kc89_second_29 -35;
+    pos @kc89_first_13 @kc89_second_34 -70;
+    pos @kc89_first_13 @kc89_second_38 -70;
+    pos @kc89_first_13 @kc89_second_45 1;
+    pos @kc89_first_13 @kc89_second_63 -70;
+    pos @kc89_first_13 @kc89_second_64 -35;
+    pos @kc89_first_14 @kc89_second_2 -35;
+    pos @kc89_first_14 @kc89_second_11 -35;
+    pos @kc89_first_14 @kc89_second_12 -70;
+    pos @kc89_first_14 @kc89_second_13 -70;
+    pos @kc89_first_14 @kc89_second_14 -35;
+    pos @kc89_first_14 @kc89_second_16 -35;
+    pos @kc89_first_14 @kc89_second_19 -35;
+    pos @kc89_first_14 @kc89_second_25 -35;
+    pos @kc89_first_14 @kc89_second_39 -70;
+    pos @kc89_first_14 @kc89_second_45 1;
+    pos @kc89_first_14 @kc89_second_47 -70;
+    pos @kc89_first_14 @kc89_second_48 -35;
+    pos @kc89_first_14 @kc89_second_56 -35;
+    pos @kc89_first_14 @kc89_second_58 -35;
+    pos @kc89_first_14 @kc89_second_60 -35;
+    pos @kc89_first_14 @kc89_second_62 -35;
+    pos @kc89_first_15 @kc89_second_3 -70;
+    pos @kc89_first_15 @kc89_second_4 -70;
+    pos @kc89_first_15 @kc89_second_6 -35;
+    pos @kc89_first_15 @kc89_second_8 -70;
+    pos @kc89_first_15 @kc89_second_17 -70;
+    pos @kc89_first_15 @kc89_second_20 -140;
+    pos @kc89_first_15 @kc89_second_22 -70;
+    pos @kc89_first_15 @kc89_second_23 -70;
+    pos @kc89_first_15 @kc89_second_25 -70;
+    pos @kc89_first_15 @kc89_second_29 -35;
+    pos @kc89_first_15 @kc89_second_31 -35;
+    pos @kc89_first_15 @kc89_second_36 -35;
+    pos @kc89_first_15 @kc89_second_38 -70;
+    pos @kc89_first_15 @kc89_second_39 -142;
+    pos @kc89_first_15 @kc89_second_40 -35;
+    pos @kc89_first_15 @kc89_second_44 -35;
+    pos @kc89_first_15 @kc89_second_45 1;
+    pos @kc89_first_15 @kc89_second_46 -35;
+    pos @kc89_first_15 @kc89_second_47 -70;
+    pos @kc89_first_15 @kc89_second_51 -35;
+    pos @kc89_first_15 @kc89_second_52 -35;
+    pos @kc89_first_15 @kc89_second_58 -105;
+    pos @kc89_first_15 @kc89_second_60 -35;
+    pos @kc89_first_15 @kc89_second_63 -35;
+    pos @kc89_first_15 @kc89_second_64 -35;
+    pos @kc89_first_16 @kc89_second_1 -280;
+    pos @kc89_first_16 @kc89_second_2 -280;
+    pos @kc89_first_16 @kc89_second_3 -140;
+    pos @kc89_first_16 @kc89_second_4 -70;
+    pos @kc89_first_16 @kc89_second_6 -280;
+    pos @kc89_first_16 @kc89_second_7 -140;
+    pos @kc89_first_16 @kc89_second_8 -175;
+    pos @kc89_first_16 @kc89_second_10 -70;
+    pos @kc89_first_16 @kc89_second_17 -245;
+    pos @kc89_first_16 @kc89_second_19 -280;
+    pos @kc89_first_16 @kc89_second_20 -210;
+    pos @kc89_first_16 @kc89_second_21 -140;
+    pos @kc89_first_16 @kc89_second_22 -280;
+    pos @kc89_first_16 @kc89_second_23 -210;
+    pos @kc89_first_16 @kc89_second_24 -350;
+    pos @kc89_first_16 @kc89_second_25 -70;
+    pos @kc89_first_16 @kc89_second_27 -140;
+    pos @kc89_first_16 @kc89_second_29 -240;
+    pos @kc89_first_16 @kc89_second_30 -140;
+    pos @kc89_first_16 @kc89_second_31 -140;
+    pos @kc89_first_16 @kc89_second_32 -245;
+    pos @kc89_first_16 @kc89_second_34 -315;
+    pos @kc89_first_16 @kc89_second_35 -70;
+    pos @kc89_first_16 @kc89_second_36 -210;
+    pos @kc89_first_16 @kc89_second_37 -210;
+    pos @kc89_first_16 @kc89_second_38 -245;
+    pos @kc89_first_16 @kc89_second_39 -245;
+    pos @kc89_first_16 @kc89_second_40 -70;
+    pos @kc89_first_16 @kc89_second_42 -35;
+    pos @kc89_first_16 @kc89_second_43 -140;
+    pos @kc89_first_16 @kc89_second_44 -140;
+    pos @kc89_first_16 @kc89_second_45 1;
+    pos @kc89_first_16 @kc89_second_46 -70;
+    pos @kc89_first_16 @kc89_second_47 -140;
+    pos @kc89_first_16 @kc89_second_49 -140;
+    pos @kc89_first_16 @kc89_second_50 -140;
+    pos @kc89_first_16 @kc89_second_51 -240;
+    pos @kc89_first_16 @kc89_second_52 -140;
+    pos @kc89_first_16 @kc89_second_53 -280;
+    pos @kc89_first_16 @kc89_second_54 -105;
+    pos @kc89_first_16 @kc89_second_55 -280;
+    pos @kc89_first_16 @kc89_second_56 -140;
+    pos @kc89_first_16 @kc89_second_57 -315;
+    pos @kc89_first_16 @kc89_second_58 -210;
+    pos @kc89_first_16 @kc89_second_59 -210;
+    pos @kc89_first_16 @kc89_second_60 -105;
+    pos @kc89_first_16 @kc89_second_63 -315;
+    pos @kc89_first_16 @kc89_second_64 -350;
+    pos @kc89_first_17 @kc89_second_1 -280;
+    pos @kc89_first_17 @kc89_second_2 -280;
+    pos @kc89_first_17 @kc89_second_3 -105;
+    pos @kc89_first_17 @kc89_second_6 -210;
+    pos @kc89_first_17 @kc89_second_7 -105;
+    pos @kc89_first_17 @kc89_second_8 -105;
+    pos @kc89_first_17 @kc89_second_10 -35;
+    pos @kc89_first_17 @kc89_second_17 -105;
+    pos @kc89_first_17 @kc89_second_19 -280;
+    pos @kc89_first_17 @kc89_second_20 -70;
+    pos @kc89_first_17 @kc89_second_21 -105;
+    pos @kc89_first_17 @kc89_second_22 -140;
+    pos @kc89_first_17 @kc89_second_23 -140;
+    pos @kc89_first_17 @kc89_second_24 -210;
+    pos @kc89_first_17 @kc89_second_27 -70;
+    pos @kc89_first_17 @kc89_second_29 -140;
+    pos @kc89_first_17 @kc89_second_30 -105;
+    pos @kc89_first_17 @kc89_second_32 -210;
+    pos @kc89_first_17 @kc89_second_34 -245;
+    pos @kc89_first_17 @kc89_second_35 -70;
+    pos @kc89_first_17 @kc89_second_36 -140;
+    pos @kc89_first_17 @kc89_second_37 -140;
+    pos @kc89_first_17 @kc89_second_38 -140;
+    pos @kc89_first_17 @kc89_second_39 -105;
+    pos @kc89_first_17 @kc89_second_40 -35;
+    pos @kc89_first_17 @kc89_second_43 -35;
+    pos @kc89_first_17 @kc89_second_44 -70;
+    pos @kc89_first_17 @kc89_second_45 1;
+    pos @kc89_first_17 @kc89_second_46 -35;
+    pos @kc89_first_17 @kc89_second_47 -70;
+    pos @kc89_first_17 @kc89_second_49 -105;
+    pos @kc89_first_17 @kc89_second_50 -70;
+    pos @kc89_first_17 @kc89_second_51 -105;
+    pos @kc89_first_17 @kc89_second_52 -70;
+    pos @kc89_first_17 @kc89_second_53 -210;
+    pos @kc89_first_17 @kc89_second_54 -35;
+    pos @kc89_first_17 @kc89_second_55 -210;
+    pos @kc89_first_17 @kc89_second_56 -70;
+    pos @kc89_first_17 @kc89_second_57 -245;
+    pos @kc89_first_17 @kc89_second_58 -105;
+    pos @kc89_first_17 @kc89_second_59 -105;
+    pos @kc89_first_17 @kc89_second_60 -70;
+    pos @kc89_first_17 @kc89_second_63 -175;
+    pos @kc89_first_17 @kc89_second_64 -245;
+    pos @kc89_first_18 @kc89_second_1 -210;
+    pos @kc89_first_18 @kc89_second_2 -245;
+    pos @kc89_first_18 @kc89_second_3 -35;
+    pos @kc89_first_18 @kc89_second_6 -140;
+    pos @kc89_first_18 @kc89_second_7 -35;
+    pos @kc89_first_18 @kc89_second_8 -70;
+    pos @kc89_first_18 @kc89_second_17 -105;
+    pos @kc89_first_18 @kc89_second_19 -210;
+    pos @kc89_first_18 @kc89_second_20 -70;
+    pos @kc89_first_18 @kc89_second_22 -105;
+    pos @kc89_first_18 @kc89_second_23 -70;
+    pos @kc89_first_18 @kc89_second_24 -140;
+    pos @kc89_first_18 @kc89_second_27 -35;
+    pos @kc89_first_18 @kc89_second_32 -140;
+    pos @kc89_first_18 @kc89_second_34 -140;
+    pos @kc89_first_18 @kc89_second_36 -105;
+    pos @kc89_first_18 @kc89_second_37 -70;
+    pos @kc89_first_18 @kc89_second_38 -105;
+    pos @kc89_first_18 @kc89_second_39 -70;
+    pos @kc89_first_18 @kc89_second_41 -35;
+    pos @kc89_first_18 @kc89_second_45 1;
+    pos @kc89_first_18 @kc89_second_50 -35;
+    pos @kc89_first_18 @kc89_second_51 -70;
+    pos @kc89_first_18 @kc89_second_53 -140;
+    pos @kc89_first_18 @kc89_second_55 -140;
+    pos @kc89_first_18 @kc89_second_57 -175;
+    pos @kc89_first_18 @kc89_second_58 -70;
+    pos @kc89_first_18 @kc89_second_63 -105;
+    pos @kc89_first_18 @kc89_second_64 -140;
+    pos @kc89_first_19 @kc89_second_12 -280;
+    pos @kc89_first_19 @kc89_second_14 -175;
+    pos @kc89_first_19 @kc89_second_15 -140;
+    pos @kc89_first_19 @kc89_second_29 -35;
+    pos @kc89_first_19 @kc89_second_45 1;
+    pos @kc89_first_19 @kc89_second_47 -70;
+    pos @kc89_first_19 @kc89_second_48 -140;
+    pos @kc89_first_19 @kc89_second_58 -70;
+    pos @kc89_first_19 @kc89_second_60 -35;
+    pos @kc89_first_19 @kc89_second_61 -105;
+    pos @kc89_first_19 @kc89_second_62 -70;
+    pos @kc89_first_20 @kc89_second_8 -35;
+    pos @kc89_first_20 @kc89_second_9 -140;
+    pos @kc89_first_20 @kc89_second_12 -280;
+    pos @kc89_first_20 @kc89_second_13 -280;
+    pos @kc89_first_20 @kc89_second_14 -280;
+    pos @kc89_first_20 @kc89_second_15 -175;
+    pos @kc89_first_20 @kc89_second_18 -140;
+    pos @kc89_first_20 @kc89_second_20 -70;
+    pos @kc89_first_20 @kc89_second_25 -70;
+    pos @kc89_first_20 @kc89_second_31 -50;
+    pos @kc89_first_20 @kc89_second_39 -140;
+    pos @kc89_first_20 @kc89_second_40 -105;
+    pos @kc89_first_20 @kc89_second_43 -210;
+    pos @kc89_first_20 @kc89_second_45 1;
+    pos @kc89_first_20 @kc89_second_46 -35;
+    pos @kc89_first_20 @kc89_second_47 -140;
+    pos @kc89_first_20 @kc89_second_48 -210;
+    pos @kc89_first_20 @kc89_second_52 -35;
+    pos @kc89_first_20 @kc89_second_58 -105;
+    pos @kc89_first_20 @kc89_second_60 -105;
+    pos @kc89_first_20 @kc89_second_61 -210;
+    pos @kc89_first_20 @kc89_second_62 -140;
+    pos @kc89_first_21 @kc89_second_1 -140;
+    pos @kc89_first_21 @kc89_second_2 -350;
+    pos @kc89_first_21 @kc89_second_19 -280;
+    pos @kc89_first_21 @kc89_second_38 -70;
+    pos @kc89_first_21 @kc89_second_45 1;
+    pos @kc89_first_21 @kc89_second_64 -210;
+    pos @kc89_first_22 @kc89_second_1 -35;
+    pos @kc89_first_22 @kc89_second_5 -105;
+    pos @kc89_first_22 @kc89_second_9 -70;
+    pos @kc89_first_22 @kc89_second_11 -70;
+    pos @kc89_first_22 @kc89_second_12 -240;
+    pos @kc89_first_22 @kc89_second_13 -280;
+    pos @kc89_first_22 @kc89_second_14 -140;
+    pos @kc89_first_22 @kc89_second_15 -105;
+    pos @kc89_first_22 @kc89_second_16 -70;
+    pos @kc89_first_22 @kc89_second_25 -35;
+    pos @kc89_first_22 @kc89_second_26 -70;
+    pos @kc89_first_22 @kc89_second_27 -105;
+    pos @kc89_first_22 @kc89_second_35 -70;
+    pos @kc89_first_22 @kc89_second_39 -70;
+    pos @kc89_first_22 @kc89_second_40 -35;
+    pos @kc89_first_22 @kc89_second_42 -35;
+    pos @kc89_first_22 @kc89_second_43 -140;
+    pos @kc89_first_22 @kc89_second_45 1;
+    pos @kc89_first_22 @kc89_second_47 -70;
+    pos @kc89_first_22 @kc89_second_48 -175;
+    pos @kc89_first_22 @kc89_second_49 -35;
+    pos @kc89_first_22 @kc89_second_56 -105;
+    pos @kc89_first_22 @kc89_second_58 -35;
+    pos @kc89_first_22 @kc89_second_60 -50;
+    pos @kc89_first_22 @kc89_second_61 -105;
+    pos @kc89_first_22 @kc89_second_62 -70;
+    pos @kc89_first_23 @kc89_second_6 -35;
+    pos @kc89_first_23 @kc89_second_12 -240;
+    pos @kc89_first_23 @kc89_second_13 -175;
+    pos @kc89_first_23 @kc89_second_14 -70;
+    pos @kc89_first_23 @kc89_second_15 -70;
+    pos @kc89_first_23 @kc89_second_22 -70;
+    pos @kc89_first_23 @kc89_second_23 -35;
+    pos @kc89_first_23 @kc89_second_34 -35;
+    pos @kc89_first_23 @kc89_second_39 -35;
+    pos @kc89_first_23 @kc89_second_40 -35;
+    pos @kc89_first_23 @kc89_second_43 -70;
+    pos @kc89_first_23 @kc89_second_44 -35;
+    pos @kc89_first_23 @kc89_second_45 1;
+    pos @kc89_first_23 @kc89_second_48 -35;
+    pos @kc89_first_23 @kc89_second_58 -35;
+    pos @kc89_first_23 @kc89_second_62 -35;
+    pos @kc89_first_23 @kc89_second_63 -35;
+    pos @kc89_first_23 @kc89_second_64 -35;
+    pos @kc89_first_24 @kc89_second_1 -70;
+    pos @kc89_first_24 @kc89_second_2 -140;
+    pos @kc89_first_24 @kc89_second_5 -105;
+    pos @kc89_first_24 @kc89_second_11 -70;
+    pos @kc89_first_24 @kc89_second_12 -280;
+    pos @kc89_first_24 @kc89_second_13 -210;
+    pos @kc89_first_24 @kc89_second_14 -70;
+    pos @kc89_first_24 @kc89_second_15 -70;
+    pos @kc89_first_24 @kc89_second_16 -140;
+    pos @kc89_first_24 @kc89_second_19 -70;
+    pos @kc89_first_24 @kc89_second_26 -70;
+    pos @kc89_first_24 @kc89_second_27 -70;
+    pos @kc89_first_24 @kc89_second_32 -70;
+    pos @kc89_first_24 @kc89_second_35 -70;
+    pos @kc89_first_24 @kc89_second_42 -35;
+    pos @kc89_first_24 @kc89_second_43 -140;
+    pos @kc89_first_24 @kc89_second_45 1;
+    pos @kc89_first_24 @kc89_second_48 -140;
+    pos @kc89_first_24 @kc89_second_49 -35;
+    pos @kc89_first_24 @kc89_second_53 -140;
+    pos @kc89_first_24 @kc89_second_55 -105;
+    pos @kc89_first_24 @kc89_second_56 -70;
+    pos @kc89_first_24 @kc89_second_57 -70;
+    pos @kc89_first_24 @kc89_second_61 -70;
+    pos @kc89_first_24 @kc89_second_62 -35;
+    pos @kc89_first_25 @kc89_second_5 -70;
+    pos @kc89_first_25 @kc89_second_9 -70;
+    pos @kc89_first_25 @kc89_second_12 -240;
+    pos @kc89_first_25 @kc89_second_13 -280;
+    pos @kc89_first_25 @kc89_second_14 -175;
+    pos @kc89_first_25 @kc89_second_15 -105;
+    pos @kc89_first_25 @kc89_second_16 -70;
+    pos @kc89_first_25 @kc89_second_25 -35;
+    pos @kc89_first_25 @kc89_second_26 -70;
+    pos @kc89_first_25 @kc89_second_27 -70;
+    pos @kc89_first_25 @kc89_second_35 -70;
+    pos @kc89_first_25 @kc89_second_39 -70;
+    pos @kc89_first_25 @kc89_second_40 -35;
+    pos @kc89_first_25 @kc89_second_43 -140;
+    pos @kc89_first_25 @kc89_second_45 1;
+    pos @kc89_first_25 @kc89_second_47 -70;
+    pos @kc89_first_25 @kc89_second_48 -140;
+    pos @kc89_first_25 @kc89_second_49 -35;
+    pos @kc89_first_25 @kc89_second_53 -50;
+    pos @kc89_first_25 @kc89_second_54 -35;
+    pos @kc89_first_25 @kc89_second_55 -50;
+    pos @kc89_first_25 @kc89_second_56 -105;
+    pos @kc89_first_25 @kc89_second_57 -50;
+    pos @kc89_first_25 @kc89_second_58 -50;
+    pos @kc89_first_25 @kc89_second_60 -35;
+    pos @kc89_first_25 @kc89_second_61 -105;
+    pos @kc89_first_25 @kc89_second_62 -70;
+    pos @kc89_first_26 @kc89_second_9 -35;
+    pos @kc89_first_26 @kc89_second_12 -140;
+    pos @kc89_first_26 @kc89_second_26 -70;
+    pos @kc89_first_26 @kc89_second_39 -35;
+    pos @kc89_first_26 @kc89_second_43 -70;
+    pos @kc89_first_26 @kc89_second_45 1;
+    pos @kc89_first_26 @kc89_second_48 -70;
+    pos @kc89_first_26 @kc89_second_61 -70;
+    pos @kc89_first_26 @kc89_second_62 -35;
+    pos @kc89_first_27 @kc89_second_5 -50;
+    pos @kc89_first_27 @kc89_second_9 -35;
+    pos @kc89_first_27 @kc89_second_11 -35;
+    pos @kc89_first_27 @kc89_second_12 -240;
+    pos @kc89_first_27 @kc89_second_13 -240;
+    pos @kc89_first_27 @kc89_second_14 -105;
+    pos @kc89_first_27 @kc89_second_15 -70;
+    pos @kc89_first_27 @kc89_second_16 -35;
+    pos @kc89_first_27 @kc89_second_26 -35;
+    pos @kc89_first_27 @kc89_second_27 -35;
+    pos @kc89_first_27 @kc89_second_35 -35;
+    pos @kc89_first_27 @kc89_second_39 -50;
+    pos @kc89_first_27 @kc89_second_40 -35;
+    pos @kc89_first_27 @kc89_second_43 -100;
+    pos @kc89_first_27 @kc89_second_45 1;
+    pos @kc89_first_27 @kc89_second_47 -35;
+    pos @kc89_first_27 @kc89_second_48 -140;
+    pos @kc89_first_27 @kc89_second_56 -35;
+    pos @kc89_first_27 @kc89_second_61 -70;
+    pos @kc89_first_27 @kc89_second_62 -35;
+    pos @kc89_first_28 @kc89_second_45 1;
+    pos @kc89_first_29 @kc89_second_8 -70;
+    pos @kc89_first_29 @kc89_second_9 -210;
+    pos @kc89_first_29 @kc89_second_12 -350;
+    pos @kc89_first_29 @kc89_second_13 -350;
+    pos @kc89_first_29 @kc89_second_14 -210;
+    pos @kc89_first_29 @kc89_second_15 -175;
+    pos @kc89_first_29 @kc89_second_25 -70;
+    pos @kc89_first_29 @kc89_second_38 -35;
+    pos @kc89_first_29 @kc89_second_39 -210;
+    pos @kc89_first_29 @kc89_second_40 -210;
+    pos @kc89_first_29 @kc89_second_43 -210;
+    pos @kc89_first_29 @kc89_second_45 1;
+    pos @kc89_first_29 @kc89_second_47 -140;
+    pos @kc89_first_29 @kc89_second_48 -280;
+    pos @kc89_first_29 @kc89_second_58 -210;
+    pos @kc89_first_29 @kc89_second_60 -105;
+    pos @kc89_first_29 @kc89_second_61 -175;
+    pos @kc89_first_29 @kc89_second_62 -140;
+    pos @kc89_first_30 @kc89_second_1 -175;
+    pos @kc89_first_30 @kc89_second_2 -175;
+    pos @kc89_first_30 @kc89_second_5 -70;
+    pos @kc89_first_30 @kc89_second_6 -105;
+    pos @kc89_first_30 @kc89_second_10 -35;
+    pos @kc89_first_30 @kc89_second_11 -105;
+    pos @kc89_first_30 @kc89_second_12 -175;
+    pos @kc89_first_30 @kc89_second_13 -140;
+    pos @kc89_first_30 @kc89_second_14 -70;
+    pos @kc89_first_30 @kc89_second_15 -35;
+    pos @kc89_first_30 @kc89_second_16 -140;
+    pos @kc89_first_30 @kc89_second_17 -70;
+    pos @kc89_first_30 @kc89_second_19 -175;
+    pos @kc89_first_30 @kc89_second_22 -70;
+    pos @kc89_first_30 @kc89_second_29 -105;
+    pos @kc89_first_30 @kc89_second_33 180;
+    pos @kc89_first_30 @kc89_second_34 -105;
+    pos @kc89_first_30 @kc89_second_35 -175;
+    pos @kc89_first_30 @kc89_second_36 -35;
+    pos @kc89_first_30 @kc89_second_38 -70;
+    pos @kc89_first_30 @kc89_second_45 1;
+    pos @kc89_first_30 @kc89_second_50 180;
+    pos @kc89_first_30 @kc89_second_51 -35;
+    pos @kc89_first_30 @kc89_second_63 -70;
+    pos @kc89_first_30 @kc89_second_64 -105;
+    pos @kc89_first_31 @kc89_second_3 -70;
+    pos @kc89_first_31 @kc89_second_4 -35;
+    pos @kc89_first_31 @kc89_second_6 -70;
+    pos @kc89_first_31 @kc89_second_8 -105;
+    pos @kc89_first_31 @kc89_second_17 -35;
+    pos @kc89_first_31 @kc89_second_20 -70;
+    pos @kc89_first_31 @kc89_second_22 -70;
+    pos @kc89_first_31 @kc89_second_23 -140;
+    pos @kc89_first_31 @kc89_second_29 -35;
+    pos @kc89_first_31 @kc89_second_34 -70;
+    pos @kc89_first_31 @kc89_second_36 -35;
+    pos @kc89_first_31 @kc89_second_38 -140;
+    pos @kc89_first_31 @kc89_second_39 -70;
+    pos @kc89_first_31 @kc89_second_45 1;
+    pos @kc89_first_31 @kc89_second_51 -35;
+    pos @kc89_first_31 @kc89_second_52 -35;
+    pos @kc89_first_31 @kc89_second_58 -140;
+    pos @kc89_first_31 @kc89_second_63 -70;
+    pos @kc89_first_31 @kc89_second_64 -70;
+    pos @kc89_first_32 @kc89_second_1 -35;
+    pos @kc89_first_32 @kc89_second_2 -105;
+    pos @kc89_first_32 @kc89_second_3 -70;
+    pos @kc89_first_32 @kc89_second_4 70;
+    pos @kc89_first_32 @kc89_second_5 -70;
+    pos @kc89_first_32 @kc89_second_11 -35;
+    pos @kc89_first_32 @kc89_second_12 -240;
+    pos @kc89_first_32 @kc89_second_13 -175;
+    pos @kc89_first_32 @kc89_second_14 -105;
+    pos @kc89_first_32 @kc89_second_15 -70;
+    pos @kc89_first_32 @kc89_second_16 -70;
+    pos @kc89_first_32 @kc89_second_24 -35;
+    pos @kc89_first_32 @kc89_second_27 -70;
+    pos @kc89_first_32 @kc89_second_35 -35;
+    pos @kc89_first_32 @kc89_second_39 -35;
+    pos @kc89_first_32 @kc89_second_40 -35;
+    pos @kc89_first_32 @kc89_second_42 -35;
+    pos @kc89_first_32 @kc89_second_43 -140;
+    pos @kc89_first_32 @kc89_second_45 1;
+    pos @kc89_first_32 @kc89_second_47 -50;
+    pos @kc89_first_32 @kc89_second_48 -140;
+    pos @kc89_first_32 @kc89_second_49 -35;
+    pos @kc89_first_32 @kc89_second_53 -70;
+    pos @kc89_first_32 @kc89_second_55 -70;
+    pos @kc89_first_32 @kc89_second_57 -70;
+    pos @kc89_first_32 @kc89_second_61 -70;
+    pos @kc89_first_32 @kc89_second_62 -35;
+    pos @kc89_first_33 @kc89_second_3 -35;
+    pos @kc89_first_33 @kc89_second_4 -70;
+    pos @kc89_first_33 @kc89_second_6 -70;
+    pos @kc89_first_33 @kc89_second_8 -70;
+    pos @kc89_first_33 @kc89_second_12 -140;
+    pos @kc89_first_33 @kc89_second_13 -105;
+    pos @kc89_first_33 @kc89_second_14 -70;
+    pos @kc89_first_33 @kc89_second_15 -35;
+    pos @kc89_first_33 @kc89_second_20 -70;
+    pos @kc89_first_33 @kc89_second_22 -105;
+    pos @kc89_first_33 @kc89_second_23 -70;
+    pos @kc89_first_33 @kc89_second_29 -35;
+    pos @kc89_first_33 @kc89_second_34 -70;
+    pos @kc89_first_33 @kc89_second_36 -70;
+    pos @kc89_first_33 @kc89_second_38 -105;
+    pos @kc89_first_33 @kc89_second_39 -70;
+    pos @kc89_first_33 @kc89_second_44 -70;
+    pos @kc89_first_33 @kc89_second_45 1;
+    pos @kc89_first_33 @kc89_second_51 -35;
+    pos @kc89_first_33 @kc89_second_52 -35;
+    pos @kc89_first_33 @kc89_second_63 -70;
+    pos @kc89_first_33 @kc89_second_64 -70;
+    pos @kc89_first_34 @kc89_second_32 -315;
+    pos @kc89_first_34 @kc89_second_45 1;
+    pos @kc89_first_35 @kc89_second_9 -70;
+    pos @kc89_first_35 @kc89_second_12 -240;
+    pos @kc89_first_35 @kc89_second_13 -210;
+    pos @kc89_first_35 @kc89_second_14 -140;
+    pos @kc89_first_35 @kc89_second_15 -105;
+    pos @kc89_first_35 @kc89_second_39 -70;
+    pos @kc89_first_35 @kc89_second_40 -35;
+    pos @kc89_first_35 @kc89_second_43 -140;
+    pos @kc89_first_35 @kc89_second_45 1;
+    pos @kc89_first_35 @kc89_second_47 -50;
+    pos @kc89_first_35 @kc89_second_48 -140;
+    pos @kc89_first_35 @kc89_second_58 -35;
+    pos @kc89_first_35 @kc89_second_60 -35;
+    pos @kc89_first_35 @kc89_second_61 -70;
+    pos @kc89_first_35 @kc89_second_62 -70;
+    pos @kc89_first_36 @kc89_second_9 -35;
+    pos @kc89_first_36 @kc89_second_12 -240;
+    pos @kc89_first_36 @kc89_second_13 -240;
+    pos @kc89_first_36 @kc89_second_14 -140;
+    pos @kc89_first_36 @kc89_second_15 -105;
+    pos @kc89_first_36 @kc89_second_16 -35;
+    pos @kc89_first_36 @kc89_second_26 -35;
+    pos @kc89_first_36 @kc89_second_27 -35;
+    pos @kc89_first_36 @kc89_second_39 -70;
+    pos @kc89_first_36 @kc89_second_40 -35;
+    pos @kc89_first_36 @kc89_second_43 -70;
+    pos @kc89_first_36 @kc89_second_45 1;
+    pos @kc89_first_36 @kc89_second_47 -35;
+    pos @kc89_first_36 @kc89_second_48 -70;
+    pos @kc89_first_36 @kc89_second_60 -35;
+    pos @kc89_first_36 @kc89_second_61 -70;
+    pos @kc89_first_36 @kc89_second_62 -70;
+    pos @kc89_first_37 @kc89_second_5 -70;
+    pos @kc89_first_37 @kc89_second_9 -70;
+    pos @kc89_first_37 @kc89_second_12 -140;
+    pos @kc89_first_37 @kc89_second_13 -210;
+    pos @kc89_first_37 @kc89_second_14 -140;
+    pos @kc89_first_37 @kc89_second_15 -105;
+    pos @kc89_first_37 @kc89_second_16 -70;
+    pos @kc89_first_37 @kc89_second_26 -70;
+    pos @kc89_first_37 @kc89_second_27 -70;
+    pos @kc89_first_37 @kc89_second_35 -50;
+    pos @kc89_first_37 @kc89_second_39 -50;
+    pos @kc89_first_37 @kc89_second_40 -35;
+    pos @kc89_first_37 @kc89_second_45 1;
+    pos @kc89_first_37 @kc89_second_47 -35;
+    pos @kc89_first_37 @kc89_second_48 -140;
+    pos @kc89_first_37 @kc89_second_56 -35;
+    pos @kc89_first_37 @kc89_second_61 -70;
+    pos @kc89_first_37 @kc89_second_62 -35;
+    pos @kc89_first_38 @kc89_second_1 -210;
+    pos @kc89_first_38 @kc89_second_2 -280;
+    pos @kc89_first_38 @kc89_second_6 -280;
+    pos @kc89_first_38 @kc89_second_8 -70;
+    pos @kc89_first_38 @kc89_second_17 -140;
+    pos @kc89_first_38 @kc89_second_19 -350;
+    pos @kc89_first_38 @kc89_second_20 -140;
+    pos @kc89_first_38 @kc89_second_22 -140;
+    pos @kc89_first_38 @kc89_second_23 -70;
+    pos @kc89_first_38 @kc89_second_24 -280;
+    pos @kc89_first_38 @kc89_second_28 -315;
+    pos @kc89_first_38 @kc89_second_29 -140;
+    pos @kc89_first_38 @kc89_second_32 -385;
+    pos @kc89_first_38 @kc89_second_34 -210;
+    pos @kc89_first_38 @kc89_second_35 -70;
+    pos @kc89_first_38 @kc89_second_36 -140;
+    pos @kc89_first_38 @kc89_second_37 -140;
+    pos @kc89_first_38 @kc89_second_38 -140;
+    pos @kc89_first_38 @kc89_second_41 -70;
+    pos @kc89_first_38 @kc89_second_45 1;
+    pos @kc89_first_38 @kc89_second_51 -140;
+    pos @kc89_first_38 @kc89_second_52 -70;
+    pos @kc89_first_38 @kc89_second_53 -140;
+    pos @kc89_first_38 @kc89_second_55 -245;
+    pos @kc89_first_38 @kc89_second_58 -70;
+    pos @kc89_first_38 @kc89_second_59 -70;
+    pos @kc89_first_38 @kc89_second_63 -245;
+    pos @kc89_first_38 @kc89_second_64 -280;
+    pos @kc89_first_38 @kc89_second_65 -315;
+    pos @kc89_first_39 @kc89_second_6 -35;
+    pos @kc89_first_39 @kc89_second_12 -240;
+    pos @kc89_first_39 @kc89_second_13 -140;
+    pos @kc89_first_39 @kc89_second_14 -35;
+    pos @kc89_first_39 @kc89_second_15 -35;
+    pos @kc89_first_39 @kc89_second_34 -35;
+    pos @kc89_first_39 @kc89_second_45 1;
+    pos @kc89_first_39 @kc89_second_63 -35;
+    pos @kc89_first_39 @kc89_second_64 -35;
+    pos @kc89_first_40 @kc89_second_12 -210;
+    pos @kc89_first_40 @kc89_second_13 -175;
+    pos @kc89_first_40 @kc89_second_14 -105;
+    pos @kc89_first_40 @kc89_second_15 -70;
+    pos @kc89_first_40 @kc89_second_43 -70;
+    pos @kc89_first_40 @kc89_second_45 1;
+    pos @kc89_first_40 @kc89_second_48 -105;
+    pos @kc89_first_40 @kc89_second_61 -70;
+    pos @kc89_first_41 @kc89_second_1 -140;
+    pos @kc89_first_41 @kc89_second_2 -175;
+    pos @kc89_first_41 @kc89_second_5 -105;
+    pos @kc89_first_41 @kc89_second_6 -70;
+    pos @kc89_first_41 @kc89_second_11 -70;
+    pos @kc89_first_41 @kc89_second_12 -175;
+    pos @kc89_first_41 @kc89_second_13 -105;
+    pos @kc89_first_41 @kc89_second_14 -70;
+    pos @kc89_first_41 @kc89_second_15 -35;
+    pos @kc89_first_41 @kc89_second_16 -105;
+    pos @kc89_first_41 @kc89_second_17 -35;
+    pos @kc89_first_41 @kc89_second_19 -175;
+    pos @kc89_first_41 @kc89_second_22 -50;
+    pos @kc89_first_41 @kc89_second_24 -105;
+    pos @kc89_first_41 @kc89_second_29 -35;
+    pos @kc89_first_41 @kc89_second_34 -70;
+    pos @kc89_first_41 @kc89_second_35 -140;
+    pos @kc89_first_41 @kc89_second_36 -35;
+    pos @kc89_first_41 @kc89_second_38 -50;
+    pos @kc89_first_41 @kc89_second_45 1;
+    pos @kc89_first_41 @kc89_second_51 -35;
+    pos @kc89_first_41 @kc89_second_53 -105;
+    pos @kc89_first_41 @kc89_second_55 -105;
+    pos @kc89_first_41 @kc89_second_57 -105;
+    pos @kc89_first_41 @kc89_second_63 -50;
+    pos @kc89_first_41 @kc89_second_64 -70;
+    pos @kc89_first_42 @kc89_second_1 -210;
+    pos @kc89_first_42 @kc89_second_2 -280;
+    pos @kc89_first_42 @kc89_second_3 -70;
+    pos @kc89_first_42 @kc89_second_6 -280;
+    pos @kc89_first_42 @kc89_second_8 -35;
+    pos @kc89_first_42 @kc89_second_11 -70;
+    pos @kc89_first_42 @kc89_second_13 -140;
+    pos @kc89_first_42 @kc89_second_14 -35;
+    pos @kc89_first_42 @kc89_second_15 -35;
+    pos @kc89_first_42 @kc89_second_16 -140;
+    pos @kc89_first_42 @kc89_second_17 -105;
+    pos @kc89_first_42 @kc89_second_19 -280;
+    pos @kc89_first_42 @kc89_second_20 -140;
+    pos @kc89_first_42 @kc89_second_22 -140;
+    pos @kc89_first_42 @kc89_second_23 -140;
+    pos @kc89_first_42 @kc89_second_24 -210;
+    pos @kc89_first_42 @kc89_second_34 -280;
+    pos @kc89_first_42 @kc89_second_35 -140;
+    pos @kc89_first_42 @kc89_second_36 -70;
+    pos @kc89_first_42 @kc89_second_37 -140;
+    pos @kc89_first_42 @kc89_second_38 -175;
+    pos @kc89_first_42 @kc89_second_44 -70;
+    pos @kc89_first_42 @kc89_second_45 1;
+    pos @kc89_first_42 @kc89_second_53 -210;
+    pos @kc89_first_42 @kc89_second_55 -175;
+    pos @kc89_first_42 @kc89_second_57 -210;
+    pos @kc89_first_42 @kc89_second_59 -70;
+    pos @kc89_first_42 @kc89_second_63 -175;
+    pos @kc89_first_42 @kc89_second_64 -175;
+    pos @kc89_first_43 @kc89_second_9 -70;
+    pos @kc89_first_43 @kc89_second_12 -240;
+    pos @kc89_first_43 @kc89_second_13 -210;
+    pos @kc89_first_43 @kc89_second_14 -140;
+    pos @kc89_first_43 @kc89_second_15 -105;
+    pos @kc89_first_43 @kc89_second_39 -70;
+    pos @kc89_first_43 @kc89_second_40 -35;
+    pos @kc89_first_43 @kc89_second_43 -140;
+    pos @kc89_first_43 @kc89_second_45 1;
+    pos @kc89_first_43 @kc89_second_47 -50;
+    pos @kc89_first_43 @kc89_second_48 -140;
+    pos @kc89_first_43 @kc89_second_58 -35;
+    pos @kc89_first_43 @kc89_second_60 -35;
+    pos @kc89_first_43 @kc89_second_61 -70;
+    pos @kc89_first_43 @kc89_second_62 -70;
+    pos @kc89_first_44 @kc89_second_8 -35;
+    pos @kc89_first_44 @kc89_second_9 -70;
+    pos @kc89_first_44 @kc89_second_12 -240;
+    pos @kc89_first_44 @kc89_second_13 -210;
+    pos @kc89_first_44 @kc89_second_14 -70;
+    pos @kc89_first_44 @kc89_second_15 -105;
+    pos @kc89_first_44 @kc89_second_22 -35;
+    pos @kc89_first_44 @kc89_second_38 -70;
+    pos @kc89_first_44 @kc89_second_39 -105;
+    pos @kc89_first_44 @kc89_second_40 -70;
+    pos @kc89_first_44 @kc89_second_43 -70;
+    pos @kc89_first_44 @kc89_second_44 -35;
+    pos @kc89_first_44 @kc89_second_45 1;
+    pos @kc89_first_44 @kc89_second_47 -70;
+    pos @kc89_first_44 @kc89_second_48 -70;
+    pos @kc89_first_44 @kc89_second_58 -70;
+    pos @kc89_first_44 @kc89_second_60 -50;
+    pos @kc89_first_44 @kc89_second_62 -70;
+    pos @kc89_first_44 @kc89_second_63 -35;
+    pos @kc89_first_44 @kc89_second_64 -35;
+    pos @kc89_first_45 @kc89_second_6 -70;
+    pos @kc89_first_45 @kc89_second_8 -35;
+    pos @kc89_first_45 @kc89_second_12 -175;
+    pos @kc89_first_45 @kc89_second_13 -140;
+    pos @kc89_first_45 @kc89_second_14 -70;
+    pos @kc89_first_45 @kc89_second_15 -35;
+    pos @kc89_first_45 @kc89_second_17 -70;
+    pos @kc89_first_45 @kc89_second_20 -70;
+    pos @kc89_first_45 @kc89_second_22 -105;
+    pos @kc89_first_45 @kc89_second_29 -35;
+    pos @kc89_first_45 @kc89_second_34 -70;
+    pos @kc89_first_45 @kc89_second_36 -35;
+    pos @kc89_first_45 @kc89_second_38 -105;
+    pos @kc89_first_45 @kc89_second_45 1;
+    pos @kc89_first_45 @kc89_second_51 -35;
+    pos @kc89_first_45 @kc89_second_63 -70;
+    pos @kc89_first_45 @kc89_second_64 -70;
+    pos @kc89_first_46 @kc89_second_3 -140;
+    pos @kc89_first_46 @kc89_second_4 -70;
+    pos @kc89_first_46 @kc89_second_6 -70;
+    pos @kc89_first_46 @kc89_second_8 -210;
+    pos @kc89_first_46 @kc89_second_9 -420;
+    pos @kc89_first_46 @kc89_second_12 -350;
+    pos @kc89_first_46 @kc89_second_13 -420;
+    pos @kc89_first_46 @kc89_second_14 -350;
+    pos @kc89_first_46 @kc89_second_15 -280;
+    pos @kc89_first_46 @kc89_second_17 -70;
+    pos @kc89_first_46 @kc89_second_18 -210;
+    pos @kc89_first_46 @kc89_second_20 -210;
+    pos @kc89_first_46 @kc89_second_22 -70;
+    pos @kc89_first_46 @kc89_second_23 -140;
+    pos @kc89_first_46 @kc89_second_29 -35;
+    pos @kc89_first_46 @kc89_second_31 -140;
+    pos @kc89_first_46 @kc89_second_34 -70;
+    pos @kc89_first_46 @kc89_second_36 -70;
+    pos @kc89_first_46 @kc89_second_38 -210;
+    pos @kc89_first_46 @kc89_second_39 -280;
+    pos @kc89_first_46 @kc89_second_40 -420;
+    pos @kc89_first_46 @kc89_second_43 -350;
+    pos @kc89_first_46 @kc89_second_45 1;
+    pos @kc89_first_46 @kc89_second_46 -35;
+    pos @kc89_first_46 @kc89_second_47 -210;
+    pos @kc89_first_46 @kc89_second_48 -350;
+    pos @kc89_first_46 @kc89_second_51 -35;
+    pos @kc89_first_46 @kc89_second_52 -35;
+    pos @kc89_first_46 @kc89_second_58 -280;
+    pos @kc89_first_46 @kc89_second_60 -175;
+    pos @kc89_first_46 @kc89_second_61 -280;
+    pos @kc89_first_46 @kc89_second_62 -210;
+    pos @kc89_first_46 @kc89_second_63 -70;
+    pos @kc89_first_47 @kc89_second_3 -140;
+    pos @kc89_first_47 @kc89_second_4 -105;
+    pos @kc89_first_47 @kc89_second_6 -70;
+    pos @kc89_first_47 @kc89_second_8 -210;
+    pos @kc89_first_47 @kc89_second_9 -280;
+    pos @kc89_first_47 @kc89_second_12 -350;
+    pos @kc89_first_47 @kc89_second_13 -385;
+    pos @kc89_first_47 @kc89_second_14 -350;
+    pos @kc89_first_47 @kc89_second_15 -280;
+    pos @kc89_first_47 @kc89_second_18 -210;
+    pos @kc89_first_47 @kc89_second_20 -140;
+    pos @kc89_first_47 @kc89_second_22 -105;
+    pos @kc89_first_47 @kc89_second_23 -140;
+    pos @kc89_first_47 @kc89_second_29 -70;
+    pos @kc89_first_47 @kc89_second_31 -175;
+    pos @kc89_first_47 @kc89_second_34 -70;
+    pos @kc89_first_47 @kc89_second_36 -35;
+    pos @kc89_first_47 @kc89_second_38 -175;
+    pos @kc89_first_47 @kc89_second_39 -280;
+    pos @kc89_first_47 @kc89_second_40 -280;
+    pos @kc89_first_47 @kc89_second_43 -280;
+    pos @kc89_first_47 @kc89_second_44 -140;
+    pos @kc89_first_47 @kc89_second_45 1;
+    pos @kc89_first_47 @kc89_second_46 -70;
+    pos @kc89_first_47 @kc89_second_47 -280;
+    pos @kc89_first_47 @kc89_second_48 -350;
+    pos @kc89_first_47 @kc89_second_51 -35;
+    pos @kc89_first_47 @kc89_second_52 -70;
+    pos @kc89_first_47 @kc89_second_58 -245;
+    pos @kc89_first_47 @kc89_second_60 -245;
+    pos @kc89_first_47 @kc89_second_61 -280;
+    pos @kc89_first_47 @kc89_second_62 -210;
+    pos @kc89_first_47 @kc89_second_63 -70;
+    pos @kc89_first_47 @kc89_second_64 -70;
+    pos @kc89_first_48 @kc89_second_3 -70;
+    pos @kc89_first_48 @kc89_second_4 -105;
+    pos @kc89_first_48 @kc89_second_6 -210;
+    pos @kc89_first_48 @kc89_second_7 -70;
+    pos @kc89_first_48 @kc89_second_8 -175;
+    pos @kc89_first_48 @kc89_second_17 -210;
+    pos @kc89_first_48 @kc89_second_20 -140;
+    pos @kc89_first_48 @kc89_second_21 -210;
+    pos @kc89_first_48 @kc89_second_22 -210;
+    pos @kc89_first_48 @kc89_second_23 -210;
+    pos @kc89_first_48 @kc89_second_24 -140;
+    pos @kc89_first_48 @kc89_second_25 -140;
+    pos @kc89_first_48 @kc89_second_27 -140;
+    pos @kc89_first_48 @kc89_second_29 -210;
+    pos @kc89_first_48 @kc89_second_30 -210;
+    pos @kc89_first_48 @kc89_second_31 -140;
+    pos @kc89_first_48 @kc89_second_34 -210;
+    pos @kc89_first_48 @kc89_second_35 -70;
+    pos @kc89_first_48 @kc89_second_36 -175;
+    pos @kc89_first_48 @kc89_second_37 -210;
+    pos @kc89_first_48 @kc89_second_38 -175;
+    pos @kc89_first_48 @kc89_second_39 -210;
+    pos @kc89_first_48 @kc89_second_40 -105;
+    pos @kc89_first_48 @kc89_second_43 -70;
+    pos @kc89_first_48 @kc89_second_44 -105;
+    pos @kc89_first_48 @kc89_second_45 1;
+    pos @kc89_first_48 @kc89_second_46 -35;
+    pos @kc89_first_48 @kc89_second_47 -210;
+    pos @kc89_first_48 @kc89_second_50 -210;
+    pos @kc89_first_48 @kc89_second_51 -210;
+    pos @kc89_first_48 @kc89_second_52 -175;
+    pos @kc89_first_48 @kc89_second_53 -175;
+    pos @kc89_first_48 @kc89_second_55 -210;
+    pos @kc89_first_48 @kc89_second_56 -140;
+    pos @kc89_first_48 @kc89_second_57 -210;
+    pos @kc89_first_48 @kc89_second_58 -210;
+    pos @kc89_first_48 @kc89_second_59 -175;
+    pos @kc89_first_48 @kc89_second_60 -175;
+    pos @kc89_first_48 @kc89_second_63 -210;
+    pos @kc89_first_48 @kc89_second_64 -210;
+    pos @kc89_first_49 @kc89_second_5 -70;
+    pos @kc89_first_49 @kc89_second_11 -35;
+    pos @kc89_first_49 @kc89_second_12 -240;
+    pos @kc89_first_49 @kc89_second_13 -70;
+    pos @kc89_first_49 @kc89_second_14 -140;
+    pos @kc89_first_49 @kc89_second_15 -105;
+    pos @kc89_first_49 @kc89_second_16 -70;
+    pos @kc89_first_49 @kc89_second_26 -70;
+    pos @kc89_first_49 @kc89_second_27 -70;
+    pos @kc89_first_49 @kc89_second_35 -35;
+    pos @kc89_first_49 @kc89_second_39 -70;
+    pos @kc89_first_49 @kc89_second_42 -35;
+    pos @kc89_first_49 @kc89_second_43 -70;
+    pos @kc89_first_49 @kc89_second_45 1;
+    pos @kc89_first_49 @kc89_second_47 -35;
+    pos @kc89_first_49 @kc89_second_48 -140;
+    pos @kc89_first_49 @kc89_second_51 1;
+    pos @kc89_first_49 @kc89_second_56 -35;
+    pos @kc89_first_49 @kc89_second_60 -35;
+    pos @kc89_first_49 @kc89_second_61 -105;
+    pos @kc89_first_49 @kc89_second_62 -70;
+    pos @kc89_first_50 @kc89_second_65 -210;
+    pos @kc89_first_51 @kc89_second_32 -315;
+    pos @kc89_first_51 @kc89_second_66 -210;
+    pos @kc89_first_52 @kc89_second_1 -105;
+    pos @kc89_first_52 @kc89_second_2 -210;
+    pos @kc89_first_52 @kc89_second_6 -140;
+    pos @kc89_first_52 @kc89_second_11 -70;
+    pos @kc89_first_52 @kc89_second_12 -210;
+    pos @kc89_first_52 @kc89_second_13 -210;
+    pos @kc89_first_52 @kc89_second_14 -105;
+    pos @kc89_first_52 @kc89_second_15 -70;
+    pos @kc89_first_52 @kc89_second_16 -140;
+    pos @kc89_first_52 @kc89_second_17 -35;
+    pos @kc89_first_52 @kc89_second_22 -35;
+    pos @kc89_first_52 @kc89_second_24 -210;
+    pos @kc89_first_52 @kc89_second_26 -70;
+    pos @kc89_first_52 @kc89_second_27 -70;
+    pos @kc89_first_52 @kc89_second_29 -35;
+    pos @kc89_first_52 @kc89_second_34 -210;
+    pos @kc89_first_52 @kc89_second_35 -140;
+    pos @kc89_first_52 @kc89_second_42 -35;
+    pos @kc89_first_52 @kc89_second_43 -70;
+    pos @kc89_first_52 @kc89_second_45 1;
+    pos @kc89_first_52 @kc89_second_47 -35;
+    pos @kc89_first_52 @kc89_second_48 -105;
+    pos @kc89_first_52 @kc89_second_53 -210;
+    pos @kc89_first_52 @kc89_second_55 -140;
+    pos @kc89_first_52 @kc89_second_57 -175;
+    pos @kc89_first_52 @kc89_second_61 -35;
+    pos @kc89_first_52 @kc89_second_62 -35;
+    pos @kc89_first_52 @kc89_second_63 -35;
+    pos @kc89_first_52 @kc89_second_64 -70;
+    pos @kc89_first_53 @kc89_second_1 -35;
+    pos @kc89_first_53 @kc89_second_2 -70;
+    pos @kc89_first_53 @kc89_second_5 -105;
+    pos @kc89_first_53 @kc89_second_6 -35;
+    pos @kc89_first_53 @kc89_second_9 -70;
+    pos @kc89_first_53 @kc89_second_11 -70;
+    pos @kc89_first_53 @kc89_second_12 -240;
+    pos @kc89_first_53 @kc89_second_13 -245;
+    pos @kc89_first_53 @kc89_second_14 -140;
+    pos @kc89_first_53 @kc89_second_15 -105;
+    pos @kc89_first_53 @kc89_second_16 -105;
+    pos @kc89_first_53 @kc89_second_18 -70;
+    pos @kc89_first_53 @kc89_second_19 -70;
+    pos @kc89_first_53 @kc89_second_24 -35;
+    pos @kc89_first_53 @kc89_second_25 -70;
+    pos @kc89_first_53 @kc89_second_26 -140;
+    pos @kc89_first_53 @kc89_second_27 -105;
+    pos @kc89_first_53 @kc89_second_34 -35;
+    pos @kc89_first_53 @kc89_second_35 -140;
+    pos @kc89_first_53 @kc89_second_39 -105;
+    pos @kc89_first_53 @kc89_second_40 -70;
+    pos @kc89_first_53 @kc89_second_42 -105;
+    pos @kc89_first_53 @kc89_second_43 -175;
+    pos @kc89_first_53 @kc89_second_45 1;
+    pos @kc89_first_53 @kc89_second_47 -70;
+    pos @kc89_first_53 @kc89_second_48 -140;
+    pos @kc89_first_53 @kc89_second_49 -70;
+    pos @kc89_first_53 @kc89_second_53 -210;
+    pos @kc89_first_53 @kc89_second_54 -70;
+    pos @kc89_first_53 @kc89_second_55 -175;
+    pos @kc89_first_53 @kc89_second_56 -105;
+    pos @kc89_first_53 @kc89_second_57 -175;
+    pos @kc89_first_53 @kc89_second_60 -50;
+    pos @kc89_first_53 @kc89_second_61 -105;
+    pos @kc89_first_53 @kc89_second_62 -70;
+    pos @kc89_first_53 @kc89_second_64 -35;
+    pos @kc89_first_54 @kc89_second_1 -105;
+    pos @kc89_first_54 @kc89_second_2 -210;
+    pos @kc89_first_54 @kc89_second_5 -70;
+    pos @kc89_first_54 @kc89_second_6 -105;
+    pos @kc89_first_54 @kc89_second_13 -70;
+    pos @kc89_first_54 @kc89_second_14 -35;
+    pos @kc89_first_54 @kc89_second_16 -140;
+    pos @kc89_first_54 @kc89_second_17 -70;
+    pos @kc89_first_54 @kc89_second_19 -210;
+    pos @kc89_first_54 @kc89_second_22 -35;
+    pos @kc89_first_54 @kc89_second_24 -210;
+    pos @kc89_first_54 @kc89_second_29 -35;
+    pos @kc89_first_54 @kc89_second_32 -105;
+    pos @kc89_first_54 @kc89_second_34 -105;
+    pos @kc89_first_54 @kc89_second_35 -140;
+    pos @kc89_first_54 @kc89_second_38 -70;
+    pos @kc89_first_54 @kc89_second_45 1;
+    pos @kc89_first_54 @kc89_second_51 -35;
+    pos @kc89_first_54 @kc89_second_53 -245;
+    pos @kc89_first_54 @kc89_second_55 -210;
+    pos @kc89_first_54 @kc89_second_57 -210;
+    pos @kc89_first_54 @kc89_second_63 -70;
+    pos @kc89_first_54 @kc89_second_64 -105;
+    pos @kc89_first_55 @kc89_second_12 -240;
+    pos @kc89_first_55 @kc89_second_13 -140;
+    pos @kc89_first_55 @kc89_second_14 -105;
+    pos @kc89_first_55 @kc89_second_15 -35;
+    pos @kc89_first_55 @kc89_second_33 100;
+    pos @kc89_first_55 @kc89_second_45 1;
+    pos @kc89_first_55 @kc89_second_50 100;
+    pos @kc89_first_56 @kc89_second_1 -140;
+    pos @kc89_first_56 @kc89_second_2 -210;
+    pos @kc89_first_56 @kc89_second_6 -140;
+    pos @kc89_first_56 @kc89_second_12 -175;
+    pos @kc89_first_56 @kc89_second_13 -140;
+    pos @kc89_first_56 @kc89_second_16 -140;
+    pos @kc89_first_56 @kc89_second_19 -210;
+    pos @kc89_first_56 @kc89_second_24 -210;
+    pos @kc89_first_56 @kc89_second_32 -140;
+    pos @kc89_first_56 @kc89_second_34 -140;
+    pos @kc89_first_56 @kc89_second_35 -210;
+    pos @kc89_first_56 @kc89_second_36 -35;
+    pos @kc89_first_56 @kc89_second_45 1;
+    pos @kc89_first_56 @kc89_second_53 -210;
+    pos @kc89_first_56 @kc89_second_55 -175;
+    pos @kc89_first_56 @kc89_second_57 -175;
+    pos @kc89_first_56 @kc89_second_63 -105;
+    pos @kc89_first_56 @kc89_second_64 -210;
+    pos @kc89_first_57 @kc89_second_12 -240;
+    pos @kc89_first_57 @kc89_second_13 -175;
+    pos @kc89_first_57 @kc89_second_14 -70;
+    pos @kc89_first_57 @kc89_second_15 -35;
+    pos @kc89_first_57 @kc89_second_19 -35;
+    pos @kc89_first_57 @kc89_second_26 -35;
+    pos @kc89_first_57 @kc89_second_39 -35;
+    pos @kc89_first_57 @kc89_second_40 -35;
+    pos @kc89_first_57 @kc89_second_43 -70;
+    pos @kc89_first_57 @kc89_second_45 1;
+    pos @kc89_first_57 @kc89_second_47 -35;
+    pos @kc89_first_57 @kc89_second_48 -70;
+    pos @kc89_first_57 @kc89_second_58 -35;
+    pos @kc89_first_57 @kc89_second_60 -35;
+    pos @kc89_first_57 @kc89_second_61 -70;
+    pos @kc89_first_57 @kc89_second_62 -35;
+    pos @kc89_first_58 @kc89_second_13 -35;
+    pos @kc89_first_58 @kc89_second_58 -35;
+    pos @kc89_first_58 @kc89_second_64 -35;
+    pos @kc89_first_59 @kc89_second_12 -175;
+    pos @kc89_first_59 @kc89_second_13 -140;
+    pos @kc89_first_59 @kc89_second_14 -35;
+    pos @kc89_first_59 @kc89_second_45 1;
+    pos @kc89_first_60 @kc89_second_1 -140;
+    pos @kc89_first_60 @kc89_second_2 -280;
+    pos @kc89_first_60 @kc89_second_5 -140;
+    pos @kc89_first_60 @kc89_second_6 -280;
+    pos @kc89_first_60 @kc89_second_8 -70;
+    pos @kc89_first_60 @kc89_second_10 -70;
+    pos @kc89_first_60 @kc89_second_11 -175;
+    pos @kc89_first_60 @kc89_second_12 -240;
+    pos @kc89_first_60 @kc89_second_13 -140;
+    pos @kc89_first_60 @kc89_second_14 -105;
+    pos @kc89_first_60 @kc89_second_15 -70;
+    pos @kc89_first_60 @kc89_second_16 -175;
+    pos @kc89_first_60 @kc89_second_17 -70;
+    pos @kc89_first_60 @kc89_second_19 -280;
+    pos @kc89_first_60 @kc89_second_22 -70;
+    pos @kc89_first_60 @kc89_second_23 -70;
+    pos @kc89_first_60 @kc89_second_24 -210;
+    pos @kc89_first_60 @kc89_second_26 -70;
+    pos @kc89_first_60 @kc89_second_27 -70;
+    pos @kc89_first_60 @kc89_second_29 -70;
+    pos @kc89_first_60 @kc89_second_32 -70;
+    pos @kc89_first_60 @kc89_second_34 -315;
+    pos @kc89_first_60 @kc89_second_35 -140;
+    pos @kc89_first_60 @kc89_second_36 -70;
+    pos @kc89_first_60 @kc89_second_38 -105;
+    pos @kc89_first_60 @kc89_second_45 1;
+    pos @kc89_first_60 @kc89_second_48 -35;
+    pos @kc89_first_60 @kc89_second_51 -50;
+    pos @kc89_first_60 @kc89_second_53 -210;
+    pos @kc89_first_60 @kc89_second_55 -175;
+    pos @kc89_first_60 @kc89_second_57 -210;
+    pos @kc89_first_60 @kc89_second_59 -35;
+    pos @kc89_first_60 @kc89_second_61 -70;
+    pos @kc89_first_60 @kc89_second_62 -35;
+    pos @kc89_first_60 @kc89_second_63 -140;
+    pos @kc89_first_60 @kc89_second_64 -210;
+    pos @kc89_first_61 @kc89_second_1 -35;
+    pos @kc89_first_61 @kc89_second_2 -70;
+    pos @kc89_first_61 @kc89_second_5 -70;
+    pos @kc89_first_61 @kc89_second_11 -35;
+    pos @kc89_first_61 @kc89_second_12 -140;
+    pos @kc89_first_61 @kc89_second_13 -140;
+    pos @kc89_first_61 @kc89_second_14 -70;
+    pos @kc89_first_61 @kc89_second_15 -35;
+    pos @kc89_first_61 @kc89_second_16 -105;
+    pos @kc89_first_61 @kc89_second_26 -35;
+    pos @kc89_first_61 @kc89_second_27 -70;
+    pos @kc89_first_61 @kc89_second_35 -70;
+    pos @kc89_first_61 @kc89_second_43 -70;
+    pos @kc89_first_61 @kc89_second_45 1;
+    pos @kc89_first_61 @kc89_second_53 -175;
+    pos @kc89_first_61 @kc89_second_55 -140;
+    pos @kc89_first_61 @kc89_second_57 -140;
+    pos @kc89_first_61 @kc89_second_61 -35;
+    pos @kc89_first_62 @kc89_second_5 -70;
+    pos @kc89_first_62 @kc89_second_9 -70;
+    pos @kc89_first_62 @kc89_second_11 -35;
+    pos @kc89_first_62 @kc89_second_12 -350;
+    pos @kc89_first_62 @kc89_second_13 -315;
+    pos @kc89_first_62 @kc89_second_14 -175;
+    pos @kc89_first_62 @kc89_second_15 -140;
+    pos @kc89_first_62 @kc89_second_16 -70;
+    pos @kc89_first_62 @kc89_second_18 -70;
+    pos @kc89_first_62 @kc89_second_27 -70;
+    pos @kc89_first_62 @kc89_second_31 -50;
+    pos @kc89_first_62 @kc89_second_39 -140;
+    pos @kc89_first_62 @kc89_second_40 -50;
+    pos @kc89_first_62 @kc89_second_42 -35;
+    pos @kc89_first_62 @kc89_second_43 -175;
+    pos @kc89_first_62 @kc89_second_45 1;
+    pos @kc89_first_62 @kc89_second_47 -70;
+    pos @kc89_first_62 @kc89_second_48 -175;
+    pos @kc89_first_62 @kc89_second_54 -70;
+    pos @kc89_first_62 @kc89_second_58 -70;
+    pos @kc89_first_62 @kc89_second_60 -50;
+    pos @kc89_first_62 @kc89_second_61 -140;
+    pos @kc89_first_62 @kc89_second_62 -105;
+    pos @kc89_first_63 @kc89_second_4 -105;
+    pos @kc89_first_63 @kc89_second_6 -35;
+    pos @kc89_first_63 @kc89_second_8 1;
+    pos @kc89_first_63 @kc89_second_9 -245;
+    pos @kc89_first_63 @kc89_second_12 -210;
+    pos @kc89_first_63 @kc89_second_13 -210;
+    pos @kc89_first_63 @kc89_second_14 -210;
+    pos @kc89_first_63 @kc89_second_15 -175;
+    pos @kc89_first_63 @kc89_second_17 -70;
+    pos @kc89_first_63 @kc89_second_18 -180;
+    pos @kc89_first_63 @kc89_second_20 -140;
+    pos @kc89_first_63 @kc89_second_22 -105;
+    pos @kc89_first_63 @kc89_second_25 -140;
+    pos @kc89_first_63 @kc89_second_29 -105;
+    pos @kc89_first_63 @kc89_second_31 -140;
+    pos @kc89_first_63 @kc89_second_34 -35;
+    pos @kc89_first_63 @kc89_second_36 -35;
+    pos @kc89_first_63 @kc89_second_38 -175;
+    pos @kc89_first_63 @kc89_second_39 -142;
+    pos @kc89_first_63 @kc89_second_40 -245;
+    pos @kc89_first_63 @kc89_second_43 -210;
+    pos @kc89_first_63 @kc89_second_44 -105;
+    pos @kc89_first_63 @kc89_second_45 1;
+    pos @kc89_first_63 @kc89_second_46 -35;
+    pos @kc89_first_63 @kc89_second_47 -210;
+    pos @kc89_first_63 @kc89_second_48 -210;
+    pos @kc89_first_63 @kc89_second_51 -35;
+    pos @kc89_first_63 @kc89_second_58 -280;
+    pos @kc89_first_63 @kc89_second_60 -175;
+    pos @kc89_first_63 @kc89_second_61 -140;
+    pos @kc89_first_63 @kc89_second_62 -140;
+    pos @kc89_first_63 @kc89_second_63 -70;
+    pos @kc89_first_63 @kc89_second_64 -70;
+    pos @kc89_first_64 @kc89_second_1 -175;
+    pos @kc89_first_64 @kc89_second_2 -175;
+    pos @kc89_first_64 @kc89_second_5 -70;
+    pos @kc89_first_64 @kc89_second_6 -105;
+    pos @kc89_first_64 @kc89_second_11 -105;
+    pos @kc89_first_64 @kc89_second_12 -175;
+    pos @kc89_first_64 @kc89_second_13 -140;
+    pos @kc89_first_64 @kc89_second_14 -70;
+    pos @kc89_first_64 @kc89_second_15 -35;
+    pos @kc89_first_64 @kc89_second_16 -140;
+    pos @kc89_first_64 @kc89_second_17 -70;
+    pos @kc89_first_64 @kc89_second_19 -175;
+    pos @kc89_first_64 @kc89_second_22 -70;
+    pos @kc89_first_64 @kc89_second_29 -35;
+    pos @kc89_first_64 @kc89_second_34 -105;
+    pos @kc89_first_64 @kc89_second_35 -175;
+    pos @kc89_first_64 @kc89_second_36 -35;
+    pos @kc89_first_64 @kc89_second_38 -70;
+    pos @kc89_first_64 @kc89_second_45 1;
+    pos @kc89_first_64 @kc89_second_51 -35;
+    pos @kc89_first_64 @kc89_second_53 -140;
+    pos @kc89_first_64 @kc89_second_55 -140;
+    pos @kc89_first_64 @kc89_second_57 -140;
+    pos @kc89_first_64 @kc89_second_63 -70;
+    pos @kc89_first_64 @kc89_second_64 -105;
+    pos @kc89_first_65 @kc89_second_1 -210;
+    pos @kc89_first_65 @kc89_second_2 -210;
+    pos @kc89_first_65 @kc89_second_3 -70;
+    pos @kc89_first_65 @kc89_second_4 -35;
+    pos @kc89_first_65 @kc89_second_6 -210;
+    pos @kc89_first_65 @kc89_second_7 -70;
+    pos @kc89_first_65 @kc89_second_8 -70;
+    pos @kc89_first_65 @kc89_second_16 -70;
+    pos @kc89_first_65 @kc89_second_17 -140;
+    pos @kc89_first_65 @kc89_second_19 -210;
+    pos @kc89_first_65 @kc89_second_20 -140;
+    pos @kc89_first_65 @kc89_second_21 -35;
+    pos @kc89_first_65 @kc89_second_22 -175;
+    pos @kc89_first_65 @kc89_second_23 -140;
+    pos @kc89_first_65 @kc89_second_24 -280;
+    pos @kc89_first_65 @kc89_second_29 -35;
+    pos @kc89_first_65 @kc89_second_30 -35;
+    pos @kc89_first_65 @kc89_second_32 -210;
+    pos @kc89_first_65 @kc89_second_34 -245;
+    pos @kc89_first_65 @kc89_second_35 -140;
+    pos @kc89_first_65 @kc89_second_36 -140;
+    pos @kc89_first_65 @kc89_second_37 -140;
+    pos @kc89_first_65 @kc89_second_38 -140;
+    pos @kc89_first_65 @kc89_second_39 -35;
+    pos @kc89_first_65 @kc89_second_44 -35;
+    pos @kc89_first_65 @kc89_second_45 1;
+    pos @kc89_first_65 @kc89_second_49 -35;
+    pos @kc89_first_65 @kc89_second_51 -140;
+    pos @kc89_first_65 @kc89_second_52 -70;
+    pos @kc89_first_65 @kc89_second_53 -210;
+    pos @kc89_first_65 @kc89_second_55 -210;
+    pos @kc89_first_65 @kc89_second_57 -210;
+    pos @kc89_first_65 @kc89_second_58 -35;
+    pos @kc89_first_65 @kc89_second_63 -175;
+    pos @kc89_first_65 @kc89_second_64 -245;
+    pos @kc89_first_66 @kc89_second_6 -35;
+    pos @kc89_first_66 @kc89_second_12 -240;
+    pos @kc89_first_66 @kc89_second_13 -140;
+    pos @kc89_first_66 @kc89_second_14 -70;
+    pos @kc89_first_66 @kc89_second_15 -35;
+    pos @kc89_first_66 @kc89_second_20 -35;
+    pos @kc89_first_66 @kc89_second_22 -35;
+    pos @kc89_first_66 @kc89_second_34 -70;
+    pos @kc89_first_66 @kc89_second_38 -70;
+    pos @kc89_first_66 @kc89_second_39 -50;
+    pos @kc89_first_66 @kc89_second_45 1;
+    pos @kc89_first_66 @kc89_second_48 -35;
+    pos @kc89_first_66 @kc89_second_63 -35;
+    pos @kc89_first_66 @kc89_second_64 -35;
+    pos @kc89_first_67 @kc89_second_3 -100;
+    pos @kc89_first_67 @kc89_second_4 -50;
+    pos @kc89_first_67 @kc89_second_6 -50;
+    pos @kc89_first_67 @kc89_second_8 -70;
+    pos @kc89_first_67 @kc89_second_9 -140;
+    pos @kc89_first_67 @kc89_second_10 -50;
+    pos @kc89_first_67 @kc89_second_12 -140;
+    pos @kc89_first_67 @kc89_second_13 -100;
+    pos @kc89_first_67 @kc89_second_14 -70;
+    pos @kc89_first_67 @kc89_second_15 -50;
+    pos @kc89_first_67 @kc89_second_18 -70;
+    pos @kc89_first_67 @kc89_second_20 -70;
+    pos @kc89_first_67 @kc89_second_22 -50;
+    pos @kc89_first_67 @kc89_second_23 -70;
+    pos @kc89_first_67 @kc89_second_29 -35;
+    pos @kc89_first_67 @kc89_second_31 -70;
+    pos @kc89_first_67 @kc89_second_33 105;
+    pos @kc89_first_67 @kc89_second_34 -35;
+    pos @kc89_first_67 @kc89_second_38 -70;
+    pos @kc89_first_67 @kc89_second_39 -140;
+    pos @kc89_first_67 @kc89_second_40 -140;
+    pos @kc89_first_67 @kc89_second_43 -140;
+    pos @kc89_first_67 @kc89_second_44 -35;
+    pos @kc89_first_67 @kc89_second_45 1;
+    pos @kc89_first_67 @kc89_second_47 -70;
+    pos @kc89_first_67 @kc89_second_48 -100;
+    pos @kc89_first_67 @kc89_second_50 105;
+    pos @kc89_first_67 @kc89_second_58 -140;
+    pos @kc89_first_67 @kc89_second_60 -70;
+    pos @kc89_first_67 @kc89_second_61 -70;
+    pos @kc89_first_67 @kc89_second_62 -50;
+    pos @kc89_first_67 @kc89_second_63 -35;
+    pos @kc89_first_67 @kc89_second_64 -35;
+    pos @kc89_first_68 @kc89_second_3 -70;
+    pos @kc89_first_68 @kc89_second_4 -50;
+    pos @kc89_first_68 @kc89_second_6 -50;
+    pos @kc89_first_68 @kc89_second_8 -70;
+    pos @kc89_first_68 @kc89_second_9 -140;
+    pos @kc89_first_68 @kc89_second_10 -50;
+    pos @kc89_first_68 @kc89_second_12 -240;
+    pos @kc89_first_68 @kc89_second_13 -240;
+    pos @kc89_first_68 @kc89_second_14 -175;
+    pos @kc89_first_68 @kc89_second_15 -140;
+    pos @kc89_first_68 @kc89_second_18 -70;
+    pos @kc89_first_68 @kc89_second_20 -70;
+    pos @kc89_first_68 @kc89_second_22 -50;
+    pos @kc89_first_68 @kc89_second_23 -70;
+    pos @kc89_first_68 @kc89_second_29 -35;
+    pos @kc89_first_68 @kc89_second_31 -70;
+    pos @kc89_first_68 @kc89_second_34 -35;
+    pos @kc89_first_68 @kc89_second_38 -70;
+    pos @kc89_first_68 @kc89_second_39 -140;
+    pos @kc89_first_68 @kc89_second_40 -140;
+    pos @kc89_first_68 @kc89_second_43 -140;
+    pos @kc89_first_68 @kc89_second_44 -35;
+    pos @kc89_first_68 @kc89_second_45 1;
+    pos @kc89_first_68 @kc89_second_47 -70;
+    pos @kc89_first_68 @kc89_second_48 -140;
+    pos @kc89_first_68 @kc89_second_58 -140;
+    pos @kc89_first_68 @kc89_second_60 -70;
+    pos @kc89_first_68 @kc89_second_61 -105;
+    pos @kc89_first_68 @kc89_second_62 -70;
+    pos @kc89_first_68 @kc89_second_63 -35;
+    pos @kc89_first_68 @kc89_second_64 -35;
+    pos @kc89_first_69 @kc89_second_3 -70;
+    pos @kc89_first_69 @kc89_second_4 -50;
+    pos @kc89_first_69 @kc89_second_6 -50;
+    pos @kc89_first_69 @kc89_second_8 -70;
+    pos @kc89_first_69 @kc89_second_9 -140;
+    pos @kc89_first_69 @kc89_second_10 -50;
+    pos @kc89_first_69 @kc89_second_12 -140;
+    pos @kc89_first_69 @kc89_second_13 -140;
+    pos @kc89_first_69 @kc89_second_14 -105;
+    pos @kc89_first_69 @kc89_second_15 -70;
+    pos @kc89_first_69 @kc89_second_18 -70;
+    pos @kc89_first_69 @kc89_second_20 -70;
+    pos @kc89_first_69 @kc89_second_22 -50;
+    pos @kc89_first_69 @kc89_second_23 -100;
+    pos @kc89_first_69 @kc89_second_29 -35;
+    pos @kc89_first_69 @kc89_second_31 -70;
+    pos @kc89_first_69 @kc89_second_33 105;
+    pos @kc89_first_69 @kc89_second_34 -35;
+    pos @kc89_first_69 @kc89_second_38 -70;
+    pos @kc89_first_69 @kc89_second_39 -140;
+    pos @kc89_first_69 @kc89_second_40 -140;
+    pos @kc89_first_69 @kc89_second_43 -140;
+    pos @kc89_first_69 @kc89_second_44 -35;
+    pos @kc89_first_69 @kc89_second_45 1;
+    pos @kc89_first_69 @kc89_second_47 -70;
+    pos @kc89_first_69 @kc89_second_48 -140;
+    pos @kc89_first_69 @kc89_second_50 105;
+    pos @kc89_first_69 @kc89_second_58 -140;
+    pos @kc89_first_69 @kc89_second_60 -70;
+    pos @kc89_first_69 @kc89_second_61 -70;
+    pos @kc89_first_69 @kc89_second_62 -50;
+    pos @kc89_first_69 @kc89_second_63 -35;
+    pos @kc89_first_69 @kc89_second_64 -35;
+    pos @kc89_first_70 @kc89_second_1 -210;
+    pos @kc89_first_70 @kc89_second_2 -210;
+    pos @kc89_first_70 @kc89_second_3 -35;
+    pos @kc89_first_70 @kc89_second_6 -140;
+    pos @kc89_first_70 @kc89_second_8 -70;
+    pos @kc89_first_70 @kc89_second_10 -35;
+    pos @kc89_first_70 @kc89_second_17 -70;
+    pos @kc89_first_70 @kc89_second_19 -210;
+    pos @kc89_first_70 @kc89_second_20 -70;
+    pos @kc89_first_70 @kc89_second_22 -105;
+    pos @kc89_first_70 @kc89_second_23 -105;
+    pos @kc89_first_70 @kc89_second_24 -175;
+    pos @kc89_first_70 @kc89_second_29 -105;
+    pos @kc89_first_70 @kc89_second_34 -175;
+    pos @kc89_first_70 @kc89_second_35 -140;
+    pos @kc89_first_70 @kc89_second_36 -70;
+    pos @kc89_first_70 @kc89_second_37 -105;
+    pos @kc89_first_70 @kc89_second_38 -105;
+    pos @kc89_first_70 @kc89_second_39 -70;
+    pos @kc89_first_70 @kc89_second_44 -35;
+    pos @kc89_first_70 @kc89_second_45 1;
+    pos @kc89_first_70 @kc89_second_50 -35;
+    pos @kc89_first_70 @kc89_second_51 -70;
+    pos @kc89_first_70 @kc89_second_52 -70;
+    pos @kc89_first_70 @kc89_second_53 -175;
+    pos @kc89_first_70 @kc89_second_55 -175;
+    pos @kc89_first_70 @kc89_second_57 -175;
+    pos @kc89_first_70 @kc89_second_58 -35;
+    pos @kc89_first_70 @kc89_second_59 -35;
+    pos @kc89_first_70 @kc89_second_63 -140;
+    pos @kc89_first_70 @kc89_second_64 -175;
+    pos @kc89_first_71 @kc89_second_5 -70;
+    pos @kc89_first_71 @kc89_second_8 -70;
+    pos @kc89_first_71 @kc89_second_9 -105;
+    pos @kc89_first_71 @kc89_second_11 -35;
+    pos @kc89_first_71 @kc89_second_12 -350;
+    pos @kc89_first_71 @kc89_second_13 -350;
+    pos @kc89_first_71 @kc89_second_14 -245;
+    pos @kc89_first_71 @kc89_second_15 -210;
+    pos @kc89_first_71 @kc89_second_16 -70;
+    pos @kc89_first_71 @kc89_second_18 -210;
+    pos @kc89_first_71 @kc89_second_23 -35;
+    pos @kc89_first_71 @kc89_second_26 -35;
+    pos @kc89_first_71 @kc89_second_27 -70;
+    pos @kc89_first_71 @kc89_second_31 -70;
+    pos @kc89_first_71 @kc89_second_38 -35;
+    pos @kc89_first_71 @kc89_second_39 -245;
+    pos @kc89_first_71 @kc89_second_40 -70;
+    pos @kc89_first_71 @kc89_second_42 -35;
+    pos @kc89_first_71 @kc89_second_43 -240;
+    pos @kc89_first_71 @kc89_second_45 1;
+    pos @kc89_first_71 @kc89_second_47 -105;
+    pos @kc89_first_71 @kc89_second_48 -280;
+    pos @kc89_first_71 @kc89_second_49 -35;
+    pos @kc89_first_71 @kc89_second_54 -35;
+    pos @kc89_first_71 @kc89_second_56 -70;
+    pos @kc89_first_71 @kc89_second_58 -105;
+    pos @kc89_first_71 @kc89_second_59 -35;
+    pos @kc89_first_71 @kc89_second_60 -70;
+    pos @kc89_first_71 @kc89_second_61 -175;
+    pos @kc89_first_71 @kc89_second_62 -140;
+    pos @kc89_first_72 @kc89_second_1 -140;
+    pos @kc89_first_72 @kc89_second_2 -140;
+    pos @kc89_first_72 @kc89_second_6 -140;
+    pos @kc89_first_72 @kc89_second_8 -35;
+    pos @kc89_first_72 @kc89_second_10 -35;
+    pos @kc89_first_72 @kc89_second_17 -35;
+    pos @kc89_first_72 @kc89_second_19 -140;
+    pos @kc89_first_72 @kc89_second_20 -35;
+    pos @kc89_first_72 @kc89_second_22 -70;
+    pos @kc89_first_72 @kc89_second_23 -70;
+    pos @kc89_first_72 @kc89_second_24 -140;
+    pos @kc89_first_72 @kc89_second_29 -70;
+    pos @kc89_first_72 @kc89_second_34 -175;
+    pos @kc89_first_72 @kc89_second_35 -105;
+    pos @kc89_first_72 @kc89_second_36 -70;
+    pos @kc89_first_72 @kc89_second_37 -70;
+    pos @kc89_first_72 @kc89_second_38 -70;
+    pos @kc89_first_72 @kc89_second_39 -35;
+    pos @kc89_first_72 @kc89_second_45 1;
+    pos @kc89_first_72 @kc89_second_50 -35;
+    pos @kc89_first_72 @kc89_second_51 -35;
+    pos @kc89_first_72 @kc89_second_53 -140;
+    pos @kc89_first_72 @kc89_second_55 -140;
+    pos @kc89_first_72 @kc89_second_57 -140;
+    pos @kc89_first_72 @kc89_second_63 -105;
+    pos @kc89_first_72 @kc89_second_64 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -10722,7 +10757,7 @@ lookup mark_Mark_positioning {
   pos base [\C \uni0421 \uni216D ] <anchor 623 -20> mark @bottom_cedilla
 	<anchor 627 0> mark @bottom_center
 	<anchor 870 1380> mark @top_center;
-  pos base [\G \Q \Oslash \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \uni1FA8 \uni1FA9 \uni1FFC \G.cv21 ] <anchor 870 1380> mark @top_center
+  pos base [\G \Q \Oslash \uni01B1 \Theta \uni0424 \uni04E8 \uni051A \uni2127 \uni1FA8 \uni1FA9 \uni1FFC \G.cv21 \Q.cv29 ] <anchor 870 1380> mark @top_center
 	<anchor 627 0> mark @bottom_center;
   pos base [\U ] <anchor 540 -10> mark @bottom_cedilla
 	<anchor 657 0> mark @bottom_right
@@ -12768,6 +12803,8 @@ lookup mark_Mark_positioning {
 	<anchor 375 1716> mark @top_center;
   pos base [\uni1E3B.cv28 ] <anchor 315 1380> mark @top_center
 	<anchor 37 -201> mark @bottom_center;
+  pos base [\q.sc.cv29 ] <anchor 534 0> mark @bottom_center
+	<anchor 746 1200> mark @top_center;
   pos base [\dotlessuni0268 ] <anchor 134 -20> mark @bottom_cedilla
 	<anchor 160 0> mark @bottom_right
 	<anchor 138 0> mark @bottom_center
@@ -13793,7 +13830,8 @@ feature mkmk {
 	\lcaron.cv28 \ldot.cv28 \lslash.cv28 \uni019A.cv28 \uni01C9.cv28 
 	\uni0234.cv28 \uni026D.cv28 \uni026E.cv28 \uni02AA.cv28 \uni02AB.cv28 
 	\uni02E1.cv28 \uni1E37.cv28 \uni1E39.cv28 \uni1E3B.cv28 \uni1E3D.cv28 
-	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \dollar.ss05 
+	\uni2097.cv28 \uni217C.cv28 \uni24A7.cv28 \uni24DB.cv28 \Q.cv29 \uni051A.cv29 
+	\uni213A.cv29 \uni24C6.cv29 \q.sc.cv29 \uni051B.sc.cv29 \dollar.ss05 
 	\cent.ss05 \sterling.ss05 \lira.ss05 \peseta.ss05 \uni20AA.ss05 \Euro.ss05 
 	\uni20B2.ss05 \one.ss06 \one.ss06.pnum \one.ss06.tnum \one.ss06.onum 
 	\one.ss06.onum.tnum \one.ss06.superior \one.ss06.superior.pnum 

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -4574,8 +4574,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \uni0456 \acutecomb  by \iacute;
     sub \i \acutecomb  by \iacute;
+    sub \uni0456 \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4631,8 +4631,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4719,13 +4719,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5651,8 +5651,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6785,29 +6785,6 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
-
 feature locl {
 
  script cyrl;
@@ -6894,6 +6871,29 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
+
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
 
 feature ss09 {
   featureNames {
@@ -12803,8 +12803,12 @@ lookup mark_Mark_positioning {
 	<anchor 375 1716> mark @top_center;
   pos base [\uni1E3B.cv28 ] <anchor 315 1380> mark @top_center
 	<anchor 37 -201> mark @bottom_center;
+  pos base [\uni051A.cv29 ] <anchor 627 1> mark @bottom_center
+	<anchor 870 1381> mark @top_center;
   pos base [\q.sc.cv29 ] <anchor 534 0> mark @bottom_center
 	<anchor 746 1200> mark @top_center;
+  pos base [\uni051B.sc.cv29 ] <anchor 534 1> mark @bottom_center
+	<anchor 746 1201> mark @top_center;
   pos base [\dotlessuni0268 ] <anchor 134 -20> mark @bottom_cedilla
 	<anchor 160 0> mark @bottom_right
 	<anchor 138 0> mark @bottom_center

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/27 23:38:03</string>
+    <string>2026/07/28 21:31:17</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/28 21:31:17</string>
+    <string>2026/07/28 21:55:02</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/Q_.cv29.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/Q_.cv29.glif
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="Q.cv29" format="2">
+  <advance width="1582"/>
+  <anchor x="627" y="0" name="bottom_center"/>
+  <anchor x="870" y="1380" name="top_center"/>
+  <outline>
+    <contour>
+      <point x="1332" y="0" type="line"/>
+      <point x="627" y="0" type="line"/>
+      <point x="774" y="42" type="line"/>
+      <point x="1339" y="42" type="line"/>
+    </contour>
+    <contour>
+      <point x="882" y="1448" type="curve" smooth="yes"/>
+      <point x="522" y="1448"/>
+      <point x="172" y="1061"/>
+      <point x="172" y="577" type="curve" smooth="yes"/>
+      <point x="172" y="216"/>
+      <point x="407" y="42"/>
+      <point x="634" y="42" type="curve" smooth="yes"/>
+      <point x="994" y="42"/>
+      <point x="1345" y="429"/>
+      <point x="1345" y="913" type="curve" smooth="yes"/>
+      <point x="1345" y="1274"/>
+      <point x="1109" y="1448"/>
+    </contour>
+    <contour>
+      <point x="126" y="572" type="curve" smooth="yes"/>
+      <point x="126" y="1038"/>
+      <point x="459" y="1490"/>
+      <point x="890" y="1490" type="curve" smooth="yes"/>
+      <point x="1190" y="1490"/>
+      <point x="1391" y="1262"/>
+      <point x="1391" y="918" type="curve" smooth="yes"/>
+      <point x="1391" y="452"/>
+      <point x="1058" y="0"/>
+      <point x="627" y="0" type="curve" smooth="yes"/>
+      <point x="327" y="0"/>
+      <point x="126" y="228"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict/>
+  </lib>
+</glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/contents.plist
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/contents.plist
@@ -9106,6 +9106,18 @@
     <string>uni24A_7.cv28.glif</string>
     <key>uni24DB.cv28</key>
     <string>uni24D_B_.cv28.glif</string>
+    <key>Q.cv29</key>
+    <string>Q_.cv29.glif</string>
+    <key>uni051A.cv29</key>
+    <string>uni051A_.cv29.glif</string>
+    <key>uni213A.cv29</key>
+    <string>uni213A_.cv29.glif</string>
+    <key>uni24C6.cv29</key>
+    <string>uni24C_6.cv29.glif</string>
+    <key>q.sc.cv29</key>
+    <string>q.sc.cv29.glif</string>
+    <key>uni051B.sc.cv29</key>
+    <string>uni051B_.sc.cv29.glif</string>
     <key>dollar.ss05</key>
     <string>dollar.ss05.glif</string>
     <key>cent.ss05</key>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/q.sc.cv29.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/q.sc.cv29.glif
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="q.sc.cv29" format="2">
+  <advance width="1376"/>
+  <anchor x="534" y="0" name="bottom_center"/>
+  <anchor x="746" y="1200" name="top_center"/>
+  <outline>
+    <contour>
+      <point x="1126" y="0" type="line"/>
+      <point x="533" y="0" type="line"/>
+      <point x="660" y="40" type="line"/>
+      <point x="1133" y="40" type="line"/>
+    </contour>
+    <contour>
+      <point x="739" y="1170" type="curve" smooth="yes"/>
+      <point x="428" y="1170"/>
+      <point x="150" y="850"/>
+      <point x="150" y="476" type="curve" smooth="yes"/>
+      <point x="150" y="197"/>
+      <point x="330" y="40"/>
+      <point x="540" y="40" type="curve" smooth="yes"/>
+      <point x="851" y="40"/>
+      <point x="1129" y="360"/>
+      <point x="1129" y="734" type="curve" smooth="yes"/>
+      <point x="1129" y="1013"/>
+      <point x="949" y="1170"/>
+    </contour>
+    <contour>
+      <point x="104" y="469" type="curve" smooth="yes"/>
+      <point x="104" y="852"/>
+      <point x="387" y="1210"/>
+      <point x="746" y="1210" type="curve" smooth="yes"/>
+      <point x="997" y="1210"/>
+      <point x="1175" y="1027"/>
+      <point x="1175" y="741" type="curve" smooth="yes"/>
+      <point x="1175" y="358"/>
+      <point x="892" y="0"/>
+      <point x="533" y="0" type="curve" smooth="yes"/>
+      <point x="282" y="0"/>
+      <point x="104" y="183"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni051A_.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051A.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1582"/>
+  <anchor x="627" y="1" name="bottom_center"/>
+  <anchor x="870" y="1381" name="top_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="Q.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni051A_.cv29.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni051A_.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051A.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni051B.sc.cv29" format="2">
+  <advance width="500"/>
+  <outline>
+    <contour>
+      <point x="122" y="108" type="curve" smooth="yes"/>
+      <point x="122" y="180"/>
+      <point x="178" y="236"/>
+      <point x="250" y="236" type="curve" smooth="yes"/>
+      <point x="322" y="236"/>
+      <point x="378" y="180"/>
+      <point x="378" y="108" type="curve" smooth="yes"/>
+      <point x="378" y="36"/>
+      <point x="322" y="-20"/>
+      <point x="250" y="-20" type="curve" smooth="yes"/>
+      <point x="178" y="-20"/>
+      <point x="122" y="36"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni051B_.sc.cv29.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni051B_.sc.cv29.glif
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <glyph name="uni051B.sc.cv29" format="2">
-  <advance width="500"/>
+  <advance width="1376"/>
+  <anchor x="534" y="1" name="bottom_center"/>
+  <anchor x="746" y="1201" name="top_center"/>
   <outline>
-    <contour>
-      <point x="122" y="108" type="curve" smooth="yes"/>
-      <point x="122" y="180"/>
-      <point x="178" y="236"/>
-      <point x="250" y="236" type="curve" smooth="yes"/>
-      <point x="322" y="236"/>
-      <point x="378" y="180"/>
-      <point x="378" y="108" type="curve" smooth="yes"/>
-      <point x="378" y="36"/>
-      <point x="322" y="-20"/>
-      <point x="250" y="-20" type="curve" smooth="yes"/>
-      <point x="178" y="-20"/>
-      <point x="122" y="36"/>
-    </contour>
+    <component base="q.sc.cv29" yOffset="1"/>
   </outline>
 </glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni213A_.cv29.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni213A_.cv29.glif
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni213A.cv29" format="2">
+  <advance width="1770"/>
+  <outline>
+    <contour>
+      <point x="1755" y="1445" type="line"/>
+      <point x="1630" y="740" type="line"/>
+      <point x="1613" y="880" type="line"/>
+      <point x="1713" y="1445" type="line"/>
+    </contour>
+    <contour>
+      <point x="986" y="1311" type="curve" smooth="yes"/>
+      <point x="479" y="1311"/>
+      <point x="175" y="953"/>
+      <point x="175" y="659" type="curve" smooth="yes"/>
+      <point x="175" y="420"/>
+      <point x="359" y="169"/>
+      <point x="785" y="169" type="curve" smooth="yes"/>
+      <point x="1292" y="169"/>
+      <point x="1596" y="527"/>
+      <point x="1596" y="821" type="curve" smooth="yes"/>
+      <point x="1596" y="1060"/>
+      <point x="1412" y="1311"/>
+    </contour>
+    <contour>
+      <point x="1639" y="840" type="curve" smooth="yes"/>
+      <point x="1639" y="466"/>
+      <point x="1276" y="123"/>
+      <point x="777" y="123" type="curve" smooth="yes"/>
+      <point x="381" y="123"/>
+      <point x="132" y="342"/>
+      <point x="132" y="640" type="curve" smooth="yes"/>
+      <point x="132" y="1014"/>
+      <point x="495" y="1357"/>
+      <point x="994" y="1357" type="curve" smooth="yes"/>
+      <point x="1390" y="1357"/>
+      <point x="1639" y="1138"/>
+    </contour>
+  </outline>
+</glyph>

--- a/sources/Giphurs-ThinItalic.ufo/glyphs/uni24C_6.cv29.glif
+++ b/sources/Giphurs-ThinItalic.ufo/glyphs/uni24C_6.cv29.glif
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="uni24C6.cv29" format="2">
+  <advance width="1700"/>
+  <outline>
+    <contour>
+      <point x="170" y="740" type="curve" smooth="yes"/>
+      <point x="170" y="330"/>
+      <point x="480" y="20"/>
+      <point x="890" y="20" type="curve" smooth="yes"/>
+      <point x="1300" y="20"/>
+      <point x="1610" y="330"/>
+      <point x="1610" y="740" type="curve" smooth="yes"/>
+      <point x="1610" y="1150"/>
+      <point x="1300" y="1460"/>
+      <point x="890" y="1460" type="curve" smooth="yes"/>
+      <point x="480" y="1460"/>
+      <point x="170" y="1150"/>
+    </contour>
+    <contour>
+      <point x="140" y="740" type="curve" smooth="yes"/>
+      <point x="140" y="1160"/>
+      <point x="470" y="1490"/>
+      <point x="890" y="1490" type="curve" smooth="yes"/>
+      <point x="1310" y="1490"/>
+      <point x="1640" y="1160"/>
+      <point x="1640" y="740" type="curve" smooth="yes"/>
+      <point x="1640" y="320"/>
+      <point x="1310" y="-10"/>
+      <point x="890" y="-10" type="curve" smooth="yes"/>
+      <point x="470" y="-10"/>
+      <point x="140" y="320"/>
+    </contour>
+    <contour>
+      <point x="507" y="644" type="curve" smooth="yes"/>
+      <point x="507" y="915"/>
+      <point x="703" y="1175"/>
+      <point x="956" y="1175" type="curve" smooth="yes"/>
+      <point x="1133" y="1175"/>
+      <point x="1253" y="1043"/>
+      <point x="1253" y="842" type="curve" smooth="yes"/>
+      <point x="1253" y="571"/>
+      <point x="1057" y="311"/>
+      <point x="804" y="311" type="curve" smooth="yes"/>
+      <point x="627" y="311"/>
+      <point x="507" y="443"/>
+    </contour>
+    <contour>
+      <point x="809" y="341" type="curve" smooth="yes"/>
+      <point x="1018" y="341"/>
+      <point x="1220" y="561"/>
+      <point x="1220" y="838" type="curve" smooth="yes"/>
+      <point x="1220" y="1045"/>
+      <point x="1083" y="1145"/>
+      <point x="951" y="1145" type="curve" smooth="yes"/>
+      <point x="742" y="1145"/>
+      <point x="540" y="925"/>
+      <point x="540" y="648" type="curve" smooth="yes"/>
+      <point x="540" y="441"/>
+      <point x="677" y="341"/>
+    </contour>
+    <contour>
+      <point x="1222" y="311" type="line"/>
+      <point x="804" y="311" type="line"/>
+      <point x="889" y="341" type="line"/>
+      <point x="1227" y="341" type="line"/>
+    </contour>
+  </outline>
+</glyph>


### PR DESCRIPTION
Closes #105.

Add the alternative 'Q' with horizontal touching crossbar described in #105 that can be accessed with the `cv29` font feature.

<img width="946" height="194" alt="image" src="https://github.com/user-attachments/assets/fad81e2d-7e5d-466a-af1d-16c84ce138e4" />

The following glyphs has been added:

* Q
* _uni051A_
* uni213A
* uni24C6
* q.sc
* _uni051B.sc_

_(this PR has 2 commits. Italic = added in the 2nd commit = based on another glyph)_

