### PR TITLE
Add proportional digits on the kerning table

### DIFF
--- a/sources/Giphurs-ExtraBlack.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlack.ufo/features.fea
@@ -7931,10 +7931,11 @@ lookup kern_Horizontal_kerning {
 	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
 	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
     @kc87_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
-	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
-	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
-	\uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA 
-	\uni1FFB \uni1FFC \uni20B2 \uni20B2.ss05 ];
+	\Q.cv29 \two.cv02.pnum \two.cv12.pnum \two.pnum \uni01E4 \uni03A9 
+	\uni051A \uni051A.cv29 \uni1E20 \uni1F68 \uni1F69 \uni1F6A \uni1F6B 
+	\uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 \uni1FA9 \uni1FAA \uni1FAB 
+	\uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA \uni1FFB \uni1FFC \uni20B2 
+	\uni20B2.ss05 ];
     @kc87_first_6 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
 	\uni0422 \uni0490 \uni0492 \uni04A4 \uni04AC \uni1E6A \uni1E6C \uni1E6E 
 	\uni1E70 ];
@@ -7946,24 +7947,27 @@ lookup kern_Horizontal_kerning {
     @kc87_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc87_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
-	\uniA7AD ];
+    @kc87_first_9 = [\L \Lacute \one.cv01.ss06.pnum \one.cv11.ss06.pnum \one.ss06.pnum \uni023D 
+	\uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 \uniA7AD ];
     @kc87_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
     @kc87_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
     @kc87_first_12 = [\Psi \uni0470 ];
     @kc87_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
-	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
-	\uni2107 ];
+    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv08.onum 
+	\eight.cv08.pnum \eight.cv18.onum \eight.cv18.pnum \three.cv03.pnum 
+	\three.pnum \uni0190 \uni01A7 \uni03E8 \uni0405 \uni0510 \uni1E60 
+	\uni1E62 \uni1E64 \uni1E66 \uni1E68 \uni2107 ];
     @kc87_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
     @kc87_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc87_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
-	\uni2163 \uni2164 \uni2C6F \universal ];
+    @kc87_first_17 = [\V \gradient \nine.cv19.pnum \seven.cv07.pnum \seven.cv07.ss07.pnum 
+	\seven.cv17.pnum \seven.cv17.ss07.pnum \seven.pnum \seven.ss07.pnum 
+	\slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE \uni2163 
+	\uni2164 \uni2C6F \universal ];
     @kc87_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
     @kc87_first_19 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
 	\atilde \uni01DF \uni01E1 \uni0201 \uni0203 \uni0227 \uni0430 \uni04D1 
@@ -8060,16 +8064,17 @@ lookup kern_Horizontal_kerning {
     @kc87_first_23 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
-	\uni0207 \uni020D \uni020F \uni0229 \uni022B \uni022D \uni022F \uni0231 
-	\uni0247 \uni0254 \uni0258 \uni0259 \uni0275 \uni0278 \uni037B \uni037D 
-	\uni03D9 \uni03F6 \uni0435 \uni043E \uni044D \uni044E \uni0473 \uni04BD 
-	\uni04BF \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni04ED 
-	\uni050D \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni018D \uni01D2 \uni01DD 
+	\uni01E3 \uni01EB \uni01ED \uni0205 \uni0207 \uni020D \uni020F \uni0229 
+	\uni022B \uni022D \uni022F \uni0231 \uni0247 \uni0254 \uni0258 \uni0259 
+	\uni0275 \uni0278 \uni037B \uni037D \uni03D9 \uni03F6 \uni0435 \uni043E 
+	\uni044D \uni044E \uni0473 \uni04BD \uni04BF \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni04ED \uni050D \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni2184 ];
     @kc87_first_24 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
@@ -8154,18 +8159,21 @@ lookup kern_Horizontal_kerning {
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc87_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
-	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
-	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
-	\uni037B.sc \uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc 
-	\uni0473.sc \uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc 
-	\uni04E9.sc \uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc 
-	\uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc 
-	\uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc 
-	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
-	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
-	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
+    @kc87_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \nine.cv09.onum \nine.cv19.onum \nine.onum 
+	\o.sc \oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohungarumlaut.sc \omacron.sc \omicron.sc \oslash.sc \otilde.sc 
+	\uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc \uni022D.sc 
+	\uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc \uni037B.sc 
+	\uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc \uni0473.sc 
+	\uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc 
+	\uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc 
+	\uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_first_34 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
@@ -8224,73 +8232,81 @@ lookup kern_Horizontal_kerning {
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
     @kc87_first_38 = [\eth \uni1EFC \uni1EFD ];
-    @kc87_first_39 = [\fraction ];
-    @kc87_first_40 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc87_first_41 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
-	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_first_42 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc87_first_39 = [\four.cv04.onum \four.cv14.onum \four.onum \l.sc \lacute.sc \lcaron.sc 
+	\lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc \uni0234.sc 
+	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
+    @kc87_first_40 = [\four.cv04.pnum \four.cv14.pnum \four.pnum \phi.sc \thorn.sc \uni01A5.sc 
+	\uni0444.sc ];
+    @kc87_first_41 = [\fraction ];
+    @kc87_first_42 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \three.cv03.onum 
+	\three.onum \uni01E5 \uni1E21 ];
+    @kc87_first_43 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \two.cv02.onum \two.cv12.onum 
+	\two.onum \uni0260.sc \uni051B.sc \uni051B.sc.cv29 \uni1F60.sc 
+	\uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc 
+	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc 
+	\uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
+	\uni1FF6.sc \uni1FF7.sc ];
+    @kc87_first_44 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc87_first_43 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc87_first_45 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc87_first_44 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc87_first_46 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc87_first_45 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc87_first_47 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc87_first_46 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc87_first_48 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc87_first_47 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
-	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc87_first_48 = [\lambda \uni019B ];
-    @kc87_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc87_first_50 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc87_first_49 = [\lambda \uni019B ];
+    @kc87_first_50 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc87_first_51 = [\theta \uni047C \uniA7B6 \uniA64C \uni0424.loclBGR \zero.pnum \nine.cv09.pnum 
+	\zero.cv10.pnum \zero.cv20.pnum \zero.zero.pnum 
+	\zero.cv10.zero.pnum \zero.cv20.zero.pnum ];
+    @kc87_first_52 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc87_first_51 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc87_first_52 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc87_first_53 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc87_first_53 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc87_first_54 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc87_first_55 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc87_first_54 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc87_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc87_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc87_first_56 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc87_first_57 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc87_first_58 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc87_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_first_59 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc87_first_59 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
-	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
-	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_first_60 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
-	\uni1E71 ];
-    @kc87_first_61 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
-    @kc87_first_62 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc87_first_63 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc87_first_64 = [\uni0196 \uni01AA ];
-    @kc87_first_65 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
-	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
-	\ygrave ];
-    @kc87_first_66 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_first_60 = [\seven.cv07.onum \seven.cv07.ss07.onum \seven.cv17.ss07.onum 
+	\seven.cv17.tnum \seven.onum \seven.ss07.onum \uni01B4.sc 
+	\uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_first_67 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
-	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
-	\zdotaccent ];
+    @kc87_first_61 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
+    @kc87_first_62 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+	\uni1E71 ];
+    @kc87_first_63 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
+    @kc87_first_64 = [\three.cv13.onum \uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 
+	\uni02A3 \uni02AB \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z 
+	\zacute \zcaron \zdotaccent ];
+    @kc87_first_65 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc87_first_66 = [\uni0196 \uni01AA ];
+    @kc87_first_67 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
+	\ygrave ];
     @kc87_first_68 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
     @kc87_first_69 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
@@ -8331,15 +8347,19 @@ lookup kern_Horizontal_kerning {
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
     @kc87_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc87_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc87_second_7 = [\Omega \nine.cv19.pnum \two.cv02.pnum \two.cv12.pnum \two.pnum \uni03A9 
+	\uni1FFC ];
     @kc87_second_8 = [\Phi \uni0424 ];
     @kc87_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
-	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
-	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
-	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
+    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv18.onum 
+	\eight.cv18.pnum \eight.onum \three.cv03.pnum \three.pnum \uni01A7 
+	\uni03E8 \uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 
+	\uni1E68 ];
+    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \three.cv13.pnum \uni01A9 \uni01B5 
+	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 ];
+    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \seven.cv07.pnum \seven.cv17.pnum \seven.pnum \uni0162 
+	\uni01AC \uni01AE \uni021A \uni0422 \uni042A \uni04AC \uni04B4 \uni050E 
+	\uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
     @kc87_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
@@ -8371,18 +8391,19 @@ lookup kern_Horizontal_kerning {
 	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 
 	\uni1FB4 \uni1FB6 \uni1FB7 \uni217E \uniA64D \uniA7C8 ];
     @kc87_second_19 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
-	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
-	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
-	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
-	\uni043B.loclBGR.sc \uni0467.sc \uni0469.sc \uni04D1.sc \uni04D3.sc 
-	\uni1E01.sc \uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc 
-	\uni1EA9.sc \uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc 
-	\uni1EB3.sc \uni1EB5.sc \uni1EB7.sc \uni1F00.sc \uni1F01.sc 
-	\uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc 
-	\uni1F07.sc \uni1F70.sc \uni1F71.sc \uni1F80.sc \uni1F81.sc 
-	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
-	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
-	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
+	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc 
+	\four.cv04.onum \four.cv14.onum \four.onum \lambda.sc \uni019B.sc 
+	\uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc \uni0203.sc 
+	\uni0227.sc \uni0430.sc \uni0434.loclBGR.sc \uni043B.loclBGR.sc 
+	\uni0467.sc \uni0469.sc \uni04D1.sc \uni04D3.sc \uni1E01.sc 
+	\uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc \uni1EA9.sc 
+	\uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc \uni1EB3.sc 
+	\uni1EB5.sc \uni1EB7.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc 
+	\uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc 
+	\uni1F70.sc \uni1F71.sc \uni1F80.sc \uni1F81.sc \uni1F82.sc 
+	\uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc \uni1F87.sc 
+	\uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc \uni1FB4.sc 
+	\uni1FB6.sc \uni1FB7.sc ];
     @kc87_second_20 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
@@ -8450,35 +8471,38 @@ lookup kern_Horizontal_kerning {
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni0188 \uni018D \uni01A3 \uni01D2 \uni01DD \uni01EB \uni020D 
-	\uni020F \uni022B \uni022D \uni022F \uni0231 \uni023C \uni0247 \uni0255 
-	\uni0258 \uni0259 \uni025A \uni0275 \uni0276 \uni029B \uni03D9 \uni03F2 
-	\uni03F5 \uni0435 \uni043E \uni0450 \uni0451 \uni0473 \uni047B \uni04A9 
-	\uni04AB \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni050D 
-	\uni1E09 \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni0188 \uni018D \uni01A3 
+	\uni01D2 \uni01DD \uni01EB \uni020D \uni020F \uni022B \uni022D \uni022F 
+	\uni0231 \uni023C \uni0247 \uni0255 \uni0258 \uni0259 \uni025A \uni0275 
+	\uni0276 \uni029B \uni03D9 \uni03F2 \uni03F5 \uni0435 \uni043E \uni0450 
+	\uni0451 \uni0473 \uni047B \uni04A9 \uni04AB \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni050D \uni1E09 \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni20C0 \uni217D ];
     @kc87_second_25 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
-	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
-	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \q.sc.cv29 \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc 
-	\uni01E5.sc \uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc 
-	\uni020F.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc 
-	\uni023C.sc \uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc 
-	\uni037C.sc \uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc 
-	\uni0444.loclBGR.sc \uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc 
-	\uni04AB.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
-	\uni04EB.sc \uni050D.sc \uni051B.sc \uni051B.sc.cv29 \uni1E09.sc 
-	\uni1E21.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
-	\uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc 
-	\uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
-	\uni1EE1.sc \uni1EE3.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc 
-	\uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc 
-	\uni217D.sc ];
+	\gdotaccent.sc \nine.cv09.onum \nine.cv19.onum \nine.onum \o.sc 
+	\oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohorn.sc \ohungarumlaut.sc \omacron.sc \omicron.sc \omicrontonos.sc 
+	\oslash.sc \oslashacute.sc \otilde.sc \q.sc \q.sc.cv29 \theta.sc 
+	\uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc \uni022B.sc 
+	\uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc \uni0259.sc 
+	\uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc \uni03D9.sc 
+	\uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc \uni0454.sc 
+	\uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc \uni04D9.sc 
+	\uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni050D.sc 
+	\uni051B.sc \uni051B.sc.cv29 \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
+	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
+	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
+	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_second_26 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
@@ -8541,14 +8565,15 @@ lookup kern_Horizontal_kerning {
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
     @kc87_second_29 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
-	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
-	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
-	\uni0457.sc \uni1E2D.sc \uni1E2F.sc \uni1EC9.sc \uni1ECB.sc 
-	\uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc 
-	\uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F76.sc \uni1F77.sc 
-	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2178.sc ];
+	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \one.cv01.ss06.onum 
+	\one.cv01.ss06.pnum \one.cv11.ss06.onum \one.cv11.ss06.pnum 
+	\one.ss06.onum \one.ss06.pnum \uni01D0.sc \uni0209.sc \uni020B.sc 
+	\uni0269.sc \uni026A.sc \uni0456.sc \uni0457.sc \uni1E2D.sc 
+	\uni1E2F.sc \uni1EC9.sc \uni1ECB.sc \uni1F30.sc \uni1F31.sc 
+	\uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
+	\uni1F37.sc \uni1F76.sc \uni1F77.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2178.sc ];
     @kc87_second_30 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
@@ -8591,21 +8616,22 @@ lookup kern_Horizontal_kerning {
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
     @kc87_second_32 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
-	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
-	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
-	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
-	\uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 \uni01D4.cv25 
-	\uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA \uni01DA.cv25 
-	\uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 \uni0215 
-	\uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 \uni0269 
-	\uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B \uni0299 
-	\uni029C \uni029F \uni0432 \uni0433 \uni0438 \uni0439 \uni043A \uni043C 
-	\uni043D \uni043F \uni0446 \uni0448 \uni0449 \uni044B \uni044C \uni044E 
-	\uni0453 \uni045C \uni045D \uni045F \uni0465 \uni0469 \uni046D \uni0491 
-	\uni0493 \uni0495 \uni049B \uni049D \uni04A1 \uni04A3 \uni04A5 \uni04A7 
-	\uni04C8 \uni04CA \uni04CE \uni04F7 \uni04FB \uni0523 \uni0525 \uni0529 
-	\uni1E3F \uni1E41 \uni1E43 \uni1E45 \uni1E47 \uni1E49 \uni1E4B \uni1E59 
-	\uni1E5B \uni1E5D \uni1E5F \uni1E73 \uni1E73.cv25 \uni1E75 
+	\ntilde \r \racute \rcaron \rcommaaccent \seven.cv07.ss07.onum 
+	\seven.cv17.ss07.onum \seven.ss07.onum \u \u.cv25 \uacute 
+	\uacute.cv25 \ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 
+	\udieresis \udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 
+	\uhungarumlaut \uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 
+	\uni01D4.cv25 \uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA 
+	\uni01DA.cv25 \uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 
+	\uni0215 \uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 
+	\uni0269 \uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B 
+	\uni0299 \uni029C \uni029F \uni0432 \uni0433 \uni0438 \uni0439 \uni043A 
+	\uni043C \uni043D \uni043F \uni0446 \uni0448 \uni0449 \uni044B \uni044C 
+	\uni044E \uni0453 \uni045C \uni045D \uni045F \uni0465 \uni0469 \uni046D 
+	\uni0491 \uni0493 \uni0495 \uni049B \uni049D \uni04A1 \uni04A3 \uni04A5 
+	\uni04A7 \uni04C8 \uni04CA \uni04CE \uni04F7 \uni04FB \uni0523 \uni0525 
+	\uni0529 \uni1E3F \uni1E41 \uni1E43 \uni1E45 \uni1E47 \uni1E49 \uni1E4B 
+	\uni1E59 \uni1E5B \uni1E5D \uni1E5F \uni1E73 \uni1E73.cv25 \uni1E75 
 	\uni1E75.cv25 \uni1E77 \uni1E77.cv25 \uni1E79 \uni1E79.cv25 \uni1E7B 
 	\uni1E7B.cv25 \uni1EE5 \uni1EE5.cv25 \uni1EE7 \uni1EE7.cv25 \uni1EE9 
 	\uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 \uni1EED \uni1EED.cv25 \uni1EEF 
@@ -8614,77 +8640,83 @@ lookup kern_Horizontal_kerning {
 	\uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 \upsilon 
 	\upsilondieresistonos \upsilontonos \uring \uring.cv25 \utilde 
 	\utilde.cv25 ];
-    @kc87_second_33 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
-	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc87_second_34 = [\fraction ];
-    @kc87_second_35 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \uni01E5 \uni1E21 ];
-    @kc87_second_36 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc87_second_37 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+    @kc87_second_33 = [\f \florin \one.cv01.onum \one.cv01.pnum \one.cv11.onum \one.cv11.pnum 
+	\one.onum \one.pnum \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 
+	\uni1E1F \uni1E6B \uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
+    @kc87_second_34 = [\four.cv04.pnum \four.cv14.pnum \four.pnum ];
+    @kc87_second_35 = [\fraction ];
+    @kc87_second_36 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \three.cv03.onum \three.onum 
+	\uni01E5 \uni1E21 ];
+    @kc87_second_37 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc87_second_38 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc87_second_38 = [\lambda \uni019B ];
-    @kc87_second_39 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc87_second_39 = [\lambda \uni019B ];
+    @kc87_second_40 = [\nine.cv09.pnum \nine.pnum \six.cv06.onum \six.cv06.pnum \six.onum \six.pnum 
+	\theta \uni0478 \uniA64C \zero.cv10.pnum \zero.cv10.zero.pnum 
+	\zero.cv20.pnum \zero.cv20.zero.pnum \zero.pnum \zero.zero.pnum ];
+    @kc87_second_41 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc87_second_40 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_second_41 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_second_42 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
-    @kc87_second_43 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc87_second_42 = [\omega.sc \omegatonos.sc \two.cv02.onum \two.cv12.onum \two.onum \uni1F60.sc 
+	\uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc 
+	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc 
+	\uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
+	\uni1FF6.sc \uni1FF7.sc ];
+    @kc87_second_43 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc87_second_44 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
+    @kc87_second_45 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc87_second_44 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_second_46 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc87_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc87_second_47 = [\seven.cv07.onum \seven.cv17.onum \seven.onum \t.sc \tau.sc \tbar.sc 
+	\tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc \uni021B.sc 
+	\uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc \uni0442.sc 
+	\uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc 
+	\uni1E71.sc \uni1E97.sc ];
+    @kc87_second_48 = [\seven.cv07.ss07.pnum \seven.cv17.ss07.pnum \seven.ss07.pnum ];
+    @kc87_second_49 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_second_46 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
-	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
-	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc87_second_47 = [\theta \uni0478 \uniA64C ];
-    @kc87_second_48 = [\tonos2 ];
-    @kc87_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc87_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc87_second_50 = [\three.cv13.onum \uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 
+	\uniA641 \uniA643 \z \zacute \zcaron \zdotaccent ];
+    @kc87_second_51 = [\tonos2 ];
+    @kc87_second_52 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc87_second_53 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc87_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_second_54 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_second_52 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
-	\z \zacute \zcaron \zdotaccent ];
-    @kc87_second_53 = [\uni0237 ];
-    @kc87_second_54 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc87_second_55 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc87_second_56 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc87_second_57 = [\uni042F \uni0518 ];
-    @kc87_second_58 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
+    @kc87_second_55 = [\uni0237 ];
+    @kc87_second_56 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc87_second_57 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc87_second_58 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc87_second_59 = [\uni042F \uni0518 ];
+    @kc87_second_60 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
 	\uni052F ];
-    @kc87_second_59 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc87_second_61 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc87_second_60 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc87_second_62 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc87_second_61 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc87_second_62 = [\uni044F.sc \uni0519.sc ];
-    @kc87_second_63 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc87_second_63 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc87_second_64 = [\uni044F.sc \uni0519.sc ];
+    @kc87_second_65 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc87_second_64 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc87_second_65 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc87_second_66 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc87_second_67 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc87_second_66 = [\uni0500 \uni0502 ];
-    @kc87_second_67 = [\uni0501.sc \uni0503.sc ];
-    @kc87_second_68 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
-	\zero.cv20.zero.dnom.pnum \zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc87_second_69 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
-	\zero.cv20.zero.numr.pnum \zero.numr.pnum \zero.zero.numr.pnum ];
+    @kc87_second_68 = [\uni0500 \uni0502 ];
+    @kc87_second_69 = [\uni0501.sc \uni0503.sc ];
+    @kc87_second_70 = [\zero.cv10.zero.dnom.pnum \zero.cv20.zero.dnom.pnum \zero.zero.dnom.pnum ];
+    @kc87_second_71 = [\zero.cv10.zero.numr.pnum \zero.cv20.zero.numr.pnum \zero.zero.numr.pnum ];
     pos @kc87_first_1 @kc87_second_3 -70;
     pos @kc87_first_1 @kc87_second_8 -70;
     pos @kc87_first_1 @kc87_second_9 -140;
     pos @kc87_first_1 @kc87_second_10 -35;
-    pos @kc87_first_1 @kc87_second_12 -280;
+    pos @kc87_first_1 @kc87_second_12 -210;
     pos @kc87_first_1 @kc87_second_13 -280;
     pos @kc87_first_1 @kc87_second_14 -280;
     pos @kc87_first_1 @kc87_second_15 -210;
@@ -8692,26 +8724,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_1 @kc87_second_25 -35;
     pos @kc87_first_1 @kc87_second_27 -50;
     pos @kc87_first_1 @kc87_second_33 -70;
-    pos @kc87_first_1 @kc87_second_41 -35;
-    pos @kc87_first_1 @kc87_second_42 -140;
-    pos @kc87_first_1 @kc87_second_43 -105;
-    pos @kc87_first_1 @kc87_second_46 -210;
-    pos @kc87_first_1 @kc87_second_47 -35;
-    pos @kc87_first_1 @kc87_second_48 1;
-    pos @kc87_first_1 @kc87_second_50 -175;
-    pos @kc87_first_1 @kc87_second_51 -210;
-    pos @kc87_first_1 @kc87_second_61 -140;
+    pos @kc87_first_1 @kc87_second_40 -35;
+    pos @kc87_first_1 @kc87_second_43 -35;
+    pos @kc87_first_1 @kc87_second_44 -140;
+    pos @kc87_first_1 @kc87_second_45 -105;
+    pos @kc87_first_1 @kc87_second_47 -210;
+    pos @kc87_first_1 @kc87_second_48 -175;
+    pos @kc87_first_1 @kc87_second_51 1;
+    pos @kc87_first_1 @kc87_second_53 -175;
+    pos @kc87_first_1 @kc87_second_54 -210;
     pos @kc87_first_1 @kc87_second_63 -140;
-    pos @kc87_first_1 @kc87_second_64 -210;
     pos @kc87_first_1 @kc87_second_65 -140;
+    pos @kc87_first_1 @kc87_second_66 -210;
+    pos @kc87_first_1 @kc87_second_67 -140;
     pos @kc87_first_2 @kc87_second_9 -35;
     pos @kc87_first_2 @kc87_second_12 -70;
     pos @kc87_first_2 @kc87_second_13 -70;
     pos @kc87_first_2 @kc87_second_14 -70;
     pos @kc87_first_2 @kc87_second_15 -35;
     pos @kc87_first_2 @kc87_second_16 -35;
-    pos @kc87_first_2 @kc87_second_42 -35;
-    pos @kc87_first_2 @kc87_second_48 1;
+    pos @kc87_first_2 @kc87_second_44 -35;
+    pos @kc87_first_2 @kc87_second_51 1;
     pos @kc87_first_3 @kc87_second_1 -35;
     pos @kc87_first_3 @kc87_second_2 -70;
     pos @kc87_first_3 @kc87_second_5 -35;
@@ -8722,8 +8755,8 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_3 @kc87_second_16 -70;
     pos @kc87_first_3 @kc87_second_19 -35;
     pos @kc87_first_3 @kc87_second_21 -70;
-    pos @kc87_first_3 @kc87_second_38 -35;
-    pos @kc87_first_3 @kc87_second_48 1;
+    pos @kc87_first_3 @kc87_second_39 -35;
+    pos @kc87_first_3 @kc87_second_51 1;
     pos @kc87_first_4 @kc87_second_1 -70;
     pos @kc87_first_4 @kc87_second_2 -140;
     pos @kc87_first_4 @kc87_second_4 70;
@@ -8739,24 +8772,24 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_4 @kc87_second_28 -70;
     pos @kc87_first_4 @kc87_second_29 -35;
     pos @kc87_first_4 @kc87_second_33 35;
-    pos @kc87_first_4 @kc87_second_35 -35;
-    pos @kc87_first_4 @kc87_second_37 -70;
+    pos @kc87_first_4 @kc87_second_36 -35;
     pos @kc87_first_4 @kc87_second_38 -70;
-    pos @kc87_first_4 @kc87_second_46 -35;
-    pos @kc87_first_4 @kc87_second_48 1;
-    pos @kc87_first_4 @kc87_second_51 -70;
-    pos @kc87_first_4 @kc87_second_56 -70;
+    pos @kc87_first_4 @kc87_second_39 -70;
+    pos @kc87_first_4 @kc87_second_47 -35;
+    pos @kc87_first_4 @kc87_second_51 1;
+    pos @kc87_first_4 @kc87_second_54 -70;
     pos @kc87_first_4 @kc87_second_58 -70;
-    pos @kc87_first_4 @kc87_second_59 -70;
-    pos @kc87_first_4 @kc87_second_64 -35;
+    pos @kc87_first_4 @kc87_second_60 -70;
+    pos @kc87_first_4 @kc87_second_61 -70;
+    pos @kc87_first_4 @kc87_second_66 -35;
     pos @kc87_first_5 @kc87_second_12 -70;
-    pos @kc87_first_5 @kc87_second_48 1;
+    pos @kc87_first_5 @kc87_second_51 1;
     pos @kc87_first_6 @kc87_second_1 -280;
     pos @kc87_first_6 @kc87_second_2 -350;
     pos @kc87_first_6 @kc87_second_3 -140;
     pos @kc87_first_6 @kc87_second_4 -70;
     pos @kc87_first_6 @kc87_second_6 -350;
-    pos @kc87_first_6 @kc87_second_7 -140;
+    pos @kc87_first_6 @kc87_second_7 -70;
     pos @kc87_first_6 @kc87_second_8 -210;
     pos @kc87_first_6 @kc87_second_10 -70;
     pos @kc87_first_6 @kc87_second_17 -240;
@@ -8773,32 +8806,33 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_6 @kc87_second_31 -240;
     pos @kc87_first_6 @kc87_second_32 -240;
     pos @kc87_first_6 @kc87_second_33 -175;
-    pos @kc87_first_6 @kc87_second_35 -240;
-    pos @kc87_first_6 @kc87_second_37 -350;
-    pos @kc87_first_6 @kc87_second_38 -105;
-    pos @kc87_first_6 @kc87_second_39 -240;
-    pos @kc87_first_6 @kc87_second_40 -210;
+    pos @kc87_first_6 @kc87_second_34 -175;
+    pos @kc87_first_6 @kc87_second_36 -240;
+    pos @kc87_first_6 @kc87_second_38 -350;
+    pos @kc87_first_6 @kc87_second_39 -105;
+    pos @kc87_first_6 @kc87_second_40 -70;
     pos @kc87_first_6 @kc87_second_41 -240;
-    pos @kc87_first_6 @kc87_second_42 -240;
+    pos @kc87_first_6 @kc87_second_42 -210;
+    pos @kc87_first_6 @kc87_second_43 -240;
     pos @kc87_first_6 @kc87_second_44 -240;
-    pos @kc87_first_6 @kc87_second_47 -140;
-    pos @kc87_first_6 @kc87_second_48 1;
-    pos @kc87_first_6 @kc87_second_49 -35;
+    pos @kc87_first_6 @kc87_second_46 -240;
     pos @kc87_first_6 @kc87_second_50 -240;
-    pos @kc87_first_6 @kc87_second_52 -240;
+    pos @kc87_first_6 @kc87_second_51 1;
+    pos @kc87_first_6 @kc87_second_52 -35;
     pos @kc87_first_6 @kc87_second_53 -240;
-    pos @kc87_first_6 @kc87_second_54 -240;
     pos @kc87_first_6 @kc87_second_55 -240;
-    pos @kc87_first_6 @kc87_second_56 -280;
-    pos @kc87_first_6 @kc87_second_57 -70;
+    pos @kc87_first_6 @kc87_second_56 -240;
+    pos @kc87_first_6 @kc87_second_57 -240;
     pos @kc87_first_6 @kc87_second_58 -280;
-    pos @kc87_first_6 @kc87_second_59 -240;
-    pos @kc87_first_6 @kc87_second_60 -175;
+    pos @kc87_first_6 @kc87_second_59 -70;
+    pos @kc87_first_6 @kc87_second_60 -280;
     pos @kc87_first_6 @kc87_second_61 -240;
-    pos @kc87_first_6 @kc87_second_62 -210;
-    pos @kc87_first_6 @kc87_second_63 -175;
-    pos @kc87_first_6 @kc87_second_66 -175;
-    pos @kc87_first_6 @kc87_second_67 -175;
+    pos @kc87_first_6 @kc87_second_62 -175;
+    pos @kc87_first_6 @kc87_second_63 -240;
+    pos @kc87_first_6 @kc87_second_64 -210;
+    pos @kc87_first_6 @kc87_second_65 -175;
+    pos @kc87_first_6 @kc87_second_68 -175;
+    pos @kc87_first_6 @kc87_second_69 -175;
     pos @kc87_first_7 @kc87_second_3 -70;
     pos @kc87_first_7 @kc87_second_8 -105;
     pos @kc87_first_7 @kc87_second_17 -35;
@@ -8806,13 +8840,14 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_7 @kc87_second_22 -105;
     pos @kc87_first_7 @kc87_second_24 -105;
     pos @kc87_first_7 @kc87_second_25 -70;
-    pos @kc87_first_7 @kc87_second_48 1;
-    pos @kc87_first_7 @kc87_second_49 -35;
-    pos @kc87_first_7 @kc87_second_50 -70;
-    pos @kc87_first_7 @kc87_second_54 -50;
-    pos @kc87_first_7 @kc87_second_63 -35;
-    pos @kc87_first_7 @kc87_second_66 -70;
-    pos @kc87_first_7 @kc87_second_67 -70;
+    pos @kc87_first_7 @kc87_second_34 -70;
+    pos @kc87_first_7 @kc87_second_51 1;
+    pos @kc87_first_7 @kc87_second_52 -35;
+    pos @kc87_first_7 @kc87_second_53 -70;
+    pos @kc87_first_7 @kc87_second_56 -50;
+    pos @kc87_first_7 @kc87_second_65 -35;
+    pos @kc87_first_7 @kc87_second_68 -70;
+    pos @kc87_first_7 @kc87_second_69 -70;
     pos @kc87_first_8 @kc87_second_3 -140;
     pos @kc87_first_8 @kc87_second_4 -70;
     pos @kc87_first_8 @kc87_second_6 -70;
@@ -8826,26 +8861,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_8 @kc87_second_27 -140;
     pos @kc87_first_8 @kc87_second_31 -35;
     pos @kc87_first_8 @kc87_second_33 -105;
-    pos @kc87_first_8 @kc87_second_37 -70;
-    pos @kc87_first_8 @kc87_second_39 -70;
-    pos @kc87_first_8 @kc87_second_41 -105;
-    pos @kc87_first_8 @kc87_second_42 -175;
-    pos @kc87_first_8 @kc87_second_43 -140;
-    pos @kc87_first_8 @kc87_second_44 -35;
-    pos @kc87_first_8 @kc87_second_46 -140;
-    pos @kc87_first_8 @kc87_second_47 -105;
-    pos @kc87_first_8 @kc87_second_48 1;
-    pos @kc87_first_8 @kc87_second_49 -70;
-    pos @kc87_first_8 @kc87_second_50 -140;
-    pos @kc87_first_8 @kc87_second_51 -70;
-    pos @kc87_first_8 @kc87_second_54 -35;
-    pos @kc87_first_8 @kc87_second_55 -35;
-    pos @kc87_first_8 @kc87_second_61 -210;
-    pos @kc87_first_8 @kc87_second_63 -105;
-    pos @kc87_first_8 @kc87_second_64 -70;
-    pos @kc87_first_8 @kc87_second_65 -35;
+    pos @kc87_first_8 @kc87_second_34 -70;
+    pos @kc87_first_8 @kc87_second_38 -70;
+    pos @kc87_first_8 @kc87_second_40 -105;
+    pos @kc87_first_8 @kc87_second_41 -70;
+    pos @kc87_first_8 @kc87_second_43 -105;
+    pos @kc87_first_8 @kc87_second_44 -175;
+    pos @kc87_first_8 @kc87_second_45 -140;
+    pos @kc87_first_8 @kc87_second_46 -35;
+    pos @kc87_first_8 @kc87_second_47 -140;
+    pos @kc87_first_8 @kc87_second_51 1;
+    pos @kc87_first_8 @kc87_second_52 -70;
+    pos @kc87_first_8 @kc87_second_53 -140;
+    pos @kc87_first_8 @kc87_second_54 -70;
+    pos @kc87_first_8 @kc87_second_56 -35;
+    pos @kc87_first_8 @kc87_second_57 -35;
+    pos @kc87_first_8 @kc87_second_63 -210;
+    pos @kc87_first_8 @kc87_second_65 -105;
     pos @kc87_first_8 @kc87_second_66 -70;
     pos @kc87_first_8 @kc87_second_67 -35;
+    pos @kc87_first_8 @kc87_second_68 -70;
+    pos @kc87_first_8 @kc87_second_69 -35;
     pos @kc87_first_9 @kc87_second_3 -140;
     pos @kc87_first_9 @kc87_second_4 -70;
     pos @kc87_first_9 @kc87_second_6 -70;
@@ -8864,24 +8900,26 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_9 @kc87_second_25 -140;
     pos @kc87_first_9 @kc87_second_31 -50;
     pos @kc87_first_9 @kc87_second_33 -140;
-    pos @kc87_first_9 @kc87_second_37 -70;
-    pos @kc87_first_9 @kc87_second_41 -105;
-    pos @kc87_first_9 @kc87_second_42 -280;
-    pos @kc87_first_9 @kc87_second_43 -350;
-    pos @kc87_first_9 @kc87_second_44 -50;
-    pos @kc87_first_9 @kc87_second_46 -350;
-    pos @kc87_first_9 @kc87_second_48 1;
-    pos @kc87_first_9 @kc87_second_49 -35;
-    pos @kc87_first_9 @kc87_second_50 -210;
-    pos @kc87_first_9 @kc87_second_51 -350;
-    pos @kc87_first_9 @kc87_second_54 -35;
-    pos @kc87_first_9 @kc87_second_55 -35;
-    pos @kc87_first_9 @kc87_second_61 -280;
-    pos @kc87_first_9 @kc87_second_63 -175;
-    pos @kc87_first_9 @kc87_second_64 -280;
-    pos @kc87_first_9 @kc87_second_65 -210;
-    pos @kc87_first_9 @kc87_second_66 -70;
-    pos @kc87_first_9 @kc87_second_67 -70;
+    pos @kc87_first_9 @kc87_second_34 -70;
+    pos @kc87_first_9 @kc87_second_38 -70;
+    pos @kc87_first_9 @kc87_second_43 -105;
+    pos @kc87_first_9 @kc87_second_44 -280;
+    pos @kc87_first_9 @kc87_second_45 -350;
+    pos @kc87_first_9 @kc87_second_46 -50;
+    pos @kc87_first_9 @kc87_second_47 -350;
+    pos @kc87_first_9 @kc87_second_48 -280;
+    pos @kc87_first_9 @kc87_second_51 1;
+    pos @kc87_first_9 @kc87_second_52 -35;
+    pos @kc87_first_9 @kc87_second_53 -210;
+    pos @kc87_first_9 @kc87_second_54 -350;
+    pos @kc87_first_9 @kc87_second_56 -35;
+    pos @kc87_first_9 @kc87_second_57 -35;
+    pos @kc87_first_9 @kc87_second_63 -280;
+    pos @kc87_first_9 @kc87_second_65 -175;
+    pos @kc87_first_9 @kc87_second_66 -280;
+    pos @kc87_first_9 @kc87_second_67 -210;
+    pos @kc87_first_9 @kc87_second_68 -70;
+    pos @kc87_first_9 @kc87_second_69 -70;
     pos @kc87_first_10 @kc87_second_1 -210;
     pos @kc87_first_10 @kc87_second_2 -350;
     pos @kc87_first_10 @kc87_second_5 -70;
@@ -8898,18 +8936,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_10 @kc87_second_24 -70;
     pos @kc87_first_10 @kc87_second_26 -350;
     pos @kc87_first_10 @kc87_second_31 -70;
-    pos @kc87_first_10 @kc87_second_34 -140;
-    pos @kc87_first_10 @kc87_second_35 -70;
-    pos @kc87_first_10 @kc87_second_37 -210;
-    pos @kc87_first_10 @kc87_second_38 -105;
-    pos @kc87_first_10 @kc87_second_41 -70;
-    pos @kc87_first_10 @kc87_second_48 1;
-    pos @kc87_first_10 @kc87_second_56 -210;
+    pos @kc87_first_10 @kc87_second_34 -35;
+    pos @kc87_first_10 @kc87_second_35 -140;
+    pos @kc87_first_10 @kc87_second_36 -70;
+    pos @kc87_first_10 @kc87_second_38 -210;
+    pos @kc87_first_10 @kc87_second_39 -105;
+    pos @kc87_first_10 @kc87_second_43 -70;
+    pos @kc87_first_10 @kc87_second_51 1;
     pos @kc87_first_10 @kc87_second_58 -210;
-    pos @kc87_first_10 @kc87_second_59 -210;
-    pos @kc87_first_10 @kc87_second_64 -70;
+    pos @kc87_first_10 @kc87_second_60 -210;
+    pos @kc87_first_10 @kc87_second_61 -210;
     pos @kc87_first_10 @kc87_second_66 -70;
-    pos @kc87_first_10 @kc87_second_67 -105;
+    pos @kc87_first_10 @kc87_second_68 -70;
+    pos @kc87_first_10 @kc87_second_69 -105;
     pos @kc87_first_11 @kc87_second_1 -70;
     pos @kc87_first_11 @kc87_second_2 -140;
     pos @kc87_first_11 @kc87_second_5 -105;
@@ -8925,22 +8964,22 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_11 @kc87_second_26 -70;
     pos @kc87_first_11 @kc87_second_28 -70;
     pos @kc87_first_11 @kc87_second_29 -70;
-    pos @kc87_first_11 @kc87_second_35 -35;
-    pos @kc87_first_11 @kc87_second_37 -35;
-    pos @kc87_first_11 @kc87_second_38 -140;
-    pos @kc87_first_11 @kc87_second_42 -70;
-    pos @kc87_first_11 @kc87_second_45 -35;
-    pos @kc87_first_11 @kc87_second_46 -35;
-    pos @kc87_first_11 @kc87_second_48 1;
-    pos @kc87_first_11 @kc87_second_51 -70;
-    pos @kc87_first_11 @kc87_second_56 -210;
-    pos @kc87_first_11 @kc87_second_58 -175;
-    pos @kc87_first_11 @kc87_second_59 -175;
-    pos @kc87_first_11 @kc87_second_60 -35;
-    pos @kc87_first_11 @kc87_second_64 -70;
-    pos @kc87_first_11 @kc87_second_65 -35;
-    pos @kc87_first_11 @kc87_second_66 -35;
-    pos @kc87_first_11 @kc87_second_67 -70;
+    pos @kc87_first_11 @kc87_second_36 -35;
+    pos @kc87_first_11 @kc87_second_38 -35;
+    pos @kc87_first_11 @kc87_second_39 -140;
+    pos @kc87_first_11 @kc87_second_44 -70;
+    pos @kc87_first_11 @kc87_second_47 -35;
+    pos @kc87_first_11 @kc87_second_49 -35;
+    pos @kc87_first_11 @kc87_second_51 1;
+    pos @kc87_first_11 @kc87_second_54 -70;
+    pos @kc87_first_11 @kc87_second_58 -210;
+    pos @kc87_first_11 @kc87_second_60 -175;
+    pos @kc87_first_11 @kc87_second_61 -175;
+    pos @kc87_first_11 @kc87_second_62 -35;
+    pos @kc87_first_11 @kc87_second_66 -70;
+    pos @kc87_first_11 @kc87_second_67 -35;
+    pos @kc87_first_11 @kc87_second_68 -35;
+    pos @kc87_first_11 @kc87_second_69 -70;
     pos @kc87_first_12 @kc87_second_1 -140;
     pos @kc87_first_12 @kc87_second_2 -210;
     pos @kc87_first_12 @kc87_second_6 -140;
@@ -8951,18 +8990,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_12 @kc87_second_24 -70;
     pos @kc87_first_12 @kc87_second_26 -350;
     pos @kc87_first_12 @kc87_second_31 -35;
-    pos @kc87_first_12 @kc87_second_34 -140;
-    pos @kc87_first_12 @kc87_second_35 -70;
-    pos @kc87_first_12 @kc87_second_37 -140;
-    pos @kc87_first_12 @kc87_second_38 -70;
-    pos @kc87_first_12 @kc87_second_41 -70;
-    pos @kc87_first_12 @kc87_second_48 1;
-    pos @kc87_first_12 @kc87_second_54 -35;
-    pos @kc87_first_12 @kc87_second_56 -210;
+    pos @kc87_first_12 @kc87_second_34 -70;
+    pos @kc87_first_12 @kc87_second_35 -140;
+    pos @kc87_first_12 @kc87_second_36 -70;
+    pos @kc87_first_12 @kc87_second_38 -140;
+    pos @kc87_first_12 @kc87_second_39 -70;
+    pos @kc87_first_12 @kc87_second_43 -70;
+    pos @kc87_first_12 @kc87_second_51 1;
+    pos @kc87_first_12 @kc87_second_56 -35;
     pos @kc87_first_12 @kc87_second_58 -210;
-    pos @kc87_first_12 @kc87_second_59 -210;
-    pos @kc87_first_12 @kc87_second_66 -70;
-    pos @kc87_first_12 @kc87_second_67 -105;
+    pos @kc87_first_12 @kc87_second_60 -210;
+    pos @kc87_first_12 @kc87_second_61 -210;
+    pos @kc87_first_12 @kc87_second_68 -70;
+    pos @kc87_first_12 @kc87_second_69 -105;
     pos @kc87_first_13 @kc87_second_6 -70;
     pos @kc87_first_13 @kc87_second_12 -70;
     pos @kc87_first_13 @kc87_second_13 -105;
@@ -8970,11 +9010,12 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_13 @kc87_second_18 -35;
     pos @kc87_first_13 @kc87_second_24 -35;
     pos @kc87_first_13 @kc87_second_31 -35;
-    pos @kc87_first_13 @kc87_second_37 -70;
-    pos @kc87_first_13 @kc87_second_41 -70;
-    pos @kc87_first_13 @kc87_second_48 1;
-    pos @kc87_first_13 @kc87_second_66 -70;
-    pos @kc87_first_13 @kc87_second_67 -35;
+    pos @kc87_first_13 @kc87_second_34 -35;
+    pos @kc87_first_13 @kc87_second_38 -70;
+    pos @kc87_first_13 @kc87_second_43 -70;
+    pos @kc87_first_13 @kc87_second_51 1;
+    pos @kc87_first_13 @kc87_second_68 -70;
+    pos @kc87_first_13 @kc87_second_69 -35;
     pos @kc87_first_14 @kc87_second_2 -35;
     pos @kc87_first_14 @kc87_second_11 -35;
     pos @kc87_first_14 @kc87_second_12 -70;
@@ -8983,15 +9024,15 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_14 @kc87_second_16 -35;
     pos @kc87_first_14 @kc87_second_21 -35;
     pos @kc87_first_14 @kc87_second_27 -35;
-    pos @kc87_first_14 @kc87_second_35 -35;
-    pos @kc87_first_14 @kc87_second_42 -70;
-    pos @kc87_first_14 @kc87_second_48 1;
-    pos @kc87_first_14 @kc87_second_50 -70;
-    pos @kc87_first_14 @kc87_second_51 -35;
-    pos @kc87_first_14 @kc87_second_60 -35;
-    pos @kc87_first_14 @kc87_second_61 -35;
+    pos @kc87_first_14 @kc87_second_36 -35;
+    pos @kc87_first_14 @kc87_second_44 -70;
+    pos @kc87_first_14 @kc87_second_51 1;
+    pos @kc87_first_14 @kc87_second_53 -70;
+    pos @kc87_first_14 @kc87_second_54 -35;
+    pos @kc87_first_14 @kc87_second_62 -35;
     pos @kc87_first_14 @kc87_second_63 -35;
     pos @kc87_first_14 @kc87_second_65 -35;
+    pos @kc87_first_14 @kc87_second_67 -35;
     pos @kc87_first_15 @kc87_second_3 -70;
     pos @kc87_first_15 @kc87_second_4 -70;
     pos @kc87_first_15 @kc87_second_6 -35;
@@ -9004,20 +9045,20 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_15 @kc87_second_27 -70;
     pos @kc87_first_15 @kc87_second_31 -35;
     pos @kc87_first_15 @kc87_second_33 -35;
-    pos @kc87_first_15 @kc87_second_39 -35;
-    pos @kc87_first_15 @kc87_second_41 -70;
-    pos @kc87_first_15 @kc87_second_42 -142;
-    pos @kc87_first_15 @kc87_second_43 -35;
-    pos @kc87_first_15 @kc87_second_47 -35;
-    pos @kc87_first_15 @kc87_second_48 1;
-    pos @kc87_first_15 @kc87_second_49 -35;
-    pos @kc87_first_15 @kc87_second_50 -70;
-    pos @kc87_first_15 @kc87_second_54 -35;
-    pos @kc87_first_15 @kc87_second_55 -35;
-    pos @kc87_first_15 @kc87_second_61 -105;
-    pos @kc87_first_15 @kc87_second_63 -35;
-    pos @kc87_first_15 @kc87_second_66 -35;
-    pos @kc87_first_15 @kc87_second_67 -35;
+    pos @kc87_first_15 @kc87_second_40 -35;
+    pos @kc87_first_15 @kc87_second_41 -35;
+    pos @kc87_first_15 @kc87_second_43 -70;
+    pos @kc87_first_15 @kc87_second_44 -142;
+    pos @kc87_first_15 @kc87_second_45 -35;
+    pos @kc87_first_15 @kc87_second_51 1;
+    pos @kc87_first_15 @kc87_second_52 -35;
+    pos @kc87_first_15 @kc87_second_53 -70;
+    pos @kc87_first_15 @kc87_second_56 -35;
+    pos @kc87_first_15 @kc87_second_57 -35;
+    pos @kc87_first_15 @kc87_second_63 -105;
+    pos @kc87_first_15 @kc87_second_65 -35;
+    pos @kc87_first_15 @kc87_second_68 -35;
+    pos @kc87_first_15 @kc87_second_69 -35;
     pos @kc87_first_16 @kc87_second_1 -280;
     pos @kc87_first_16 @kc87_second_2 -280;
     pos @kc87_first_16 @kc87_second_3 -140;
@@ -9040,35 +9081,35 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_16 @kc87_second_31 -240;
     pos @kc87_first_16 @kc87_second_32 -140;
     pos @kc87_first_16 @kc87_second_33 -140;
-    pos @kc87_first_16 @kc87_second_34 -245;
-    pos @kc87_first_16 @kc87_second_35 -315;
-    pos @kc87_first_16 @kc87_second_37 -315;
-    pos @kc87_first_16 @kc87_second_38 -70;
-    pos @kc87_first_16 @kc87_second_39 -210;
-    pos @kc87_first_16 @kc87_second_40 -210;
-    pos @kc87_first_16 @kc87_second_41 -245;
-    pos @kc87_first_16 @kc87_second_42 -245;
-    pos @kc87_first_16 @kc87_second_43 -70;
-    pos @kc87_first_16 @kc87_second_45 -35;
-    pos @kc87_first_16 @kc87_second_46 -140;
+    pos @kc87_first_16 @kc87_second_35 -245;
+    pos @kc87_first_16 @kc87_second_36 -315;
+    pos @kc87_first_16 @kc87_second_38 -315;
+    pos @kc87_first_16 @kc87_second_39 -70;
+    pos @kc87_first_16 @kc87_second_40 -140;
+    pos @kc87_first_16 @kc87_second_41 -210;
+    pos @kc87_first_16 @kc87_second_42 -210;
+    pos @kc87_first_16 @kc87_second_43 -245;
+    pos @kc87_first_16 @kc87_second_44 -245;
+    pos @kc87_first_16 @kc87_second_45 -70;
     pos @kc87_first_16 @kc87_second_47 -140;
-    pos @kc87_first_16 @kc87_second_48 1;
-    pos @kc87_first_16 @kc87_second_49 -70;
+    pos @kc87_first_16 @kc87_second_49 -35;
     pos @kc87_first_16 @kc87_second_50 -140;
-    pos @kc87_first_16 @kc87_second_52 -140;
+    pos @kc87_first_16 @kc87_second_51 1;
+    pos @kc87_first_16 @kc87_second_52 -70;
     pos @kc87_first_16 @kc87_second_53 -140;
-    pos @kc87_first_16 @kc87_second_54 -240;
     pos @kc87_first_16 @kc87_second_55 -140;
-    pos @kc87_first_16 @kc87_second_56 -280;
-    pos @kc87_first_16 @kc87_second_57 -105;
-    pos @kc87_first_16 @kc87_second_58 -315;
-    pos @kc87_first_16 @kc87_second_59 -280;
-    pos @kc87_first_16 @kc87_second_60 -140;
-    pos @kc87_first_16 @kc87_second_61 -210;
-    pos @kc87_first_16 @kc87_second_62 -210;
-    pos @kc87_first_16 @kc87_second_63 -105;
-    pos @kc87_first_16 @kc87_second_66 -315;
-    pos @kc87_first_16 @kc87_second_67 -350;
+    pos @kc87_first_16 @kc87_second_56 -240;
+    pos @kc87_first_16 @kc87_second_57 -140;
+    pos @kc87_first_16 @kc87_second_58 -280;
+    pos @kc87_first_16 @kc87_second_59 -105;
+    pos @kc87_first_16 @kc87_second_60 -315;
+    pos @kc87_first_16 @kc87_second_61 -280;
+    pos @kc87_first_16 @kc87_second_62 -140;
+    pos @kc87_first_16 @kc87_second_63 -210;
+    pos @kc87_first_16 @kc87_second_64 -210;
+    pos @kc87_first_16 @kc87_second_65 -105;
+    pos @kc87_first_16 @kc87_second_68 -315;
+    pos @kc87_first_16 @kc87_second_69 -350;
     pos @kc87_first_17 @kc87_second_1 -280;
     pos @kc87_first_17 @kc87_second_2 -280;
     pos @kc87_first_17 @kc87_second_3 -105;
@@ -9088,34 +9129,35 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_17 @kc87_second_29 -70;
     pos @kc87_first_17 @kc87_second_31 -140;
     pos @kc87_first_17 @kc87_second_32 -105;
-    pos @kc87_first_17 @kc87_second_34 -210;
-    pos @kc87_first_17 @kc87_second_35 -175;
-    pos @kc87_first_17 @kc87_second_37 -245;
-    pos @kc87_first_17 @kc87_second_38 -70;
-    pos @kc87_first_17 @kc87_second_39 -140;
-    pos @kc87_first_17 @kc87_second_40 -140;
+    pos @kc87_first_17 @kc87_second_34 -175;
+    pos @kc87_first_17 @kc87_second_35 -210;
+    pos @kc87_first_17 @kc87_second_36 -175;
+    pos @kc87_first_17 @kc87_second_38 -245;
+    pos @kc87_first_17 @kc87_second_39 -70;
+    pos @kc87_first_17 @kc87_second_40 -70;
     pos @kc87_first_17 @kc87_second_41 -140;
-    pos @kc87_first_17 @kc87_second_42 -105;
-    pos @kc87_first_17 @kc87_second_43 -35;
-    pos @kc87_first_17 @kc87_second_46 -35;
-    pos @kc87_first_17 @kc87_second_47 -70;
-    pos @kc87_first_17 @kc87_second_48 1;
-    pos @kc87_first_17 @kc87_second_49 -35;
-    pos @kc87_first_17 @kc87_second_50 -70;
-    pos @kc87_first_17 @kc87_second_52 -105;
+    pos @kc87_first_17 @kc87_second_42 -140;
+    pos @kc87_first_17 @kc87_second_43 -140;
+    pos @kc87_first_17 @kc87_second_44 -105;
+    pos @kc87_first_17 @kc87_second_45 -35;
+    pos @kc87_first_17 @kc87_second_47 -35;
+    pos @kc87_first_17 @kc87_second_50 -105;
+    pos @kc87_first_17 @kc87_second_51 1;
+    pos @kc87_first_17 @kc87_second_52 -35;
     pos @kc87_first_17 @kc87_second_53 -70;
-    pos @kc87_first_17 @kc87_second_54 -105;
     pos @kc87_first_17 @kc87_second_55 -70;
-    pos @kc87_first_17 @kc87_second_56 -210;
-    pos @kc87_first_17 @kc87_second_57 -35;
-    pos @kc87_first_17 @kc87_second_58 -245;
-    pos @kc87_first_17 @kc87_second_59 -210;
-    pos @kc87_first_17 @kc87_second_60 -70;
-    pos @kc87_first_17 @kc87_second_61 -105;
-    pos @kc87_first_17 @kc87_second_62 -105;
-    pos @kc87_first_17 @kc87_second_63 -70;
-    pos @kc87_first_17 @kc87_second_66 -175;
-    pos @kc87_first_17 @kc87_second_67 -245;
+    pos @kc87_first_17 @kc87_second_56 -105;
+    pos @kc87_first_17 @kc87_second_57 -70;
+    pos @kc87_first_17 @kc87_second_58 -210;
+    pos @kc87_first_17 @kc87_second_59 -35;
+    pos @kc87_first_17 @kc87_second_60 -245;
+    pos @kc87_first_17 @kc87_second_61 -210;
+    pos @kc87_first_17 @kc87_second_62 -70;
+    pos @kc87_first_17 @kc87_second_63 -105;
+    pos @kc87_first_17 @kc87_second_64 -105;
+    pos @kc87_first_17 @kc87_second_65 -70;
+    pos @kc87_first_17 @kc87_second_68 -175;
+    pos @kc87_first_17 @kc87_second_69 -245;
     pos @kc87_first_18 @kc87_second_1 -210;
     pos @kc87_first_18 @kc87_second_2 -245;
     pos @kc87_first_18 @kc87_second_3 -35;
@@ -9131,41 +9173,42 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_18 @kc87_second_25 -70;
     pos @kc87_first_18 @kc87_second_26 -140;
     pos @kc87_first_18 @kc87_second_29 -35;
-    pos @kc87_first_18 @kc87_second_34 -140;
-    pos @kc87_first_18 @kc87_second_35 -105;
-    pos @kc87_first_18 @kc87_second_37 -140;
-    pos @kc87_first_18 @kc87_second_39 -105;
-    pos @kc87_first_18 @kc87_second_40 -70;
+    pos @kc87_first_18 @kc87_second_34 -105;
+    pos @kc87_first_18 @kc87_second_35 -140;
+    pos @kc87_first_18 @kc87_second_36 -105;
+    pos @kc87_first_18 @kc87_second_38 -140;
     pos @kc87_first_18 @kc87_second_41 -105;
     pos @kc87_first_18 @kc87_second_42 -70;
-    pos @kc87_first_18 @kc87_second_44 -35;
-    pos @kc87_first_18 @kc87_second_48 1;
-    pos @kc87_first_18 @kc87_second_53 -35;
-    pos @kc87_first_18 @kc87_second_54 -70;
-    pos @kc87_first_18 @kc87_second_56 -140;
-    pos @kc87_first_18 @kc87_second_58 -175;
-    pos @kc87_first_18 @kc87_second_59 -140;
-    pos @kc87_first_18 @kc87_second_61 -70;
-    pos @kc87_first_18 @kc87_second_66 -105;
-    pos @kc87_first_18 @kc87_second_67 -140;
+    pos @kc87_first_18 @kc87_second_43 -105;
+    pos @kc87_first_18 @kc87_second_44 -70;
+    pos @kc87_first_18 @kc87_second_46 -35;
+    pos @kc87_first_18 @kc87_second_51 1;
+    pos @kc87_first_18 @kc87_second_55 -35;
+    pos @kc87_first_18 @kc87_second_56 -70;
+    pos @kc87_first_18 @kc87_second_58 -140;
+    pos @kc87_first_18 @kc87_second_60 -175;
+    pos @kc87_first_18 @kc87_second_61 -140;
+    pos @kc87_first_18 @kc87_second_63 -70;
+    pos @kc87_first_18 @kc87_second_68 -105;
+    pos @kc87_first_18 @kc87_second_69 -140;
     pos @kc87_first_19 @kc87_second_12 -280;
     pos @kc87_first_19 @kc87_second_14 -175;
     pos @kc87_first_19 @kc87_second_15 -140;
     pos @kc87_first_19 @kc87_second_18 -35;
     pos @kc87_first_19 @kc87_second_31 -35;
     pos @kc87_first_19 @kc87_second_33 -50;
-    pos @kc87_first_19 @kc87_second_48 1;
-    pos @kc87_first_19 @kc87_second_50 -70;
-    pos @kc87_first_19 @kc87_second_51 -140;
-    pos @kc87_first_19 @kc87_second_61 -70;
-    pos @kc87_first_19 @kc87_second_63 -35;
-    pos @kc87_first_19 @kc87_second_64 -105;
-    pos @kc87_first_19 @kc87_second_65 -70;
+    pos @kc87_first_19 @kc87_second_51 1;
+    pos @kc87_first_19 @kc87_second_53 -70;
+    pos @kc87_first_19 @kc87_second_54 -140;
+    pos @kc87_first_19 @kc87_second_63 -70;
+    pos @kc87_first_19 @kc87_second_65 -35;
+    pos @kc87_first_19 @kc87_second_66 -105;
+    pos @kc87_first_19 @kc87_second_67 -70;
     pos @kc87_first_20 @kc87_second_12 -240;
     pos @kc87_first_20 @kc87_second_13 -140;
     pos @kc87_first_20 @kc87_second_14 -105;
     pos @kc87_first_20 @kc87_second_15 -35;
-    pos @kc87_first_20 @kc87_second_48 1;
+    pos @kc87_first_20 @kc87_second_51 1;
     pos @kc87_first_21 @kc87_second_8 -35;
     pos @kc87_first_21 @kc87_second_9 -140;
     pos @kc87_first_21 @kc87_second_12 -280;
@@ -9176,25 +9219,26 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_21 @kc87_second_22 -70;
     pos @kc87_first_21 @kc87_second_27 -70;
     pos @kc87_first_21 @kc87_second_33 -50;
-    pos @kc87_first_21 @kc87_second_42 -140;
-    pos @kc87_first_21 @kc87_second_43 -105;
-    pos @kc87_first_21 @kc87_second_46 -210;
-    pos @kc87_first_21 @kc87_second_48 1;
-    pos @kc87_first_21 @kc87_second_49 -35;
-    pos @kc87_first_21 @kc87_second_50 -140;
-    pos @kc87_first_21 @kc87_second_51 -210;
-    pos @kc87_first_21 @kc87_second_55 -35;
-    pos @kc87_first_21 @kc87_second_61 -105;
+    pos @kc87_first_21 @kc87_second_44 -140;
+    pos @kc87_first_21 @kc87_second_45 -105;
+    pos @kc87_first_21 @kc87_second_47 -210;
+    pos @kc87_first_21 @kc87_second_48 -175;
+    pos @kc87_first_21 @kc87_second_51 1;
+    pos @kc87_first_21 @kc87_second_52 -35;
+    pos @kc87_first_21 @kc87_second_53 -140;
+    pos @kc87_first_21 @kc87_second_54 -210;
+    pos @kc87_first_21 @kc87_second_57 -35;
     pos @kc87_first_21 @kc87_second_63 -105;
-    pos @kc87_first_21 @kc87_second_64 -210;
-    pos @kc87_first_21 @kc87_second_65 -140;
+    pos @kc87_first_21 @kc87_second_65 -105;
+    pos @kc87_first_21 @kc87_second_66 -210;
+    pos @kc87_first_21 @kc87_second_67 -140;
     pos @kc87_first_22 @kc87_second_1 -140;
     pos @kc87_first_22 @kc87_second_2 -350;
     pos @kc87_first_22 @kc87_second_19 -140;
     pos @kc87_first_22 @kc87_second_21 -280;
-    pos @kc87_first_22 @kc87_second_41 -70;
-    pos @kc87_first_22 @kc87_second_48 1;
-    pos @kc87_first_22 @kc87_second_67 -210;
+    pos @kc87_first_22 @kc87_second_43 -70;
+    pos @kc87_first_22 @kc87_second_51 1;
+    pos @kc87_first_22 @kc87_second_69 -210;
     pos @kc87_first_23 @kc87_second_1 -35;
     pos @kc87_first_23 @kc87_second_5 -105;
     pos @kc87_first_23 @kc87_second_9 -70;
@@ -9207,21 +9251,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_23 @kc87_second_27 -35;
     pos @kc87_first_23 @kc87_second_28 -70;
     pos @kc87_first_23 @kc87_second_29 -105;
-    pos @kc87_first_23 @kc87_second_35 -35;
-    pos @kc87_first_23 @kc87_second_38 -70;
-    pos @kc87_first_23 @kc87_second_42 -70;
-    pos @kc87_first_23 @kc87_second_43 -35;
+    pos @kc87_first_23 @kc87_second_36 -35;
+    pos @kc87_first_23 @kc87_second_39 -70;
+    pos @kc87_first_23 @kc87_second_44 -70;
     pos @kc87_first_23 @kc87_second_45 -35;
-    pos @kc87_first_23 @kc87_second_46 -140;
-    pos @kc87_first_23 @kc87_second_48 1;
-    pos @kc87_first_23 @kc87_second_50 -70;
-    pos @kc87_first_23 @kc87_second_51 -175;
-    pos @kc87_first_23 @kc87_second_52 -35;
-    pos @kc87_first_23 @kc87_second_60 -105;
-    pos @kc87_first_23 @kc87_second_61 -35;
-    pos @kc87_first_23 @kc87_second_63 -50;
-    pos @kc87_first_23 @kc87_second_64 -105;
-    pos @kc87_first_23 @kc87_second_65 -70;
+    pos @kc87_first_23 @kc87_second_47 -140;
+    pos @kc87_first_23 @kc87_second_49 -35;
+    pos @kc87_first_23 @kc87_second_50 -35;
+    pos @kc87_first_23 @kc87_second_51 1;
+    pos @kc87_first_23 @kc87_second_53 -70;
+    pos @kc87_first_23 @kc87_second_54 -175;
+    pos @kc87_first_23 @kc87_second_62 -105;
+    pos @kc87_first_23 @kc87_second_63 -35;
+    pos @kc87_first_23 @kc87_second_65 -50;
+    pos @kc87_first_23 @kc87_second_66 -105;
+    pos @kc87_first_23 @kc87_second_67 -70;
     pos @kc87_first_24 @kc87_second_6 -35;
     pos @kc87_first_24 @kc87_second_12 -240;
     pos @kc87_first_24 @kc87_second_13 -175;
@@ -9230,17 +9274,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_24 @kc87_second_18 -70;
     pos @kc87_first_24 @kc87_second_24 -70;
     pos @kc87_first_24 @kc87_second_25 -35;
-    pos @kc87_first_24 @kc87_second_37 -35;
-    pos @kc87_first_24 @kc87_second_42 -35;
-    pos @kc87_first_24 @kc87_second_43 -35;
-    pos @kc87_first_24 @kc87_second_46 -70;
-    pos @kc87_first_24 @kc87_second_47 -35;
-    pos @kc87_first_24 @kc87_second_48 1;
-    pos @kc87_first_24 @kc87_second_51 -35;
-    pos @kc87_first_24 @kc87_second_61 -35;
-    pos @kc87_first_24 @kc87_second_65 -35;
-    pos @kc87_first_24 @kc87_second_66 -35;
+    pos @kc87_first_24 @kc87_second_38 -35;
+    pos @kc87_first_24 @kc87_second_40 -35;
+    pos @kc87_first_24 @kc87_second_44 -35;
+    pos @kc87_first_24 @kc87_second_45 -35;
+    pos @kc87_first_24 @kc87_second_47 -70;
+    pos @kc87_first_24 @kc87_second_51 1;
+    pos @kc87_first_24 @kc87_second_54 -35;
+    pos @kc87_first_24 @kc87_second_63 -35;
     pos @kc87_first_24 @kc87_second_67 -35;
+    pos @kc87_first_24 @kc87_second_68 -35;
+    pos @kc87_first_24 @kc87_second_69 -35;
     pos @kc87_first_25 @kc87_second_1 -70;
     pos @kc87_first_25 @kc87_second_2 -140;
     pos @kc87_first_25 @kc87_second_5 -105;
@@ -9253,19 +9297,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_25 @kc87_second_21 -70;
     pos @kc87_first_25 @kc87_second_28 -70;
     pos @kc87_first_25 @kc87_second_29 -70;
-    pos @kc87_first_25 @kc87_second_34 -70;
-    pos @kc87_first_25 @kc87_second_38 -70;
-    pos @kc87_first_25 @kc87_second_45 -35;
-    pos @kc87_first_25 @kc87_second_46 -140;
-    pos @kc87_first_25 @kc87_second_48 1;
-    pos @kc87_first_25 @kc87_second_51 -140;
-    pos @kc87_first_25 @kc87_second_52 -35;
-    pos @kc87_first_25 @kc87_second_56 -140;
-    pos @kc87_first_25 @kc87_second_58 -70;
-    pos @kc87_first_25 @kc87_second_59 -105;
+    pos @kc87_first_25 @kc87_second_35 -70;
+    pos @kc87_first_25 @kc87_second_39 -70;
+    pos @kc87_first_25 @kc87_second_47 -140;
+    pos @kc87_first_25 @kc87_second_49 -35;
+    pos @kc87_first_25 @kc87_second_50 -35;
+    pos @kc87_first_25 @kc87_second_51 1;
+    pos @kc87_first_25 @kc87_second_54 -140;
+    pos @kc87_first_25 @kc87_second_58 -140;
     pos @kc87_first_25 @kc87_second_60 -70;
-    pos @kc87_first_25 @kc87_second_64 -70;
-    pos @kc87_first_25 @kc87_second_65 -35;
+    pos @kc87_first_25 @kc87_second_61 -105;
+    pos @kc87_first_25 @kc87_second_62 -70;
+    pos @kc87_first_25 @kc87_second_66 -70;
+    pos @kc87_first_25 @kc87_second_67 -35;
     pos @kc87_first_26 @kc87_second_5 -70;
     pos @kc87_first_26 @kc87_second_9 -70;
     pos @kc87_first_26 @kc87_second_12 -240;
@@ -9276,32 +9320,33 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_26 @kc87_second_27 -35;
     pos @kc87_first_26 @kc87_second_28 -70;
     pos @kc87_first_26 @kc87_second_29 -70;
-    pos @kc87_first_26 @kc87_second_38 -70;
-    pos @kc87_first_26 @kc87_second_42 -70;
-    pos @kc87_first_26 @kc87_second_43 -35;
-    pos @kc87_first_26 @kc87_second_46 -140;
-    pos @kc87_first_26 @kc87_second_48 1;
-    pos @kc87_first_26 @kc87_second_50 -70;
-    pos @kc87_first_26 @kc87_second_51 -140;
-    pos @kc87_first_26 @kc87_second_52 -35;
-    pos @kc87_first_26 @kc87_second_56 -50;
-    pos @kc87_first_26 @kc87_second_57 -35;
+    pos @kc87_first_26 @kc87_second_39 -70;
+    pos @kc87_first_26 @kc87_second_44 -70;
+    pos @kc87_first_26 @kc87_second_45 -35;
+    pos @kc87_first_26 @kc87_second_47 -140;
+    pos @kc87_first_26 @kc87_second_48 -105;
+    pos @kc87_first_26 @kc87_second_50 -35;
+    pos @kc87_first_26 @kc87_second_51 1;
+    pos @kc87_first_26 @kc87_second_53 -70;
+    pos @kc87_first_26 @kc87_second_54 -140;
     pos @kc87_first_26 @kc87_second_58 -50;
-    pos @kc87_first_26 @kc87_second_59 -50;
-    pos @kc87_first_26 @kc87_second_60 -105;
+    pos @kc87_first_26 @kc87_second_59 -35;
+    pos @kc87_first_26 @kc87_second_60 -50;
     pos @kc87_first_26 @kc87_second_61 -50;
-    pos @kc87_first_26 @kc87_second_63 -35;
-    pos @kc87_first_26 @kc87_second_64 -105;
-    pos @kc87_first_26 @kc87_second_65 -70;
+    pos @kc87_first_26 @kc87_second_62 -105;
+    pos @kc87_first_26 @kc87_second_63 -50;
+    pos @kc87_first_26 @kc87_second_65 -35;
+    pos @kc87_first_26 @kc87_second_66 -105;
+    pos @kc87_first_26 @kc87_second_67 -70;
     pos @kc87_first_27 @kc87_second_9 -35;
     pos @kc87_first_27 @kc87_second_12 -140;
     pos @kc87_first_27 @kc87_second_28 -70;
-    pos @kc87_first_27 @kc87_second_42 -35;
-    pos @kc87_first_27 @kc87_second_46 -70;
-    pos @kc87_first_27 @kc87_second_48 1;
-    pos @kc87_first_27 @kc87_second_51 -70;
-    pos @kc87_first_27 @kc87_second_64 -70;
-    pos @kc87_first_27 @kc87_second_65 -35;
+    pos @kc87_first_27 @kc87_second_44 -35;
+    pos @kc87_first_27 @kc87_second_47 -70;
+    pos @kc87_first_27 @kc87_second_51 1;
+    pos @kc87_first_27 @kc87_second_54 -70;
+    pos @kc87_first_27 @kc87_second_66 -70;
+    pos @kc87_first_27 @kc87_second_67 -35;
     pos @kc87_first_28 @kc87_second_5 -50;
     pos @kc87_first_28 @kc87_second_9 -35;
     pos @kc87_first_28 @kc87_second_11 -35;
@@ -9312,18 +9357,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_28 @kc87_second_16 -35;
     pos @kc87_first_28 @kc87_second_28 -35;
     pos @kc87_first_28 @kc87_second_29 -35;
-    pos @kc87_first_28 @kc87_second_35 -35;
-    pos @kc87_first_28 @kc87_second_38 -35;
-    pos @kc87_first_28 @kc87_second_42 -50;
-    pos @kc87_first_28 @kc87_second_43 -35;
-    pos @kc87_first_28 @kc87_second_46 -100;
-    pos @kc87_first_28 @kc87_second_48 1;
-    pos @kc87_first_28 @kc87_second_50 -35;
-    pos @kc87_first_28 @kc87_second_51 -140;
-    pos @kc87_first_28 @kc87_second_60 -35;
-    pos @kc87_first_28 @kc87_second_64 -70;
-    pos @kc87_first_28 @kc87_second_65 -35;
-    pos @kc87_first_29 @kc87_second_48 1;
+    pos @kc87_first_28 @kc87_second_36 -35;
+    pos @kc87_first_28 @kc87_second_39 -35;
+    pos @kc87_first_28 @kc87_second_44 -50;
+    pos @kc87_first_28 @kc87_second_45 -35;
+    pos @kc87_first_28 @kc87_second_47 -100;
+    pos @kc87_first_28 @kc87_second_48 -35;
+    pos @kc87_first_28 @kc87_second_51 1;
+    pos @kc87_first_28 @kc87_second_53 -35;
+    pos @kc87_first_28 @kc87_second_54 -140;
+    pos @kc87_first_28 @kc87_second_62 -35;
+    pos @kc87_first_28 @kc87_second_66 -70;
+    pos @kc87_first_28 @kc87_second_67 -35;
+    pos @kc87_first_29 @kc87_second_51 1;
     pos @kc87_first_30 @kc87_second_8 -70;
     pos @kc87_first_30 @kc87_second_9 -210;
     pos @kc87_first_30 @kc87_second_12 -350;
@@ -9331,17 +9377,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_30 @kc87_second_14 -210;
     pos @kc87_first_30 @kc87_second_15 -175;
     pos @kc87_first_30 @kc87_second_27 -70;
-    pos @kc87_first_30 @kc87_second_41 -35;
-    pos @kc87_first_30 @kc87_second_42 -210;
-    pos @kc87_first_30 @kc87_second_43 -210;
-    pos @kc87_first_30 @kc87_second_46 -210;
-    pos @kc87_first_30 @kc87_second_48 1;
-    pos @kc87_first_30 @kc87_second_50 -140;
-    pos @kc87_first_30 @kc87_second_51 -280;
-    pos @kc87_first_30 @kc87_second_61 -210;
-    pos @kc87_first_30 @kc87_second_63 -105;
-    pos @kc87_first_30 @kc87_second_64 -175;
-    pos @kc87_first_30 @kc87_second_65 -140;
+    pos @kc87_first_30 @kc87_second_43 -35;
+    pos @kc87_first_30 @kc87_second_44 -210;
+    pos @kc87_first_30 @kc87_second_45 -210;
+    pos @kc87_first_30 @kc87_second_47 -210;
+    pos @kc87_first_30 @kc87_second_51 1;
+    pos @kc87_first_30 @kc87_second_53 -140;
+    pos @kc87_first_30 @kc87_second_54 -280;
+    pos @kc87_first_30 @kc87_second_63 -210;
+    pos @kc87_first_30 @kc87_second_65 -105;
+    pos @kc87_first_30 @kc87_second_66 -175;
+    pos @kc87_first_30 @kc87_second_67 -140;
     pos @kc87_first_31 @kc87_second_1 -175;
     pos @kc87_first_31 @kc87_second_2 -175;
     pos @kc87_first_31 @kc87_second_5 -70;
@@ -9359,16 +9405,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_31 @kc87_second_21 -175;
     pos @kc87_first_31 @kc87_second_24 -70;
     pos @kc87_first_31 @kc87_second_31 -105;
-    pos @kc87_first_31 @kc87_second_36 165;
-    pos @kc87_first_31 @kc87_second_37 -105;
-    pos @kc87_first_31 @kc87_second_38 -175;
-    pos @kc87_first_31 @kc87_second_39 -35;
-    pos @kc87_first_31 @kc87_second_41 -70;
-    pos @kc87_first_31 @kc87_second_48 1;
-    pos @kc87_first_31 @kc87_second_53 165;
-    pos @kc87_first_31 @kc87_second_54 -35;
-    pos @kc87_first_31 @kc87_second_66 -70;
-    pos @kc87_first_31 @kc87_second_67 -105;
+    pos @kc87_first_31 @kc87_second_37 165;
+    pos @kc87_first_31 @kc87_second_38 -105;
+    pos @kc87_first_31 @kc87_second_39 -175;
+    pos @kc87_first_31 @kc87_second_41 -35;
+    pos @kc87_first_31 @kc87_second_43 -70;
+    pos @kc87_first_31 @kc87_second_51 1;
+    pos @kc87_first_31 @kc87_second_55 165;
+    pos @kc87_first_31 @kc87_second_56 -35;
+    pos @kc87_first_31 @kc87_second_68 -70;
+    pos @kc87_first_31 @kc87_second_69 -105;
     pos @kc87_first_32 @kc87_second_3 -70;
     pos @kc87_first_32 @kc87_second_4 -35;
     pos @kc87_first_32 @kc87_second_6 -70;
@@ -9379,16 +9425,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_32 @kc87_second_24 -70;
     pos @kc87_first_32 @kc87_second_25 -140;
     pos @kc87_first_32 @kc87_second_31 -35;
-    pos @kc87_first_32 @kc87_second_37 -70;
-    pos @kc87_first_32 @kc87_second_39 -35;
-    pos @kc87_first_32 @kc87_second_41 -140;
-    pos @kc87_first_32 @kc87_second_42 -70;
-    pos @kc87_first_32 @kc87_second_48 1;
-    pos @kc87_first_32 @kc87_second_54 -35;
-    pos @kc87_first_32 @kc87_second_55 -35;
-    pos @kc87_first_32 @kc87_second_61 -140;
-    pos @kc87_first_32 @kc87_second_66 -70;
-    pos @kc87_first_32 @kc87_second_67 -70;
+    pos @kc87_first_32 @kc87_second_38 -70;
+    pos @kc87_first_32 @kc87_second_41 -35;
+    pos @kc87_first_32 @kc87_second_43 -140;
+    pos @kc87_first_32 @kc87_second_44 -70;
+    pos @kc87_first_32 @kc87_second_51 1;
+    pos @kc87_first_32 @kc87_second_56 -35;
+    pos @kc87_first_32 @kc87_second_57 -35;
+    pos @kc87_first_32 @kc87_second_63 -140;
+    pos @kc87_first_32 @kc87_second_68 -70;
+    pos @kc87_first_32 @kc87_second_69 -70;
     pos @kc87_first_33 @kc87_second_1 -35;
     pos @kc87_first_33 @kc87_second_2 -105;
     pos @kc87_first_33 @kc87_second_3 -70;
@@ -9403,21 +9449,22 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_33 @kc87_second_19 -70;
     pos @kc87_first_33 @kc87_second_26 -35;
     pos @kc87_first_33 @kc87_second_29 -70;
-    pos @kc87_first_33 @kc87_second_35 -35;
-    pos @kc87_first_33 @kc87_second_38 -35;
-    pos @kc87_first_33 @kc87_second_42 -35;
-    pos @kc87_first_33 @kc87_second_43 -35;
+    pos @kc87_first_33 @kc87_second_36 -35;
+    pos @kc87_first_33 @kc87_second_39 -35;
+    pos @kc87_first_33 @kc87_second_44 -35;
     pos @kc87_first_33 @kc87_second_45 -35;
-    pos @kc87_first_33 @kc87_second_46 -140;
-    pos @kc87_first_33 @kc87_second_48 1;
-    pos @kc87_first_33 @kc87_second_50 -50;
-    pos @kc87_first_33 @kc87_second_51 -140;
-    pos @kc87_first_33 @kc87_second_52 -35;
-    pos @kc87_first_33 @kc87_second_56 -70;
+    pos @kc87_first_33 @kc87_second_47 -140;
+    pos @kc87_first_33 @kc87_second_48 -70;
+    pos @kc87_first_33 @kc87_second_49 -35;
+    pos @kc87_first_33 @kc87_second_50 -35;
+    pos @kc87_first_33 @kc87_second_51 1;
+    pos @kc87_first_33 @kc87_second_53 -50;
+    pos @kc87_first_33 @kc87_second_54 -140;
     pos @kc87_first_33 @kc87_second_58 -70;
-    pos @kc87_first_33 @kc87_second_59 -70;
-    pos @kc87_first_33 @kc87_second_64 -70;
-    pos @kc87_first_33 @kc87_second_65 -35;
+    pos @kc87_first_33 @kc87_second_60 -70;
+    pos @kc87_first_33 @kc87_second_61 -70;
+    pos @kc87_first_33 @kc87_second_66 -70;
+    pos @kc87_first_33 @kc87_second_67 -35;
     pos @kc87_first_34 @kc87_second_3 -35;
     pos @kc87_first_34 @kc87_second_4 -70;
     pos @kc87_first_34 @kc87_second_6 -70;
@@ -9431,35 +9478,36 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_34 @kc87_second_24 -105;
     pos @kc87_first_34 @kc87_second_25 -70;
     pos @kc87_first_34 @kc87_second_31 -35;
-    pos @kc87_first_34 @kc87_second_37 -70;
-    pos @kc87_first_34 @kc87_second_39 -70;
-    pos @kc87_first_34 @kc87_second_41 -105;
-    pos @kc87_first_34 @kc87_second_42 -70;
-    pos @kc87_first_34 @kc87_second_47 -70;
-    pos @kc87_first_34 @kc87_second_48 1;
-    pos @kc87_first_34 @kc87_second_54 -35;
-    pos @kc87_first_34 @kc87_second_55 -35;
-    pos @kc87_first_34 @kc87_second_66 -70;
-    pos @kc87_first_34 @kc87_second_67 -70;
-    pos @kc87_first_35 @kc87_second_34 -315;
-    pos @kc87_first_35 @kc87_second_48 1;
+    pos @kc87_first_34 @kc87_second_34 -70;
+    pos @kc87_first_34 @kc87_second_38 -70;
+    pos @kc87_first_34 @kc87_second_40 -70;
+    pos @kc87_first_34 @kc87_second_41 -70;
+    pos @kc87_first_34 @kc87_second_43 -105;
+    pos @kc87_first_34 @kc87_second_44 -70;
+    pos @kc87_first_34 @kc87_second_51 1;
+    pos @kc87_first_34 @kc87_second_56 -35;
+    pos @kc87_first_34 @kc87_second_57 -35;
+    pos @kc87_first_34 @kc87_second_68 -70;
+    pos @kc87_first_34 @kc87_second_69 -70;
+    pos @kc87_first_35 @kc87_second_35 -315;
+    pos @kc87_first_35 @kc87_second_51 1;
     pos @kc87_first_36 @kc87_second_9 -70;
     pos @kc87_first_36 @kc87_second_12 -240;
     pos @kc87_first_36 @kc87_second_13 -210;
     pos @kc87_first_36 @kc87_second_14 -140;
     pos @kc87_first_36 @kc87_second_15 -105;
-    pos @kc87_first_36 @kc87_second_36 70;
-    pos @kc87_first_36 @kc87_second_42 -70;
-    pos @kc87_first_36 @kc87_second_43 -35;
-    pos @kc87_first_36 @kc87_second_46 -140;
-    pos @kc87_first_36 @kc87_second_48 1;
-    pos @kc87_first_36 @kc87_second_50 -50;
-    pos @kc87_first_36 @kc87_second_51 -140;
-    pos @kc87_first_36 @kc87_second_53 165;
-    pos @kc87_first_36 @kc87_second_61 -35;
+    pos @kc87_first_36 @kc87_second_37 70;
+    pos @kc87_first_36 @kc87_second_44 -70;
+    pos @kc87_first_36 @kc87_second_45 -35;
+    pos @kc87_first_36 @kc87_second_47 -140;
+    pos @kc87_first_36 @kc87_second_51 1;
+    pos @kc87_first_36 @kc87_second_53 -50;
+    pos @kc87_first_36 @kc87_second_54 -140;
+    pos @kc87_first_36 @kc87_second_55 165;
     pos @kc87_first_36 @kc87_second_63 -35;
-    pos @kc87_first_36 @kc87_second_64 -70;
-    pos @kc87_first_36 @kc87_second_65 -70;
+    pos @kc87_first_36 @kc87_second_65 -35;
+    pos @kc87_first_36 @kc87_second_66 -70;
+    pos @kc87_first_36 @kc87_second_67 -70;
     pos @kc87_first_37 @kc87_second_9 -35;
     pos @kc87_first_37 @kc87_second_12 -240;
     pos @kc87_first_37 @kc87_second_13 -240;
@@ -9468,15 +9516,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_37 @kc87_second_16 -35;
     pos @kc87_first_37 @kc87_second_28 -35;
     pos @kc87_first_37 @kc87_second_29 -35;
-    pos @kc87_first_37 @kc87_second_42 -70;
-    pos @kc87_first_37 @kc87_second_43 -35;
-    pos @kc87_first_37 @kc87_second_46 -70;
-    pos @kc87_first_37 @kc87_second_48 1;
-    pos @kc87_first_37 @kc87_second_50 -35;
-    pos @kc87_first_37 @kc87_second_51 -70;
-    pos @kc87_first_37 @kc87_second_63 -35;
-    pos @kc87_first_37 @kc87_second_64 -70;
-    pos @kc87_first_37 @kc87_second_65 -70;
+    pos @kc87_first_37 @kc87_second_44 -70;
+    pos @kc87_first_37 @kc87_second_45 -35;
+    pos @kc87_first_37 @kc87_second_47 -70;
+    pos @kc87_first_37 @kc87_second_48 -35;
+    pos @kc87_first_37 @kc87_second_51 1;
+    pos @kc87_first_37 @kc87_second_53 -35;
+    pos @kc87_first_37 @kc87_second_54 -70;
+    pos @kc87_first_37 @kc87_second_65 -35;
+    pos @kc87_first_37 @kc87_second_66 -70;
+    pos @kc87_first_37 @kc87_second_67 -70;
     pos @kc87_first_38 @kc87_second_5 -70;
     pos @kc87_first_38 @kc87_second_9 -70;
     pos @kc87_first_38 @kc87_second_12 -140;
@@ -9486,664 +9535,680 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_38 @kc87_second_16 -70;
     pos @kc87_first_38 @kc87_second_28 -70;
     pos @kc87_first_38 @kc87_second_29 -70;
-    pos @kc87_first_38 @kc87_second_38 -50;
-    pos @kc87_first_38 @kc87_second_42 -50;
-    pos @kc87_first_38 @kc87_second_43 -35;
-    pos @kc87_first_38 @kc87_second_48 1;
-    pos @kc87_first_38 @kc87_second_50 -35;
-    pos @kc87_first_38 @kc87_second_51 -140;
-    pos @kc87_first_38 @kc87_second_60 -35;
-    pos @kc87_first_38 @kc87_second_64 -70;
-    pos @kc87_first_38 @kc87_second_65 -35;
-    pos @kc87_first_39 @kc87_second_1 -210;
-    pos @kc87_first_39 @kc87_second_2 -280;
-    pos @kc87_first_39 @kc87_second_6 -280;
-    pos @kc87_first_39 @kc87_second_8 -70;
-    pos @kc87_first_39 @kc87_second_17 -140;
-    pos @kc87_first_39 @kc87_second_18 -140;
-    pos @kc87_first_39 @kc87_second_19 -245;
-    pos @kc87_first_39 @kc87_second_21 -350;
-    pos @kc87_first_39 @kc87_second_22 -140;
-    pos @kc87_first_39 @kc87_second_24 -140;
-    pos @kc87_first_39 @kc87_second_25 -70;
-    pos @kc87_first_39 @kc87_second_26 -280;
-    pos @kc87_first_39 @kc87_second_30 -315;
-    pos @kc87_first_39 @kc87_second_31 -140;
-    pos @kc87_first_39 @kc87_second_34 -385;
-    pos @kc87_first_39 @kc87_second_35 -140;
-    pos @kc87_first_39 @kc87_second_37 -210;
+    pos @kc87_first_38 @kc87_second_39 -50;
+    pos @kc87_first_38 @kc87_second_44 -50;
+    pos @kc87_first_38 @kc87_second_45 -35;
+    pos @kc87_first_38 @kc87_second_51 1;
+    pos @kc87_first_38 @kc87_second_53 -35;
+    pos @kc87_first_38 @kc87_second_54 -140;
+    pos @kc87_first_38 @kc87_second_62 -35;
+    pos @kc87_first_38 @kc87_second_66 -70;
+    pos @kc87_first_38 @kc87_second_67 -35;
+    pos @kc87_first_39 @kc87_second_3 -140;
+    pos @kc87_first_39 @kc87_second_4 -70;
+    pos @kc87_first_39 @kc87_second_6 -70;
+    pos @kc87_first_39 @kc87_second_8 -210;
+    pos @kc87_first_39 @kc87_second_9 -420;
+    pos @kc87_first_39 @kc87_second_12 -350;
+    pos @kc87_first_39 @kc87_second_13 -420;
+    pos @kc87_first_39 @kc87_second_14 -350;
+    pos @kc87_first_39 @kc87_second_15 -280;
+    pos @kc87_first_39 @kc87_second_17 -70;
+    pos @kc87_first_39 @kc87_second_18 -70;
+    pos @kc87_first_39 @kc87_second_20 -210;
+    pos @kc87_first_39 @kc87_second_22 -210;
+    pos @kc87_first_39 @kc87_second_24 -70;
+    pos @kc87_first_39 @kc87_second_25 -140;
+    pos @kc87_first_39 @kc87_second_31 -35;
+    pos @kc87_first_39 @kc87_second_33 -140;
     pos @kc87_first_39 @kc87_second_38 -70;
-    pos @kc87_first_39 @kc87_second_39 -140;
-    pos @kc87_first_39 @kc87_second_40 -140;
-    pos @kc87_first_39 @kc87_second_41 -140;
-    pos @kc87_first_39 @kc87_second_42 -70;
-    pos @kc87_first_39 @kc87_second_44 -70;
-    pos @kc87_first_39 @kc87_second_48 1;
-    pos @kc87_first_39 @kc87_second_54 -140;
-    pos @kc87_first_39 @kc87_second_55 -70;
-    pos @kc87_first_39 @kc87_second_56 -140;
-    pos @kc87_first_39 @kc87_second_58 -245;
-    pos @kc87_first_39 @kc87_second_59 -210;
-    pos @kc87_first_39 @kc87_second_60 -70;
-    pos @kc87_first_39 @kc87_second_61 -70;
-    pos @kc87_first_39 @kc87_second_62 -70;
-    pos @kc87_first_39 @kc87_second_63 -70;
-    pos @kc87_first_39 @kc87_second_66 -245;
-    pos @kc87_first_39 @kc87_second_67 -280;
-    pos @kc87_first_39 @kc87_second_68 -315;
+    pos @kc87_first_39 @kc87_second_41 -70;
+    pos @kc87_first_39 @kc87_second_43 -210;
+    pos @kc87_first_39 @kc87_second_44 -280;
+    pos @kc87_first_39 @kc87_second_45 -420;
+    pos @kc87_first_39 @kc87_second_47 -350;
+    pos @kc87_first_39 @kc87_second_48 -280;
+    pos @kc87_first_39 @kc87_second_51 1;
+    pos @kc87_first_39 @kc87_second_52 -35;
+    pos @kc87_first_39 @kc87_second_53 -210;
+    pos @kc87_first_39 @kc87_second_54 -350;
+    pos @kc87_first_39 @kc87_second_56 -35;
+    pos @kc87_first_39 @kc87_second_57 -35;
+    pos @kc87_first_39 @kc87_second_63 -280;
+    pos @kc87_first_39 @kc87_second_65 -175;
+    pos @kc87_first_39 @kc87_second_66 -280;
+    pos @kc87_first_39 @kc87_second_67 -210;
+    pos @kc87_first_39 @kc87_second_68 -70;
+    pos @kc87_first_40 @kc87_second_1 -35;
+    pos @kc87_first_40 @kc87_second_2 -70;
+    pos @kc87_first_40 @kc87_second_5 -105;
     pos @kc87_first_40 @kc87_second_6 -35;
+    pos @kc87_first_40 @kc87_second_9 -70;
+    pos @kc87_first_40 @kc87_second_11 -70;
     pos @kc87_first_40 @kc87_second_12 -240;
-    pos @kc87_first_40 @kc87_second_13 -140;
-    pos @kc87_first_40 @kc87_second_14 -35;
-    pos @kc87_first_40 @kc87_second_15 -35;
-    pos @kc87_first_40 @kc87_second_37 -35;
-    pos @kc87_first_40 @kc87_second_48 1;
-    pos @kc87_first_40 @kc87_second_53 105;
-    pos @kc87_first_40 @kc87_second_66 -35;
-    pos @kc87_first_40 @kc87_second_67 -35;
-    pos @kc87_first_41 @kc87_second_12 -210;
-    pos @kc87_first_41 @kc87_second_13 -175;
-    pos @kc87_first_41 @kc87_second_14 -105;
-    pos @kc87_first_41 @kc87_second_15 -70;
+    pos @kc87_first_40 @kc87_second_13 -245;
+    pos @kc87_first_40 @kc87_second_14 -140;
+    pos @kc87_first_40 @kc87_second_15 -105;
+    pos @kc87_first_40 @kc87_second_16 -105;
+    pos @kc87_first_40 @kc87_second_19 -35;
+    pos @kc87_first_40 @kc87_second_20 -70;
+    pos @kc87_first_40 @kc87_second_21 -70;
+    pos @kc87_first_40 @kc87_second_26 -35;
+    pos @kc87_first_40 @kc87_second_27 -70;
+    pos @kc87_first_40 @kc87_second_28 -140;
+    pos @kc87_first_40 @kc87_second_29 -105;
+    pos @kc87_first_40 @kc87_second_36 -35;
+    pos @kc87_first_40 @kc87_second_38 -35;
+    pos @kc87_first_40 @kc87_second_39 -140;
+    pos @kc87_first_40 @kc87_second_44 -105;
+    pos @kc87_first_40 @kc87_second_45 -70;
+    pos @kc87_first_40 @kc87_second_47 -175;
+    pos @kc87_first_40 @kc87_second_49 -105;
+    pos @kc87_first_40 @kc87_second_50 -70;
+    pos @kc87_first_40 @kc87_second_51 1;
+    pos @kc87_first_40 @kc87_second_53 -70;
+    pos @kc87_first_40 @kc87_second_54 -140;
+    pos @kc87_first_40 @kc87_second_58 -210;
+    pos @kc87_first_40 @kc87_second_59 -70;
+    pos @kc87_first_40 @kc87_second_60 -175;
+    pos @kc87_first_40 @kc87_second_61 -175;
+    pos @kc87_first_40 @kc87_second_62 -105;
+    pos @kc87_first_40 @kc87_second_65 -50;
+    pos @kc87_first_40 @kc87_second_66 -105;
+    pos @kc87_first_40 @kc87_second_67 -70;
+    pos @kc87_first_40 @kc87_second_69 -35;
+    pos @kc87_first_41 @kc87_second_1 -210;
+    pos @kc87_first_41 @kc87_second_2 -280;
+    pos @kc87_first_41 @kc87_second_6 -280;
+    pos @kc87_first_41 @kc87_second_8 -70;
+    pos @kc87_first_41 @kc87_second_17 -140;
+    pos @kc87_first_41 @kc87_second_18 -140;
+    pos @kc87_first_41 @kc87_second_19 -245;
+    pos @kc87_first_41 @kc87_second_21 -350;
+    pos @kc87_first_41 @kc87_second_22 -140;
+    pos @kc87_first_41 @kc87_second_24 -140;
+    pos @kc87_first_41 @kc87_second_25 -70;
+    pos @kc87_first_41 @kc87_second_26 -280;
+    pos @kc87_first_41 @kc87_second_30 -315;
+    pos @kc87_first_41 @kc87_second_31 -140;
+    pos @kc87_first_41 @kc87_second_35 -385;
+    pos @kc87_first_41 @kc87_second_36 -140;
+    pos @kc87_first_41 @kc87_second_38 -210;
+    pos @kc87_first_41 @kc87_second_39 -70;
+    pos @kc87_first_41 @kc87_second_41 -140;
+    pos @kc87_first_41 @kc87_second_42 -140;
+    pos @kc87_first_41 @kc87_second_43 -140;
+    pos @kc87_first_41 @kc87_second_44 -70;
     pos @kc87_first_41 @kc87_second_46 -70;
-    pos @kc87_first_41 @kc87_second_48 1;
-    pos @kc87_first_41 @kc87_second_51 -105;
+    pos @kc87_first_41 @kc87_second_51 1;
+    pos @kc87_first_41 @kc87_second_56 -140;
+    pos @kc87_first_41 @kc87_second_57 -70;
+    pos @kc87_first_41 @kc87_second_58 -140;
+    pos @kc87_first_41 @kc87_second_60 -245;
+    pos @kc87_first_41 @kc87_second_61 -210;
+    pos @kc87_first_41 @kc87_second_62 -70;
+    pos @kc87_first_41 @kc87_second_63 -70;
     pos @kc87_first_41 @kc87_second_64 -70;
-    pos @kc87_first_42 @kc87_second_1 -140;
-    pos @kc87_first_42 @kc87_second_2 -175;
-    pos @kc87_first_42 @kc87_second_5 -105;
-    pos @kc87_first_42 @kc87_second_6 -70;
-    pos @kc87_first_42 @kc87_second_11 -70;
-    pos @kc87_first_42 @kc87_second_12 -175;
-    pos @kc87_first_42 @kc87_second_13 -105;
-    pos @kc87_first_42 @kc87_second_14 -70;
+    pos @kc87_first_41 @kc87_second_65 -70;
+    pos @kc87_first_41 @kc87_second_68 -245;
+    pos @kc87_first_41 @kc87_second_69 -280;
+    pos @kc87_first_41 @kc87_second_70 -315;
+    pos @kc87_first_42 @kc87_second_6 -35;
+    pos @kc87_first_42 @kc87_second_12 -240;
+    pos @kc87_first_42 @kc87_second_13 -140;
+    pos @kc87_first_42 @kc87_second_14 -35;
     pos @kc87_first_42 @kc87_second_15 -35;
-    pos @kc87_first_42 @kc87_second_16 -105;
-    pos @kc87_first_42 @kc87_second_17 -35;
-    pos @kc87_first_42 @kc87_second_18 -50;
-    pos @kc87_first_42 @kc87_second_19 -140;
-    pos @kc87_first_42 @kc87_second_21 -175;
-    pos @kc87_first_42 @kc87_second_24 -50;
-    pos @kc87_first_42 @kc87_second_26 -105;
-    pos @kc87_first_42 @kc87_second_31 -35;
-    pos @kc87_first_42 @kc87_second_34 -70;
-    pos @kc87_first_42 @kc87_second_35 -50;
-    pos @kc87_first_42 @kc87_second_37 -70;
-    pos @kc87_first_42 @kc87_second_38 -140;
-    pos @kc87_first_42 @kc87_second_39 -35;
-    pos @kc87_first_42 @kc87_second_41 -50;
-    pos @kc87_first_42 @kc87_second_48 1;
-    pos @kc87_first_42 @kc87_second_54 -35;
-    pos @kc87_first_42 @kc87_second_56 -105;
-    pos @kc87_first_42 @kc87_second_58 -105;
-    pos @kc87_first_42 @kc87_second_59 -105;
-    pos @kc87_first_42 @kc87_second_66 -50;
-    pos @kc87_first_42 @kc87_second_67 -70;
-    pos @kc87_first_43 @kc87_second_1 -210;
-    pos @kc87_first_43 @kc87_second_2 -280;
-    pos @kc87_first_43 @kc87_second_3 -70;
-    pos @kc87_first_43 @kc87_second_6 -280;
-    pos @kc87_first_43 @kc87_second_8 -35;
-    pos @kc87_first_43 @kc87_second_11 -70;
-    pos @kc87_first_43 @kc87_second_13 -140;
-    pos @kc87_first_43 @kc87_second_14 -35;
-    pos @kc87_first_43 @kc87_second_15 -35;
-    pos @kc87_first_43 @kc87_second_16 -140;
-    pos @kc87_first_43 @kc87_second_17 -105;
-    pos @kc87_first_43 @kc87_second_18 -140;
-    pos @kc87_first_43 @kc87_second_19 -210;
-    pos @kc87_first_43 @kc87_second_21 -280;
-    pos @kc87_first_43 @kc87_second_22 -140;
-    pos @kc87_first_43 @kc87_second_24 -140;
-    pos @kc87_first_43 @kc87_second_25 -140;
-    pos @kc87_first_43 @kc87_second_26 -210;
-    pos @kc87_first_43 @kc87_second_34 -140;
-    pos @kc87_first_43 @kc87_second_35 -140;
-    pos @kc87_first_43 @kc87_second_37 -280;
-    pos @kc87_first_43 @kc87_second_38 -140;
-    pos @kc87_first_43 @kc87_second_39 -70;
-    pos @kc87_first_43 @kc87_second_40 -140;
-    pos @kc87_first_43 @kc87_second_41 -175;
+    pos @kc87_first_42 @kc87_second_38 -35;
+    pos @kc87_first_42 @kc87_second_51 1;
+    pos @kc87_first_42 @kc87_second_55 105;
+    pos @kc87_first_42 @kc87_second_68 -35;
+    pos @kc87_first_42 @kc87_second_69 -35;
+    pos @kc87_first_43 @kc87_second_12 -210;
+    pos @kc87_first_43 @kc87_second_13 -175;
+    pos @kc87_first_43 @kc87_second_14 -105;
+    pos @kc87_first_43 @kc87_second_15 -70;
     pos @kc87_first_43 @kc87_second_47 -70;
-    pos @kc87_first_43 @kc87_second_48 1;
-    pos @kc87_first_43 @kc87_second_56 -210;
-    pos @kc87_first_43 @kc87_second_58 -210;
-    pos @kc87_first_43 @kc87_second_59 -175;
-    pos @kc87_first_43 @kc87_second_62 -70;
-    pos @kc87_first_43 @kc87_second_66 -175;
-    pos @kc87_first_43 @kc87_second_67 -175;
-    pos @kc87_first_44 @kc87_second_9 -70;
-    pos @kc87_first_44 @kc87_second_12 -240;
-    pos @kc87_first_44 @kc87_second_13 -210;
-    pos @kc87_first_44 @kc87_second_14 -140;
-    pos @kc87_first_44 @kc87_second_15 -105;
-    pos @kc87_first_44 @kc87_second_42 -70;
-    pos @kc87_first_44 @kc87_second_43 -35;
-    pos @kc87_first_44 @kc87_second_46 -140;
-    pos @kc87_first_44 @kc87_second_48 1;
-    pos @kc87_first_44 @kc87_second_50 -50;
-    pos @kc87_first_44 @kc87_second_51 -140;
-    pos @kc87_first_44 @kc87_second_61 -35;
-    pos @kc87_first_44 @kc87_second_63 -35;
-    pos @kc87_first_44 @kc87_second_64 -70;
-    pos @kc87_first_44 @kc87_second_65 -70;
+    pos @kc87_first_43 @kc87_second_48 -35;
+    pos @kc87_first_43 @kc87_second_51 1;
+    pos @kc87_first_43 @kc87_second_54 -105;
+    pos @kc87_first_43 @kc87_second_66 -70;
+    pos @kc87_first_44 @kc87_second_1 -140;
+    pos @kc87_first_44 @kc87_second_2 -175;
+    pos @kc87_first_44 @kc87_second_5 -105;
+    pos @kc87_first_44 @kc87_second_6 -70;
+    pos @kc87_first_44 @kc87_second_11 -70;
+    pos @kc87_first_44 @kc87_second_12 -175;
+    pos @kc87_first_44 @kc87_second_13 -105;
+    pos @kc87_first_44 @kc87_second_14 -70;
+    pos @kc87_first_44 @kc87_second_15 -35;
+    pos @kc87_first_44 @kc87_second_16 -105;
+    pos @kc87_first_44 @kc87_second_17 -35;
+    pos @kc87_first_44 @kc87_second_18 -50;
+    pos @kc87_first_44 @kc87_second_19 -140;
+    pos @kc87_first_44 @kc87_second_21 -175;
+    pos @kc87_first_44 @kc87_second_24 -50;
+    pos @kc87_first_44 @kc87_second_26 -105;
+    pos @kc87_first_44 @kc87_second_31 -35;
+    pos @kc87_first_44 @kc87_second_34 -70;
+    pos @kc87_first_44 @kc87_second_35 -70;
+    pos @kc87_first_44 @kc87_second_36 -50;
+    pos @kc87_first_44 @kc87_second_38 -70;
+    pos @kc87_first_44 @kc87_second_39 -140;
+    pos @kc87_first_44 @kc87_second_41 -35;
+    pos @kc87_first_44 @kc87_second_43 -50;
+    pos @kc87_first_44 @kc87_second_51 1;
+    pos @kc87_first_44 @kc87_second_56 -35;
+    pos @kc87_first_44 @kc87_second_58 -105;
+    pos @kc87_first_44 @kc87_second_60 -105;
+    pos @kc87_first_44 @kc87_second_61 -105;
+    pos @kc87_first_44 @kc87_second_68 -50;
+    pos @kc87_first_44 @kc87_second_69 -70;
+    pos @kc87_first_45 @kc87_second_1 -210;
+    pos @kc87_first_45 @kc87_second_2 -280;
+    pos @kc87_first_45 @kc87_second_3 -70;
+    pos @kc87_first_45 @kc87_second_6 -280;
     pos @kc87_first_45 @kc87_second_8 -35;
-    pos @kc87_first_45 @kc87_second_9 -70;
-    pos @kc87_first_45 @kc87_second_12 -240;
-    pos @kc87_first_45 @kc87_second_13 -210;
-    pos @kc87_first_45 @kc87_second_14 -70;
-    pos @kc87_first_45 @kc87_second_15 -105;
-    pos @kc87_first_45 @kc87_second_18 -35;
-    pos @kc87_first_45 @kc87_second_24 -35;
+    pos @kc87_first_45 @kc87_second_11 -70;
+    pos @kc87_first_45 @kc87_second_13 -140;
+    pos @kc87_first_45 @kc87_second_14 -35;
+    pos @kc87_first_45 @kc87_second_15 -35;
+    pos @kc87_first_45 @kc87_second_16 -140;
+    pos @kc87_first_45 @kc87_second_17 -105;
+    pos @kc87_first_45 @kc87_second_18 -140;
+    pos @kc87_first_45 @kc87_second_19 -210;
+    pos @kc87_first_45 @kc87_second_21 -280;
+    pos @kc87_first_45 @kc87_second_22 -140;
+    pos @kc87_first_45 @kc87_second_24 -140;
+    pos @kc87_first_45 @kc87_second_25 -140;
+    pos @kc87_first_45 @kc87_second_26 -210;
+    pos @kc87_first_45 @kc87_second_34 -70;
+    pos @kc87_first_45 @kc87_second_35 -140;
+    pos @kc87_first_45 @kc87_second_36 -140;
+    pos @kc87_first_45 @kc87_second_38 -280;
+    pos @kc87_first_45 @kc87_second_39 -140;
+    pos @kc87_first_45 @kc87_second_40 -70;
     pos @kc87_first_45 @kc87_second_41 -70;
-    pos @kc87_first_45 @kc87_second_42 -105;
-    pos @kc87_first_45 @kc87_second_43 -70;
-    pos @kc87_first_45 @kc87_second_46 -70;
-    pos @kc87_first_45 @kc87_second_47 -35;
-    pos @kc87_first_45 @kc87_second_48 1;
-    pos @kc87_first_45 @kc87_second_50 -70;
-    pos @kc87_first_45 @kc87_second_51 -70;
-    pos @kc87_first_45 @kc87_second_61 -70;
-    pos @kc87_first_45 @kc87_second_63 -50;
-    pos @kc87_first_45 @kc87_second_65 -70;
-    pos @kc87_first_45 @kc87_second_66 -35;
-    pos @kc87_first_45 @kc87_second_67 -35;
-    pos @kc87_first_46 @kc87_second_6 -70;
-    pos @kc87_first_46 @kc87_second_8 -35;
-    pos @kc87_first_46 @kc87_second_12 -175;
-    pos @kc87_first_46 @kc87_second_13 -140;
-    pos @kc87_first_46 @kc87_second_14 -70;
-    pos @kc87_first_46 @kc87_second_15 -35;
-    pos @kc87_first_46 @kc87_second_17 -70;
-    pos @kc87_first_46 @kc87_second_18 -105;
-    pos @kc87_first_46 @kc87_second_22 -70;
-    pos @kc87_first_46 @kc87_second_24 -105;
-    pos @kc87_first_46 @kc87_second_31 -35;
-    pos @kc87_first_46 @kc87_second_37 -70;
-    pos @kc87_first_46 @kc87_second_39 -35;
-    pos @kc87_first_46 @kc87_second_41 -105;
-    pos @kc87_first_46 @kc87_second_48 1;
-    pos @kc87_first_46 @kc87_second_54 -35;
+    pos @kc87_first_45 @kc87_second_42 -140;
+    pos @kc87_first_45 @kc87_second_43 -175;
+    pos @kc87_first_45 @kc87_second_51 1;
+    pos @kc87_first_45 @kc87_second_58 -210;
+    pos @kc87_first_45 @kc87_second_60 -210;
+    pos @kc87_first_45 @kc87_second_61 -175;
+    pos @kc87_first_45 @kc87_second_64 -70;
+    pos @kc87_first_45 @kc87_second_68 -175;
+    pos @kc87_first_45 @kc87_second_69 -175;
+    pos @kc87_first_46 @kc87_second_9 -70;
+    pos @kc87_first_46 @kc87_second_12 -240;
+    pos @kc87_first_46 @kc87_second_13 -210;
+    pos @kc87_first_46 @kc87_second_14 -140;
+    pos @kc87_first_46 @kc87_second_15 -105;
+    pos @kc87_first_46 @kc87_second_44 -70;
+    pos @kc87_first_46 @kc87_second_45 -35;
+    pos @kc87_first_46 @kc87_second_47 -140;
+    pos @kc87_first_46 @kc87_second_48 -70;
+    pos @kc87_first_46 @kc87_second_51 1;
+    pos @kc87_first_46 @kc87_second_53 -50;
+    pos @kc87_first_46 @kc87_second_54 -140;
+    pos @kc87_first_46 @kc87_second_63 -35;
+    pos @kc87_first_46 @kc87_second_65 -35;
     pos @kc87_first_46 @kc87_second_66 -70;
     pos @kc87_first_46 @kc87_second_67 -70;
-    pos @kc87_first_47 @kc87_second_3 -140;
-    pos @kc87_first_47 @kc87_second_4 -70;
-    pos @kc87_first_47 @kc87_second_6 -70;
-    pos @kc87_first_47 @kc87_second_8 -210;
-    pos @kc87_first_47 @kc87_second_9 -420;
-    pos @kc87_first_47 @kc87_second_12 -350;
-    pos @kc87_first_47 @kc87_second_13 -420;
-    pos @kc87_first_47 @kc87_second_14 -350;
-    pos @kc87_first_47 @kc87_second_15 -280;
-    pos @kc87_first_47 @kc87_second_17 -70;
-    pos @kc87_first_47 @kc87_second_18 -70;
-    pos @kc87_first_47 @kc87_second_20 -210;
-    pos @kc87_first_47 @kc87_second_22 -210;
-    pos @kc87_first_47 @kc87_second_24 -70;
-    pos @kc87_first_47 @kc87_second_25 -140;
-    pos @kc87_first_47 @kc87_second_31 -35;
-    pos @kc87_first_47 @kc87_second_33 -140;
-    pos @kc87_first_47 @kc87_second_37 -70;
-    pos @kc87_first_47 @kc87_second_39 -70;
-    pos @kc87_first_47 @kc87_second_41 -210;
-    pos @kc87_first_47 @kc87_second_42 -280;
-    pos @kc87_first_47 @kc87_second_43 -420;
-    pos @kc87_first_47 @kc87_second_46 -350;
-    pos @kc87_first_47 @kc87_second_48 1;
-    pos @kc87_first_47 @kc87_second_49 -35;
-    pos @kc87_first_47 @kc87_second_50 -210;
-    pos @kc87_first_47 @kc87_second_51 -350;
-    pos @kc87_first_47 @kc87_second_54 -35;
-    pos @kc87_first_47 @kc87_second_55 -35;
-    pos @kc87_first_47 @kc87_second_61 -280;
-    pos @kc87_first_47 @kc87_second_63 -175;
-    pos @kc87_first_47 @kc87_second_64 -280;
-    pos @kc87_first_47 @kc87_second_65 -210;
-    pos @kc87_first_47 @kc87_second_66 -70;
-    pos @kc87_first_48 @kc87_second_3 -140;
-    pos @kc87_first_48 @kc87_second_4 -105;
+    pos @kc87_first_47 @kc87_second_8 -35;
+    pos @kc87_first_47 @kc87_second_9 -70;
+    pos @kc87_first_47 @kc87_second_12 -240;
+    pos @kc87_first_47 @kc87_second_13 -210;
+    pos @kc87_first_47 @kc87_second_14 -70;
+    pos @kc87_first_47 @kc87_second_15 -105;
+    pos @kc87_first_47 @kc87_second_18 -35;
+    pos @kc87_first_47 @kc87_second_24 -35;
+    pos @kc87_first_47 @kc87_second_40 -35;
+    pos @kc87_first_47 @kc87_second_43 -70;
+    pos @kc87_first_47 @kc87_second_44 -105;
+    pos @kc87_first_47 @kc87_second_45 -70;
+    pos @kc87_first_47 @kc87_second_47 -70;
+    pos @kc87_first_47 @kc87_second_51 1;
+    pos @kc87_first_47 @kc87_second_53 -70;
+    pos @kc87_first_47 @kc87_second_54 -70;
+    pos @kc87_first_47 @kc87_second_63 -70;
+    pos @kc87_first_47 @kc87_second_65 -50;
+    pos @kc87_first_47 @kc87_second_67 -70;
+    pos @kc87_first_47 @kc87_second_68 -35;
+    pos @kc87_first_47 @kc87_second_69 -35;
     pos @kc87_first_48 @kc87_second_6 -70;
-    pos @kc87_first_48 @kc87_second_8 -210;
-    pos @kc87_first_48 @kc87_second_9 -280;
-    pos @kc87_first_48 @kc87_second_12 -350;
-    pos @kc87_first_48 @kc87_second_13 -385;
-    pos @kc87_first_48 @kc87_second_14 -350;
-    pos @kc87_first_48 @kc87_second_15 -280;
+    pos @kc87_first_48 @kc87_second_8 -35;
+    pos @kc87_first_48 @kc87_second_12 -175;
+    pos @kc87_first_48 @kc87_second_13 -140;
+    pos @kc87_first_48 @kc87_second_14 -70;
+    pos @kc87_first_48 @kc87_second_15 -35;
+    pos @kc87_first_48 @kc87_second_17 -70;
     pos @kc87_first_48 @kc87_second_18 -105;
-    pos @kc87_first_48 @kc87_second_20 -210;
-    pos @kc87_first_48 @kc87_second_22 -140;
+    pos @kc87_first_48 @kc87_second_22 -70;
     pos @kc87_first_48 @kc87_second_24 -105;
-    pos @kc87_first_48 @kc87_second_25 -140;
-    pos @kc87_first_48 @kc87_second_31 -70;
-    pos @kc87_first_48 @kc87_second_33 -175;
-    pos @kc87_first_48 @kc87_second_37 -70;
-    pos @kc87_first_48 @kc87_second_39 -35;
-    pos @kc87_first_48 @kc87_second_41 -175;
-    pos @kc87_first_48 @kc87_second_42 -280;
-    pos @kc87_first_48 @kc87_second_43 -280;
-    pos @kc87_first_48 @kc87_second_46 -280;
-    pos @kc87_first_48 @kc87_second_47 -140;
-    pos @kc87_first_48 @kc87_second_48 1;
-    pos @kc87_first_48 @kc87_second_49 -70;
-    pos @kc87_first_48 @kc87_second_50 -280;
-    pos @kc87_first_48 @kc87_second_51 -350;
-    pos @kc87_first_48 @kc87_second_54 -35;
-    pos @kc87_first_48 @kc87_second_55 -70;
-    pos @kc87_first_48 @kc87_second_61 -245;
-    pos @kc87_first_48 @kc87_second_63 -245;
-    pos @kc87_first_48 @kc87_second_64 -280;
-    pos @kc87_first_48 @kc87_second_65 -210;
-    pos @kc87_first_48 @kc87_second_66 -70;
-    pos @kc87_first_48 @kc87_second_67 -70;
-    pos @kc87_first_49 @kc87_second_3 -70;
+    pos @kc87_first_48 @kc87_second_31 -35;
+    pos @kc87_first_48 @kc87_second_34 -70;
+    pos @kc87_first_48 @kc87_second_38 -70;
+    pos @kc87_first_48 @kc87_second_41 -35;
+    pos @kc87_first_48 @kc87_second_43 -105;
+    pos @kc87_first_48 @kc87_second_51 1;
+    pos @kc87_first_48 @kc87_second_56 -35;
+    pos @kc87_first_48 @kc87_second_68 -70;
+    pos @kc87_first_48 @kc87_second_69 -70;
+    pos @kc87_first_49 @kc87_second_3 -140;
     pos @kc87_first_49 @kc87_second_4 -105;
-    pos @kc87_first_49 @kc87_second_6 -210;
-    pos @kc87_first_49 @kc87_second_7 -70;
-    pos @kc87_first_49 @kc87_second_8 -175;
-    pos @kc87_first_49 @kc87_second_17 -210;
-    pos @kc87_first_49 @kc87_second_18 -210;
+    pos @kc87_first_49 @kc87_second_6 -70;
+    pos @kc87_first_49 @kc87_second_8 -210;
+    pos @kc87_first_49 @kc87_second_9 -280;
+    pos @kc87_first_49 @kc87_second_12 -350;
+    pos @kc87_first_49 @kc87_second_13 -385;
+    pos @kc87_first_49 @kc87_second_14 -350;
+    pos @kc87_first_49 @kc87_second_15 -280;
+    pos @kc87_first_49 @kc87_second_18 -105;
+    pos @kc87_first_49 @kc87_second_20 -210;
     pos @kc87_first_49 @kc87_second_22 -140;
-    pos @kc87_first_49 @kc87_second_23 -210;
-    pos @kc87_first_49 @kc87_second_24 -210;
-    pos @kc87_first_49 @kc87_second_25 -210;
-    pos @kc87_first_49 @kc87_second_26 -140;
-    pos @kc87_first_49 @kc87_second_27 -140;
-    pos @kc87_first_49 @kc87_second_29 -140;
-    pos @kc87_first_49 @kc87_second_31 -210;
-    pos @kc87_first_49 @kc87_second_32 -210;
-    pos @kc87_first_49 @kc87_second_33 -140;
-    pos @kc87_first_49 @kc87_second_35 -210;
-    pos @kc87_first_49 @kc87_second_37 -210;
+    pos @kc87_first_49 @kc87_second_24 -105;
+    pos @kc87_first_49 @kc87_second_25 -140;
+    pos @kc87_first_49 @kc87_second_31 -70;
+    pos @kc87_first_49 @kc87_second_33 -175;
     pos @kc87_first_49 @kc87_second_38 -70;
-    pos @kc87_first_49 @kc87_second_39 -175;
-    pos @kc87_first_49 @kc87_second_40 -210;
-    pos @kc87_first_49 @kc87_second_41 -175;
-    pos @kc87_first_49 @kc87_second_42 -210;
-    pos @kc87_first_49 @kc87_second_43 -105;
-    pos @kc87_first_49 @kc87_second_46 -70;
-    pos @kc87_first_49 @kc87_second_47 -105;
-    pos @kc87_first_49 @kc87_second_48 1;
-    pos @kc87_first_49 @kc87_second_49 -35;
-    pos @kc87_first_49 @kc87_second_50 -210;
-    pos @kc87_first_49 @kc87_second_53 -210;
-    pos @kc87_first_49 @kc87_second_54 -210;
-    pos @kc87_first_49 @kc87_second_55 -175;
-    pos @kc87_first_49 @kc87_second_56 -175;
-    pos @kc87_first_49 @kc87_second_58 -210;
-    pos @kc87_first_49 @kc87_second_59 -210;
-    pos @kc87_first_49 @kc87_second_60 -140;
-    pos @kc87_first_49 @kc87_second_61 -210;
-    pos @kc87_first_49 @kc87_second_62 -175;
-    pos @kc87_first_49 @kc87_second_63 -175;
-    pos @kc87_first_49 @kc87_second_66 -210;
+    pos @kc87_first_49 @kc87_second_40 -140;
+    pos @kc87_first_49 @kc87_second_41 -35;
+    pos @kc87_first_49 @kc87_second_43 -175;
+    pos @kc87_first_49 @kc87_second_44 -280;
+    pos @kc87_first_49 @kc87_second_45 -280;
+    pos @kc87_first_49 @kc87_second_47 -280;
+    pos @kc87_first_49 @kc87_second_48 -210;
+    pos @kc87_first_49 @kc87_second_51 1;
+    pos @kc87_first_49 @kc87_second_52 -70;
+    pos @kc87_first_49 @kc87_second_53 -280;
+    pos @kc87_first_49 @kc87_second_54 -350;
+    pos @kc87_first_49 @kc87_second_56 -35;
+    pos @kc87_first_49 @kc87_second_57 -70;
+    pos @kc87_first_49 @kc87_second_63 -245;
+    pos @kc87_first_49 @kc87_second_65 -245;
+    pos @kc87_first_49 @kc87_second_66 -280;
     pos @kc87_first_49 @kc87_second_67 -210;
-    pos @kc87_first_50 @kc87_second_5 -70;
-    pos @kc87_first_50 @kc87_second_11 -35;
-    pos @kc87_first_50 @kc87_second_12 -240;
-    pos @kc87_first_50 @kc87_second_13 -70;
-    pos @kc87_first_50 @kc87_second_14 -140;
-    pos @kc87_first_50 @kc87_second_15 -105;
-    pos @kc87_first_50 @kc87_second_16 -70;
-    pos @kc87_first_50 @kc87_second_28 -70;
-    pos @kc87_first_50 @kc87_second_29 -70;
-    pos @kc87_first_50 @kc87_second_38 -35;
-    pos @kc87_first_50 @kc87_second_42 -70;
-    pos @kc87_first_50 @kc87_second_45 -35;
-    pos @kc87_first_50 @kc87_second_46 -70;
-    pos @kc87_first_50 @kc87_second_48 1;
-    pos @kc87_first_50 @kc87_second_50 -35;
-    pos @kc87_first_50 @kc87_second_51 -140;
-    pos @kc87_first_50 @kc87_second_54 1;
-    pos @kc87_first_50 @kc87_second_60 -35;
-    pos @kc87_first_50 @kc87_second_63 -35;
-    pos @kc87_first_50 @kc87_second_64 -105;
-    pos @kc87_first_50 @kc87_second_65 -70;
-    pos @kc87_first_51 @kc87_second_68 -70;
-    pos @kc87_first_52 @kc87_second_34 -315;
-    pos @kc87_first_52 @kc87_second_69 -70;
-    pos @kc87_first_53 @kc87_second_1 -105;
-    pos @kc87_first_53 @kc87_second_2 -210;
-    pos @kc87_first_53 @kc87_second_6 -140;
-    pos @kc87_first_53 @kc87_second_11 -70;
-    pos @kc87_first_53 @kc87_second_12 -210;
-    pos @kc87_first_53 @kc87_second_13 -210;
-    pos @kc87_first_53 @kc87_second_14 -105;
-    pos @kc87_first_53 @kc87_second_15 -70;
-    pos @kc87_first_53 @kc87_second_16 -140;
-    pos @kc87_first_53 @kc87_second_17 -35;
-    pos @kc87_first_53 @kc87_second_18 -35;
-    pos @kc87_first_53 @kc87_second_19 -105;
-    pos @kc87_first_53 @kc87_second_24 -35;
-    pos @kc87_first_53 @kc87_second_26 -210;
-    pos @kc87_first_53 @kc87_second_28 -70;
-    pos @kc87_first_53 @kc87_second_29 -70;
-    pos @kc87_first_53 @kc87_second_31 -35;
-    pos @kc87_first_53 @kc87_second_35 -70;
-    pos @kc87_first_53 @kc87_second_37 -210;
-    pos @kc87_first_53 @kc87_second_38 -140;
-    pos @kc87_first_53 @kc87_second_45 -35;
-    pos @kc87_first_53 @kc87_second_46 -70;
-    pos @kc87_first_53 @kc87_second_48 1;
-    pos @kc87_first_53 @kc87_second_50 -35;
-    pos @kc87_first_53 @kc87_second_51 -105;
-    pos @kc87_first_53 @kc87_second_56 -210;
-    pos @kc87_first_53 @kc87_second_58 -175;
-    pos @kc87_first_53 @kc87_second_59 -140;
-    pos @kc87_first_53 @kc87_second_64 -35;
-    pos @kc87_first_53 @kc87_second_65 -35;
-    pos @kc87_first_53 @kc87_second_66 -35;
-    pos @kc87_first_53 @kc87_second_67 -70;
-    pos @kc87_first_54 @kc87_second_1 -35;
-    pos @kc87_first_54 @kc87_second_2 -70;
-    pos @kc87_first_54 @kc87_second_5 -105;
-    pos @kc87_first_54 @kc87_second_6 -35;
-    pos @kc87_first_54 @kc87_second_9 -70;
-    pos @kc87_first_54 @kc87_second_11 -70;
-    pos @kc87_first_54 @kc87_second_12 -240;
-    pos @kc87_first_54 @kc87_second_13 -245;
-    pos @kc87_first_54 @kc87_second_14 -140;
-    pos @kc87_first_54 @kc87_second_15 -105;
-    pos @kc87_first_54 @kc87_second_16 -105;
-    pos @kc87_first_54 @kc87_second_19 -35;
-    pos @kc87_first_54 @kc87_second_20 -70;
-    pos @kc87_first_54 @kc87_second_21 -70;
-    pos @kc87_first_54 @kc87_second_26 -35;
-    pos @kc87_first_54 @kc87_second_27 -70;
-    pos @kc87_first_54 @kc87_second_28 -140;
-    pos @kc87_first_54 @kc87_second_29 -105;
-    pos @kc87_first_54 @kc87_second_35 -35;
-    pos @kc87_first_54 @kc87_second_37 -35;
-    pos @kc87_first_54 @kc87_second_38 -140;
-    pos @kc87_first_54 @kc87_second_42 -105;
-    pos @kc87_first_54 @kc87_second_43 -70;
-    pos @kc87_first_54 @kc87_second_45 -105;
-    pos @kc87_first_54 @kc87_second_46 -175;
-    pos @kc87_first_54 @kc87_second_48 1;
-    pos @kc87_first_54 @kc87_second_50 -70;
-    pos @kc87_first_54 @kc87_second_51 -140;
-    pos @kc87_first_54 @kc87_second_52 -70;
-    pos @kc87_first_54 @kc87_second_56 -210;
-    pos @kc87_first_54 @kc87_second_57 -70;
-    pos @kc87_first_54 @kc87_second_58 -175;
-    pos @kc87_first_54 @kc87_second_59 -175;
-    pos @kc87_first_54 @kc87_second_60 -105;
-    pos @kc87_first_54 @kc87_second_63 -50;
-    pos @kc87_first_54 @kc87_second_64 -105;
-    pos @kc87_first_54 @kc87_second_65 -70;
-    pos @kc87_first_54 @kc87_second_67 -35;
+    pos @kc87_first_49 @kc87_second_68 -70;
+    pos @kc87_first_49 @kc87_second_69 -70;
+    pos @kc87_first_50 @kc87_second_3 -70;
+    pos @kc87_first_50 @kc87_second_4 -105;
+    pos @kc87_first_50 @kc87_second_6 -210;
+    pos @kc87_first_50 @kc87_second_7 -70;
+    pos @kc87_first_50 @kc87_second_8 -175;
+    pos @kc87_first_50 @kc87_second_17 -210;
+    pos @kc87_first_50 @kc87_second_18 -210;
+    pos @kc87_first_50 @kc87_second_22 -140;
+    pos @kc87_first_50 @kc87_second_23 -210;
+    pos @kc87_first_50 @kc87_second_24 -210;
+    pos @kc87_first_50 @kc87_second_25 -210;
+    pos @kc87_first_50 @kc87_second_26 -140;
+    pos @kc87_first_50 @kc87_second_27 -140;
+    pos @kc87_first_50 @kc87_second_29 -140;
+    pos @kc87_first_50 @kc87_second_31 -210;
+    pos @kc87_first_50 @kc87_second_32 -210;
+    pos @kc87_first_50 @kc87_second_33 -140;
+    pos @kc87_first_50 @kc87_second_34 -140;
+    pos @kc87_first_50 @kc87_second_36 -210;
+    pos @kc87_first_50 @kc87_second_38 -210;
+    pos @kc87_first_50 @kc87_second_39 -70;
+    pos @kc87_first_50 @kc87_second_40 -105;
+    pos @kc87_first_50 @kc87_second_41 -175;
+    pos @kc87_first_50 @kc87_second_42 -210;
+    pos @kc87_first_50 @kc87_second_43 -175;
+    pos @kc87_first_50 @kc87_second_44 -210;
+    pos @kc87_first_50 @kc87_second_45 -105;
+    pos @kc87_first_50 @kc87_second_47 -70;
+    pos @kc87_first_50 @kc87_second_51 1;
+    pos @kc87_first_50 @kc87_second_52 -35;
+    pos @kc87_first_50 @kc87_second_53 -210;
+    pos @kc87_first_50 @kc87_second_55 -210;
+    pos @kc87_first_50 @kc87_second_56 -210;
+    pos @kc87_first_50 @kc87_second_57 -175;
+    pos @kc87_first_50 @kc87_second_58 -175;
+    pos @kc87_first_50 @kc87_second_60 -210;
+    pos @kc87_first_50 @kc87_second_61 -210;
+    pos @kc87_first_50 @kc87_second_62 -140;
+    pos @kc87_first_50 @kc87_second_63 -210;
+    pos @kc87_first_50 @kc87_second_64 -175;
+    pos @kc87_first_50 @kc87_second_65 -175;
+    pos @kc87_first_50 @kc87_second_68 -210;
+    pos @kc87_first_50 @kc87_second_69 -210;
+    pos @kc87_first_51 @kc87_second_1 -35;
+    pos @kc87_first_51 @kc87_second_2 -70;
+    pos @kc87_first_51 @kc87_second_5 -70;
+    pos @kc87_first_51 @kc87_second_11 -35;
+    pos @kc87_first_51 @kc87_second_12 -70;
+    pos @kc87_first_51 @kc87_second_13 -140;
+    pos @kc87_first_51 @kc87_second_14 -70;
+    pos @kc87_first_51 @kc87_second_15 -35;
+    pos @kc87_first_51 @kc87_second_16 -105;
+    pos @kc87_first_51 @kc87_second_28 -35;
+    pos @kc87_first_51 @kc87_second_29 -70;
+    pos @kc87_first_51 @kc87_second_36 -35;
+    pos @kc87_first_51 @kc87_second_39 -70;
+    pos @kc87_first_51 @kc87_second_47 -70;
+    pos @kc87_first_51 @kc87_second_51 1;
+    pos @kc87_first_51 @kc87_second_58 -175;
+    pos @kc87_first_51 @kc87_second_60 -140;
+    pos @kc87_first_51 @kc87_second_61 -140;
+    pos @kc87_first_51 @kc87_second_66 -35;
+    pos @kc87_first_52 @kc87_second_5 -70;
+    pos @kc87_first_52 @kc87_second_11 -35;
+    pos @kc87_first_52 @kc87_second_12 -240;
+    pos @kc87_first_52 @kc87_second_13 -70;
+    pos @kc87_first_52 @kc87_second_14 -140;
+    pos @kc87_first_52 @kc87_second_15 -105;
+    pos @kc87_first_52 @kc87_second_16 -70;
+    pos @kc87_first_52 @kc87_second_28 -70;
+    pos @kc87_first_52 @kc87_second_29 -70;
+    pos @kc87_first_52 @kc87_second_39 -35;
+    pos @kc87_first_52 @kc87_second_44 -70;
+    pos @kc87_first_52 @kc87_second_47 -70;
+    pos @kc87_first_52 @kc87_second_49 -35;
+    pos @kc87_first_52 @kc87_second_51 1;
+    pos @kc87_first_52 @kc87_second_53 -35;
+    pos @kc87_first_52 @kc87_second_54 -140;
+    pos @kc87_first_52 @kc87_second_56 1;
+    pos @kc87_first_52 @kc87_second_62 -35;
+    pos @kc87_first_52 @kc87_second_65 -35;
+    pos @kc87_first_52 @kc87_second_66 -105;
+    pos @kc87_first_52 @kc87_second_67 -70;
+    pos @kc87_first_53 @kc87_second_70 -70;
+    pos @kc87_first_54 @kc87_second_35 -315;
+    pos @kc87_first_54 @kc87_second_71 -70;
     pos @kc87_first_55 @kc87_second_1 -105;
     pos @kc87_first_55 @kc87_second_2 -210;
-    pos @kc87_first_55 @kc87_second_5 -70;
-    pos @kc87_first_55 @kc87_second_6 -105;
-    pos @kc87_first_55 @kc87_second_13 -70;
-    pos @kc87_first_55 @kc87_second_14 -35;
+    pos @kc87_first_55 @kc87_second_6 -140;
+    pos @kc87_first_55 @kc87_second_11 -70;
+    pos @kc87_first_55 @kc87_second_12 -210;
+    pos @kc87_first_55 @kc87_second_13 -210;
+    pos @kc87_first_55 @kc87_second_14 -105;
+    pos @kc87_first_55 @kc87_second_15 -70;
     pos @kc87_first_55 @kc87_second_16 -140;
-    pos @kc87_first_55 @kc87_second_17 -70;
+    pos @kc87_first_55 @kc87_second_17 -35;
     pos @kc87_first_55 @kc87_second_18 -35;
     pos @kc87_first_55 @kc87_second_19 -105;
-    pos @kc87_first_55 @kc87_second_21 -210;
     pos @kc87_first_55 @kc87_second_24 -35;
     pos @kc87_first_55 @kc87_second_26 -210;
+    pos @kc87_first_55 @kc87_second_28 -70;
+    pos @kc87_first_55 @kc87_second_29 -70;
     pos @kc87_first_55 @kc87_second_31 -35;
-    pos @kc87_first_55 @kc87_second_34 -105;
-    pos @kc87_first_55 @kc87_second_35 -35;
-    pos @kc87_first_55 @kc87_second_37 -105;
-    pos @kc87_first_55 @kc87_second_38 -140;
-    pos @kc87_first_55 @kc87_second_41 -70;
-    pos @kc87_first_55 @kc87_second_48 1;
-    pos @kc87_first_55 @kc87_second_54 -35;
-    pos @kc87_first_55 @kc87_second_56 -245;
+    pos @kc87_first_55 @kc87_second_36 -70;
+    pos @kc87_first_55 @kc87_second_38 -210;
+    pos @kc87_first_55 @kc87_second_39 -140;
+    pos @kc87_first_55 @kc87_second_47 -70;
+    pos @kc87_first_55 @kc87_second_49 -35;
+    pos @kc87_first_55 @kc87_second_51 1;
+    pos @kc87_first_55 @kc87_second_53 -35;
+    pos @kc87_first_55 @kc87_second_54 -105;
     pos @kc87_first_55 @kc87_second_58 -210;
-    pos @kc87_first_55 @kc87_second_59 -210;
-    pos @kc87_first_55 @kc87_second_66 -70;
-    pos @kc87_first_55 @kc87_second_67 -105;
-    pos @kc87_first_56 @kc87_second_12 -240;
-    pos @kc87_first_56 @kc87_second_13 -140;
-    pos @kc87_first_56 @kc87_second_14 -105;
-    pos @kc87_first_56 @kc87_second_15 -35;
-    pos @kc87_first_56 @kc87_second_36 165;
-    pos @kc87_first_56 @kc87_second_48 1;
-    pos @kc87_first_56 @kc87_second_53 165;
-    pos @kc87_first_57 @kc87_second_1 -140;
-    pos @kc87_first_57 @kc87_second_2 -210;
-    pos @kc87_first_57 @kc87_second_6 -140;
-    pos @kc87_first_57 @kc87_second_12 -175;
+    pos @kc87_first_55 @kc87_second_60 -175;
+    pos @kc87_first_55 @kc87_second_61 -140;
+    pos @kc87_first_55 @kc87_second_66 -35;
+    pos @kc87_first_55 @kc87_second_67 -35;
+    pos @kc87_first_55 @kc87_second_68 -35;
+    pos @kc87_first_55 @kc87_second_69 -70;
+    pos @kc87_first_56 @kc87_second_1 -105;
+    pos @kc87_first_56 @kc87_second_2 -210;
+    pos @kc87_first_56 @kc87_second_5 -70;
+    pos @kc87_first_56 @kc87_second_6 -105;
+    pos @kc87_first_56 @kc87_second_13 -70;
+    pos @kc87_first_56 @kc87_second_14 -35;
+    pos @kc87_first_56 @kc87_second_16 -140;
+    pos @kc87_first_56 @kc87_second_17 -70;
+    pos @kc87_first_56 @kc87_second_18 -35;
+    pos @kc87_first_56 @kc87_second_19 -105;
+    pos @kc87_first_56 @kc87_second_21 -210;
+    pos @kc87_first_56 @kc87_second_24 -35;
+    pos @kc87_first_56 @kc87_second_26 -210;
+    pos @kc87_first_56 @kc87_second_31 -35;
+    pos @kc87_first_56 @kc87_second_34 -70;
+    pos @kc87_first_56 @kc87_second_35 -105;
+    pos @kc87_first_56 @kc87_second_36 -35;
+    pos @kc87_first_56 @kc87_second_38 -105;
+    pos @kc87_first_56 @kc87_second_39 -140;
+    pos @kc87_first_56 @kc87_second_43 -70;
+    pos @kc87_first_56 @kc87_second_51 1;
+    pos @kc87_first_56 @kc87_second_56 -35;
+    pos @kc87_first_56 @kc87_second_58 -245;
+    pos @kc87_first_56 @kc87_second_60 -210;
+    pos @kc87_first_56 @kc87_second_61 -210;
+    pos @kc87_first_56 @kc87_second_68 -70;
+    pos @kc87_first_56 @kc87_second_69 -105;
+    pos @kc87_first_57 @kc87_second_12 -240;
     pos @kc87_first_57 @kc87_second_13 -140;
-    pos @kc87_first_57 @kc87_second_16 -140;
-    pos @kc87_first_57 @kc87_second_19 -140;
-    pos @kc87_first_57 @kc87_second_21 -210;
-    pos @kc87_first_57 @kc87_second_26 -210;
-    pos @kc87_first_57 @kc87_second_34 -140;
-    pos @kc87_first_57 @kc87_second_35 -50;
-    pos @kc87_first_57 @kc87_second_37 -140;
-    pos @kc87_first_57 @kc87_second_38 -210;
-    pos @kc87_first_57 @kc87_second_39 -35;
-    pos @kc87_first_57 @kc87_second_48 1;
-    pos @kc87_first_57 @kc87_second_56 -210;
-    pos @kc87_first_57 @kc87_second_58 -175;
-    pos @kc87_first_57 @kc87_second_59 -175;
-    pos @kc87_first_57 @kc87_second_66 -105;
-    pos @kc87_first_57 @kc87_second_67 -210;
-    pos @kc87_first_58 @kc87_second_12 -240;
-    pos @kc87_first_58 @kc87_second_13 -175;
-    pos @kc87_first_58 @kc87_second_14 -70;
-    pos @kc87_first_58 @kc87_second_15 -35;
-    pos @kc87_first_58 @kc87_second_21 -35;
-    pos @kc87_first_58 @kc87_second_28 -35;
-    pos @kc87_first_58 @kc87_second_42 -35;
-    pos @kc87_first_58 @kc87_second_43 -35;
-    pos @kc87_first_58 @kc87_second_46 -70;
-    pos @kc87_first_58 @kc87_second_48 1;
-    pos @kc87_first_58 @kc87_second_50 -35;
-    pos @kc87_first_58 @kc87_second_51 -70;
-    pos @kc87_first_58 @kc87_second_61 -35;
-    pos @kc87_first_58 @kc87_second_63 -35;
-    pos @kc87_first_58 @kc87_second_64 -70;
-    pos @kc87_first_58 @kc87_second_65 -35;
-    pos @kc87_first_59 @kc87_second_13 -35;
-    pos @kc87_first_59 @kc87_second_18 -70;
-    pos @kc87_first_59 @kc87_second_61 -35;
+    pos @kc87_first_57 @kc87_second_14 -105;
+    pos @kc87_first_57 @kc87_second_15 -35;
+    pos @kc87_first_57 @kc87_second_37 165;
+    pos @kc87_first_57 @kc87_second_51 1;
+    pos @kc87_first_57 @kc87_second_55 165;
+    pos @kc87_first_58 @kc87_second_1 -140;
+    pos @kc87_first_58 @kc87_second_2 -210;
+    pos @kc87_first_58 @kc87_second_6 -140;
+    pos @kc87_first_58 @kc87_second_12 -175;
+    pos @kc87_first_58 @kc87_second_13 -140;
+    pos @kc87_first_58 @kc87_second_16 -140;
+    pos @kc87_first_58 @kc87_second_19 -140;
+    pos @kc87_first_58 @kc87_second_21 -210;
+    pos @kc87_first_58 @kc87_second_26 -210;
+    pos @kc87_first_58 @kc87_second_34 -35;
+    pos @kc87_first_58 @kc87_second_35 -140;
+    pos @kc87_first_58 @kc87_second_36 -50;
+    pos @kc87_first_58 @kc87_second_38 -140;
+    pos @kc87_first_58 @kc87_second_39 -210;
+    pos @kc87_first_58 @kc87_second_41 -35;
+    pos @kc87_first_58 @kc87_second_51 1;
+    pos @kc87_first_58 @kc87_second_58 -210;
+    pos @kc87_first_58 @kc87_second_60 -175;
+    pos @kc87_first_58 @kc87_second_61 -175;
+    pos @kc87_first_58 @kc87_second_68 -105;
+    pos @kc87_first_58 @kc87_second_69 -210;
+    pos @kc87_first_59 @kc87_second_12 -240;
+    pos @kc87_first_59 @kc87_second_13 -175;
+    pos @kc87_first_59 @kc87_second_14 -70;
+    pos @kc87_first_59 @kc87_second_15 -35;
+    pos @kc87_first_59 @kc87_second_21 -35;
+    pos @kc87_first_59 @kc87_second_28 -35;
+    pos @kc87_first_59 @kc87_second_44 -35;
+    pos @kc87_first_59 @kc87_second_45 -35;
+    pos @kc87_first_59 @kc87_second_47 -70;
+    pos @kc87_first_59 @kc87_second_51 1;
+    pos @kc87_first_59 @kc87_second_53 -35;
+    pos @kc87_first_59 @kc87_second_54 -70;
+    pos @kc87_first_59 @kc87_second_63 -35;
+    pos @kc87_first_59 @kc87_second_65 -35;
+    pos @kc87_first_59 @kc87_second_66 -70;
     pos @kc87_first_59 @kc87_second_67 -35;
-    pos @kc87_first_60 @kc87_second_12 -175;
-    pos @kc87_first_60 @kc87_second_13 -140;
-    pos @kc87_first_60 @kc87_second_14 -35;
-    pos @kc87_first_60 @kc87_second_48 1;
-    pos @kc87_first_61 @kc87_second_1 -140;
-    pos @kc87_first_61 @kc87_second_2 -280;
-    pos @kc87_first_61 @kc87_second_5 -140;
-    pos @kc87_first_61 @kc87_second_6 -280;
-    pos @kc87_first_61 @kc87_second_8 -70;
-    pos @kc87_first_61 @kc87_second_10 -70;
-    pos @kc87_first_61 @kc87_second_11 -175;
-    pos @kc87_first_61 @kc87_second_12 -240;
-    pos @kc87_first_61 @kc87_second_13 -140;
-    pos @kc87_first_61 @kc87_second_14 -105;
-    pos @kc87_first_61 @kc87_second_15 -70;
-    pos @kc87_first_61 @kc87_second_16 -175;
-    pos @kc87_first_61 @kc87_second_17 -70;
+    pos @kc87_first_60 @kc87_second_1 -210;
+    pos @kc87_first_60 @kc87_second_2 -210;
+    pos @kc87_first_60 @kc87_second_3 -70;
+    pos @kc87_first_60 @kc87_second_4 -35;
+    pos @kc87_first_60 @kc87_second_6 -210;
+    pos @kc87_first_60 @kc87_second_7 -70;
+    pos @kc87_first_60 @kc87_second_8 -70;
+    pos @kc87_first_60 @kc87_second_16 -70;
+    pos @kc87_first_60 @kc87_second_17 -70;
+    pos @kc87_first_60 @kc87_second_18 -175;
+    pos @kc87_first_60 @kc87_second_19 -210;
+    pos @kc87_first_60 @kc87_second_21 -210;
+    pos @kc87_first_60 @kc87_second_22 -140;
+    pos @kc87_first_60 @kc87_second_23 -35;
+    pos @kc87_first_60 @kc87_second_24 -175;
+    pos @kc87_first_60 @kc87_second_25 -140;
+    pos @kc87_first_60 @kc87_second_26 -280;
+    pos @kc87_first_60 @kc87_second_31 -35;
+    pos @kc87_first_60 @kc87_second_32 -35;
+    pos @kc87_first_60 @kc87_second_34 -140;
+    pos @kc87_first_60 @kc87_second_35 -210;
+    pos @kc87_first_60 @kc87_second_36 -175;
+    pos @kc87_first_60 @kc87_second_38 -245;
+    pos @kc87_first_60 @kc87_second_39 -140;
+    pos @kc87_first_60 @kc87_second_40 -35;
+    pos @kc87_first_60 @kc87_second_41 -140;
+    pos @kc87_first_60 @kc87_second_42 -140;
+    pos @kc87_first_60 @kc87_second_43 -140;
+    pos @kc87_first_60 @kc87_second_44 -35;
+    pos @kc87_first_60 @kc87_second_50 -35;
+    pos @kc87_first_60 @kc87_second_51 1;
+    pos @kc87_first_60 @kc87_second_56 -140;
+    pos @kc87_first_60 @kc87_second_57 -70;
+    pos @kc87_first_60 @kc87_second_58 -210;
+    pos @kc87_first_60 @kc87_second_60 -210;
+    pos @kc87_first_60 @kc87_second_61 -210;
+    pos @kc87_first_60 @kc87_second_63 -35;
+    pos @kc87_first_60 @kc87_second_68 -175;
+    pos @kc87_first_60 @kc87_second_69 -245;
+    pos @kc87_first_61 @kc87_second_13 -35;
     pos @kc87_first_61 @kc87_second_18 -70;
-    pos @kc87_first_61 @kc87_second_19 -140;
-    pos @kc87_first_61 @kc87_second_21 -280;
-    pos @kc87_first_61 @kc87_second_24 -70;
-    pos @kc87_first_61 @kc87_second_25 -70;
-    pos @kc87_first_61 @kc87_second_26 -210;
-    pos @kc87_first_61 @kc87_second_28 -70;
-    pos @kc87_first_61 @kc87_second_29 -70;
-    pos @kc87_first_61 @kc87_second_31 -70;
     pos @kc87_first_61 @kc87_second_34 -70;
-    pos @kc87_first_61 @kc87_second_35 -70;
-    pos @kc87_first_61 @kc87_second_37 -315;
-    pos @kc87_first_61 @kc87_second_38 -140;
-    pos @kc87_first_61 @kc87_second_39 -70;
-    pos @kc87_first_61 @kc87_second_41 -105;
-    pos @kc87_first_61 @kc87_second_48 1;
-    pos @kc87_first_61 @kc87_second_51 -35;
-    pos @kc87_first_61 @kc87_second_54 -50;
-    pos @kc87_first_61 @kc87_second_56 -210;
-    pos @kc87_first_61 @kc87_second_58 -210;
-    pos @kc87_first_61 @kc87_second_59 -175;
-    pos @kc87_first_61 @kc87_second_62 -35;
-    pos @kc87_first_61 @kc87_second_64 -70;
-    pos @kc87_first_61 @kc87_second_65 -35;
-    pos @kc87_first_61 @kc87_second_66 -140;
-    pos @kc87_first_61 @kc87_second_67 -210;
-    pos @kc87_first_62 @kc87_second_1 -35;
-    pos @kc87_first_62 @kc87_second_2 -70;
-    pos @kc87_first_62 @kc87_second_5 -70;
-    pos @kc87_first_62 @kc87_second_11 -35;
-    pos @kc87_first_62 @kc87_second_12 -140;
+    pos @kc87_first_61 @kc87_second_63 -35;
+    pos @kc87_first_61 @kc87_second_69 -35;
+    pos @kc87_first_62 @kc87_second_12 -175;
     pos @kc87_first_62 @kc87_second_13 -140;
-    pos @kc87_first_62 @kc87_second_14 -70;
-    pos @kc87_first_62 @kc87_second_15 -35;
-    pos @kc87_first_62 @kc87_second_16 -105;
-    pos @kc87_first_62 @kc87_second_28 -35;
-    pos @kc87_first_62 @kc87_second_29 -70;
-    pos @kc87_first_62 @kc87_second_35 -35;
-    pos @kc87_first_62 @kc87_second_38 -70;
-    pos @kc87_first_62 @kc87_second_46 -70;
-    pos @kc87_first_62 @kc87_second_48 1;
-    pos @kc87_first_62 @kc87_second_56 -175;
-    pos @kc87_first_62 @kc87_second_58 -140;
-    pos @kc87_first_62 @kc87_second_59 -140;
-    pos @kc87_first_62 @kc87_second_64 -35;
-    pos @kc87_first_63 @kc87_second_5 -70;
-    pos @kc87_first_63 @kc87_second_9 -70;
-    pos @kc87_first_63 @kc87_second_11 -35;
-    pos @kc87_first_63 @kc87_second_12 -350;
-    pos @kc87_first_63 @kc87_second_13 -315;
-    pos @kc87_first_63 @kc87_second_14 -175;
-    pos @kc87_first_63 @kc87_second_15 -140;
-    pos @kc87_first_63 @kc87_second_16 -70;
-    pos @kc87_first_63 @kc87_second_20 -70;
+    pos @kc87_first_62 @kc87_second_14 -35;
+    pos @kc87_first_62 @kc87_second_51 1;
+    pos @kc87_first_63 @kc87_second_1 -140;
+    pos @kc87_first_63 @kc87_second_2 -280;
+    pos @kc87_first_63 @kc87_second_5 -140;
+    pos @kc87_first_63 @kc87_second_6 -280;
+    pos @kc87_first_63 @kc87_second_8 -70;
+    pos @kc87_first_63 @kc87_second_10 -70;
+    pos @kc87_first_63 @kc87_second_11 -175;
+    pos @kc87_first_63 @kc87_second_12 -240;
+    pos @kc87_first_63 @kc87_second_13 -140;
+    pos @kc87_first_63 @kc87_second_14 -105;
+    pos @kc87_first_63 @kc87_second_15 -70;
+    pos @kc87_first_63 @kc87_second_16 -175;
+    pos @kc87_first_63 @kc87_second_17 -70;
+    pos @kc87_first_63 @kc87_second_18 -70;
+    pos @kc87_first_63 @kc87_second_19 -140;
+    pos @kc87_first_63 @kc87_second_21 -280;
+    pos @kc87_first_63 @kc87_second_24 -70;
+    pos @kc87_first_63 @kc87_second_25 -70;
+    pos @kc87_first_63 @kc87_second_26 -210;
+    pos @kc87_first_63 @kc87_second_28 -70;
     pos @kc87_first_63 @kc87_second_29 -70;
-    pos @kc87_first_63 @kc87_second_33 -50;
-    pos @kc87_first_63 @kc87_second_42 -140;
-    pos @kc87_first_63 @kc87_second_43 -50;
-    pos @kc87_first_63 @kc87_second_45 -35;
-    pos @kc87_first_63 @kc87_second_46 -175;
-    pos @kc87_first_63 @kc87_second_48 1;
-    pos @kc87_first_63 @kc87_second_50 -70;
-    pos @kc87_first_63 @kc87_second_51 -175;
-    pos @kc87_first_63 @kc87_second_57 -70;
-    pos @kc87_first_63 @kc87_second_61 -70;
-    pos @kc87_first_63 @kc87_second_63 -50;
-    pos @kc87_first_63 @kc87_second_64 -140;
-    pos @kc87_first_63 @kc87_second_65 -105;
-    pos @kc87_first_64 @kc87_second_4 -105;
+    pos @kc87_first_63 @kc87_second_31 -70;
+    pos @kc87_first_63 @kc87_second_34 -70;
+    pos @kc87_first_63 @kc87_second_35 -70;
+    pos @kc87_first_63 @kc87_second_36 -70;
+    pos @kc87_first_63 @kc87_second_38 -315;
+    pos @kc87_first_63 @kc87_second_39 -140;
+    pos @kc87_first_63 @kc87_second_41 -70;
+    pos @kc87_first_63 @kc87_second_43 -105;
+    pos @kc87_first_63 @kc87_second_51 1;
+    pos @kc87_first_63 @kc87_second_54 -35;
+    pos @kc87_first_63 @kc87_second_56 -50;
+    pos @kc87_first_63 @kc87_second_58 -210;
+    pos @kc87_first_63 @kc87_second_60 -210;
+    pos @kc87_first_63 @kc87_second_61 -175;
+    pos @kc87_first_63 @kc87_second_64 -35;
+    pos @kc87_first_63 @kc87_second_66 -70;
+    pos @kc87_first_63 @kc87_second_67 -35;
+    pos @kc87_first_63 @kc87_second_68 -140;
+    pos @kc87_first_63 @kc87_second_69 -210;
     pos @kc87_first_64 @kc87_second_6 -35;
-    pos @kc87_first_64 @kc87_second_8 1;
-    pos @kc87_first_64 @kc87_second_9 -245;
-    pos @kc87_first_64 @kc87_second_12 -210;
-    pos @kc87_first_64 @kc87_second_13 -210;
-    pos @kc87_first_64 @kc87_second_14 -210;
-    pos @kc87_first_64 @kc87_second_15 -175;
-    pos @kc87_first_64 @kc87_second_17 -70;
-    pos @kc87_first_64 @kc87_second_18 -105;
-    pos @kc87_first_64 @kc87_second_20 -180;
-    pos @kc87_first_64 @kc87_second_22 -140;
-    pos @kc87_first_64 @kc87_second_24 -105;
-    pos @kc87_first_64 @kc87_second_27 -140;
-    pos @kc87_first_64 @kc87_second_31 -105;
-    pos @kc87_first_64 @kc87_second_33 -140;
-    pos @kc87_first_64 @kc87_second_37 -35;
-    pos @kc87_first_64 @kc87_second_39 -35;
-    pos @kc87_first_64 @kc87_second_41 -175;
-    pos @kc87_first_64 @kc87_second_42 -142;
-    pos @kc87_first_64 @kc87_second_43 -245;
-    pos @kc87_first_64 @kc87_second_46 -210;
-    pos @kc87_first_64 @kc87_second_47 -105;
-    pos @kc87_first_64 @kc87_second_48 1;
-    pos @kc87_first_64 @kc87_second_49 -35;
-    pos @kc87_first_64 @kc87_second_50 -210;
-    pos @kc87_first_64 @kc87_second_51 -210;
+    pos @kc87_first_64 @kc87_second_12 -240;
+    pos @kc87_first_64 @kc87_second_13 -140;
+    pos @kc87_first_64 @kc87_second_14 -70;
+    pos @kc87_first_64 @kc87_second_15 -35;
+    pos @kc87_first_64 @kc87_second_18 -35;
+    pos @kc87_first_64 @kc87_second_22 -35;
+    pos @kc87_first_64 @kc87_second_24 -35;
+    pos @kc87_first_64 @kc87_second_38 -70;
+    pos @kc87_first_64 @kc87_second_43 -70;
+    pos @kc87_first_64 @kc87_second_44 -50;
+    pos @kc87_first_64 @kc87_second_51 1;
     pos @kc87_first_64 @kc87_second_54 -35;
-    pos @kc87_first_64 @kc87_second_61 -280;
-    pos @kc87_first_64 @kc87_second_63 -175;
-    pos @kc87_first_64 @kc87_second_64 -140;
-    pos @kc87_first_64 @kc87_second_65 -140;
-    pos @kc87_first_64 @kc87_second_66 -70;
-    pos @kc87_first_64 @kc87_second_67 -70;
-    pos @kc87_first_65 @kc87_second_1 -175;
-    pos @kc87_first_65 @kc87_second_2 -175;
+    pos @kc87_first_64 @kc87_second_68 -35;
+    pos @kc87_first_64 @kc87_second_69 -35;
     pos @kc87_first_65 @kc87_second_5 -70;
-    pos @kc87_first_65 @kc87_second_6 -105;
-    pos @kc87_first_65 @kc87_second_11 -105;
-    pos @kc87_first_65 @kc87_second_12 -175;
-    pos @kc87_first_65 @kc87_second_13 -140;
-    pos @kc87_first_65 @kc87_second_14 -70;
-    pos @kc87_first_65 @kc87_second_15 -35;
-    pos @kc87_first_65 @kc87_second_16 -140;
-    pos @kc87_first_65 @kc87_second_17 -70;
-    pos @kc87_first_65 @kc87_second_18 -70;
-    pos @kc87_first_65 @kc87_second_19 -140;
-    pos @kc87_first_65 @kc87_second_21 -175;
-    pos @kc87_first_65 @kc87_second_24 -70;
-    pos @kc87_first_65 @kc87_second_31 -35;
-    pos @kc87_first_65 @kc87_second_35 -70;
-    pos @kc87_first_65 @kc87_second_37 -105;
-    pos @kc87_first_65 @kc87_second_38 -175;
-    pos @kc87_first_65 @kc87_second_39 -35;
-    pos @kc87_first_65 @kc87_second_41 -70;
-    pos @kc87_first_65 @kc87_second_48 1;
-    pos @kc87_first_65 @kc87_second_54 -35;
-    pos @kc87_first_65 @kc87_second_56 -140;
-    pos @kc87_first_65 @kc87_second_58 -140;
-    pos @kc87_first_65 @kc87_second_59 -140;
-    pos @kc87_first_65 @kc87_second_66 -70;
+    pos @kc87_first_65 @kc87_second_9 -70;
+    pos @kc87_first_65 @kc87_second_11 -35;
+    pos @kc87_first_65 @kc87_second_12 -350;
+    pos @kc87_first_65 @kc87_second_13 -315;
+    pos @kc87_first_65 @kc87_second_14 -175;
+    pos @kc87_first_65 @kc87_second_15 -140;
+    pos @kc87_first_65 @kc87_second_16 -70;
+    pos @kc87_first_65 @kc87_second_20 -70;
+    pos @kc87_first_65 @kc87_second_29 -70;
+    pos @kc87_first_65 @kc87_second_33 -50;
+    pos @kc87_first_65 @kc87_second_44 -140;
+    pos @kc87_first_65 @kc87_second_45 -50;
+    pos @kc87_first_65 @kc87_second_47 -175;
+    pos @kc87_first_65 @kc87_second_49 -35;
+    pos @kc87_first_65 @kc87_second_51 1;
+    pos @kc87_first_65 @kc87_second_53 -70;
+    pos @kc87_first_65 @kc87_second_54 -175;
+    pos @kc87_first_65 @kc87_second_59 -70;
+    pos @kc87_first_65 @kc87_second_63 -70;
+    pos @kc87_first_65 @kc87_second_65 -50;
+    pos @kc87_first_65 @kc87_second_66 -140;
     pos @kc87_first_65 @kc87_second_67 -105;
-    pos @kc87_first_66 @kc87_second_1 -210;
-    pos @kc87_first_66 @kc87_second_2 -210;
-    pos @kc87_first_66 @kc87_second_3 -70;
-    pos @kc87_first_66 @kc87_second_4 -35;
-    pos @kc87_first_66 @kc87_second_6 -210;
-    pos @kc87_first_66 @kc87_second_7 -70;
-    pos @kc87_first_66 @kc87_second_8 -70;
-    pos @kc87_first_66 @kc87_second_16 -70;
-    pos @kc87_first_66 @kc87_second_17 -140;
-    pos @kc87_first_66 @kc87_second_18 -175;
-    pos @kc87_first_66 @kc87_second_19 -210;
-    pos @kc87_first_66 @kc87_second_21 -210;
+    pos @kc87_first_66 @kc87_second_4 -105;
+    pos @kc87_first_66 @kc87_second_6 -35;
+    pos @kc87_first_66 @kc87_second_8 1;
+    pos @kc87_first_66 @kc87_second_9 -245;
+    pos @kc87_first_66 @kc87_second_12 -210;
+    pos @kc87_first_66 @kc87_second_13 -210;
+    pos @kc87_first_66 @kc87_second_14 -210;
+    pos @kc87_first_66 @kc87_second_15 -175;
+    pos @kc87_first_66 @kc87_second_17 -70;
+    pos @kc87_first_66 @kc87_second_18 -105;
+    pos @kc87_first_66 @kc87_second_20 -180;
     pos @kc87_first_66 @kc87_second_22 -140;
-    pos @kc87_first_66 @kc87_second_23 -35;
-    pos @kc87_first_66 @kc87_second_24 -175;
-    pos @kc87_first_66 @kc87_second_25 -140;
-    pos @kc87_first_66 @kc87_second_26 -280;
-    pos @kc87_first_66 @kc87_second_31 -35;
-    pos @kc87_first_66 @kc87_second_32 -35;
-    pos @kc87_first_66 @kc87_second_34 -210;
-    pos @kc87_first_66 @kc87_second_35 -175;
-    pos @kc87_first_66 @kc87_second_37 -245;
-    pos @kc87_first_66 @kc87_second_38 -140;
-    pos @kc87_first_66 @kc87_second_39 -140;
-    pos @kc87_first_66 @kc87_second_40 -140;
-    pos @kc87_first_66 @kc87_second_41 -140;
-    pos @kc87_first_66 @kc87_second_42 -35;
-    pos @kc87_first_66 @kc87_second_47 -35;
-    pos @kc87_first_66 @kc87_second_48 1;
+    pos @kc87_first_66 @kc87_second_24 -105;
+    pos @kc87_first_66 @kc87_second_27 -140;
+    pos @kc87_first_66 @kc87_second_31 -105;
+    pos @kc87_first_66 @kc87_second_33 -140;
+    pos @kc87_first_66 @kc87_second_34 -105;
+    pos @kc87_first_66 @kc87_second_38 -35;
+    pos @kc87_first_66 @kc87_second_40 -105;
+    pos @kc87_first_66 @kc87_second_41 -35;
+    pos @kc87_first_66 @kc87_second_43 -175;
+    pos @kc87_first_66 @kc87_second_44 -142;
+    pos @kc87_first_66 @kc87_second_45 -245;
+    pos @kc87_first_66 @kc87_second_47 -210;
+    pos @kc87_first_66 @kc87_second_48 -175;
+    pos @kc87_first_66 @kc87_second_51 1;
     pos @kc87_first_66 @kc87_second_52 -35;
-    pos @kc87_first_66 @kc87_second_54 -140;
-    pos @kc87_first_66 @kc87_second_55 -70;
-    pos @kc87_first_66 @kc87_second_56 -210;
-    pos @kc87_first_66 @kc87_second_58 -210;
-    pos @kc87_first_66 @kc87_second_59 -210;
-    pos @kc87_first_66 @kc87_second_61 -35;
-    pos @kc87_first_66 @kc87_second_66 -175;
-    pos @kc87_first_66 @kc87_second_67 -245;
-    pos @kc87_first_67 @kc87_second_6 -35;
-    pos @kc87_first_67 @kc87_second_12 -240;
+    pos @kc87_first_66 @kc87_second_53 -210;
+    pos @kc87_first_66 @kc87_second_54 -210;
+    pos @kc87_first_66 @kc87_second_56 -35;
+    pos @kc87_first_66 @kc87_second_63 -280;
+    pos @kc87_first_66 @kc87_second_65 -175;
+    pos @kc87_first_66 @kc87_second_66 -140;
+    pos @kc87_first_66 @kc87_second_67 -140;
+    pos @kc87_first_66 @kc87_second_68 -70;
+    pos @kc87_first_66 @kc87_second_69 -70;
+    pos @kc87_first_67 @kc87_second_1 -175;
+    pos @kc87_first_67 @kc87_second_2 -175;
+    pos @kc87_first_67 @kc87_second_5 -70;
+    pos @kc87_first_67 @kc87_second_6 -105;
+    pos @kc87_first_67 @kc87_second_11 -105;
+    pos @kc87_first_67 @kc87_second_12 -175;
     pos @kc87_first_67 @kc87_second_13 -140;
     pos @kc87_first_67 @kc87_second_14 -70;
     pos @kc87_first_67 @kc87_second_15 -35;
-    pos @kc87_first_67 @kc87_second_18 -35;
-    pos @kc87_first_67 @kc87_second_22 -35;
-    pos @kc87_first_67 @kc87_second_24 -35;
-    pos @kc87_first_67 @kc87_second_37 -70;
-    pos @kc87_first_67 @kc87_second_41 -70;
-    pos @kc87_first_67 @kc87_second_42 -50;
-    pos @kc87_first_67 @kc87_second_48 1;
-    pos @kc87_first_67 @kc87_second_51 -35;
-    pos @kc87_first_67 @kc87_second_66 -35;
-    pos @kc87_first_67 @kc87_second_67 -35;
+    pos @kc87_first_67 @kc87_second_16 -140;
+    pos @kc87_first_67 @kc87_second_17 -70;
+    pos @kc87_first_67 @kc87_second_18 -70;
+    pos @kc87_first_67 @kc87_second_19 -140;
+    pos @kc87_first_67 @kc87_second_21 -175;
+    pos @kc87_first_67 @kc87_second_24 -70;
+    pos @kc87_first_67 @kc87_second_31 -35;
+    pos @kc87_first_67 @kc87_second_34 -70;
+    pos @kc87_first_67 @kc87_second_36 -70;
+    pos @kc87_first_67 @kc87_second_38 -105;
+    pos @kc87_first_67 @kc87_second_39 -175;
+    pos @kc87_first_67 @kc87_second_41 -35;
+    pos @kc87_first_67 @kc87_second_43 -70;
+    pos @kc87_first_67 @kc87_second_51 1;
+    pos @kc87_first_67 @kc87_second_56 -35;
+    pos @kc87_first_67 @kc87_second_58 -140;
+    pos @kc87_first_67 @kc87_second_60 -140;
+    pos @kc87_first_67 @kc87_second_61 -140;
+    pos @kc87_first_67 @kc87_second_68 -70;
+    pos @kc87_first_67 @kc87_second_69 -105;
     pos @kc87_first_68 @kc87_second_3 -100;
     pos @kc87_first_68 @kc87_second_4 -50;
     pos @kc87_first_68 @kc87_second_6 -50;
@@ -10161,23 +10226,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_68 @kc87_second_25 -70;
     pos @kc87_first_68 @kc87_second_31 -35;
     pos @kc87_first_68 @kc87_second_33 -70;
-    pos @kc87_first_68 @kc87_second_36 105;
-    pos @kc87_first_68 @kc87_second_37 -35;
-    pos @kc87_first_68 @kc87_second_41 -70;
-    pos @kc87_first_68 @kc87_second_42 -140;
-    pos @kc87_first_68 @kc87_second_43 -140;
-    pos @kc87_first_68 @kc87_second_46 -140;
-    pos @kc87_first_68 @kc87_second_47 -35;
-    pos @kc87_first_68 @kc87_second_48 1;
-    pos @kc87_first_68 @kc87_second_50 -70;
-    pos @kc87_first_68 @kc87_second_51 -100;
-    pos @kc87_first_68 @kc87_second_53 105;
-    pos @kc87_first_68 @kc87_second_61 -140;
-    pos @kc87_first_68 @kc87_second_63 -70;
-    pos @kc87_first_68 @kc87_second_64 -70;
-    pos @kc87_first_68 @kc87_second_65 -50;
-    pos @kc87_first_68 @kc87_second_66 -35;
-    pos @kc87_first_68 @kc87_second_67 -35;
+    pos @kc87_first_68 @kc87_second_34 -50;
+    pos @kc87_first_68 @kc87_second_37 105;
+    pos @kc87_first_68 @kc87_second_38 -35;
+    pos @kc87_first_68 @kc87_second_40 -35;
+    pos @kc87_first_68 @kc87_second_43 -70;
+    pos @kc87_first_68 @kc87_second_44 -140;
+    pos @kc87_first_68 @kc87_second_45 -140;
+    pos @kc87_first_68 @kc87_second_47 -140;
+    pos @kc87_first_68 @kc87_second_48 -50;
+    pos @kc87_first_68 @kc87_second_51 1;
+    pos @kc87_first_68 @kc87_second_53 -70;
+    pos @kc87_first_68 @kc87_second_54 -100;
+    pos @kc87_first_68 @kc87_second_55 105;
+    pos @kc87_first_68 @kc87_second_63 -140;
+    pos @kc87_first_68 @kc87_second_65 -70;
+    pos @kc87_first_68 @kc87_second_66 -70;
+    pos @kc87_first_68 @kc87_second_67 -50;
+    pos @kc87_first_68 @kc87_second_68 -35;
+    pos @kc87_first_68 @kc87_second_69 -35;
     pos @kc87_first_69 @kc87_second_3 -70;
     pos @kc87_first_69 @kc87_second_4 -50;
     pos @kc87_first_69 @kc87_second_6 -50;
@@ -10195,23 +10262,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_69 @kc87_second_25 -70;
     pos @kc87_first_69 @kc87_second_31 -35;
     pos @kc87_first_69 @kc87_second_33 -70;
-    pos @kc87_first_69 @kc87_second_36 105;
-    pos @kc87_first_69 @kc87_second_37 -35;
-    pos @kc87_first_69 @kc87_second_41 -70;
-    pos @kc87_first_69 @kc87_second_42 -140;
-    pos @kc87_first_69 @kc87_second_43 -140;
-    pos @kc87_first_69 @kc87_second_46 -140;
-    pos @kc87_first_69 @kc87_second_47 -35;
-    pos @kc87_first_69 @kc87_second_48 1;
-    pos @kc87_first_69 @kc87_second_50 -70;
-    pos @kc87_first_69 @kc87_second_51 -140;
-    pos @kc87_first_69 @kc87_second_53 105;
-    pos @kc87_first_69 @kc87_second_61 -140;
-    pos @kc87_first_69 @kc87_second_63 -70;
-    pos @kc87_first_69 @kc87_second_64 -105;
+    pos @kc87_first_69 @kc87_second_34 -50;
+    pos @kc87_first_69 @kc87_second_37 105;
+    pos @kc87_first_69 @kc87_second_38 -35;
+    pos @kc87_first_69 @kc87_second_40 -35;
+    pos @kc87_first_69 @kc87_second_43 -70;
+    pos @kc87_first_69 @kc87_second_44 -140;
+    pos @kc87_first_69 @kc87_second_45 -140;
+    pos @kc87_first_69 @kc87_second_47 -140;
+    pos @kc87_first_69 @kc87_second_48 -50;
+    pos @kc87_first_69 @kc87_second_51 1;
+    pos @kc87_first_69 @kc87_second_53 -70;
+    pos @kc87_first_69 @kc87_second_54 -140;
+    pos @kc87_first_69 @kc87_second_55 105;
+    pos @kc87_first_69 @kc87_second_63 -140;
     pos @kc87_first_69 @kc87_second_65 -70;
-    pos @kc87_first_69 @kc87_second_66 -35;
-    pos @kc87_first_69 @kc87_second_67 -35;
+    pos @kc87_first_69 @kc87_second_66 -105;
+    pos @kc87_first_69 @kc87_second_67 -70;
+    pos @kc87_first_69 @kc87_second_68 -35;
+    pos @kc87_first_69 @kc87_second_69 -35;
     pos @kc87_first_70 @kc87_second_3 -70;
     pos @kc87_first_70 @kc87_second_4 -50;
     pos @kc87_first_70 @kc87_second_6 -50;
@@ -10229,23 +10298,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_70 @kc87_second_25 -100;
     pos @kc87_first_70 @kc87_second_31 -35;
     pos @kc87_first_70 @kc87_second_33 -70;
-    pos @kc87_first_70 @kc87_second_36 105;
-    pos @kc87_first_70 @kc87_second_37 -35;
-    pos @kc87_first_70 @kc87_second_41 -70;
-    pos @kc87_first_70 @kc87_second_42 -140;
-    pos @kc87_first_70 @kc87_second_43 -140;
-    pos @kc87_first_70 @kc87_second_46 -140;
-    pos @kc87_first_70 @kc87_second_47 -35;
-    pos @kc87_first_70 @kc87_second_48 1;
-    pos @kc87_first_70 @kc87_second_50 -70;
-    pos @kc87_first_70 @kc87_second_51 -140;
-    pos @kc87_first_70 @kc87_second_53 105;
-    pos @kc87_first_70 @kc87_second_61 -140;
-    pos @kc87_first_70 @kc87_second_63 -70;
-    pos @kc87_first_70 @kc87_second_64 -70;
-    pos @kc87_first_70 @kc87_second_65 -50;
-    pos @kc87_first_70 @kc87_second_66 -35;
-    pos @kc87_first_70 @kc87_second_67 -35;
+    pos @kc87_first_70 @kc87_second_34 -50;
+    pos @kc87_first_70 @kc87_second_37 105;
+    pos @kc87_first_70 @kc87_second_38 -35;
+    pos @kc87_first_70 @kc87_second_40 -35;
+    pos @kc87_first_70 @kc87_second_43 -70;
+    pos @kc87_first_70 @kc87_second_44 -140;
+    pos @kc87_first_70 @kc87_second_45 -140;
+    pos @kc87_first_70 @kc87_second_47 -140;
+    pos @kc87_first_70 @kc87_second_48 -50;
+    pos @kc87_first_70 @kc87_second_51 1;
+    pos @kc87_first_70 @kc87_second_53 -70;
+    pos @kc87_first_70 @kc87_second_54 -140;
+    pos @kc87_first_70 @kc87_second_55 105;
+    pos @kc87_first_70 @kc87_second_63 -140;
+    pos @kc87_first_70 @kc87_second_65 -70;
+    pos @kc87_first_70 @kc87_second_66 -70;
+    pos @kc87_first_70 @kc87_second_67 -50;
+    pos @kc87_first_70 @kc87_second_68 -35;
+    pos @kc87_first_70 @kc87_second_69 -35;
     pos @kc87_first_71 @kc87_second_1 -210;
     pos @kc87_first_71 @kc87_second_2 -210;
     pos @kc87_first_71 @kc87_second_3 -35;
@@ -10261,26 +10332,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_71 @kc87_second_25 -105;
     pos @kc87_first_71 @kc87_second_26 -175;
     pos @kc87_first_71 @kc87_second_31 -105;
-    pos @kc87_first_71 @kc87_second_34 -210;
-    pos @kc87_first_71 @kc87_second_35 -105;
-    pos @kc87_first_71 @kc87_second_37 -175;
-    pos @kc87_first_71 @kc87_second_38 -140;
-    pos @kc87_first_71 @kc87_second_39 -70;
-    pos @kc87_first_71 @kc87_second_40 -105;
-    pos @kc87_first_71 @kc87_second_41 -105;
-    pos @kc87_first_71 @kc87_second_42 -70;
-    pos @kc87_first_71 @kc87_second_47 -35;
-    pos @kc87_first_71 @kc87_second_48 1;
-    pos @kc87_first_71 @kc87_second_53 -35;
-    pos @kc87_first_71 @kc87_second_54 -70;
-    pos @kc87_first_71 @kc87_second_55 -70;
-    pos @kc87_first_71 @kc87_second_56 -175;
+    pos @kc87_first_71 @kc87_second_34 -140;
+    pos @kc87_first_71 @kc87_second_35 -210;
+    pos @kc87_first_71 @kc87_second_36 -105;
+    pos @kc87_first_71 @kc87_second_38 -175;
+    pos @kc87_first_71 @kc87_second_39 -140;
+    pos @kc87_first_71 @kc87_second_40 -35;
+    pos @kc87_first_71 @kc87_second_41 -70;
+    pos @kc87_first_71 @kc87_second_42 -105;
+    pos @kc87_first_71 @kc87_second_43 -105;
+    pos @kc87_first_71 @kc87_second_44 -70;
+    pos @kc87_first_71 @kc87_second_51 1;
+    pos @kc87_first_71 @kc87_second_55 -35;
+    pos @kc87_first_71 @kc87_second_56 -70;
+    pos @kc87_first_71 @kc87_second_57 -70;
     pos @kc87_first_71 @kc87_second_58 -175;
-    pos @kc87_first_71 @kc87_second_59 -175;
-    pos @kc87_first_71 @kc87_second_61 -35;
-    pos @kc87_first_71 @kc87_second_62 -35;
-    pos @kc87_first_71 @kc87_second_66 -140;
-    pos @kc87_first_71 @kc87_second_67 -175;
+    pos @kc87_first_71 @kc87_second_60 -175;
+    pos @kc87_first_71 @kc87_second_61 -175;
+    pos @kc87_first_71 @kc87_second_63 -35;
+    pos @kc87_first_71 @kc87_second_64 -35;
+    pos @kc87_first_71 @kc87_second_68 -140;
+    pos @kc87_first_71 @kc87_second_69 -175;
     pos @kc87_first_72 @kc87_second_5 -70;
     pos @kc87_first_72 @kc87_second_8 -70;
     pos @kc87_first_72 @kc87_second_9 -105;
@@ -10295,22 +10367,23 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_72 @kc87_second_28 -35;
     pos @kc87_first_72 @kc87_second_29 -70;
     pos @kc87_first_72 @kc87_second_33 -70;
-    pos @kc87_first_72 @kc87_second_41 -35;
-    pos @kc87_first_72 @kc87_second_42 -245;
-    pos @kc87_first_72 @kc87_second_43 -70;
-    pos @kc87_first_72 @kc87_second_45 -35;
-    pos @kc87_first_72 @kc87_second_46 -240;
-    pos @kc87_first_72 @kc87_second_48 1;
-    pos @kc87_first_72 @kc87_second_50 -105;
-    pos @kc87_first_72 @kc87_second_51 -280;
-    pos @kc87_first_72 @kc87_second_52 -35;
-    pos @kc87_first_72 @kc87_second_57 -35;
-    pos @kc87_first_72 @kc87_second_60 -70;
-    pos @kc87_first_72 @kc87_second_61 -105;
-    pos @kc87_first_72 @kc87_second_62 -35;
-    pos @kc87_first_72 @kc87_second_63 -70;
-    pos @kc87_first_72 @kc87_second_64 -175;
-    pos @kc87_first_72 @kc87_second_65 -140;
+    pos @kc87_first_72 @kc87_second_43 -35;
+    pos @kc87_first_72 @kc87_second_44 -245;
+    pos @kc87_first_72 @kc87_second_45 -70;
+    pos @kc87_first_72 @kc87_second_47 -240;
+    pos @kc87_first_72 @kc87_second_48 -210;
+    pos @kc87_first_72 @kc87_second_49 -35;
+    pos @kc87_first_72 @kc87_second_50 -35;
+    pos @kc87_first_72 @kc87_second_51 1;
+    pos @kc87_first_72 @kc87_second_53 -105;
+    pos @kc87_first_72 @kc87_second_54 -280;
+    pos @kc87_first_72 @kc87_second_59 -35;
+    pos @kc87_first_72 @kc87_second_62 -70;
+    pos @kc87_first_72 @kc87_second_63 -105;
+    pos @kc87_first_72 @kc87_second_64 -35;
+    pos @kc87_first_72 @kc87_second_65 -70;
+    pos @kc87_first_72 @kc87_second_66 -175;
+    pos @kc87_first_72 @kc87_second_67 -140;
     pos @kc87_first_73 @kc87_second_1 -140;
     pos @kc87_first_73 @kc87_second_2 -140;
     pos @kc87_first_73 @kc87_second_6 -140;
@@ -10325,21 +10398,22 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_73 @kc87_second_25 -70;
     pos @kc87_first_73 @kc87_second_26 -140;
     pos @kc87_first_73 @kc87_second_31 -70;
-    pos @kc87_first_73 @kc87_second_35 -70;
-    pos @kc87_first_73 @kc87_second_37 -175;
-    pos @kc87_first_73 @kc87_second_38 -105;
-    pos @kc87_first_73 @kc87_second_39 -70;
-    pos @kc87_first_73 @kc87_second_40 -70;
+    pos @kc87_first_73 @kc87_second_34 -35;
+    pos @kc87_first_73 @kc87_second_36 -70;
+    pos @kc87_first_73 @kc87_second_38 -175;
+    pos @kc87_first_73 @kc87_second_39 -105;
     pos @kc87_first_73 @kc87_second_41 -70;
-    pos @kc87_first_73 @kc87_second_42 -35;
-    pos @kc87_first_73 @kc87_second_48 1;
-    pos @kc87_first_73 @kc87_second_53 -35;
-    pos @kc87_first_73 @kc87_second_54 -35;
-    pos @kc87_first_73 @kc87_second_56 -140;
+    pos @kc87_first_73 @kc87_second_42 -70;
+    pos @kc87_first_73 @kc87_second_43 -70;
+    pos @kc87_first_73 @kc87_second_44 -35;
+    pos @kc87_first_73 @kc87_second_51 1;
+    pos @kc87_first_73 @kc87_second_55 -35;
+    pos @kc87_first_73 @kc87_second_56 -35;
     pos @kc87_first_73 @kc87_second_58 -140;
-    pos @kc87_first_73 @kc87_second_59 -140;
-    pos @kc87_first_73 @kc87_second_66 -105;
-    pos @kc87_first_73 @kc87_second_67 -105;
+    pos @kc87_first_73 @kc87_second_60 -140;
+    pos @kc87_first_73 @kc87_second_61 -140;
+    pos @kc87_first_73 @kc87_second_68 -105;
+    pos @kc87_first_73 @kc87_second_69 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -13272,6 +13346,7 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
+#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 

--- a/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlack.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/30 16:15:58</string>
+    <string>2026/07/30 22:01:16</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/features.fea
@@ -7920,16 +7920,17 @@ lookup kern_Horizontal_kerning {
     @kc87_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
 	\Gcommaaccent.cv21 \Gdotaccent.cv21 \O \Oacute \Obreve \Ocircumflex 
 	\Odieresis \Ograve \Ohungarumlaut \Omacron \Omicron \Omicrontonos 
-	\Oslash \Oslashacute \Otilde \Theta \uni0189 \uni018A \uni018F 
-	\uni0193.cv21 \uni019F \uni01D1 \uni01E4.cv21 \uni01EA \uni01EC 
-	\uni01F4.cv21 \uni020C \uni020E \uni022A \uni022C \uni022E \uni0230 
-	\uni0298 \uni03D8 \uni03F4 \uni03FD \uni03FF \uni041E \uni042E \uni0472 
-	\uni047A \uni04BC \uni04BE \uni04D8 \uni04DA \uni04E6 \uni04E8 \uni04EA 
-	\uni04EC \uni050C \uni1E0A \uni1E0C \uni1E0E \uni1E10 \uni1E12 
-	\uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE 
-	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
-	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
-	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
+	\Oslash \Oslashacute \Otilde \Theta \two.cv02.pnum \two.cv12.pnum 
+	\two.pnum \uni0189 \uni018A \uni018F \uni0193.cv21 \uni019F \uni01D1 
+	\uni01E4.cv21 \uni01EA \uni01EC \uni01F4.cv21 \uni020C \uni020E 
+	\uni022A \uni022C \uni022E \uni0230 \uni0298 \uni03D8 \uni03F4 \uni03FD 
+	\uni03FF \uni041E \uni042E \uni0472 \uni047A \uni04BC \uni04BE \uni04D8 
+	\uni04DA \uni04E6 \uni04E8 \uni04EA \uni04EC \uni050C \uni1E0A \uni1E0C 
+	\uni1E0E \uni1E10 \uni1E12 \uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 
+	\uni1E52 \uni1ECC \uni1ECE \uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 
+	\uni1EDA \uni1EDC \uni1EDE \uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A 
+	\uni1F4B \uni1F4C \uni1F4D \uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 
+	\uni2181 \uni2182 \uniA7C7 ];
     @kc87_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
 	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
 	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
@@ -7946,24 +7947,27 @@ lookup kern_Horizontal_kerning {
     @kc87_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc87_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
-	\uniA7AD ];
+    @kc87_first_9 = [\L \Lacute \one.cv01.ss06.pnum \one.cv11.ss06.pnum \one.ss06.pnum \uni023D 
+	\uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 \uniA7AD ];
     @kc87_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
     @kc87_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
     @kc87_first_12 = [\Psi \uni0470 ];
     @kc87_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
-	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
-	\uni2107 ];
+    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv08.onum 
+	\eight.cv08.pnum \eight.cv18.onum \eight.cv18.pnum \eight.onum 
+	\eight.pnum \three.cv03.pnum \three.pnum \uni0190 \uni01A7 \uni03E8 
+	\uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 \uni2107 ];
     @kc87_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
     @kc87_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc87_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
-	\uni2163 \uni2164 \universal ];
+    @kc87_first_17 = [\V \gradient \nine.cv19.pnum \seven.cv07.pnum \seven.cv07.ss07.pnum 
+	\seven.cv17.pnum \seven.cv17.ss07.pnum \seven.pnum \seven.ss07.pnum 
+	\slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE \uni2163 
+	\uni2164 \universal ];
     @kc87_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
     @kc87_first_19 = [\a \a.cv23 \aacute \aacute.cv23 \abreve \abreve.cv23 \acircumflex 
 	\acircumflex.cv23 \adieresis \adieresis.cv23 \agrave \agrave.cv23 
@@ -8059,16 +8063,17 @@ lookup kern_Horizontal_kerning {
     @kc87_first_22 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
-	\uni0207 \uni020D \uni020F \uni0229 \uni022B \uni022D \uni022F \uni0231 
-	\uni0247 \uni0254 \uni0258 \uni0259 \uni0275 \uni0278 \uni037B \uni037D 
-	\uni03D9 \uni03F6 \uni0435 \uni043E \uni044D \uni044E \uni0473 \uni04BD 
-	\uni04BF \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni04ED 
-	\uni050D \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni018D \uni01D2 \uni01DD 
+	\uni01E3 \uni01EB \uni01ED \uni0205 \uni0207 \uni020D \uni020F \uni0229 
+	\uni022B \uni022D \uni022F \uni0231 \uni0247 \uni0254 \uni0258 \uni0259 
+	\uni0275 \uni0278 \uni037B \uni037D \uni03D9 \uni03F6 \uni0435 \uni043E 
+	\uni044D \uni044E \uni0473 \uni04BD \uni04BF \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni04ED \uni050D \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni2184 ];
     @kc87_first_23 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
@@ -8153,18 +8158,21 @@ lookup kern_Horizontal_kerning {
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc87_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
-	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
-	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
-	\uni037B.sc \uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc 
-	\uni0473.sc \uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc 
-	\uni04E9.sc \uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc 
-	\uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc 
-	\uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc 
-	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
-	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
-	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
+    @kc87_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \nine.cv09.onum \nine.cv19.onum \nine.onum 
+	\o.sc \oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohungarumlaut.sc \omacron.sc \omicron.sc \oslash.sc \otilde.sc 
+	\uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc \uni022D.sc 
+	\uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc \uni037B.sc 
+	\uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc \uni0473.sc 
+	\uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc 
+	\uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc 
+	\uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_first_33 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
@@ -8223,73 +8231,82 @@ lookup kern_Horizontal_kerning {
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
     @kc87_first_37 = [\eth \uni1EFC \uni1EFD ];
-    @kc87_first_38 = [\fraction ];
-    @kc87_first_39 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc87_first_40 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
-	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_first_41 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc87_first_38 = [\four.cv04.onum \four.cv14.onum \four.onum \l.sc \lacute.sc \lcaron.sc 
+	\lcommaaccent.sc \ldot.sc \lslash.sc \one.cv01.ss06.onum 
+	\one.cv11.ss06.onum \one.ss06.onum \uni019A.sc \uni0234.sc 
+	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
+    @kc87_first_39 = [\four.cv04.pnum \four.cv14.pnum \four.pnum \phi.sc \thorn.sc \uni01A5.sc 
+	\uni0444.sc ];
+    @kc87_first_40 = [\fraction ];
+    @kc87_first_41 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \three.cv03.onum 
+	\three.onum \uni01E5 \uni1E21 ];
+    @kc87_first_42 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \two.cv02.onum \two.cv12.onum 
+	\two.onum \uni0260.sc \uni051B.sc \uni051B.sc.cv29 \uni1F60.sc 
+	\uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc 
+	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc 
+	\uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
+	\uni1FF6.sc \uni1FF7.sc ];
+    @kc87_first_43 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc87_first_42 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc87_first_44 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc87_first_43 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc87_first_45 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc87_first_44 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc87_first_46 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc87_first_45 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc87_first_47 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc87_first_46 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
-	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc87_first_47 = [\lambda \uni019B ];
-    @kc87_first_48 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc87_first_49 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc87_first_48 = [\lambda \uni019B ];
+    @kc87_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc87_first_50 = [\theta \uni047C \uniA7B6 \uniA64C \uni0424.loclBGR \zero.pnum \nine.pnum 
+	\nine.cv09.pnum \zero.cv10.pnum \zero.cv20.pnum \zero.zero.pnum 
+	\zero.cv10.zero.pnum \zero.cv20.zero.pnum ];
+    @kc87_first_51 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc87_first_50 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc87_first_51 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc87_first_52 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc87_first_52 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc87_first_53 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc87_first_54 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc87_first_53 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_first_54 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc87_first_55 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc87_first_56 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc87_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc87_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc87_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc87_first_57 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc87_first_58 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
-	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
-	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_first_59 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
-	\uni1E71 ];
-    @kc87_first_60 = [\tau \uni0491 \uni04A5 ];
-    @kc87_first_61 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc87_first_62 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc87_first_63 = [\uni0196 \uni01AA ];
-    @kc87_first_64 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
-	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
-	\ygrave ];
-    @kc87_first_65 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_first_59 = [\seven.cv07.onum \seven.cv07.ss07.onum \seven.cv17.onum 
+	\seven.cv17.ss07.onum \seven.onum \seven.ss07.onum \uni01B4.sc 
+	\uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_first_66 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
-	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
-	\zdotaccent ];
+    @kc87_first_60 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
+    @kc87_first_61 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+	\uni1E71 ];
+    @kc87_first_62 = [\tau \uni0491 \uni04A5 ];
+    @kc87_first_63 = [\three.cv13.onum \uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 
+	\uni02A3 \uni02AB \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z 
+	\zacute \zcaron \zdotaccent ];
+    @kc87_first_64 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc87_first_65 = [\uni0196 \uni01AA ];
+    @kc87_first_66 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
+	\ygrave ];
     @kc87_first_67 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
     @kc87_first_68 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
@@ -8330,15 +8347,19 @@ lookup kern_Horizontal_kerning {
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
     @kc87_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc87_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc87_second_7 = [\Omega \nine.cv19.pnum \two.cv02.pnum \two.cv12.pnum \two.pnum \uni03A9 
+	\uni1FFC ];
     @kc87_second_8 = [\Phi \uni0424 ];
     @kc87_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
-	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
-	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
-	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
+    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv08.onum 
+	\eight.cv08.pnum \eight.cv18.onum \eight.cv18.pnum \eight.onum 
+	\eight.tnum \three.cv03.pnum \three.tnum \uni01A7 \uni03E8 \uni0405 
+	\uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
+    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \three.cv13.pnum \uni01A9 \uni01B5 
+	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 ];
+    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \seven.cv07.pnum \seven.cv17.pnum \seven.pnum \uni0162 
+	\uni01AC \uni01AE \uni021A \uni0422 \uni042A \uni04AC \uni04B4 \uni050E 
+	\uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
     @kc87_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
@@ -8354,15 +8375,16 @@ lookup kern_Horizontal_kerning {
 	\agrave.cv23 \agrave.sc \alpha \alpha.sc \alphatonos \amacron 
 	\amacron.cv23 \amacron.sc \aogonek \aogonek.cv23 \aogonek.sc \aring 
 	\aring.cv23 \aring.sc \aringacute.cv23 \atilde \atilde.cv23 
-	\atilde.sc \d \dcaron \dcroat \delta.sc \dong \eth \g \g.cv24 \gbreve 
-	\gbreve.cv24 \gcaron.cv24 \gcircumflex \gcircumflex.cv24 
-	\gcommaaccent \gcommaaccent.cv24 \gdotaccent \gdotaccent.cv24 
-	\lambda.sc \phi \q \sigma \uni019B.sc \uni01CE.cv23 \uni01CE.sc 
-	\uni01DF \uni01DF.cv23 \uni01DF.sc \uni01E1 \uni01E1.cv23 \uni01E1.sc 
-	\uni01E3.cv23 \uni01E5 \uni01E5.cv24 \uni01F5.cv24 \uni0201 
-	\uni0201.cv23 \uni0201.sc \uni0203 \uni0203.cv23 \uni0203.sc \uni0227 
-	\uni0227.cv23 \uni0227.sc \uni0238 \uni0239 \uni024B \uni0260 \uni0261 
-	\uni0278 \uni0430 \uni0430.cv23 \uni0430.sc \uni0432 \uni0434 
+	\atilde.sc \d \dcaron \dcroat \delta.sc \dong \eth \four.cv04.onum 
+	\four.cv14.onum \four.onum \g \g.cv24 \gbreve \gbreve.cv24 
+	\gcaron.cv24 \gcircumflex \gcircumflex.cv24 \gcommaaccent 
+	\gcommaaccent.cv24 \gdotaccent \gdotaccent.cv24 \lambda.sc \phi \q 
+	\sigma \three.cv03.onum \three.onum \uni019B.sc \uni01CE.cv23 
+	\uni01CE.sc \uni01DF \uni01DF.cv23 \uni01DF.sc \uni01E1 \uni01E1.cv23 
+	\uni01E1.sc \uni01E3.cv23 \uni01E5 \uni01E5.cv24 \uni01F5.cv24 
+	\uni0201 \uni0201.cv23 \uni0201.sc \uni0203 \uni0203.cv23 \uni0203.sc 
+	\uni0227 \uni0227.cv23 \uni0227.sc \uni0238 \uni0239 \uni024B \uni0260 
+	\uni0261 \uni0278 \uni0430 \uni0430.cv23 \uni0430.sc \uni0432 \uni0434 
 	\uni0434.loclBGR \uni0434.loclBGR.sc \uni043B.loclBGR.sc \uni0444 
 	\uni0467.sc \uni0469.sc \uni04D1 \uni04D1.cv23 \uni04D1.sc \uni04D3 
 	\uni04D3.cv23 \uni04D3.sc \uni04D5.cv23 \uni0501 \uni0503 \uni051B 
@@ -8449,12 +8471,12 @@ lookup kern_Horizontal_kerning {
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \q.sc.cv29 \uni0188 \uni018D \uni01A3 \uni01D2 \uni01DD 
-	\uni01EB \uni020D \uni020F \uni022B \uni022D \uni022F \uni0231 \uni023C 
-	\uni0247 \uni0255 \uni0258 \uni0259 \uni025A \uni0275 \uni0276 \uni029B 
-	\uni03D9 \uni03F2 \uni03F5 \uni0435 \uni043E \uni0450 \uni0451 \uni0473 
-	\uni047B \uni04A9 \uni04AB \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 
-	\uni04EB \uni050D \uni051B.sc.cv29 \uni1E09 \uni1E15 \uni1E17 \uni1E19 
+	\otilde \six.cv16.onum \six.cv16.pnum \uni0188 \uni018D \uni01A3 
+	\uni01D2 \uni01DD \uni01EB \uni020D \uni020F \uni022B \uni022D \uni022F 
+	\uni0231 \uni023C \uni0247 \uni0255 \uni0258 \uni0259 \uni025A \uni0275 
+	\uni0276 \uni029B \uni03D9 \uni03F2 \uni03F5 \uni0435 \uni043E \uni0450 
+	\uni0451 \uni0473 \uni047B \uni04A9 \uni04AB \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni050D \uni1E09 \uni1E15 \uni1E17 \uni1E19 
 	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
 	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
 	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
@@ -8462,22 +8484,25 @@ lookup kern_Horizontal_kerning {
 	\uni1F78 \uni1F79 \uni20C0 \uni217D ];
     @kc87_second_23 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
-	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
-	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc 
-	\uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc 
-	\uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc 
-	\uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc 
-	\uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc 
-	\uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc 
-	\uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc 
-	\uni050D.sc \uni051B.sc \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
+	\gdotaccent.sc \nine.cv09.onum \nine.cv19.onum \nine.onum \o.sc 
+	\oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohorn.sc \ohungarumlaut.sc \omacron.sc \omicron.sc \omicrontonos.sc 
+	\oslash.sc \oslashacute.sc \otilde.sc \q.sc \q.sc.cv29 \theta.sc 
+	\uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc \uni022B.sc 
+	\uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc \uni0259.sc 
+	\uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc \uni03D9.sc 
+	\uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc \uni0454.sc 
+	\uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc \uni04D9.sc 
+	\uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni050D.sc 
+	\uni051B.sc \uni051B.sc.cv29 \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
 	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
 	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
 	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
 	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
-	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc ];
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_second_24 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
@@ -8540,14 +8565,15 @@ lookup kern_Horizontal_kerning {
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
     @kc87_second_27 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
-	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
-	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
-	\uni0457.sc \uni1E2D.sc \uni1E2F.sc \uni1EC9.sc \uni1ECB.sc 
-	\uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc 
-	\uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F76.sc \uni1F77.sc 
-	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2178.sc ];
+	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \one.cv01.ss06.onum 
+	\one.cv01.ss06.pnum \one.cv11.ss06.onum \one.cv11.ss06.pnum 
+	\one.ss06.onum \one.ss06.pnum \uni01D0.sc \uni0209.sc \uni020B.sc 
+	\uni0269.sc \uni026A.sc \uni0456.sc \uni0457.sc \uni1E2D.sc 
+	\uni1E2F.sc \uni1EC9.sc \uni1ECB.sc \uni1F30.sc \uni1F31.sc 
+	\uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
+	\uni1F37.sc \uni1F76.sc \uni1F77.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2178.sc ];
     @kc87_second_28 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
@@ -8590,97 +8616,105 @@ lookup kern_Horizontal_kerning {
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
     @kc87_second_30 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
-	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
-	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
-	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
-	\uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 \uni01D4.cv25 
-	\uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA \uni01DA.cv25 
-	\uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 \uni0215 
-	\uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 \uni0269 
-	\uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B \uni0299 
-	\uni029C \uni029F \uni0438 \uni0439 \uni043A \uni043C \uni043D \uni043F 
-	\uni0442 \uni0446 \uni0448 \uni0449 \uni044B \uni044C \uni044E \uni045C 
-	\uni045D \uni045F \uni0465 \uni0469 \uni046D \uni0491 \uni0495 \uni049B 
-	\uni049D \uni04A1 \uni04A3 \uni04A5 \uni04A7 \uni04AD \uni04C8 \uni04CA 
-	\uni04CE \uni0523 \uni0525 \uni0529 \uni1E3F \uni1E41 \uni1E43 \uni1E45 
-	\uni1E47 \uni1E49 \uni1E4B \uni1E59 \uni1E5B \uni1E5D \uni1E5F \uni1E73 
-	\uni1E73.cv25 \uni1E75 \uni1E75.cv25 \uni1E77 \uni1E77.cv25 \uni1E79 
-	\uni1E79.cv25 \uni1E7B \uni1E7B.cv25 \uni1EE5 \uni1EE5.cv25 \uni1EE7 
-	\uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 \uni1EED 
-	\uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 \uni1F50 
-	\uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F7A 
-	\uni1F7B \uni1FE6 \uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 
-	\upsilon \upsilondieresistonos \upsilontonos \uring \uring.cv25 
-	\utilde \utilde.cv25 ];
-    @kc87_second_31 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
-	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc87_second_32 = [\fraction ];
-    @kc87_second_33 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc87_second_34 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+	\ntilde \r \racute \rcaron \rcommaaccent \seven.cv07.ss07.onum 
+	\seven.cv17.ss07.onum \seven.ss07.onum \u \u.cv25 \uacute 
+	\uacute.cv25 \ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 
+	\udieresis \udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 
+	\uhungarumlaut \uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 
+	\uni01D4.cv25 \uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA 
+	\uni01DA.cv25 \uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 
+	\uni0215 \uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 
+	\uni0269 \uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B 
+	\uni0299 \uni029C \uni029F \uni0438 \uni0439 \uni043A \uni043C \uni043D 
+	\uni043F \uni0442 \uni0446 \uni0448 \uni0449 \uni044B \uni044C \uni044E 
+	\uni045C \uni045D \uni045F \uni0465 \uni0469 \uni046D \uni0491 \uni0495 
+	\uni049B \uni049D \uni04A1 \uni04A3 \uni04A5 \uni04A7 \uni04AD \uni04C8 
+	\uni04CA \uni04CE \uni0523 \uni0525 \uni0529 \uni1E3F \uni1E41 \uni1E43 
+	\uni1E45 \uni1E47 \uni1E49 \uni1E4B \uni1E59 \uni1E5B \uni1E5D \uni1E5F 
+	\uni1E73 \uni1E73.cv25 \uni1E75 \uni1E75.cv25 \uni1E77 \uni1E77.cv25 
+	\uni1E79 \uni1E79.cv25 \uni1E7B \uni1E7B.cv25 \uni1EE5 \uni1EE5.cv25 
+	\uni1EE7 \uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 
+	\uni1EED \uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 
+	\uni1F50 \uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 
+	\uni1F7A \uni1F7B \uni1FE6 \uni1FE7 \uni20AA \uniA657 \uogonek 
+	\uogonek.cv25 \upsilon \upsilondieresistonos \upsilontonos \uring 
+	\uring.cv25 \utilde \utilde.cv25 ];
+    @kc87_second_31 = [\f \florin \one.cv01.onum \one.cv01.pnum \one.cv11.onum \one.cv11.pnum 
+	\one.onum \one.pnum \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 
+	\uni1E1F \uni1E6B \uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
+    @kc87_second_32 = [\four.cv04.pnum \four.cv14.pnum \four.pnum ];
+    @kc87_second_33 = [\fraction ];
+    @kc87_second_34 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc87_second_35 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc87_second_35 = [\lambda \uni019B ];
-    @kc87_second_36 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc87_second_36 = [\lambda \uni019B ];
+    @kc87_second_37 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc87_second_37 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_second_38 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_second_39 = [\pi \tau \uni044A \uni04B5 ];
-    @kc87_second_40 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc87_second_38 = [\omega.sc \omegatonos.sc \two.cv02.onum \two.cv12.onum \two.onum.tnum 
+	\uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc 
+	\uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc 
+	\uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc 
+	\uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc 
+	\uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
+    @kc87_second_39 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc87_second_40 = [\pi \tau \uni044A \uni04B5 ];
+    @kc87_second_41 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc87_second_41 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_second_42 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc87_second_42 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc87_second_43 = [\seven.cv07.onum \seven.cv17.onum \seven.onum \t.sc \tau.sc \tbar.sc 
+	\tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc \uni021B.sc 
+	\uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc \uni0442.sc 
+	\uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc 
+	\uni1E71.sc \uni1E97.sc ];
+    @kc87_second_44 = [\seven.cv07.ss07.pnum \seven.cv17.ss07.pnum \seven.ss07.pnum ];
+    @kc87_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_second_43 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
-	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
-	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc87_second_44 = [\theta \uni0478 \uniA64C ];
-    @kc87_second_45 = [\tonos2 ];
-    @kc87_second_46 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc87_second_47 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc87_second_46 = [\six.cv06.onum \six.cv06.pnum \six.onum \six.pnum \theta \uni0478 \uniA64C 
+	\zero.cv10.pnum \zero.cv10.zero.pnum \zero.cv20.pnum 
+	\zero.cv20.zero.pnum \zero.pnum \zero.zero.pnum ];
+    @kc87_second_47 = [\three.cv13.onum \uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 
+	\uniA641 \uniA643 \z \zacute \zcaron \zdotaccent ];
+    @kc87_second_48 = [\tonos2 ];
+    @kc87_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc87_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc87_second_48 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_second_49 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
-	\z \zacute \zcaron \zdotaccent ];
-    @kc87_second_50 = [\uni0237 ];
-    @kc87_second_51 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc87_second_52 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc87_second_53 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc87_second_54 = [\uni042F \uni0518 ];
-    @kc87_second_55 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc87_second_52 = [\uni0237 ];
+    @kc87_second_53 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc87_second_54 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc87_second_55 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc87_second_56 = [\uni042F \uni0518 ];
+    @kc87_second_57 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc87_second_56 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc87_second_58 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc87_second_57 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
-    @kc87_second_58 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc87_second_59 = [\uni044F.sc \uni0519.sc ];
-    @kc87_second_60 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc87_second_59 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
+    @kc87_second_60 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc87_second_61 = [\uni044F.sc \uni0519.sc ];
+    @kc87_second_62 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc87_second_61 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc87_second_62 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc87_second_63 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc87_second_64 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc87_second_63 = [\uni0500 \uni0502 ];
-    @kc87_second_64 = [\uni0501.sc \uni0503.sc ];
-    @kc87_second_65 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
+    @kc87_second_65 = [\uni0500 \uni0502 ];
+    @kc87_second_66 = [\uni0501.sc \uni0503.sc ];
+    @kc87_second_67 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
 	\zero.cv20.zero.dnom.pnum \zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc87_second_66 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
+    @kc87_second_68 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
 	\zero.cv20.zero.numr.pnum \zero.numr.pnum \zero.zero.numr.pnum ];
     pos @kc87_first_1 @kc87_second_3 -70;
     pos @kc87_first_1 @kc87_second_8 -70;
     pos @kc87_first_1 @kc87_second_9 -140;
     pos @kc87_first_1 @kc87_second_10 -35;
-    pos @kc87_first_1 @kc87_second_12 -280;
+    pos @kc87_first_1 @kc87_second_12 -210;
     pos @kc87_first_1 @kc87_second_13 -280;
     pos @kc87_first_1 @kc87_second_14 -280;
     pos @kc87_first_1 @kc87_second_15 -210;
@@ -8688,26 +8722,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_1 @kc87_second_23 -35;
     pos @kc87_first_1 @kc87_second_25 -50;
     pos @kc87_first_1 @kc87_second_31 -70;
-    pos @kc87_first_1 @kc87_second_38 -35;
-    pos @kc87_first_1 @kc87_second_39 -140;
-    pos @kc87_first_1 @kc87_second_40 -105;
+    pos @kc87_first_1 @kc87_second_39 -35;
+    pos @kc87_first_1 @kc87_second_40 -140;
+    pos @kc87_first_1 @kc87_second_41 -105;
     pos @kc87_first_1 @kc87_second_43 -210;
-    pos @kc87_first_1 @kc87_second_44 -35;
-    pos @kc87_first_1 @kc87_second_45 1;
-    pos @kc87_first_1 @kc87_second_47 -175;
-    pos @kc87_first_1 @kc87_second_48 -210;
-    pos @kc87_first_1 @kc87_second_58 -140;
+    pos @kc87_first_1 @kc87_second_44 -175;
+    pos @kc87_first_1 @kc87_second_46 -35;
+    pos @kc87_first_1 @kc87_second_48 1;
+    pos @kc87_first_1 @kc87_second_50 -175;
+    pos @kc87_first_1 @kc87_second_51 -210;
     pos @kc87_first_1 @kc87_second_60 -140;
-    pos @kc87_first_1 @kc87_second_61 -210;
     pos @kc87_first_1 @kc87_second_62 -140;
+    pos @kc87_first_1 @kc87_second_63 -210;
+    pos @kc87_first_1 @kc87_second_64 -140;
     pos @kc87_first_2 @kc87_second_9 -35;
     pos @kc87_first_2 @kc87_second_12 -70;
     pos @kc87_first_2 @kc87_second_13 -70;
     pos @kc87_first_2 @kc87_second_14 -70;
     pos @kc87_first_2 @kc87_second_15 -35;
     pos @kc87_first_2 @kc87_second_16 -35;
-    pos @kc87_first_2 @kc87_second_39 -35;
-    pos @kc87_first_2 @kc87_second_45 1;
+    pos @kc87_first_2 @kc87_second_40 -35;
+    pos @kc87_first_2 @kc87_second_48 1;
     pos @kc87_first_3 @kc87_second_1 -35;
     pos @kc87_first_3 @kc87_second_2 -70;
     pos @kc87_first_3 @kc87_second_5 -35;
@@ -8717,14 +8752,14 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_3 @kc87_second_14 -35;
     pos @kc87_first_3 @kc87_second_16 -70;
     pos @kc87_first_3 @kc87_second_19 -70;
-    pos @kc87_first_3 @kc87_second_35 -35;
-    pos @kc87_first_3 @kc87_second_45 1;
+    pos @kc87_first_3 @kc87_second_36 -35;
+    pos @kc87_first_3 @kc87_second_48 1;
     pos @kc87_first_4 @kc87_second_1 -70;
     pos @kc87_first_4 @kc87_second_2 -140;
     pos @kc87_first_4 @kc87_second_4 70;
     pos @kc87_first_4 @kc87_second_5 -70;
     pos @kc87_first_4 @kc87_second_11 -105;
-    pos @kc87_first_4 @kc87_second_12 -140;
+    pos @kc87_first_4 @kc87_second_12 -70;
     pos @kc87_first_4 @kc87_second_13 -140;
     pos @kc87_first_4 @kc87_second_14 -105;
     pos @kc87_first_4 @kc87_second_15 -35;
@@ -8733,23 +8768,23 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_4 @kc87_second_26 -70;
     pos @kc87_first_4 @kc87_second_27 -35;
     pos @kc87_first_4 @kc87_second_31 35;
-    pos @kc87_first_4 @kc87_second_34 -70;
     pos @kc87_first_4 @kc87_second_35 -70;
+    pos @kc87_first_4 @kc87_second_36 -70;
     pos @kc87_first_4 @kc87_second_43 -35;
-    pos @kc87_first_4 @kc87_second_45 1;
-    pos @kc87_first_4 @kc87_second_48 -70;
-    pos @kc87_first_4 @kc87_second_53 -70;
+    pos @kc87_first_4 @kc87_second_48 1;
+    pos @kc87_first_4 @kc87_second_51 -70;
     pos @kc87_first_4 @kc87_second_55 -70;
     pos @kc87_first_4 @kc87_second_57 -70;
-    pos @kc87_first_4 @kc87_second_61 -35;
+    pos @kc87_first_4 @kc87_second_59 -70;
+    pos @kc87_first_4 @kc87_second_63 -35;
     pos @kc87_first_5 @kc87_second_12 -70;
-    pos @kc87_first_5 @kc87_second_45 1;
+    pos @kc87_first_5 @kc87_second_48 1;
     pos @kc87_first_6 @kc87_second_1 -280;
     pos @kc87_first_6 @kc87_second_2 -350;
     pos @kc87_first_6 @kc87_second_3 -140;
     pos @kc87_first_6 @kc87_second_4 -70;
     pos @kc87_first_6 @kc87_second_6 -350;
-    pos @kc87_first_6 @kc87_second_7 -140;
+    pos @kc87_first_6 @kc87_second_7 -70;
     pos @kc87_first_6 @kc87_second_8 -210;
     pos @kc87_first_6 @kc87_second_10 -70;
     pos @kc87_first_6 @kc87_second_17 -240;
@@ -8764,44 +8799,46 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_6 @kc87_second_29 -240;
     pos @kc87_first_6 @kc87_second_30 -240;
     pos @kc87_first_6 @kc87_second_31 -175;
-    pos @kc87_first_6 @kc87_second_34 -350;
-    pos @kc87_first_6 @kc87_second_35 -105;
-    pos @kc87_first_6 @kc87_second_36 -240;
-    pos @kc87_first_6 @kc87_second_37 -210;
-    pos @kc87_first_6 @kc87_second_38 -240;
+    pos @kc87_first_6 @kc87_second_32 -175;
+    pos @kc87_first_6 @kc87_second_35 -350;
+    pos @kc87_first_6 @kc87_second_36 -105;
+    pos @kc87_first_6 @kc87_second_37 -240;
+    pos @kc87_first_6 @kc87_second_38 -210;
     pos @kc87_first_6 @kc87_second_39 -240;
-    pos @kc87_first_6 @kc87_second_41 -240;
-    pos @kc87_first_6 @kc87_second_44 -140;
-    pos @kc87_first_6 @kc87_second_45 1;
-    pos @kc87_first_6 @kc87_second_46 -35;
+    pos @kc87_first_6 @kc87_second_40 -240;
+    pos @kc87_first_6 @kc87_second_42 -240;
+    pos @kc87_first_6 @kc87_second_46 -70;
     pos @kc87_first_6 @kc87_second_47 -240;
-    pos @kc87_first_6 @kc87_second_49 -240;
+    pos @kc87_first_6 @kc87_second_48 1;
+    pos @kc87_first_6 @kc87_second_49 -35;
     pos @kc87_first_6 @kc87_second_50 -240;
-    pos @kc87_first_6 @kc87_second_51 -240;
     pos @kc87_first_6 @kc87_second_52 -240;
-    pos @kc87_first_6 @kc87_second_53 -280;
-    pos @kc87_first_6 @kc87_second_54 -70;
-    pos @kc87_first_6 @kc87_second_55 -240;
-    pos @kc87_first_6 @kc87_second_56 -175;
-    pos @kc87_first_6 @kc87_second_57 -280;
-    pos @kc87_first_6 @kc87_second_58 -240;
-    pos @kc87_first_6 @kc87_second_59 -210;
-    pos @kc87_first_6 @kc87_second_60 -175;
-    pos @kc87_first_6 @kc87_second_63 -175;
-    pos @kc87_first_6 @kc87_second_64 -175;
+    pos @kc87_first_6 @kc87_second_53 -240;
+    pos @kc87_first_6 @kc87_second_54 -240;
+    pos @kc87_first_6 @kc87_second_55 -280;
+    pos @kc87_first_6 @kc87_second_56 -70;
+    pos @kc87_first_6 @kc87_second_57 -240;
+    pos @kc87_first_6 @kc87_second_58 -175;
+    pos @kc87_first_6 @kc87_second_59 -280;
+    pos @kc87_first_6 @kc87_second_60 -240;
+    pos @kc87_first_6 @kc87_second_61 -210;
+    pos @kc87_first_6 @kc87_second_62 -175;
+    pos @kc87_first_6 @kc87_second_65 -175;
+    pos @kc87_first_6 @kc87_second_66 -175;
     pos @kc87_first_7 @kc87_second_3 -70;
     pos @kc87_first_7 @kc87_second_8 -105;
     pos @kc87_first_7 @kc87_second_17 -35;
     pos @kc87_first_7 @kc87_second_20 -105;
     pos @kc87_first_7 @kc87_second_22 -105;
     pos @kc87_first_7 @kc87_second_23 -70;
-    pos @kc87_first_7 @kc87_second_45 1;
-    pos @kc87_first_7 @kc87_second_46 -35;
-    pos @kc87_first_7 @kc87_second_47 -70;
-    pos @kc87_first_7 @kc87_second_51 -50;
-    pos @kc87_first_7 @kc87_second_60 -35;
-    pos @kc87_first_7 @kc87_second_63 -70;
-    pos @kc87_first_7 @kc87_second_64 -70;
+    pos @kc87_first_7 @kc87_second_32 -70;
+    pos @kc87_first_7 @kc87_second_48 1;
+    pos @kc87_first_7 @kc87_second_49 -35;
+    pos @kc87_first_7 @kc87_second_50 -70;
+    pos @kc87_first_7 @kc87_second_53 -50;
+    pos @kc87_first_7 @kc87_second_62 -35;
+    pos @kc87_first_7 @kc87_second_65 -70;
+    pos @kc87_first_7 @kc87_second_66 -70;
     pos @kc87_first_8 @kc87_second_3 -140;
     pos @kc87_first_8 @kc87_second_4 -70;
     pos @kc87_first_8 @kc87_second_6 -70;
@@ -8814,26 +8851,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_8 @kc87_second_25 -140;
     pos @kc87_first_8 @kc87_second_29 -35;
     pos @kc87_first_8 @kc87_second_31 -105;
-    pos @kc87_first_8 @kc87_second_34 -70;
-    pos @kc87_first_8 @kc87_second_36 -70;
-    pos @kc87_first_8 @kc87_second_38 -105;
-    pos @kc87_first_8 @kc87_second_39 -175;
-    pos @kc87_first_8 @kc87_second_40 -140;
-    pos @kc87_first_8 @kc87_second_41 -35;
+    pos @kc87_first_8 @kc87_second_32 -70;
+    pos @kc87_first_8 @kc87_second_35 -70;
+    pos @kc87_first_8 @kc87_second_37 -70;
+    pos @kc87_first_8 @kc87_second_39 -105;
+    pos @kc87_first_8 @kc87_second_40 -175;
+    pos @kc87_first_8 @kc87_second_41 -140;
+    pos @kc87_first_8 @kc87_second_42 -35;
     pos @kc87_first_8 @kc87_second_43 -140;
-    pos @kc87_first_8 @kc87_second_44 -105;
-    pos @kc87_first_8 @kc87_second_45 1;
-    pos @kc87_first_8 @kc87_second_46 -70;
-    pos @kc87_first_8 @kc87_second_47 -140;
-    pos @kc87_first_8 @kc87_second_48 -70;
-    pos @kc87_first_8 @kc87_second_51 -35;
-    pos @kc87_first_8 @kc87_second_52 -35;
-    pos @kc87_first_8 @kc87_second_58 -210;
-    pos @kc87_first_8 @kc87_second_60 -105;
-    pos @kc87_first_8 @kc87_second_61 -70;
-    pos @kc87_first_8 @kc87_second_62 -35;
+    pos @kc87_first_8 @kc87_second_46 -105;
+    pos @kc87_first_8 @kc87_second_48 1;
+    pos @kc87_first_8 @kc87_second_49 -70;
+    pos @kc87_first_8 @kc87_second_50 -140;
+    pos @kc87_first_8 @kc87_second_51 -70;
+    pos @kc87_first_8 @kc87_second_53 -35;
+    pos @kc87_first_8 @kc87_second_54 -35;
+    pos @kc87_first_8 @kc87_second_60 -210;
+    pos @kc87_first_8 @kc87_second_62 -105;
     pos @kc87_first_8 @kc87_second_63 -70;
     pos @kc87_first_8 @kc87_second_64 -35;
+    pos @kc87_first_8 @kc87_second_65 -70;
+    pos @kc87_first_8 @kc87_second_66 -35;
     pos @kc87_first_9 @kc87_second_3 -140;
     pos @kc87_first_9 @kc87_second_4 -70;
     pos @kc87_first_9 @kc87_second_6 -70;
@@ -8851,24 +8889,26 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_9 @kc87_second_23 -140;
     pos @kc87_first_9 @kc87_second_29 -50;
     pos @kc87_first_9 @kc87_second_31 -140;
-    pos @kc87_first_9 @kc87_second_34 -70;
-    pos @kc87_first_9 @kc87_second_38 -105;
-    pos @kc87_first_9 @kc87_second_39 -280;
-    pos @kc87_first_9 @kc87_second_40 -350;
-    pos @kc87_first_9 @kc87_second_41 -50;
+    pos @kc87_first_9 @kc87_second_32 -70;
+    pos @kc87_first_9 @kc87_second_35 -70;
+    pos @kc87_first_9 @kc87_second_39 -105;
+    pos @kc87_first_9 @kc87_second_40 -280;
+    pos @kc87_first_9 @kc87_second_41 -350;
+    pos @kc87_first_9 @kc87_second_42 -50;
     pos @kc87_first_9 @kc87_second_43 -350;
-    pos @kc87_first_9 @kc87_second_45 1;
-    pos @kc87_first_9 @kc87_second_46 -35;
-    pos @kc87_first_9 @kc87_second_47 -210;
-    pos @kc87_first_9 @kc87_second_48 -350;
-    pos @kc87_first_9 @kc87_second_51 -35;
-    pos @kc87_first_9 @kc87_second_52 -35;
-    pos @kc87_first_9 @kc87_second_58 -280;
-    pos @kc87_first_9 @kc87_second_60 -175;
-    pos @kc87_first_9 @kc87_second_61 -280;
-    pos @kc87_first_9 @kc87_second_62 -210;
-    pos @kc87_first_9 @kc87_second_63 -70;
-    pos @kc87_first_9 @kc87_second_64 -70;
+    pos @kc87_first_9 @kc87_second_44 -280;
+    pos @kc87_first_9 @kc87_second_48 1;
+    pos @kc87_first_9 @kc87_second_49 -35;
+    pos @kc87_first_9 @kc87_second_50 -210;
+    pos @kc87_first_9 @kc87_second_51 -350;
+    pos @kc87_first_9 @kc87_second_53 -35;
+    pos @kc87_first_9 @kc87_second_54 -35;
+    pos @kc87_first_9 @kc87_second_60 -280;
+    pos @kc87_first_9 @kc87_second_62 -175;
+    pos @kc87_first_9 @kc87_second_63 -280;
+    pos @kc87_first_9 @kc87_second_64 -210;
+    pos @kc87_first_9 @kc87_second_65 -70;
+    pos @kc87_first_9 @kc87_second_66 -70;
     pos @kc87_first_10 @kc87_second_1 -210;
     pos @kc87_first_10 @kc87_second_2 -350;
     pos @kc87_first_10 @kc87_second_5 -70;
@@ -8883,17 +8923,18 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_10 @kc87_second_22 -70;
     pos @kc87_first_10 @kc87_second_24 -350;
     pos @kc87_first_10 @kc87_second_29 -70;
-    pos @kc87_first_10 @kc87_second_32 -140;
-    pos @kc87_first_10 @kc87_second_34 -210;
-    pos @kc87_first_10 @kc87_second_35 -105;
-    pos @kc87_first_10 @kc87_second_38 -70;
-    pos @kc87_first_10 @kc87_second_45 1;
-    pos @kc87_first_10 @kc87_second_53 -210;
+    pos @kc87_first_10 @kc87_second_32 -35;
+    pos @kc87_first_10 @kc87_second_33 -140;
+    pos @kc87_first_10 @kc87_second_35 -210;
+    pos @kc87_first_10 @kc87_second_36 -105;
+    pos @kc87_first_10 @kc87_second_39 -70;
+    pos @kc87_first_10 @kc87_second_48 1;
     pos @kc87_first_10 @kc87_second_55 -210;
     pos @kc87_first_10 @kc87_second_57 -210;
-    pos @kc87_first_10 @kc87_second_61 -70;
+    pos @kc87_first_10 @kc87_second_59 -210;
     pos @kc87_first_10 @kc87_second_63 -70;
-    pos @kc87_first_10 @kc87_second_64 -105;
+    pos @kc87_first_10 @kc87_second_65 -70;
+    pos @kc87_first_10 @kc87_second_66 -105;
     pos @kc87_first_11 @kc87_second_1 -70;
     pos @kc87_first_11 @kc87_second_2 -140;
     pos @kc87_first_11 @kc87_second_5 -105;
@@ -8908,21 +8949,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_11 @kc87_second_24 -70;
     pos @kc87_first_11 @kc87_second_26 -70;
     pos @kc87_first_11 @kc87_second_27 -70;
-    pos @kc87_first_11 @kc87_second_34 -35;
-    pos @kc87_first_11 @kc87_second_35 -140;
-    pos @kc87_first_11 @kc87_second_39 -70;
-    pos @kc87_first_11 @kc87_second_42 -35;
+    pos @kc87_first_11 @kc87_second_35 -35;
+    pos @kc87_first_11 @kc87_second_36 -140;
+    pos @kc87_first_11 @kc87_second_40 -70;
     pos @kc87_first_11 @kc87_second_43 -35;
-    pos @kc87_first_11 @kc87_second_45 1;
-    pos @kc87_first_11 @kc87_second_48 -70;
-    pos @kc87_first_11 @kc87_second_53 -210;
-    pos @kc87_first_11 @kc87_second_55 -175;
-    pos @kc87_first_11 @kc87_second_56 -35;
+    pos @kc87_first_11 @kc87_second_45 -35;
+    pos @kc87_first_11 @kc87_second_48 1;
+    pos @kc87_first_11 @kc87_second_51 -70;
+    pos @kc87_first_11 @kc87_second_55 -210;
     pos @kc87_first_11 @kc87_second_57 -175;
-    pos @kc87_first_11 @kc87_second_61 -70;
-    pos @kc87_first_11 @kc87_second_62 -35;
-    pos @kc87_first_11 @kc87_second_63 -35;
-    pos @kc87_first_11 @kc87_second_64 -70;
+    pos @kc87_first_11 @kc87_second_58 -35;
+    pos @kc87_first_11 @kc87_second_59 -175;
+    pos @kc87_first_11 @kc87_second_63 -70;
+    pos @kc87_first_11 @kc87_second_64 -35;
+    pos @kc87_first_11 @kc87_second_65 -35;
+    pos @kc87_first_11 @kc87_second_66 -70;
     pos @kc87_first_12 @kc87_second_1 -140;
     pos @kc87_first_12 @kc87_second_2 -210;
     pos @kc87_first_12 @kc87_second_6 -140;
@@ -8931,28 +8972,30 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_12 @kc87_second_22 -70;
     pos @kc87_first_12 @kc87_second_24 -350;
     pos @kc87_first_12 @kc87_second_29 -35;
-    pos @kc87_first_12 @kc87_second_32 -140;
-    pos @kc87_first_12 @kc87_second_34 -140;
-    pos @kc87_first_12 @kc87_second_35 -70;
-    pos @kc87_first_12 @kc87_second_38 -70;
-    pos @kc87_first_12 @kc87_second_45 1;
-    pos @kc87_first_12 @kc87_second_51 -35;
-    pos @kc87_first_12 @kc87_second_53 -210;
+    pos @kc87_first_12 @kc87_second_32 -70;
+    pos @kc87_first_12 @kc87_second_33 -140;
+    pos @kc87_first_12 @kc87_second_35 -140;
+    pos @kc87_first_12 @kc87_second_36 -70;
+    pos @kc87_first_12 @kc87_second_39 -70;
+    pos @kc87_first_12 @kc87_second_48 1;
+    pos @kc87_first_12 @kc87_second_53 -35;
     pos @kc87_first_12 @kc87_second_55 -210;
     pos @kc87_first_12 @kc87_second_57 -210;
-    pos @kc87_first_12 @kc87_second_63 -70;
-    pos @kc87_first_12 @kc87_second_64 -105;
+    pos @kc87_first_12 @kc87_second_59 -210;
+    pos @kc87_first_12 @kc87_second_65 -70;
+    pos @kc87_first_12 @kc87_second_66 -105;
     pos @kc87_first_13 @kc87_second_6 -70;
     pos @kc87_first_13 @kc87_second_12 -70;
     pos @kc87_first_13 @kc87_second_13 -105;
     pos @kc87_first_13 @kc87_second_14 -35;
     pos @kc87_first_13 @kc87_second_22 -35;
     pos @kc87_first_13 @kc87_second_29 -35;
-    pos @kc87_first_13 @kc87_second_34 -70;
-    pos @kc87_first_13 @kc87_second_38 -70;
-    pos @kc87_first_13 @kc87_second_45 1;
-    pos @kc87_first_13 @kc87_second_63 -70;
-    pos @kc87_first_13 @kc87_second_64 -35;
+    pos @kc87_first_13 @kc87_second_32 -35;
+    pos @kc87_first_13 @kc87_second_35 -70;
+    pos @kc87_first_13 @kc87_second_39 -70;
+    pos @kc87_first_13 @kc87_second_48 1;
+    pos @kc87_first_13 @kc87_second_65 -70;
+    pos @kc87_first_13 @kc87_second_66 -35;
     pos @kc87_first_14 @kc87_second_2 -35;
     pos @kc87_first_14 @kc87_second_11 -35;
     pos @kc87_first_14 @kc87_second_12 -70;
@@ -8961,14 +9004,14 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_14 @kc87_second_16 -35;
     pos @kc87_first_14 @kc87_second_19 -35;
     pos @kc87_first_14 @kc87_second_25 -35;
-    pos @kc87_first_14 @kc87_second_39 -70;
-    pos @kc87_first_14 @kc87_second_45 1;
-    pos @kc87_first_14 @kc87_second_47 -70;
-    pos @kc87_first_14 @kc87_second_48 -35;
-    pos @kc87_first_14 @kc87_second_56 -35;
+    pos @kc87_first_14 @kc87_second_40 -70;
+    pos @kc87_first_14 @kc87_second_48 1;
+    pos @kc87_first_14 @kc87_second_50 -70;
+    pos @kc87_first_14 @kc87_second_51 -35;
     pos @kc87_first_14 @kc87_second_58 -35;
     pos @kc87_first_14 @kc87_second_60 -35;
     pos @kc87_first_14 @kc87_second_62 -35;
+    pos @kc87_first_14 @kc87_second_64 -35;
     pos @kc87_first_15 @kc87_second_3 -70;
     pos @kc87_first_15 @kc87_second_4 -70;
     pos @kc87_first_15 @kc87_second_6 -35;
@@ -8980,20 +9023,20 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_15 @kc87_second_25 -70;
     pos @kc87_first_15 @kc87_second_29 -35;
     pos @kc87_first_15 @kc87_second_31 -35;
-    pos @kc87_first_15 @kc87_second_36 -35;
-    pos @kc87_first_15 @kc87_second_38 -70;
-    pos @kc87_first_15 @kc87_second_39 -142;
-    pos @kc87_first_15 @kc87_second_40 -35;
-    pos @kc87_first_15 @kc87_second_44 -35;
-    pos @kc87_first_15 @kc87_second_45 1;
+    pos @kc87_first_15 @kc87_second_37 -35;
+    pos @kc87_first_15 @kc87_second_39 -70;
+    pos @kc87_first_15 @kc87_second_40 -142;
+    pos @kc87_first_15 @kc87_second_41 -35;
     pos @kc87_first_15 @kc87_second_46 -35;
-    pos @kc87_first_15 @kc87_second_47 -70;
-    pos @kc87_first_15 @kc87_second_51 -35;
-    pos @kc87_first_15 @kc87_second_52 -35;
-    pos @kc87_first_15 @kc87_second_58 -105;
-    pos @kc87_first_15 @kc87_second_60 -35;
-    pos @kc87_first_15 @kc87_second_63 -35;
-    pos @kc87_first_15 @kc87_second_64 -35;
+    pos @kc87_first_15 @kc87_second_48 1;
+    pos @kc87_first_15 @kc87_second_49 -35;
+    pos @kc87_first_15 @kc87_second_50 -70;
+    pos @kc87_first_15 @kc87_second_53 -35;
+    pos @kc87_first_15 @kc87_second_54 -35;
+    pos @kc87_first_15 @kc87_second_60 -105;
+    pos @kc87_first_15 @kc87_second_62 -35;
+    pos @kc87_first_15 @kc87_second_65 -35;
+    pos @kc87_first_15 @kc87_second_66 -35;
     pos @kc87_first_16 @kc87_second_1 -280;
     pos @kc87_first_16 @kc87_second_2 -280;
     pos @kc87_first_16 @kc87_second_3 -140;
@@ -9014,34 +9057,35 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_16 @kc87_second_29 -240;
     pos @kc87_first_16 @kc87_second_30 -140;
     pos @kc87_first_16 @kc87_second_31 -140;
-    pos @kc87_first_16 @kc87_second_32 -245;
-    pos @kc87_first_16 @kc87_second_34 -315;
-    pos @kc87_first_16 @kc87_second_35 -70;
-    pos @kc87_first_16 @kc87_second_36 -210;
+    pos @kc87_first_16 @kc87_second_32 -280;
+    pos @kc87_first_16 @kc87_second_33 -245;
+    pos @kc87_first_16 @kc87_second_35 -315;
+    pos @kc87_first_16 @kc87_second_36 -70;
     pos @kc87_first_16 @kc87_second_37 -210;
-    pos @kc87_first_16 @kc87_second_38 -245;
+    pos @kc87_first_16 @kc87_second_38 -210;
     pos @kc87_first_16 @kc87_second_39 -245;
-    pos @kc87_first_16 @kc87_second_40 -70;
-    pos @kc87_first_16 @kc87_second_42 -35;
+    pos @kc87_first_16 @kc87_second_40 -245;
+    pos @kc87_first_16 @kc87_second_41 -70;
     pos @kc87_first_16 @kc87_second_43 -140;
-    pos @kc87_first_16 @kc87_second_44 -140;
-    pos @kc87_first_16 @kc87_second_45 1;
-    pos @kc87_first_16 @kc87_second_46 -70;
+    pos @kc87_first_16 @kc87_second_45 -35;
+    pos @kc87_first_16 @kc87_second_46 -140;
     pos @kc87_first_16 @kc87_second_47 -140;
-    pos @kc87_first_16 @kc87_second_49 -140;
+    pos @kc87_first_16 @kc87_second_48 1;
+    pos @kc87_first_16 @kc87_second_49 -70;
     pos @kc87_first_16 @kc87_second_50 -140;
-    pos @kc87_first_16 @kc87_second_51 -240;
     pos @kc87_first_16 @kc87_second_52 -140;
-    pos @kc87_first_16 @kc87_second_53 -280;
-    pos @kc87_first_16 @kc87_second_54 -105;
+    pos @kc87_first_16 @kc87_second_53 -240;
+    pos @kc87_first_16 @kc87_second_54 -140;
     pos @kc87_first_16 @kc87_second_55 -280;
-    pos @kc87_first_16 @kc87_second_56 -140;
-    pos @kc87_first_16 @kc87_second_57 -315;
-    pos @kc87_first_16 @kc87_second_58 -210;
-    pos @kc87_first_16 @kc87_second_59 -210;
-    pos @kc87_first_16 @kc87_second_60 -105;
-    pos @kc87_first_16 @kc87_second_63 -315;
-    pos @kc87_first_16 @kc87_second_64 -350;
+    pos @kc87_first_16 @kc87_second_56 -105;
+    pos @kc87_first_16 @kc87_second_57 -280;
+    pos @kc87_first_16 @kc87_second_58 -140;
+    pos @kc87_first_16 @kc87_second_59 -315;
+    pos @kc87_first_16 @kc87_second_60 -210;
+    pos @kc87_first_16 @kc87_second_61 -210;
+    pos @kc87_first_16 @kc87_second_62 -105;
+    pos @kc87_first_16 @kc87_second_65 -315;
+    pos @kc87_first_16 @kc87_second_66 -350;
     pos @kc87_first_17 @kc87_second_1 -280;
     pos @kc87_first_17 @kc87_second_2 -280;
     pos @kc87_first_17 @kc87_second_3 -105;
@@ -9059,33 +9103,34 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_17 @kc87_second_27 -70;
     pos @kc87_first_17 @kc87_second_29 -140;
     pos @kc87_first_17 @kc87_second_30 -105;
-    pos @kc87_first_17 @kc87_second_32 -210;
-    pos @kc87_first_17 @kc87_second_34 -245;
-    pos @kc87_first_17 @kc87_second_35 -70;
-    pos @kc87_first_17 @kc87_second_36 -140;
+    pos @kc87_first_17 @kc87_second_32 -175;
+    pos @kc87_first_17 @kc87_second_33 -210;
+    pos @kc87_first_17 @kc87_second_35 -245;
+    pos @kc87_first_17 @kc87_second_36 -70;
     pos @kc87_first_17 @kc87_second_37 -140;
     pos @kc87_first_17 @kc87_second_38 -140;
-    pos @kc87_first_17 @kc87_second_39 -105;
-    pos @kc87_first_17 @kc87_second_40 -35;
+    pos @kc87_first_17 @kc87_second_39 -140;
+    pos @kc87_first_17 @kc87_second_40 -105;
+    pos @kc87_first_17 @kc87_second_41 -35;
     pos @kc87_first_17 @kc87_second_43 -35;
-    pos @kc87_first_17 @kc87_second_44 -70;
-    pos @kc87_first_17 @kc87_second_45 1;
-    pos @kc87_first_17 @kc87_second_46 -35;
-    pos @kc87_first_17 @kc87_second_47 -70;
-    pos @kc87_first_17 @kc87_second_49 -105;
+    pos @kc87_first_17 @kc87_second_46 -70;
+    pos @kc87_first_17 @kc87_second_47 -105;
+    pos @kc87_first_17 @kc87_second_48 1;
+    pos @kc87_first_17 @kc87_second_49 -35;
     pos @kc87_first_17 @kc87_second_50 -70;
-    pos @kc87_first_17 @kc87_second_51 -105;
     pos @kc87_first_17 @kc87_second_52 -70;
-    pos @kc87_first_17 @kc87_second_53 -210;
-    pos @kc87_first_17 @kc87_second_54 -35;
+    pos @kc87_first_17 @kc87_second_53 -105;
+    pos @kc87_first_17 @kc87_second_54 -70;
     pos @kc87_first_17 @kc87_second_55 -210;
-    pos @kc87_first_17 @kc87_second_56 -70;
-    pos @kc87_first_17 @kc87_second_57 -245;
-    pos @kc87_first_17 @kc87_second_58 -105;
-    pos @kc87_first_17 @kc87_second_59 -105;
-    pos @kc87_first_17 @kc87_second_60 -70;
-    pos @kc87_first_17 @kc87_second_63 -175;
-    pos @kc87_first_17 @kc87_second_64 -245;
+    pos @kc87_first_17 @kc87_second_56 -35;
+    pos @kc87_first_17 @kc87_second_57 -210;
+    pos @kc87_first_17 @kc87_second_58 -70;
+    pos @kc87_first_17 @kc87_second_59 -245;
+    pos @kc87_first_17 @kc87_second_60 -105;
+    pos @kc87_first_17 @kc87_second_61 -105;
+    pos @kc87_first_17 @kc87_second_62 -70;
+    pos @kc87_first_17 @kc87_second_65 -175;
+    pos @kc87_first_17 @kc87_second_66 -245;
     pos @kc87_first_18 @kc87_second_1 -210;
     pos @kc87_first_18 @kc87_second_2 -245;
     pos @kc87_first_18 @kc87_second_3 -35;
@@ -9099,33 +9144,34 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_18 @kc87_second_23 -70;
     pos @kc87_first_18 @kc87_second_24 -140;
     pos @kc87_first_18 @kc87_second_27 -35;
-    pos @kc87_first_18 @kc87_second_32 -140;
-    pos @kc87_first_18 @kc87_second_34 -140;
-    pos @kc87_first_18 @kc87_second_36 -105;
-    pos @kc87_first_18 @kc87_second_37 -70;
-    pos @kc87_first_18 @kc87_second_38 -105;
-    pos @kc87_first_18 @kc87_second_39 -70;
-    pos @kc87_first_18 @kc87_second_41 -35;
-    pos @kc87_first_18 @kc87_second_45 1;
-    pos @kc87_first_18 @kc87_second_50 -35;
-    pos @kc87_first_18 @kc87_second_51 -70;
-    pos @kc87_first_18 @kc87_second_53 -140;
+    pos @kc87_first_18 @kc87_second_32 -105;
+    pos @kc87_first_18 @kc87_second_33 -140;
+    pos @kc87_first_18 @kc87_second_35 -140;
+    pos @kc87_first_18 @kc87_second_37 -105;
+    pos @kc87_first_18 @kc87_second_38 -70;
+    pos @kc87_first_18 @kc87_second_39 -105;
+    pos @kc87_first_18 @kc87_second_40 -70;
+    pos @kc87_first_18 @kc87_second_42 -35;
+    pos @kc87_first_18 @kc87_second_48 1;
+    pos @kc87_first_18 @kc87_second_52 -35;
+    pos @kc87_first_18 @kc87_second_53 -70;
     pos @kc87_first_18 @kc87_second_55 -140;
-    pos @kc87_first_18 @kc87_second_57 -175;
-    pos @kc87_first_18 @kc87_second_58 -70;
-    pos @kc87_first_18 @kc87_second_63 -105;
-    pos @kc87_first_18 @kc87_second_64 -140;
+    pos @kc87_first_18 @kc87_second_57 -140;
+    pos @kc87_first_18 @kc87_second_59 -175;
+    pos @kc87_first_18 @kc87_second_60 -70;
+    pos @kc87_first_18 @kc87_second_65 -105;
+    pos @kc87_first_18 @kc87_second_66 -140;
     pos @kc87_first_19 @kc87_second_12 -280;
     pos @kc87_first_19 @kc87_second_14 -175;
     pos @kc87_first_19 @kc87_second_15 -140;
     pos @kc87_first_19 @kc87_second_29 -35;
-    pos @kc87_first_19 @kc87_second_45 1;
-    pos @kc87_first_19 @kc87_second_47 -70;
-    pos @kc87_first_19 @kc87_second_48 -140;
-    pos @kc87_first_19 @kc87_second_58 -70;
-    pos @kc87_first_19 @kc87_second_60 -35;
-    pos @kc87_first_19 @kc87_second_61 -105;
-    pos @kc87_first_19 @kc87_second_62 -70;
+    pos @kc87_first_19 @kc87_second_48 1;
+    pos @kc87_first_19 @kc87_second_50 -70;
+    pos @kc87_first_19 @kc87_second_51 -140;
+    pos @kc87_first_19 @kc87_second_60 -70;
+    pos @kc87_first_19 @kc87_second_62 -35;
+    pos @kc87_first_19 @kc87_second_63 -105;
+    pos @kc87_first_19 @kc87_second_64 -70;
     pos @kc87_first_20 @kc87_second_8 -35;
     pos @kc87_first_20 @kc87_second_9 -140;
     pos @kc87_first_20 @kc87_second_12 -280;
@@ -9136,24 +9182,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_20 @kc87_second_20 -70;
     pos @kc87_first_20 @kc87_second_25 -70;
     pos @kc87_first_20 @kc87_second_31 -50;
-    pos @kc87_first_20 @kc87_second_39 -140;
-    pos @kc87_first_20 @kc87_second_40 -105;
+    pos @kc87_first_20 @kc87_second_40 -140;
+    pos @kc87_first_20 @kc87_second_41 -105;
     pos @kc87_first_20 @kc87_second_43 -210;
-    pos @kc87_first_20 @kc87_second_45 1;
-    pos @kc87_first_20 @kc87_second_46 -35;
-    pos @kc87_first_20 @kc87_second_47 -140;
-    pos @kc87_first_20 @kc87_second_48 -210;
-    pos @kc87_first_20 @kc87_second_52 -35;
-    pos @kc87_first_20 @kc87_second_58 -105;
+    pos @kc87_first_20 @kc87_second_44 -175;
+    pos @kc87_first_20 @kc87_second_48 1;
+    pos @kc87_first_20 @kc87_second_49 -35;
+    pos @kc87_first_20 @kc87_second_50 -140;
+    pos @kc87_first_20 @kc87_second_51 -210;
+    pos @kc87_first_20 @kc87_second_54 -35;
     pos @kc87_first_20 @kc87_second_60 -105;
-    pos @kc87_first_20 @kc87_second_61 -210;
-    pos @kc87_first_20 @kc87_second_62 -140;
+    pos @kc87_first_20 @kc87_second_62 -105;
+    pos @kc87_first_20 @kc87_second_63 -210;
+    pos @kc87_first_20 @kc87_second_64 -140;
     pos @kc87_first_21 @kc87_second_1 -140;
     pos @kc87_first_21 @kc87_second_2 -350;
     pos @kc87_first_21 @kc87_second_19 -280;
-    pos @kc87_first_21 @kc87_second_38 -70;
-    pos @kc87_first_21 @kc87_second_45 1;
-    pos @kc87_first_21 @kc87_second_64 -210;
+    pos @kc87_first_21 @kc87_second_39 -70;
+    pos @kc87_first_21 @kc87_second_48 1;
+    pos @kc87_first_21 @kc87_second_66 -210;
     pos @kc87_first_22 @kc87_second_1 -35;
     pos @kc87_first_22 @kc87_second_5 -105;
     pos @kc87_first_22 @kc87_second_9 -70;
@@ -9166,20 +9213,20 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_22 @kc87_second_25 -35;
     pos @kc87_first_22 @kc87_second_26 -70;
     pos @kc87_first_22 @kc87_second_27 -105;
-    pos @kc87_first_22 @kc87_second_35 -70;
-    pos @kc87_first_22 @kc87_second_39 -70;
-    pos @kc87_first_22 @kc87_second_40 -35;
-    pos @kc87_first_22 @kc87_second_42 -35;
+    pos @kc87_first_22 @kc87_second_36 -70;
+    pos @kc87_first_22 @kc87_second_40 -70;
+    pos @kc87_first_22 @kc87_second_41 -35;
     pos @kc87_first_22 @kc87_second_43 -140;
-    pos @kc87_first_22 @kc87_second_45 1;
-    pos @kc87_first_22 @kc87_second_47 -70;
-    pos @kc87_first_22 @kc87_second_48 -175;
-    pos @kc87_first_22 @kc87_second_49 -35;
-    pos @kc87_first_22 @kc87_second_56 -105;
-    pos @kc87_first_22 @kc87_second_58 -35;
-    pos @kc87_first_22 @kc87_second_60 -50;
-    pos @kc87_first_22 @kc87_second_61 -105;
-    pos @kc87_first_22 @kc87_second_62 -70;
+    pos @kc87_first_22 @kc87_second_45 -35;
+    pos @kc87_first_22 @kc87_second_47 -35;
+    pos @kc87_first_22 @kc87_second_48 1;
+    pos @kc87_first_22 @kc87_second_50 -70;
+    pos @kc87_first_22 @kc87_second_51 -175;
+    pos @kc87_first_22 @kc87_second_58 -105;
+    pos @kc87_first_22 @kc87_second_60 -35;
+    pos @kc87_first_22 @kc87_second_62 -50;
+    pos @kc87_first_22 @kc87_second_63 -105;
+    pos @kc87_first_22 @kc87_second_64 -70;
     pos @kc87_first_23 @kc87_second_6 -35;
     pos @kc87_first_23 @kc87_second_12 -240;
     pos @kc87_first_23 @kc87_second_13 -175;
@@ -9187,17 +9234,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_23 @kc87_second_15 -70;
     pos @kc87_first_23 @kc87_second_22 -70;
     pos @kc87_first_23 @kc87_second_23 -35;
-    pos @kc87_first_23 @kc87_second_34 -35;
-    pos @kc87_first_23 @kc87_second_39 -35;
+    pos @kc87_first_23 @kc87_second_35 -35;
     pos @kc87_first_23 @kc87_second_40 -35;
+    pos @kc87_first_23 @kc87_second_41 -35;
     pos @kc87_first_23 @kc87_second_43 -70;
-    pos @kc87_first_23 @kc87_second_44 -35;
-    pos @kc87_first_23 @kc87_second_45 1;
-    pos @kc87_first_23 @kc87_second_48 -35;
-    pos @kc87_first_23 @kc87_second_58 -35;
-    pos @kc87_first_23 @kc87_second_62 -35;
-    pos @kc87_first_23 @kc87_second_63 -35;
+    pos @kc87_first_23 @kc87_second_46 -35;
+    pos @kc87_first_23 @kc87_second_48 1;
+    pos @kc87_first_23 @kc87_second_51 -35;
+    pos @kc87_first_23 @kc87_second_60 -35;
     pos @kc87_first_23 @kc87_second_64 -35;
+    pos @kc87_first_23 @kc87_second_65 -35;
+    pos @kc87_first_23 @kc87_second_66 -35;
     pos @kc87_first_24 @kc87_second_1 -70;
     pos @kc87_first_24 @kc87_second_2 -140;
     pos @kc87_first_24 @kc87_second_5 -105;
@@ -9210,19 +9257,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_24 @kc87_second_19 -70;
     pos @kc87_first_24 @kc87_second_26 -70;
     pos @kc87_first_24 @kc87_second_27 -70;
-    pos @kc87_first_24 @kc87_second_32 -70;
-    pos @kc87_first_24 @kc87_second_35 -70;
-    pos @kc87_first_24 @kc87_second_42 -35;
+    pos @kc87_first_24 @kc87_second_33 -70;
+    pos @kc87_first_24 @kc87_second_36 -70;
     pos @kc87_first_24 @kc87_second_43 -140;
-    pos @kc87_first_24 @kc87_second_45 1;
-    pos @kc87_first_24 @kc87_second_48 -140;
-    pos @kc87_first_24 @kc87_second_49 -35;
-    pos @kc87_first_24 @kc87_second_53 -140;
-    pos @kc87_first_24 @kc87_second_55 -105;
-    pos @kc87_first_24 @kc87_second_56 -70;
-    pos @kc87_first_24 @kc87_second_57 -70;
-    pos @kc87_first_24 @kc87_second_61 -70;
-    pos @kc87_first_24 @kc87_second_62 -35;
+    pos @kc87_first_24 @kc87_second_45 -35;
+    pos @kc87_first_24 @kc87_second_47 -35;
+    pos @kc87_first_24 @kc87_second_48 1;
+    pos @kc87_first_24 @kc87_second_51 -140;
+    pos @kc87_first_24 @kc87_second_55 -140;
+    pos @kc87_first_24 @kc87_second_57 -105;
+    pos @kc87_first_24 @kc87_second_58 -70;
+    pos @kc87_first_24 @kc87_second_59 -70;
+    pos @kc87_first_24 @kc87_second_63 -70;
+    pos @kc87_first_24 @kc87_second_64 -35;
     pos @kc87_first_25 @kc87_second_5 -70;
     pos @kc87_first_25 @kc87_second_9 -70;
     pos @kc87_first_25 @kc87_second_12 -240;
@@ -9233,32 +9280,33 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_25 @kc87_second_25 -35;
     pos @kc87_first_25 @kc87_second_26 -70;
     pos @kc87_first_25 @kc87_second_27 -70;
-    pos @kc87_first_25 @kc87_second_35 -70;
-    pos @kc87_first_25 @kc87_second_39 -70;
-    pos @kc87_first_25 @kc87_second_40 -35;
+    pos @kc87_first_25 @kc87_second_36 -70;
+    pos @kc87_first_25 @kc87_second_40 -70;
+    pos @kc87_first_25 @kc87_second_41 -35;
     pos @kc87_first_25 @kc87_second_43 -140;
-    pos @kc87_first_25 @kc87_second_45 1;
-    pos @kc87_first_25 @kc87_second_47 -70;
-    pos @kc87_first_25 @kc87_second_48 -140;
-    pos @kc87_first_25 @kc87_second_49 -35;
-    pos @kc87_first_25 @kc87_second_53 -50;
-    pos @kc87_first_25 @kc87_second_54 -35;
+    pos @kc87_first_25 @kc87_second_44 -105;
+    pos @kc87_first_25 @kc87_second_47 -35;
+    pos @kc87_first_25 @kc87_second_48 1;
+    pos @kc87_first_25 @kc87_second_50 -70;
+    pos @kc87_first_25 @kc87_second_51 -140;
     pos @kc87_first_25 @kc87_second_55 -50;
-    pos @kc87_first_25 @kc87_second_56 -105;
+    pos @kc87_first_25 @kc87_second_56 -35;
     pos @kc87_first_25 @kc87_second_57 -50;
-    pos @kc87_first_25 @kc87_second_58 -50;
-    pos @kc87_first_25 @kc87_second_60 -35;
-    pos @kc87_first_25 @kc87_second_61 -105;
-    pos @kc87_first_25 @kc87_second_62 -70;
+    pos @kc87_first_25 @kc87_second_58 -105;
+    pos @kc87_first_25 @kc87_second_59 -50;
+    pos @kc87_first_25 @kc87_second_60 -50;
+    pos @kc87_first_25 @kc87_second_62 -35;
+    pos @kc87_first_25 @kc87_second_63 -105;
+    pos @kc87_first_25 @kc87_second_64 -70;
     pos @kc87_first_26 @kc87_second_9 -35;
     pos @kc87_first_26 @kc87_second_12 -140;
     pos @kc87_first_26 @kc87_second_26 -70;
-    pos @kc87_first_26 @kc87_second_39 -35;
+    pos @kc87_first_26 @kc87_second_40 -35;
     pos @kc87_first_26 @kc87_second_43 -70;
-    pos @kc87_first_26 @kc87_second_45 1;
-    pos @kc87_first_26 @kc87_second_48 -70;
-    pos @kc87_first_26 @kc87_second_61 -70;
-    pos @kc87_first_26 @kc87_second_62 -35;
+    pos @kc87_first_26 @kc87_second_48 1;
+    pos @kc87_first_26 @kc87_second_51 -70;
+    pos @kc87_first_26 @kc87_second_63 -70;
+    pos @kc87_first_26 @kc87_second_64 -35;
     pos @kc87_first_27 @kc87_second_5 -50;
     pos @kc87_first_27 @kc87_second_9 -35;
     pos @kc87_first_27 @kc87_second_11 -35;
@@ -9269,17 +9317,18 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_27 @kc87_second_16 -35;
     pos @kc87_first_27 @kc87_second_26 -35;
     pos @kc87_first_27 @kc87_second_27 -35;
-    pos @kc87_first_27 @kc87_second_35 -35;
-    pos @kc87_first_27 @kc87_second_39 -50;
-    pos @kc87_first_27 @kc87_second_40 -35;
+    pos @kc87_first_27 @kc87_second_36 -35;
+    pos @kc87_first_27 @kc87_second_40 -50;
+    pos @kc87_first_27 @kc87_second_41 -35;
     pos @kc87_first_27 @kc87_second_43 -100;
-    pos @kc87_first_27 @kc87_second_45 1;
-    pos @kc87_first_27 @kc87_second_47 -35;
-    pos @kc87_first_27 @kc87_second_48 -140;
-    pos @kc87_first_27 @kc87_second_56 -35;
-    pos @kc87_first_27 @kc87_second_61 -70;
-    pos @kc87_first_27 @kc87_second_62 -35;
-    pos @kc87_first_28 @kc87_second_45 1;
+    pos @kc87_first_27 @kc87_second_44 -35;
+    pos @kc87_first_27 @kc87_second_48 1;
+    pos @kc87_first_27 @kc87_second_50 -35;
+    pos @kc87_first_27 @kc87_second_51 -140;
+    pos @kc87_first_27 @kc87_second_58 -35;
+    pos @kc87_first_27 @kc87_second_63 -70;
+    pos @kc87_first_27 @kc87_second_64 -35;
+    pos @kc87_first_28 @kc87_second_48 1;
     pos @kc87_first_29 @kc87_second_8 -70;
     pos @kc87_first_29 @kc87_second_9 -210;
     pos @kc87_first_29 @kc87_second_12 -350;
@@ -9287,17 +9336,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_29 @kc87_second_14 -210;
     pos @kc87_first_29 @kc87_second_15 -175;
     pos @kc87_first_29 @kc87_second_25 -70;
-    pos @kc87_first_29 @kc87_second_38 -35;
-    pos @kc87_first_29 @kc87_second_39 -210;
+    pos @kc87_first_29 @kc87_second_39 -35;
     pos @kc87_first_29 @kc87_second_40 -210;
+    pos @kc87_first_29 @kc87_second_41 -210;
     pos @kc87_first_29 @kc87_second_43 -210;
-    pos @kc87_first_29 @kc87_second_45 1;
-    pos @kc87_first_29 @kc87_second_47 -140;
-    pos @kc87_first_29 @kc87_second_48 -280;
-    pos @kc87_first_29 @kc87_second_58 -210;
-    pos @kc87_first_29 @kc87_second_60 -105;
-    pos @kc87_first_29 @kc87_second_61 -175;
-    pos @kc87_first_29 @kc87_second_62 -140;
+    pos @kc87_first_29 @kc87_second_48 1;
+    pos @kc87_first_29 @kc87_second_50 -140;
+    pos @kc87_first_29 @kc87_second_51 -280;
+    pos @kc87_first_29 @kc87_second_60 -210;
+    pos @kc87_first_29 @kc87_second_62 -105;
+    pos @kc87_first_29 @kc87_second_63 -175;
+    pos @kc87_first_29 @kc87_second_64 -140;
     pos @kc87_first_30 @kc87_second_1 -175;
     pos @kc87_first_30 @kc87_second_2 -175;
     pos @kc87_first_30 @kc87_second_5 -70;
@@ -9313,16 +9362,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_30 @kc87_second_19 -175;
     pos @kc87_first_30 @kc87_second_22 -70;
     pos @kc87_first_30 @kc87_second_29 -105;
-    pos @kc87_first_30 @kc87_second_33 165;
-    pos @kc87_first_30 @kc87_second_34 -105;
-    pos @kc87_first_30 @kc87_second_35 -175;
-    pos @kc87_first_30 @kc87_second_36 -35;
-    pos @kc87_first_30 @kc87_second_38 -70;
-    pos @kc87_first_30 @kc87_second_45 1;
-    pos @kc87_first_30 @kc87_second_50 165;
-    pos @kc87_first_30 @kc87_second_51 -35;
-    pos @kc87_first_30 @kc87_second_63 -70;
-    pos @kc87_first_30 @kc87_second_64 -105;
+    pos @kc87_first_30 @kc87_second_34 165;
+    pos @kc87_first_30 @kc87_second_35 -105;
+    pos @kc87_first_30 @kc87_second_36 -175;
+    pos @kc87_first_30 @kc87_second_37 -35;
+    pos @kc87_first_30 @kc87_second_39 -70;
+    pos @kc87_first_30 @kc87_second_48 1;
+    pos @kc87_first_30 @kc87_second_52 165;
+    pos @kc87_first_30 @kc87_second_53 -35;
+    pos @kc87_first_30 @kc87_second_65 -70;
+    pos @kc87_first_30 @kc87_second_66 -105;
     pos @kc87_first_31 @kc87_second_3 -70;
     pos @kc87_first_31 @kc87_second_4 -35;
     pos @kc87_first_31 @kc87_second_6 -70;
@@ -9332,16 +9381,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_31 @kc87_second_22 -70;
     pos @kc87_first_31 @kc87_second_23 -140;
     pos @kc87_first_31 @kc87_second_29 -35;
-    pos @kc87_first_31 @kc87_second_34 -70;
-    pos @kc87_first_31 @kc87_second_36 -35;
-    pos @kc87_first_31 @kc87_second_38 -140;
-    pos @kc87_first_31 @kc87_second_39 -70;
-    pos @kc87_first_31 @kc87_second_45 1;
-    pos @kc87_first_31 @kc87_second_51 -35;
-    pos @kc87_first_31 @kc87_second_52 -35;
-    pos @kc87_first_31 @kc87_second_58 -140;
-    pos @kc87_first_31 @kc87_second_63 -70;
-    pos @kc87_first_31 @kc87_second_64 -70;
+    pos @kc87_first_31 @kc87_second_32 -70;
+    pos @kc87_first_31 @kc87_second_35 -70;
+    pos @kc87_first_31 @kc87_second_37 -35;
+    pos @kc87_first_31 @kc87_second_39 -140;
+    pos @kc87_first_31 @kc87_second_40 -70;
+    pos @kc87_first_31 @kc87_second_48 1;
+    pos @kc87_first_31 @kc87_second_53 -35;
+    pos @kc87_first_31 @kc87_second_54 -35;
+    pos @kc87_first_31 @kc87_second_60 -140;
+    pos @kc87_first_31 @kc87_second_65 -70;
+    pos @kc87_first_31 @kc87_second_66 -70;
     pos @kc87_first_32 @kc87_second_1 -35;
     pos @kc87_first_32 @kc87_second_2 -105;
     pos @kc87_first_32 @kc87_second_3 -70;
@@ -9355,20 +9405,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_32 @kc87_second_16 -70;
     pos @kc87_first_32 @kc87_second_24 -35;
     pos @kc87_first_32 @kc87_second_27 -70;
-    pos @kc87_first_32 @kc87_second_35 -35;
-    pos @kc87_first_32 @kc87_second_39 -35;
+    pos @kc87_first_32 @kc87_second_36 -35;
     pos @kc87_first_32 @kc87_second_40 -35;
-    pos @kc87_first_32 @kc87_second_42 -35;
+    pos @kc87_first_32 @kc87_second_41 -35;
     pos @kc87_first_32 @kc87_second_43 -140;
-    pos @kc87_first_32 @kc87_second_45 1;
-    pos @kc87_first_32 @kc87_second_47 -50;
-    pos @kc87_first_32 @kc87_second_48 -140;
-    pos @kc87_first_32 @kc87_second_49 -35;
-    pos @kc87_first_32 @kc87_second_53 -70;
+    pos @kc87_first_32 @kc87_second_44 -70;
+    pos @kc87_first_32 @kc87_second_45 -35;
+    pos @kc87_first_32 @kc87_second_47 -35;
+    pos @kc87_first_32 @kc87_second_48 1;
+    pos @kc87_first_32 @kc87_second_50 -50;
+    pos @kc87_first_32 @kc87_second_51 -140;
     pos @kc87_first_32 @kc87_second_55 -70;
     pos @kc87_first_32 @kc87_second_57 -70;
-    pos @kc87_first_32 @kc87_second_61 -70;
-    pos @kc87_first_32 @kc87_second_62 -35;
+    pos @kc87_first_32 @kc87_second_59 -70;
+    pos @kc87_first_32 @kc87_second_63 -70;
+    pos @kc87_first_32 @kc87_second_64 -35;
     pos @kc87_first_33 @kc87_second_3 -35;
     pos @kc87_first_33 @kc87_second_4 -70;
     pos @kc87_first_33 @kc87_second_6 -70;
@@ -9381,33 +9432,34 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_33 @kc87_second_22 -105;
     pos @kc87_first_33 @kc87_second_23 -70;
     pos @kc87_first_33 @kc87_second_29 -35;
-    pos @kc87_first_33 @kc87_second_34 -70;
-    pos @kc87_first_33 @kc87_second_36 -70;
-    pos @kc87_first_33 @kc87_second_38 -105;
-    pos @kc87_first_33 @kc87_second_39 -70;
-    pos @kc87_first_33 @kc87_second_44 -70;
-    pos @kc87_first_33 @kc87_second_45 1;
-    pos @kc87_first_33 @kc87_second_51 -35;
-    pos @kc87_first_33 @kc87_second_52 -35;
-    pos @kc87_first_33 @kc87_second_63 -70;
-    pos @kc87_first_33 @kc87_second_64 -70;
-    pos @kc87_first_34 @kc87_second_32 -315;
-    pos @kc87_first_34 @kc87_second_45 1;
+    pos @kc87_first_33 @kc87_second_32 -70;
+    pos @kc87_first_33 @kc87_second_35 -70;
+    pos @kc87_first_33 @kc87_second_37 -70;
+    pos @kc87_first_33 @kc87_second_39 -105;
+    pos @kc87_first_33 @kc87_second_40 -70;
+    pos @kc87_first_33 @kc87_second_46 -70;
+    pos @kc87_first_33 @kc87_second_48 1;
+    pos @kc87_first_33 @kc87_second_53 -35;
+    pos @kc87_first_33 @kc87_second_54 -35;
+    pos @kc87_first_33 @kc87_second_65 -70;
+    pos @kc87_first_33 @kc87_second_66 -70;
+    pos @kc87_first_34 @kc87_second_33 -315;
+    pos @kc87_first_34 @kc87_second_48 1;
     pos @kc87_first_35 @kc87_second_9 -70;
     pos @kc87_first_35 @kc87_second_12 -240;
     pos @kc87_first_35 @kc87_second_13 -210;
     pos @kc87_first_35 @kc87_second_14 -140;
     pos @kc87_first_35 @kc87_second_15 -105;
-    pos @kc87_first_35 @kc87_second_39 -70;
-    pos @kc87_first_35 @kc87_second_40 -35;
+    pos @kc87_first_35 @kc87_second_40 -70;
+    pos @kc87_first_35 @kc87_second_41 -35;
     pos @kc87_first_35 @kc87_second_43 -140;
-    pos @kc87_first_35 @kc87_second_45 1;
-    pos @kc87_first_35 @kc87_second_47 -50;
-    pos @kc87_first_35 @kc87_second_48 -140;
-    pos @kc87_first_35 @kc87_second_58 -35;
+    pos @kc87_first_35 @kc87_second_48 1;
+    pos @kc87_first_35 @kc87_second_50 -50;
+    pos @kc87_first_35 @kc87_second_51 -140;
     pos @kc87_first_35 @kc87_second_60 -35;
-    pos @kc87_first_35 @kc87_second_61 -70;
-    pos @kc87_first_35 @kc87_second_62 -70;
+    pos @kc87_first_35 @kc87_second_62 -35;
+    pos @kc87_first_35 @kc87_second_63 -70;
+    pos @kc87_first_35 @kc87_second_64 -70;
     pos @kc87_first_36 @kc87_second_9 -35;
     pos @kc87_first_36 @kc87_second_12 -240;
     pos @kc87_first_36 @kc87_second_13 -240;
@@ -9416,15 +9468,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_36 @kc87_second_16 -35;
     pos @kc87_first_36 @kc87_second_26 -35;
     pos @kc87_first_36 @kc87_second_27 -35;
-    pos @kc87_first_36 @kc87_second_39 -70;
-    pos @kc87_first_36 @kc87_second_40 -35;
+    pos @kc87_first_36 @kc87_second_40 -70;
+    pos @kc87_first_36 @kc87_second_41 -35;
     pos @kc87_first_36 @kc87_second_43 -70;
-    pos @kc87_first_36 @kc87_second_45 1;
-    pos @kc87_first_36 @kc87_second_47 -35;
-    pos @kc87_first_36 @kc87_second_48 -70;
-    pos @kc87_first_36 @kc87_second_60 -35;
-    pos @kc87_first_36 @kc87_second_61 -70;
-    pos @kc87_first_36 @kc87_second_62 -70;
+    pos @kc87_first_36 @kc87_second_44 -35;
+    pos @kc87_first_36 @kc87_second_48 1;
+    pos @kc87_first_36 @kc87_second_50 -35;
+    pos @kc87_first_36 @kc87_second_51 -70;
+    pos @kc87_first_36 @kc87_second_62 -35;
+    pos @kc87_first_36 @kc87_second_63 -70;
+    pos @kc87_first_36 @kc87_second_64 -70;
     pos @kc87_first_37 @kc87_second_5 -70;
     pos @kc87_first_37 @kc87_second_9 -70;
     pos @kc87_first_37 @kc87_second_12 -140;
@@ -9434,619 +9487,636 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_37 @kc87_second_16 -70;
     pos @kc87_first_37 @kc87_second_26 -70;
     pos @kc87_first_37 @kc87_second_27 -70;
-    pos @kc87_first_37 @kc87_second_35 -50;
-    pos @kc87_first_37 @kc87_second_39 -50;
-    pos @kc87_first_37 @kc87_second_40 -35;
-    pos @kc87_first_37 @kc87_second_45 1;
-    pos @kc87_first_37 @kc87_second_47 -35;
-    pos @kc87_first_37 @kc87_second_48 -140;
-    pos @kc87_first_37 @kc87_second_56 -35;
-    pos @kc87_first_37 @kc87_second_61 -70;
-    pos @kc87_first_37 @kc87_second_62 -35;
-    pos @kc87_first_38 @kc87_second_1 -210;
-    pos @kc87_first_38 @kc87_second_2 -280;
-    pos @kc87_first_38 @kc87_second_6 -280;
-    pos @kc87_first_38 @kc87_second_8 -70;
-    pos @kc87_first_38 @kc87_second_17 -140;
-    pos @kc87_first_38 @kc87_second_19 -350;
-    pos @kc87_first_38 @kc87_second_20 -140;
-    pos @kc87_first_38 @kc87_second_22 -140;
-    pos @kc87_first_38 @kc87_second_23 -70;
-    pos @kc87_first_38 @kc87_second_24 -280;
-    pos @kc87_first_38 @kc87_second_28 -315;
-    pos @kc87_first_38 @kc87_second_29 -140;
-    pos @kc87_first_38 @kc87_second_32 -385;
-    pos @kc87_first_38 @kc87_second_34 -210;
+    pos @kc87_first_37 @kc87_second_36 -50;
+    pos @kc87_first_37 @kc87_second_40 -50;
+    pos @kc87_first_37 @kc87_second_41 -35;
+    pos @kc87_first_37 @kc87_second_48 1;
+    pos @kc87_first_37 @kc87_second_50 -35;
+    pos @kc87_first_37 @kc87_second_51 -140;
+    pos @kc87_first_37 @kc87_second_58 -35;
+    pos @kc87_first_37 @kc87_second_63 -70;
+    pos @kc87_first_37 @kc87_second_64 -35;
+    pos @kc87_first_38 @kc87_second_3 -140;
+    pos @kc87_first_38 @kc87_second_4 -70;
+    pos @kc87_first_38 @kc87_second_6 -70;
+    pos @kc87_first_38 @kc87_second_8 -210;
+    pos @kc87_first_38 @kc87_second_9 -420;
+    pos @kc87_first_38 @kc87_second_12 -350;
+    pos @kc87_first_38 @kc87_second_13 -420;
+    pos @kc87_first_38 @kc87_second_14 -350;
+    pos @kc87_first_38 @kc87_second_15 -280;
+    pos @kc87_first_38 @kc87_second_17 -70;
+    pos @kc87_first_38 @kc87_second_18 -210;
+    pos @kc87_first_38 @kc87_second_20 -210;
+    pos @kc87_first_38 @kc87_second_22 -70;
+    pos @kc87_first_38 @kc87_second_23 -140;
+    pos @kc87_first_38 @kc87_second_29 -35;
+    pos @kc87_first_38 @kc87_second_31 -140;
+    pos @kc87_first_38 @kc87_second_32 -70;
     pos @kc87_first_38 @kc87_second_35 -70;
-    pos @kc87_first_38 @kc87_second_36 -140;
-    pos @kc87_first_38 @kc87_second_37 -140;
-    pos @kc87_first_38 @kc87_second_38 -140;
-    pos @kc87_first_38 @kc87_second_41 -70;
-    pos @kc87_first_38 @kc87_second_45 1;
-    pos @kc87_first_38 @kc87_second_51 -140;
-    pos @kc87_first_38 @kc87_second_52 -70;
-    pos @kc87_first_38 @kc87_second_53 -140;
-    pos @kc87_first_38 @kc87_second_55 -245;
-    pos @kc87_first_38 @kc87_second_58 -70;
-    pos @kc87_first_38 @kc87_second_59 -70;
-    pos @kc87_first_38 @kc87_second_63 -245;
-    pos @kc87_first_38 @kc87_second_64 -280;
-    pos @kc87_first_38 @kc87_second_65 -315;
+    pos @kc87_first_38 @kc87_second_37 -70;
+    pos @kc87_first_38 @kc87_second_39 -210;
+    pos @kc87_first_38 @kc87_second_40 -280;
+    pos @kc87_first_38 @kc87_second_41 -420;
+    pos @kc87_first_38 @kc87_second_43 -350;
+    pos @kc87_first_38 @kc87_second_44 -280;
+    pos @kc87_first_38 @kc87_second_48 1;
+    pos @kc87_first_38 @kc87_second_49 -35;
+    pos @kc87_first_38 @kc87_second_50 -210;
+    pos @kc87_first_38 @kc87_second_51 -350;
+    pos @kc87_first_38 @kc87_second_53 -35;
+    pos @kc87_first_38 @kc87_second_54 -35;
+    pos @kc87_first_38 @kc87_second_60 -280;
+    pos @kc87_first_38 @kc87_second_62 -175;
+    pos @kc87_first_38 @kc87_second_63 -280;
+    pos @kc87_first_38 @kc87_second_64 -210;
+    pos @kc87_first_38 @kc87_second_65 -70;
+    pos @kc87_first_39 @kc87_second_1 -35;
+    pos @kc87_first_39 @kc87_second_2 -70;
+    pos @kc87_first_39 @kc87_second_5 -105;
     pos @kc87_first_39 @kc87_second_6 -35;
+    pos @kc87_first_39 @kc87_second_9 -70;
+    pos @kc87_first_39 @kc87_second_11 -70;
     pos @kc87_first_39 @kc87_second_12 -240;
-    pos @kc87_first_39 @kc87_second_13 -140;
-    pos @kc87_first_39 @kc87_second_14 -35;
-    pos @kc87_first_39 @kc87_second_15 -35;
-    pos @kc87_first_39 @kc87_second_34 -35;
-    pos @kc87_first_39 @kc87_second_45 1;
-    pos @kc87_first_39 @kc87_second_63 -35;
-    pos @kc87_first_39 @kc87_second_64 -35;
-    pos @kc87_first_40 @kc87_second_12 -210;
-    pos @kc87_first_40 @kc87_second_13 -175;
-    pos @kc87_first_40 @kc87_second_14 -105;
-    pos @kc87_first_40 @kc87_second_15 -70;
-    pos @kc87_first_40 @kc87_second_43 -70;
-    pos @kc87_first_40 @kc87_second_45 1;
-    pos @kc87_first_40 @kc87_second_48 -105;
+    pos @kc87_first_39 @kc87_second_13 -245;
+    pos @kc87_first_39 @kc87_second_14 -140;
+    pos @kc87_first_39 @kc87_second_15 -105;
+    pos @kc87_first_39 @kc87_second_16 -105;
+    pos @kc87_first_39 @kc87_second_18 -70;
+    pos @kc87_first_39 @kc87_second_19 -70;
+    pos @kc87_first_39 @kc87_second_24 -35;
+    pos @kc87_first_39 @kc87_second_25 -70;
+    pos @kc87_first_39 @kc87_second_26 -140;
+    pos @kc87_first_39 @kc87_second_27 -105;
+    pos @kc87_first_39 @kc87_second_35 -35;
+    pos @kc87_first_39 @kc87_second_36 -140;
+    pos @kc87_first_39 @kc87_second_40 -105;
+    pos @kc87_first_39 @kc87_second_41 -70;
+    pos @kc87_first_39 @kc87_second_43 -175;
+    pos @kc87_first_39 @kc87_second_45 -105;
+    pos @kc87_first_39 @kc87_second_47 -70;
+    pos @kc87_first_39 @kc87_second_48 1;
+    pos @kc87_first_39 @kc87_second_50 -70;
+    pos @kc87_first_39 @kc87_second_51 -140;
+    pos @kc87_first_39 @kc87_second_55 -210;
+    pos @kc87_first_39 @kc87_second_56 -70;
+    pos @kc87_first_39 @kc87_second_57 -175;
+    pos @kc87_first_39 @kc87_second_58 -105;
+    pos @kc87_first_39 @kc87_second_59 -175;
+    pos @kc87_first_39 @kc87_second_62 -50;
+    pos @kc87_first_39 @kc87_second_63 -105;
+    pos @kc87_first_39 @kc87_second_64 -70;
+    pos @kc87_first_39 @kc87_second_66 -35;
+    pos @kc87_first_40 @kc87_second_1 -210;
+    pos @kc87_first_40 @kc87_second_2 -280;
+    pos @kc87_first_40 @kc87_second_6 -280;
+    pos @kc87_first_40 @kc87_second_8 -70;
+    pos @kc87_first_40 @kc87_second_17 -140;
+    pos @kc87_first_40 @kc87_second_19 -350;
+    pos @kc87_first_40 @kc87_second_20 -140;
+    pos @kc87_first_40 @kc87_second_22 -140;
+    pos @kc87_first_40 @kc87_second_23 -70;
+    pos @kc87_first_40 @kc87_second_24 -280;
+    pos @kc87_first_40 @kc87_second_28 -315;
+    pos @kc87_first_40 @kc87_second_29 -140;
+    pos @kc87_first_40 @kc87_second_33 -385;
+    pos @kc87_first_40 @kc87_second_35 -210;
+    pos @kc87_first_40 @kc87_second_36 -70;
+    pos @kc87_first_40 @kc87_second_37 -140;
+    pos @kc87_first_40 @kc87_second_38 -140;
+    pos @kc87_first_40 @kc87_second_39 -140;
+    pos @kc87_first_40 @kc87_second_42 -70;
+    pos @kc87_first_40 @kc87_second_48 1;
+    pos @kc87_first_40 @kc87_second_53 -140;
+    pos @kc87_first_40 @kc87_second_54 -70;
+    pos @kc87_first_40 @kc87_second_55 -140;
+    pos @kc87_first_40 @kc87_second_57 -245;
+    pos @kc87_first_40 @kc87_second_60 -70;
     pos @kc87_first_40 @kc87_second_61 -70;
-    pos @kc87_first_41 @kc87_second_1 -140;
-    pos @kc87_first_41 @kc87_second_2 -175;
-    pos @kc87_first_41 @kc87_second_5 -105;
-    pos @kc87_first_41 @kc87_second_6 -70;
-    pos @kc87_first_41 @kc87_second_11 -70;
-    pos @kc87_first_41 @kc87_second_12 -175;
-    pos @kc87_first_41 @kc87_second_13 -105;
-    pos @kc87_first_41 @kc87_second_14 -70;
+    pos @kc87_first_40 @kc87_second_65 -245;
+    pos @kc87_first_40 @kc87_second_66 -280;
+    pos @kc87_first_40 @kc87_second_67 -315;
+    pos @kc87_first_41 @kc87_second_6 -35;
+    pos @kc87_first_41 @kc87_second_12 -240;
+    pos @kc87_first_41 @kc87_second_13 -140;
+    pos @kc87_first_41 @kc87_second_14 -35;
     pos @kc87_first_41 @kc87_second_15 -35;
-    pos @kc87_first_41 @kc87_second_16 -105;
-    pos @kc87_first_41 @kc87_second_17 -35;
-    pos @kc87_first_41 @kc87_second_19 -175;
-    pos @kc87_first_41 @kc87_second_22 -50;
-    pos @kc87_first_41 @kc87_second_24 -105;
-    pos @kc87_first_41 @kc87_second_29 -35;
-    pos @kc87_first_41 @kc87_second_34 -70;
-    pos @kc87_first_41 @kc87_second_35 -140;
-    pos @kc87_first_41 @kc87_second_36 -35;
-    pos @kc87_first_41 @kc87_second_38 -50;
-    pos @kc87_first_41 @kc87_second_45 1;
-    pos @kc87_first_41 @kc87_second_51 -35;
-    pos @kc87_first_41 @kc87_second_53 -105;
-    pos @kc87_first_41 @kc87_second_55 -105;
-    pos @kc87_first_41 @kc87_second_57 -105;
-    pos @kc87_first_41 @kc87_second_63 -50;
-    pos @kc87_first_41 @kc87_second_64 -70;
-    pos @kc87_first_42 @kc87_second_1 -210;
-    pos @kc87_first_42 @kc87_second_2 -280;
-    pos @kc87_first_42 @kc87_second_3 -70;
-    pos @kc87_first_42 @kc87_second_6 -280;
-    pos @kc87_first_42 @kc87_second_8 -35;
-    pos @kc87_first_42 @kc87_second_11 -70;
-    pos @kc87_first_42 @kc87_second_13 -140;
-    pos @kc87_first_42 @kc87_second_14 -35;
-    pos @kc87_first_42 @kc87_second_15 -35;
-    pos @kc87_first_42 @kc87_second_16 -140;
-    pos @kc87_first_42 @kc87_second_17 -105;
-    pos @kc87_first_42 @kc87_second_19 -280;
-    pos @kc87_first_42 @kc87_second_20 -140;
-    pos @kc87_first_42 @kc87_second_22 -140;
-    pos @kc87_first_42 @kc87_second_23 -140;
-    pos @kc87_first_42 @kc87_second_24 -210;
-    pos @kc87_first_42 @kc87_second_34 -280;
-    pos @kc87_first_42 @kc87_second_35 -140;
-    pos @kc87_first_42 @kc87_second_36 -70;
-    pos @kc87_first_42 @kc87_second_37 -140;
-    pos @kc87_first_42 @kc87_second_38 -175;
-    pos @kc87_first_42 @kc87_second_44 -70;
-    pos @kc87_first_42 @kc87_second_45 1;
-    pos @kc87_first_42 @kc87_second_53 -210;
-    pos @kc87_first_42 @kc87_second_55 -175;
-    pos @kc87_first_42 @kc87_second_57 -210;
-    pos @kc87_first_42 @kc87_second_59 -70;
-    pos @kc87_first_42 @kc87_second_63 -175;
-    pos @kc87_first_42 @kc87_second_64 -175;
-    pos @kc87_first_43 @kc87_second_9 -70;
-    pos @kc87_first_43 @kc87_second_12 -240;
-    pos @kc87_first_43 @kc87_second_13 -210;
-    pos @kc87_first_43 @kc87_second_14 -140;
-    pos @kc87_first_43 @kc87_second_15 -105;
-    pos @kc87_first_43 @kc87_second_39 -70;
-    pos @kc87_first_43 @kc87_second_40 -35;
-    pos @kc87_first_43 @kc87_second_43 -140;
-    pos @kc87_first_43 @kc87_second_45 1;
-    pos @kc87_first_43 @kc87_second_47 -50;
-    pos @kc87_first_43 @kc87_second_48 -140;
-    pos @kc87_first_43 @kc87_second_58 -35;
-    pos @kc87_first_43 @kc87_second_60 -35;
-    pos @kc87_first_43 @kc87_second_61 -70;
-    pos @kc87_first_43 @kc87_second_62 -70;
+    pos @kc87_first_41 @kc87_second_35 -35;
+    pos @kc87_first_41 @kc87_second_48 1;
+    pos @kc87_first_41 @kc87_second_65 -35;
+    pos @kc87_first_41 @kc87_second_66 -35;
+    pos @kc87_first_42 @kc87_second_12 -210;
+    pos @kc87_first_42 @kc87_second_13 -175;
+    pos @kc87_first_42 @kc87_second_14 -105;
+    pos @kc87_first_42 @kc87_second_15 -70;
+    pos @kc87_first_42 @kc87_second_43 -70;
+    pos @kc87_first_42 @kc87_second_44 -35;
+    pos @kc87_first_42 @kc87_second_48 1;
+    pos @kc87_first_42 @kc87_second_51 -105;
+    pos @kc87_first_42 @kc87_second_63 -70;
+    pos @kc87_first_43 @kc87_second_1 -140;
+    pos @kc87_first_43 @kc87_second_2 -175;
+    pos @kc87_first_43 @kc87_second_5 -105;
+    pos @kc87_first_43 @kc87_second_6 -70;
+    pos @kc87_first_43 @kc87_second_11 -70;
+    pos @kc87_first_43 @kc87_second_12 -175;
+    pos @kc87_first_43 @kc87_second_13 -105;
+    pos @kc87_first_43 @kc87_second_14 -70;
+    pos @kc87_first_43 @kc87_second_15 -35;
+    pos @kc87_first_43 @kc87_second_16 -105;
+    pos @kc87_first_43 @kc87_second_17 -35;
+    pos @kc87_first_43 @kc87_second_19 -175;
+    pos @kc87_first_43 @kc87_second_22 -50;
+    pos @kc87_first_43 @kc87_second_24 -105;
+    pos @kc87_first_43 @kc87_second_29 -35;
+    pos @kc87_first_43 @kc87_second_32 -70;
+    pos @kc87_first_43 @kc87_second_35 -70;
+    pos @kc87_first_43 @kc87_second_36 -140;
+    pos @kc87_first_43 @kc87_second_37 -35;
+    pos @kc87_first_43 @kc87_second_39 -50;
+    pos @kc87_first_43 @kc87_second_48 1;
+    pos @kc87_first_43 @kc87_second_53 -35;
+    pos @kc87_first_43 @kc87_second_55 -105;
+    pos @kc87_first_43 @kc87_second_57 -105;
+    pos @kc87_first_43 @kc87_second_59 -105;
+    pos @kc87_first_43 @kc87_second_65 -50;
+    pos @kc87_first_43 @kc87_second_66 -70;
+    pos @kc87_first_44 @kc87_second_1 -210;
+    pos @kc87_first_44 @kc87_second_2 -280;
+    pos @kc87_first_44 @kc87_second_3 -70;
+    pos @kc87_first_44 @kc87_second_6 -280;
     pos @kc87_first_44 @kc87_second_8 -35;
-    pos @kc87_first_44 @kc87_second_9 -70;
-    pos @kc87_first_44 @kc87_second_12 -240;
-    pos @kc87_first_44 @kc87_second_13 -210;
-    pos @kc87_first_44 @kc87_second_14 -70;
-    pos @kc87_first_44 @kc87_second_15 -105;
-    pos @kc87_first_44 @kc87_second_22 -35;
-    pos @kc87_first_44 @kc87_second_38 -70;
-    pos @kc87_first_44 @kc87_second_39 -105;
-    pos @kc87_first_44 @kc87_second_40 -70;
-    pos @kc87_first_44 @kc87_second_43 -70;
-    pos @kc87_first_44 @kc87_second_44 -35;
-    pos @kc87_first_44 @kc87_second_45 1;
-    pos @kc87_first_44 @kc87_second_47 -70;
-    pos @kc87_first_44 @kc87_second_48 -70;
-    pos @kc87_first_44 @kc87_second_58 -70;
-    pos @kc87_first_44 @kc87_second_60 -50;
-    pos @kc87_first_44 @kc87_second_62 -70;
-    pos @kc87_first_44 @kc87_second_63 -35;
-    pos @kc87_first_44 @kc87_second_64 -35;
-    pos @kc87_first_45 @kc87_second_6 -70;
-    pos @kc87_first_45 @kc87_second_8 -35;
-    pos @kc87_first_45 @kc87_second_12 -175;
-    pos @kc87_first_45 @kc87_second_13 -140;
-    pos @kc87_first_45 @kc87_second_14 -70;
-    pos @kc87_first_45 @kc87_second_15 -35;
-    pos @kc87_first_45 @kc87_second_17 -70;
-    pos @kc87_first_45 @kc87_second_20 -70;
-    pos @kc87_first_45 @kc87_second_22 -105;
-    pos @kc87_first_45 @kc87_second_29 -35;
-    pos @kc87_first_45 @kc87_second_34 -70;
-    pos @kc87_first_45 @kc87_second_36 -35;
-    pos @kc87_first_45 @kc87_second_38 -105;
-    pos @kc87_first_45 @kc87_second_45 1;
-    pos @kc87_first_45 @kc87_second_51 -35;
+    pos @kc87_first_44 @kc87_second_11 -70;
+    pos @kc87_first_44 @kc87_second_13 -140;
+    pos @kc87_first_44 @kc87_second_14 -35;
+    pos @kc87_first_44 @kc87_second_15 -35;
+    pos @kc87_first_44 @kc87_second_16 -140;
+    pos @kc87_first_44 @kc87_second_17 -105;
+    pos @kc87_first_44 @kc87_second_19 -280;
+    pos @kc87_first_44 @kc87_second_20 -140;
+    pos @kc87_first_44 @kc87_second_22 -140;
+    pos @kc87_first_44 @kc87_second_23 -140;
+    pos @kc87_first_44 @kc87_second_24 -210;
+    pos @kc87_first_44 @kc87_second_32 -70;
+    pos @kc87_first_44 @kc87_second_35 -280;
+    pos @kc87_first_44 @kc87_second_36 -140;
+    pos @kc87_first_44 @kc87_second_37 -70;
+    pos @kc87_first_44 @kc87_second_38 -140;
+    pos @kc87_first_44 @kc87_second_39 -175;
+    pos @kc87_first_44 @kc87_second_46 -70;
+    pos @kc87_first_44 @kc87_second_48 1;
+    pos @kc87_first_44 @kc87_second_55 -210;
+    pos @kc87_first_44 @kc87_second_57 -175;
+    pos @kc87_first_44 @kc87_second_59 -210;
+    pos @kc87_first_44 @kc87_second_61 -70;
+    pos @kc87_first_44 @kc87_second_65 -175;
+    pos @kc87_first_44 @kc87_second_66 -175;
+    pos @kc87_first_45 @kc87_second_9 -70;
+    pos @kc87_first_45 @kc87_second_12 -240;
+    pos @kc87_first_45 @kc87_second_13 -210;
+    pos @kc87_first_45 @kc87_second_14 -140;
+    pos @kc87_first_45 @kc87_second_15 -105;
+    pos @kc87_first_45 @kc87_second_40 -70;
+    pos @kc87_first_45 @kc87_second_41 -35;
+    pos @kc87_first_45 @kc87_second_43 -140;
+    pos @kc87_first_45 @kc87_second_44 -70;
+    pos @kc87_first_45 @kc87_second_48 1;
+    pos @kc87_first_45 @kc87_second_50 -50;
+    pos @kc87_first_45 @kc87_second_51 -140;
+    pos @kc87_first_45 @kc87_second_60 -35;
+    pos @kc87_first_45 @kc87_second_62 -35;
     pos @kc87_first_45 @kc87_second_63 -70;
     pos @kc87_first_45 @kc87_second_64 -70;
-    pos @kc87_first_46 @kc87_second_3 -140;
-    pos @kc87_first_46 @kc87_second_4 -70;
-    pos @kc87_first_46 @kc87_second_6 -70;
-    pos @kc87_first_46 @kc87_second_8 -210;
-    pos @kc87_first_46 @kc87_second_9 -420;
-    pos @kc87_first_46 @kc87_second_12 -350;
-    pos @kc87_first_46 @kc87_second_13 -420;
-    pos @kc87_first_46 @kc87_second_14 -350;
-    pos @kc87_first_46 @kc87_second_15 -280;
-    pos @kc87_first_46 @kc87_second_17 -70;
-    pos @kc87_first_46 @kc87_second_18 -210;
-    pos @kc87_first_46 @kc87_second_20 -210;
-    pos @kc87_first_46 @kc87_second_22 -70;
-    pos @kc87_first_46 @kc87_second_23 -140;
-    pos @kc87_first_46 @kc87_second_29 -35;
-    pos @kc87_first_46 @kc87_second_31 -140;
-    pos @kc87_first_46 @kc87_second_34 -70;
-    pos @kc87_first_46 @kc87_second_36 -70;
-    pos @kc87_first_46 @kc87_second_38 -210;
-    pos @kc87_first_46 @kc87_second_39 -280;
-    pos @kc87_first_46 @kc87_second_40 -420;
-    pos @kc87_first_46 @kc87_second_43 -350;
-    pos @kc87_first_46 @kc87_second_45 1;
+    pos @kc87_first_46 @kc87_second_8 -35;
+    pos @kc87_first_46 @kc87_second_9 -70;
+    pos @kc87_first_46 @kc87_second_12 -240;
+    pos @kc87_first_46 @kc87_second_13 -210;
+    pos @kc87_first_46 @kc87_second_14 -70;
+    pos @kc87_first_46 @kc87_second_15 -105;
+    pos @kc87_first_46 @kc87_second_22 -35;
+    pos @kc87_first_46 @kc87_second_39 -70;
+    pos @kc87_first_46 @kc87_second_40 -105;
+    pos @kc87_first_46 @kc87_second_41 -70;
+    pos @kc87_first_46 @kc87_second_43 -70;
     pos @kc87_first_46 @kc87_second_46 -35;
-    pos @kc87_first_46 @kc87_second_47 -210;
-    pos @kc87_first_46 @kc87_second_48 -350;
-    pos @kc87_first_46 @kc87_second_51 -35;
-    pos @kc87_first_46 @kc87_second_52 -35;
-    pos @kc87_first_46 @kc87_second_58 -280;
-    pos @kc87_first_46 @kc87_second_60 -175;
-    pos @kc87_first_46 @kc87_second_61 -280;
-    pos @kc87_first_46 @kc87_second_62 -210;
-    pos @kc87_first_46 @kc87_second_63 -70;
-    pos @kc87_first_47 @kc87_second_3 -140;
-    pos @kc87_first_47 @kc87_second_4 -105;
+    pos @kc87_first_46 @kc87_second_48 1;
+    pos @kc87_first_46 @kc87_second_50 -70;
+    pos @kc87_first_46 @kc87_second_51 -70;
+    pos @kc87_first_46 @kc87_second_60 -70;
+    pos @kc87_first_46 @kc87_second_62 -50;
+    pos @kc87_first_46 @kc87_second_64 -70;
+    pos @kc87_first_46 @kc87_second_65 -35;
+    pos @kc87_first_46 @kc87_second_66 -35;
     pos @kc87_first_47 @kc87_second_6 -70;
-    pos @kc87_first_47 @kc87_second_8 -210;
-    pos @kc87_first_47 @kc87_second_9 -280;
-    pos @kc87_first_47 @kc87_second_12 -350;
-    pos @kc87_first_47 @kc87_second_13 -385;
-    pos @kc87_first_47 @kc87_second_14 -350;
-    pos @kc87_first_47 @kc87_second_15 -280;
-    pos @kc87_first_47 @kc87_second_18 -210;
-    pos @kc87_first_47 @kc87_second_20 -140;
+    pos @kc87_first_47 @kc87_second_8 -35;
+    pos @kc87_first_47 @kc87_second_12 -175;
+    pos @kc87_first_47 @kc87_second_13 -140;
+    pos @kc87_first_47 @kc87_second_14 -70;
+    pos @kc87_first_47 @kc87_second_15 -35;
+    pos @kc87_first_47 @kc87_second_17 -70;
+    pos @kc87_first_47 @kc87_second_20 -70;
     pos @kc87_first_47 @kc87_second_22 -105;
-    pos @kc87_first_47 @kc87_second_23 -140;
-    pos @kc87_first_47 @kc87_second_29 -70;
-    pos @kc87_first_47 @kc87_second_31 -175;
-    pos @kc87_first_47 @kc87_second_34 -70;
-    pos @kc87_first_47 @kc87_second_36 -35;
-    pos @kc87_first_47 @kc87_second_38 -175;
-    pos @kc87_first_47 @kc87_second_39 -280;
-    pos @kc87_first_47 @kc87_second_40 -280;
-    pos @kc87_first_47 @kc87_second_43 -280;
-    pos @kc87_first_47 @kc87_second_44 -140;
-    pos @kc87_first_47 @kc87_second_45 1;
-    pos @kc87_first_47 @kc87_second_46 -70;
-    pos @kc87_first_47 @kc87_second_47 -280;
-    pos @kc87_first_47 @kc87_second_48 -350;
-    pos @kc87_first_47 @kc87_second_51 -35;
-    pos @kc87_first_47 @kc87_second_52 -70;
-    pos @kc87_first_47 @kc87_second_58 -245;
-    pos @kc87_first_47 @kc87_second_60 -245;
-    pos @kc87_first_47 @kc87_second_61 -280;
-    pos @kc87_first_47 @kc87_second_62 -210;
-    pos @kc87_first_47 @kc87_second_63 -70;
-    pos @kc87_first_47 @kc87_second_64 -70;
-    pos @kc87_first_48 @kc87_second_3 -70;
+    pos @kc87_first_47 @kc87_second_29 -35;
+    pos @kc87_first_47 @kc87_second_32 -70;
+    pos @kc87_first_47 @kc87_second_35 -70;
+    pos @kc87_first_47 @kc87_second_37 -35;
+    pos @kc87_first_47 @kc87_second_39 -105;
+    pos @kc87_first_47 @kc87_second_48 1;
+    pos @kc87_first_47 @kc87_second_53 -35;
+    pos @kc87_first_47 @kc87_second_65 -70;
+    pos @kc87_first_47 @kc87_second_66 -70;
+    pos @kc87_first_48 @kc87_second_3 -140;
     pos @kc87_first_48 @kc87_second_4 -105;
-    pos @kc87_first_48 @kc87_second_6 -210;
-    pos @kc87_first_48 @kc87_second_7 -70;
-    pos @kc87_first_48 @kc87_second_8 -175;
-    pos @kc87_first_48 @kc87_second_17 -210;
+    pos @kc87_first_48 @kc87_second_6 -70;
+    pos @kc87_first_48 @kc87_second_8 -210;
+    pos @kc87_first_48 @kc87_second_9 -280;
+    pos @kc87_first_48 @kc87_second_12 -350;
+    pos @kc87_first_48 @kc87_second_13 -385;
+    pos @kc87_first_48 @kc87_second_14 -350;
+    pos @kc87_first_48 @kc87_second_15 -280;
+    pos @kc87_first_48 @kc87_second_18 -210;
     pos @kc87_first_48 @kc87_second_20 -140;
-    pos @kc87_first_48 @kc87_second_21 -210;
-    pos @kc87_first_48 @kc87_second_22 -210;
-    pos @kc87_first_48 @kc87_second_23 -210;
-    pos @kc87_first_48 @kc87_second_24 -140;
-    pos @kc87_first_48 @kc87_second_25 -140;
-    pos @kc87_first_48 @kc87_second_27 -140;
-    pos @kc87_first_48 @kc87_second_29 -210;
-    pos @kc87_first_48 @kc87_second_30 -210;
-    pos @kc87_first_48 @kc87_second_31 -140;
-    pos @kc87_first_48 @kc87_second_34 -210;
+    pos @kc87_first_48 @kc87_second_22 -105;
+    pos @kc87_first_48 @kc87_second_23 -140;
+    pos @kc87_first_48 @kc87_second_29 -70;
+    pos @kc87_first_48 @kc87_second_31 -175;
     pos @kc87_first_48 @kc87_second_35 -70;
-    pos @kc87_first_48 @kc87_second_36 -175;
-    pos @kc87_first_48 @kc87_second_37 -210;
-    pos @kc87_first_48 @kc87_second_38 -175;
-    pos @kc87_first_48 @kc87_second_39 -210;
-    pos @kc87_first_48 @kc87_second_40 -105;
-    pos @kc87_first_48 @kc87_second_43 -70;
-    pos @kc87_first_48 @kc87_second_44 -105;
-    pos @kc87_first_48 @kc87_second_45 1;
-    pos @kc87_first_48 @kc87_second_46 -35;
-    pos @kc87_first_48 @kc87_second_47 -210;
-    pos @kc87_first_48 @kc87_second_50 -210;
-    pos @kc87_first_48 @kc87_second_51 -210;
-    pos @kc87_first_48 @kc87_second_52 -175;
-    pos @kc87_first_48 @kc87_second_53 -175;
-    pos @kc87_first_48 @kc87_second_55 -210;
-    pos @kc87_first_48 @kc87_second_56 -140;
-    pos @kc87_first_48 @kc87_second_57 -210;
-    pos @kc87_first_48 @kc87_second_58 -210;
-    pos @kc87_first_48 @kc87_second_59 -175;
-    pos @kc87_first_48 @kc87_second_60 -175;
-    pos @kc87_first_48 @kc87_second_63 -210;
+    pos @kc87_first_48 @kc87_second_37 -35;
+    pos @kc87_first_48 @kc87_second_39 -175;
+    pos @kc87_first_48 @kc87_second_40 -280;
+    pos @kc87_first_48 @kc87_second_41 -280;
+    pos @kc87_first_48 @kc87_second_43 -280;
+    pos @kc87_first_48 @kc87_second_44 -210;
+    pos @kc87_first_48 @kc87_second_46 -140;
+    pos @kc87_first_48 @kc87_second_48 1;
+    pos @kc87_first_48 @kc87_second_49 -70;
+    pos @kc87_first_48 @kc87_second_50 -280;
+    pos @kc87_first_48 @kc87_second_51 -350;
+    pos @kc87_first_48 @kc87_second_53 -35;
+    pos @kc87_first_48 @kc87_second_54 -70;
+    pos @kc87_first_48 @kc87_second_60 -245;
+    pos @kc87_first_48 @kc87_second_62 -245;
+    pos @kc87_first_48 @kc87_second_63 -280;
     pos @kc87_first_48 @kc87_second_64 -210;
-    pos @kc87_first_49 @kc87_second_5 -70;
-    pos @kc87_first_49 @kc87_second_11 -35;
-    pos @kc87_first_49 @kc87_second_12 -240;
-    pos @kc87_first_49 @kc87_second_13 -70;
-    pos @kc87_first_49 @kc87_second_14 -140;
-    pos @kc87_first_49 @kc87_second_15 -105;
-    pos @kc87_first_49 @kc87_second_16 -70;
-    pos @kc87_first_49 @kc87_second_26 -70;
-    pos @kc87_first_49 @kc87_second_27 -70;
-    pos @kc87_first_49 @kc87_second_35 -35;
-    pos @kc87_first_49 @kc87_second_39 -70;
-    pos @kc87_first_49 @kc87_second_42 -35;
+    pos @kc87_first_48 @kc87_second_65 -70;
+    pos @kc87_first_48 @kc87_second_66 -70;
+    pos @kc87_first_49 @kc87_second_3 -70;
+    pos @kc87_first_49 @kc87_second_4 -105;
+    pos @kc87_first_49 @kc87_second_6 -210;
+    pos @kc87_first_49 @kc87_second_7 -70;
+    pos @kc87_first_49 @kc87_second_8 -175;
+    pos @kc87_first_49 @kc87_second_17 -210;
+    pos @kc87_first_49 @kc87_second_20 -140;
+    pos @kc87_first_49 @kc87_second_21 -210;
+    pos @kc87_first_49 @kc87_second_22 -210;
+    pos @kc87_first_49 @kc87_second_23 -210;
+    pos @kc87_first_49 @kc87_second_24 -140;
+    pos @kc87_first_49 @kc87_second_25 -140;
+    pos @kc87_first_49 @kc87_second_27 -140;
+    pos @kc87_first_49 @kc87_second_29 -210;
+    pos @kc87_first_49 @kc87_second_30 -210;
+    pos @kc87_first_49 @kc87_second_31 -140;
+    pos @kc87_first_49 @kc87_second_32 -140;
+    pos @kc87_first_49 @kc87_second_35 -210;
+    pos @kc87_first_49 @kc87_second_36 -70;
+    pos @kc87_first_49 @kc87_second_37 -175;
+    pos @kc87_first_49 @kc87_second_38 -210;
+    pos @kc87_first_49 @kc87_second_39 -175;
+    pos @kc87_first_49 @kc87_second_40 -210;
+    pos @kc87_first_49 @kc87_second_41 -105;
     pos @kc87_first_49 @kc87_second_43 -70;
-    pos @kc87_first_49 @kc87_second_45 1;
-    pos @kc87_first_49 @kc87_second_47 -35;
-    pos @kc87_first_49 @kc87_second_48 -140;
-    pos @kc87_first_49 @kc87_second_51 1;
-    pos @kc87_first_49 @kc87_second_56 -35;
-    pos @kc87_first_49 @kc87_second_60 -35;
-    pos @kc87_first_49 @kc87_second_61 -105;
-    pos @kc87_first_49 @kc87_second_62 -70;
-    pos @kc87_first_50 @kc87_second_65 -70;
-    pos @kc87_first_51 @kc87_second_32 -315;
-    pos @kc87_first_51 @kc87_second_66 -70;
-    pos @kc87_first_52 @kc87_second_1 -105;
-    pos @kc87_first_52 @kc87_second_2 -210;
-    pos @kc87_first_52 @kc87_second_6 -140;
-    pos @kc87_first_52 @kc87_second_11 -70;
-    pos @kc87_first_52 @kc87_second_12 -210;
-    pos @kc87_first_52 @kc87_second_13 -210;
-    pos @kc87_first_52 @kc87_second_14 -105;
-    pos @kc87_first_52 @kc87_second_15 -70;
-    pos @kc87_first_52 @kc87_second_16 -140;
-    pos @kc87_first_52 @kc87_second_17 -35;
-    pos @kc87_first_52 @kc87_second_22 -35;
-    pos @kc87_first_52 @kc87_second_24 -210;
-    pos @kc87_first_52 @kc87_second_26 -70;
-    pos @kc87_first_52 @kc87_second_27 -70;
-    pos @kc87_first_52 @kc87_second_29 -35;
-    pos @kc87_first_52 @kc87_second_34 -210;
-    pos @kc87_first_52 @kc87_second_35 -140;
-    pos @kc87_first_52 @kc87_second_42 -35;
-    pos @kc87_first_52 @kc87_second_43 -70;
-    pos @kc87_first_52 @kc87_second_45 1;
-    pos @kc87_first_52 @kc87_second_47 -35;
-    pos @kc87_first_52 @kc87_second_48 -105;
-    pos @kc87_first_52 @kc87_second_53 -210;
-    pos @kc87_first_52 @kc87_second_55 -140;
-    pos @kc87_first_52 @kc87_second_57 -175;
-    pos @kc87_first_52 @kc87_second_61 -35;
-    pos @kc87_first_52 @kc87_second_62 -35;
-    pos @kc87_first_52 @kc87_second_63 -35;
-    pos @kc87_first_52 @kc87_second_64 -70;
-    pos @kc87_first_53 @kc87_second_1 -35;
-    pos @kc87_first_53 @kc87_second_2 -70;
-    pos @kc87_first_53 @kc87_second_5 -105;
-    pos @kc87_first_53 @kc87_second_6 -35;
-    pos @kc87_first_53 @kc87_second_9 -70;
-    pos @kc87_first_53 @kc87_second_11 -70;
-    pos @kc87_first_53 @kc87_second_12 -240;
-    pos @kc87_first_53 @kc87_second_13 -245;
-    pos @kc87_first_53 @kc87_second_14 -140;
-    pos @kc87_first_53 @kc87_second_15 -105;
-    pos @kc87_first_53 @kc87_second_16 -105;
-    pos @kc87_first_53 @kc87_second_18 -70;
-    pos @kc87_first_53 @kc87_second_19 -70;
-    pos @kc87_first_53 @kc87_second_24 -35;
-    pos @kc87_first_53 @kc87_second_25 -70;
-    pos @kc87_first_53 @kc87_second_26 -140;
-    pos @kc87_first_53 @kc87_second_27 -105;
-    pos @kc87_first_53 @kc87_second_34 -35;
-    pos @kc87_first_53 @kc87_second_35 -140;
-    pos @kc87_first_53 @kc87_second_39 -105;
-    pos @kc87_first_53 @kc87_second_40 -70;
-    pos @kc87_first_53 @kc87_second_42 -105;
-    pos @kc87_first_53 @kc87_second_43 -175;
-    pos @kc87_first_53 @kc87_second_45 1;
-    pos @kc87_first_53 @kc87_second_47 -70;
-    pos @kc87_first_53 @kc87_second_48 -140;
-    pos @kc87_first_53 @kc87_second_49 -70;
-    pos @kc87_first_53 @kc87_second_53 -210;
-    pos @kc87_first_53 @kc87_second_54 -70;
-    pos @kc87_first_53 @kc87_second_55 -175;
-    pos @kc87_first_53 @kc87_second_56 -105;
-    pos @kc87_first_53 @kc87_second_57 -175;
-    pos @kc87_first_53 @kc87_second_60 -50;
-    pos @kc87_first_53 @kc87_second_61 -105;
-    pos @kc87_first_53 @kc87_second_62 -70;
-    pos @kc87_first_53 @kc87_second_64 -35;
+    pos @kc87_first_49 @kc87_second_46 -105;
+    pos @kc87_first_49 @kc87_second_48 1;
+    pos @kc87_first_49 @kc87_second_49 -35;
+    pos @kc87_first_49 @kc87_second_50 -210;
+    pos @kc87_first_49 @kc87_second_52 -210;
+    pos @kc87_first_49 @kc87_second_53 -210;
+    pos @kc87_first_49 @kc87_second_54 -175;
+    pos @kc87_first_49 @kc87_second_55 -175;
+    pos @kc87_first_49 @kc87_second_57 -210;
+    pos @kc87_first_49 @kc87_second_58 -140;
+    pos @kc87_first_49 @kc87_second_59 -210;
+    pos @kc87_first_49 @kc87_second_60 -210;
+    pos @kc87_first_49 @kc87_second_61 -175;
+    pos @kc87_first_49 @kc87_second_62 -175;
+    pos @kc87_first_49 @kc87_second_65 -210;
+    pos @kc87_first_49 @kc87_second_66 -210;
+    pos @kc87_first_50 @kc87_second_1 -35;
+    pos @kc87_first_50 @kc87_second_2 -70;
+    pos @kc87_first_50 @kc87_second_5 -70;
+    pos @kc87_first_50 @kc87_second_11 -35;
+    pos @kc87_first_50 @kc87_second_12 -70;
+    pos @kc87_first_50 @kc87_second_13 -140;
+    pos @kc87_first_50 @kc87_second_14 -70;
+    pos @kc87_first_50 @kc87_second_15 -35;
+    pos @kc87_first_50 @kc87_second_16 -105;
+    pos @kc87_first_50 @kc87_second_26 -35;
+    pos @kc87_first_50 @kc87_second_27 -70;
+    pos @kc87_first_50 @kc87_second_36 -70;
+    pos @kc87_first_50 @kc87_second_43 -70;
+    pos @kc87_first_50 @kc87_second_48 1;
+    pos @kc87_first_50 @kc87_second_55 -175;
+    pos @kc87_first_50 @kc87_second_57 -140;
+    pos @kc87_first_50 @kc87_second_59 -140;
+    pos @kc87_first_50 @kc87_second_63 -35;
+    pos @kc87_first_51 @kc87_second_5 -70;
+    pos @kc87_first_51 @kc87_second_11 -35;
+    pos @kc87_first_51 @kc87_second_12 -240;
+    pos @kc87_first_51 @kc87_second_13 -70;
+    pos @kc87_first_51 @kc87_second_14 -140;
+    pos @kc87_first_51 @kc87_second_15 -105;
+    pos @kc87_first_51 @kc87_second_16 -70;
+    pos @kc87_first_51 @kc87_second_26 -70;
+    pos @kc87_first_51 @kc87_second_27 -70;
+    pos @kc87_first_51 @kc87_second_36 -35;
+    pos @kc87_first_51 @kc87_second_40 -70;
+    pos @kc87_first_51 @kc87_second_43 -70;
+    pos @kc87_first_51 @kc87_second_45 -35;
+    pos @kc87_first_51 @kc87_second_48 1;
+    pos @kc87_first_51 @kc87_second_50 -35;
+    pos @kc87_first_51 @kc87_second_51 -140;
+    pos @kc87_first_51 @kc87_second_53 1;
+    pos @kc87_first_51 @kc87_second_58 -35;
+    pos @kc87_first_51 @kc87_second_62 -35;
+    pos @kc87_first_51 @kc87_second_63 -105;
+    pos @kc87_first_51 @kc87_second_64 -70;
+    pos @kc87_first_52 @kc87_second_67 -70;
+    pos @kc87_first_53 @kc87_second_33 -315;
+    pos @kc87_first_53 @kc87_second_68 -70;
     pos @kc87_first_54 @kc87_second_1 -105;
     pos @kc87_first_54 @kc87_second_2 -210;
-    pos @kc87_first_54 @kc87_second_5 -70;
-    pos @kc87_first_54 @kc87_second_6 -105;
-    pos @kc87_first_54 @kc87_second_13 -70;
-    pos @kc87_first_54 @kc87_second_14 -35;
+    pos @kc87_first_54 @kc87_second_6 -140;
+    pos @kc87_first_54 @kc87_second_11 -70;
+    pos @kc87_first_54 @kc87_second_12 -210;
+    pos @kc87_first_54 @kc87_second_13 -210;
+    pos @kc87_first_54 @kc87_second_14 -105;
+    pos @kc87_first_54 @kc87_second_15 -70;
     pos @kc87_first_54 @kc87_second_16 -140;
-    pos @kc87_first_54 @kc87_second_17 -70;
-    pos @kc87_first_54 @kc87_second_19 -210;
+    pos @kc87_first_54 @kc87_second_17 -35;
     pos @kc87_first_54 @kc87_second_22 -35;
     pos @kc87_first_54 @kc87_second_24 -210;
+    pos @kc87_first_54 @kc87_second_26 -70;
+    pos @kc87_first_54 @kc87_second_27 -70;
     pos @kc87_first_54 @kc87_second_29 -35;
-    pos @kc87_first_54 @kc87_second_32 -105;
-    pos @kc87_first_54 @kc87_second_34 -105;
-    pos @kc87_first_54 @kc87_second_35 -140;
-    pos @kc87_first_54 @kc87_second_38 -70;
-    pos @kc87_first_54 @kc87_second_45 1;
-    pos @kc87_first_54 @kc87_second_51 -35;
-    pos @kc87_first_54 @kc87_second_53 -245;
+    pos @kc87_first_54 @kc87_second_35 -210;
+    pos @kc87_first_54 @kc87_second_36 -140;
+    pos @kc87_first_54 @kc87_second_43 -70;
+    pos @kc87_first_54 @kc87_second_45 -35;
+    pos @kc87_first_54 @kc87_second_48 1;
+    pos @kc87_first_54 @kc87_second_50 -35;
+    pos @kc87_first_54 @kc87_second_51 -105;
     pos @kc87_first_54 @kc87_second_55 -210;
-    pos @kc87_first_54 @kc87_second_57 -210;
-    pos @kc87_first_54 @kc87_second_63 -70;
-    pos @kc87_first_54 @kc87_second_64 -105;
-    pos @kc87_first_55 @kc87_second_12 -240;
-    pos @kc87_first_55 @kc87_second_13 -140;
-    pos @kc87_first_55 @kc87_second_14 -105;
-    pos @kc87_first_55 @kc87_second_15 -35;
-    pos @kc87_first_55 @kc87_second_33 165;
-    pos @kc87_first_55 @kc87_second_45 1;
-    pos @kc87_first_55 @kc87_second_50 165;
-    pos @kc87_first_56 @kc87_second_1 -140;
-    pos @kc87_first_56 @kc87_second_2 -210;
-    pos @kc87_first_56 @kc87_second_6 -140;
-    pos @kc87_first_56 @kc87_second_12 -175;
+    pos @kc87_first_54 @kc87_second_57 -140;
+    pos @kc87_first_54 @kc87_second_59 -175;
+    pos @kc87_first_54 @kc87_second_63 -35;
+    pos @kc87_first_54 @kc87_second_64 -35;
+    pos @kc87_first_54 @kc87_second_65 -35;
+    pos @kc87_first_54 @kc87_second_66 -70;
+    pos @kc87_first_55 @kc87_second_1 -105;
+    pos @kc87_first_55 @kc87_second_2 -210;
+    pos @kc87_first_55 @kc87_second_5 -70;
+    pos @kc87_first_55 @kc87_second_6 -105;
+    pos @kc87_first_55 @kc87_second_13 -70;
+    pos @kc87_first_55 @kc87_second_14 -35;
+    pos @kc87_first_55 @kc87_second_16 -140;
+    pos @kc87_first_55 @kc87_second_17 -70;
+    pos @kc87_first_55 @kc87_second_19 -210;
+    pos @kc87_first_55 @kc87_second_22 -35;
+    pos @kc87_first_55 @kc87_second_24 -210;
+    pos @kc87_first_55 @kc87_second_29 -35;
+    pos @kc87_first_55 @kc87_second_32 -70;
+    pos @kc87_first_55 @kc87_second_33 -105;
+    pos @kc87_first_55 @kc87_second_35 -105;
+    pos @kc87_first_55 @kc87_second_36 -140;
+    pos @kc87_first_55 @kc87_second_39 -70;
+    pos @kc87_first_55 @kc87_second_48 1;
+    pos @kc87_first_55 @kc87_second_53 -35;
+    pos @kc87_first_55 @kc87_second_55 -245;
+    pos @kc87_first_55 @kc87_second_57 -210;
+    pos @kc87_first_55 @kc87_second_59 -210;
+    pos @kc87_first_55 @kc87_second_65 -70;
+    pos @kc87_first_55 @kc87_second_66 -105;
+    pos @kc87_first_56 @kc87_second_12 -240;
     pos @kc87_first_56 @kc87_second_13 -140;
-    pos @kc87_first_56 @kc87_second_16 -140;
-    pos @kc87_first_56 @kc87_second_19 -210;
-    pos @kc87_first_56 @kc87_second_24 -210;
-    pos @kc87_first_56 @kc87_second_32 -140;
-    pos @kc87_first_56 @kc87_second_34 -140;
-    pos @kc87_first_56 @kc87_second_35 -210;
-    pos @kc87_first_56 @kc87_second_36 -35;
-    pos @kc87_first_56 @kc87_second_45 1;
-    pos @kc87_first_56 @kc87_second_53 -210;
-    pos @kc87_first_56 @kc87_second_55 -175;
-    pos @kc87_first_56 @kc87_second_57 -175;
-    pos @kc87_first_56 @kc87_second_63 -105;
-    pos @kc87_first_56 @kc87_second_64 -210;
-    pos @kc87_first_57 @kc87_second_12 -240;
-    pos @kc87_first_57 @kc87_second_13 -175;
-    pos @kc87_first_57 @kc87_second_14 -70;
-    pos @kc87_first_57 @kc87_second_15 -35;
-    pos @kc87_first_57 @kc87_second_19 -35;
-    pos @kc87_first_57 @kc87_second_26 -35;
-    pos @kc87_first_57 @kc87_second_39 -35;
-    pos @kc87_first_57 @kc87_second_40 -35;
-    pos @kc87_first_57 @kc87_second_43 -70;
-    pos @kc87_first_57 @kc87_second_45 1;
-    pos @kc87_first_57 @kc87_second_47 -35;
-    pos @kc87_first_57 @kc87_second_48 -70;
-    pos @kc87_first_57 @kc87_second_58 -35;
-    pos @kc87_first_57 @kc87_second_60 -35;
-    pos @kc87_first_57 @kc87_second_61 -70;
-    pos @kc87_first_57 @kc87_second_62 -35;
-    pos @kc87_first_58 @kc87_second_13 -35;
-    pos @kc87_first_58 @kc87_second_58 -35;
+    pos @kc87_first_56 @kc87_second_14 -105;
+    pos @kc87_first_56 @kc87_second_15 -35;
+    pos @kc87_first_56 @kc87_second_34 165;
+    pos @kc87_first_56 @kc87_second_48 1;
+    pos @kc87_first_56 @kc87_second_52 165;
+    pos @kc87_first_57 @kc87_second_1 -140;
+    pos @kc87_first_57 @kc87_second_2 -210;
+    pos @kc87_first_57 @kc87_second_6 -140;
+    pos @kc87_first_57 @kc87_second_12 -175;
+    pos @kc87_first_57 @kc87_second_13 -140;
+    pos @kc87_first_57 @kc87_second_16 -140;
+    pos @kc87_first_57 @kc87_second_19 -210;
+    pos @kc87_first_57 @kc87_second_24 -210;
+    pos @kc87_first_57 @kc87_second_32 -35;
+    pos @kc87_first_57 @kc87_second_33 -140;
+    pos @kc87_first_57 @kc87_second_35 -140;
+    pos @kc87_first_57 @kc87_second_36 -210;
+    pos @kc87_first_57 @kc87_second_37 -35;
+    pos @kc87_first_57 @kc87_second_48 1;
+    pos @kc87_first_57 @kc87_second_55 -210;
+    pos @kc87_first_57 @kc87_second_57 -175;
+    pos @kc87_first_57 @kc87_second_59 -175;
+    pos @kc87_first_57 @kc87_second_65 -105;
+    pos @kc87_first_57 @kc87_second_66 -210;
+    pos @kc87_first_58 @kc87_second_12 -240;
+    pos @kc87_first_58 @kc87_second_13 -175;
+    pos @kc87_first_58 @kc87_second_14 -70;
+    pos @kc87_first_58 @kc87_second_15 -35;
+    pos @kc87_first_58 @kc87_second_19 -35;
+    pos @kc87_first_58 @kc87_second_26 -35;
+    pos @kc87_first_58 @kc87_second_40 -35;
+    pos @kc87_first_58 @kc87_second_41 -35;
+    pos @kc87_first_58 @kc87_second_43 -70;
+    pos @kc87_first_58 @kc87_second_48 1;
+    pos @kc87_first_58 @kc87_second_50 -35;
+    pos @kc87_first_58 @kc87_second_51 -70;
+    pos @kc87_first_58 @kc87_second_60 -35;
+    pos @kc87_first_58 @kc87_second_62 -35;
+    pos @kc87_first_58 @kc87_second_63 -70;
     pos @kc87_first_58 @kc87_second_64 -35;
-    pos @kc87_first_59 @kc87_second_12 -175;
-    pos @kc87_first_59 @kc87_second_13 -140;
-    pos @kc87_first_59 @kc87_second_14 -35;
-    pos @kc87_first_59 @kc87_second_45 1;
-    pos @kc87_first_60 @kc87_second_1 -140;
-    pos @kc87_first_60 @kc87_second_2 -280;
-    pos @kc87_first_60 @kc87_second_5 -140;
-    pos @kc87_first_60 @kc87_second_6 -280;
-    pos @kc87_first_60 @kc87_second_8 -70;
-    pos @kc87_first_60 @kc87_second_10 -70;
-    pos @kc87_first_60 @kc87_second_11 -175;
-    pos @kc87_first_60 @kc87_second_12 -240;
-    pos @kc87_first_60 @kc87_second_13 -140;
-    pos @kc87_first_60 @kc87_second_14 -105;
-    pos @kc87_first_60 @kc87_second_15 -70;
-    pos @kc87_first_60 @kc87_second_16 -175;
-    pos @kc87_first_60 @kc87_second_17 -70;
-    pos @kc87_first_60 @kc87_second_19 -280;
-    pos @kc87_first_60 @kc87_second_22 -70;
-    pos @kc87_first_60 @kc87_second_23 -70;
-    pos @kc87_first_60 @kc87_second_24 -210;
-    pos @kc87_first_60 @kc87_second_26 -70;
-    pos @kc87_first_60 @kc87_second_27 -70;
-    pos @kc87_first_60 @kc87_second_29 -70;
+    pos @kc87_first_59 @kc87_second_1 -210;
+    pos @kc87_first_59 @kc87_second_2 -210;
+    pos @kc87_first_59 @kc87_second_3 -70;
+    pos @kc87_first_59 @kc87_second_4 -35;
+    pos @kc87_first_59 @kc87_second_6 -210;
+    pos @kc87_first_59 @kc87_second_7 -70;
+    pos @kc87_first_59 @kc87_second_8 -70;
+    pos @kc87_first_59 @kc87_second_16 -70;
+    pos @kc87_first_59 @kc87_second_17 -140;
+    pos @kc87_first_59 @kc87_second_19 -210;
+    pos @kc87_first_59 @kc87_second_20 -140;
+    pos @kc87_first_59 @kc87_second_21 -35;
+    pos @kc87_first_59 @kc87_second_22 -175;
+    pos @kc87_first_59 @kc87_second_23 -140;
+    pos @kc87_first_59 @kc87_second_24 -280;
+    pos @kc87_first_59 @kc87_second_29 -35;
+    pos @kc87_first_59 @kc87_second_30 -35;
+    pos @kc87_first_59 @kc87_second_32 -140;
+    pos @kc87_first_59 @kc87_second_33 -210;
+    pos @kc87_first_59 @kc87_second_35 -245;
+    pos @kc87_first_59 @kc87_second_36 -140;
+    pos @kc87_first_59 @kc87_second_37 -140;
+    pos @kc87_first_59 @kc87_second_38 -140;
+    pos @kc87_first_59 @kc87_second_39 -140;
+    pos @kc87_first_59 @kc87_second_40 -35;
+    pos @kc87_first_59 @kc87_second_46 -35;
+    pos @kc87_first_59 @kc87_second_47 -35;
+    pos @kc87_first_59 @kc87_second_48 1;
+    pos @kc87_first_59 @kc87_second_53 -140;
+    pos @kc87_first_59 @kc87_second_54 -70;
+    pos @kc87_first_59 @kc87_second_55 -210;
+    pos @kc87_first_59 @kc87_second_57 -210;
+    pos @kc87_first_59 @kc87_second_59 -210;
+    pos @kc87_first_59 @kc87_second_60 -35;
+    pos @kc87_first_59 @kc87_second_65 -175;
+    pos @kc87_first_59 @kc87_second_66 -245;
+    pos @kc87_first_60 @kc87_second_13 -35;
     pos @kc87_first_60 @kc87_second_32 -70;
-    pos @kc87_first_60 @kc87_second_34 -315;
-    pos @kc87_first_60 @kc87_second_35 -140;
-    pos @kc87_first_60 @kc87_second_36 -70;
-    pos @kc87_first_60 @kc87_second_38 -105;
-    pos @kc87_first_60 @kc87_second_45 1;
-    pos @kc87_first_60 @kc87_second_48 -35;
-    pos @kc87_first_60 @kc87_second_51 -50;
-    pos @kc87_first_60 @kc87_second_53 -210;
-    pos @kc87_first_60 @kc87_second_55 -175;
-    pos @kc87_first_60 @kc87_second_57 -210;
-    pos @kc87_first_60 @kc87_second_59 -35;
-    pos @kc87_first_60 @kc87_second_61 -70;
-    pos @kc87_first_60 @kc87_second_62 -35;
-    pos @kc87_first_60 @kc87_second_63 -140;
-    pos @kc87_first_60 @kc87_second_64 -210;
-    pos @kc87_first_61 @kc87_second_1 -35;
-    pos @kc87_first_61 @kc87_second_2 -70;
-    pos @kc87_first_61 @kc87_second_5 -70;
-    pos @kc87_first_61 @kc87_second_11 -35;
-    pos @kc87_first_61 @kc87_second_12 -140;
+    pos @kc87_first_60 @kc87_second_60 -35;
+    pos @kc87_first_60 @kc87_second_66 -35;
+    pos @kc87_first_61 @kc87_second_12 -175;
     pos @kc87_first_61 @kc87_second_13 -140;
-    pos @kc87_first_61 @kc87_second_14 -70;
-    pos @kc87_first_61 @kc87_second_15 -35;
-    pos @kc87_first_61 @kc87_second_16 -105;
-    pos @kc87_first_61 @kc87_second_26 -35;
-    pos @kc87_first_61 @kc87_second_27 -70;
-    pos @kc87_first_61 @kc87_second_35 -70;
-    pos @kc87_first_61 @kc87_second_43 -70;
-    pos @kc87_first_61 @kc87_second_45 1;
-    pos @kc87_first_61 @kc87_second_53 -175;
-    pos @kc87_first_61 @kc87_second_55 -140;
-    pos @kc87_first_61 @kc87_second_57 -140;
-    pos @kc87_first_61 @kc87_second_61 -35;
-    pos @kc87_first_62 @kc87_second_5 -70;
-    pos @kc87_first_62 @kc87_second_9 -70;
-    pos @kc87_first_62 @kc87_second_11 -35;
-    pos @kc87_first_62 @kc87_second_12 -350;
-    pos @kc87_first_62 @kc87_second_13 -315;
-    pos @kc87_first_62 @kc87_second_14 -175;
-    pos @kc87_first_62 @kc87_second_15 -140;
-    pos @kc87_first_62 @kc87_second_16 -70;
-    pos @kc87_first_62 @kc87_second_18 -70;
+    pos @kc87_first_61 @kc87_second_14 -35;
+    pos @kc87_first_61 @kc87_second_48 1;
+    pos @kc87_first_62 @kc87_second_1 -140;
+    pos @kc87_first_62 @kc87_second_2 -280;
+    pos @kc87_first_62 @kc87_second_5 -140;
+    pos @kc87_first_62 @kc87_second_6 -280;
+    pos @kc87_first_62 @kc87_second_8 -70;
+    pos @kc87_first_62 @kc87_second_10 -70;
+    pos @kc87_first_62 @kc87_second_11 -175;
+    pos @kc87_first_62 @kc87_second_12 -240;
+    pos @kc87_first_62 @kc87_second_13 -140;
+    pos @kc87_first_62 @kc87_second_14 -105;
+    pos @kc87_first_62 @kc87_second_15 -70;
+    pos @kc87_first_62 @kc87_second_16 -175;
+    pos @kc87_first_62 @kc87_second_17 -70;
+    pos @kc87_first_62 @kc87_second_19 -280;
+    pos @kc87_first_62 @kc87_second_22 -70;
+    pos @kc87_first_62 @kc87_second_23 -70;
+    pos @kc87_first_62 @kc87_second_24 -210;
+    pos @kc87_first_62 @kc87_second_26 -70;
     pos @kc87_first_62 @kc87_second_27 -70;
-    pos @kc87_first_62 @kc87_second_31 -50;
-    pos @kc87_first_62 @kc87_second_39 -140;
-    pos @kc87_first_62 @kc87_second_40 -50;
-    pos @kc87_first_62 @kc87_second_42 -35;
-    pos @kc87_first_62 @kc87_second_43 -175;
-    pos @kc87_first_62 @kc87_second_45 1;
-    pos @kc87_first_62 @kc87_second_47 -70;
-    pos @kc87_first_62 @kc87_second_48 -175;
-    pos @kc87_first_62 @kc87_second_54 -70;
-    pos @kc87_first_62 @kc87_second_58 -70;
-    pos @kc87_first_62 @kc87_second_60 -50;
-    pos @kc87_first_62 @kc87_second_61 -140;
-    pos @kc87_first_62 @kc87_second_62 -105;
-    pos @kc87_first_63 @kc87_second_4 -105;
+    pos @kc87_first_62 @kc87_second_29 -70;
+    pos @kc87_first_62 @kc87_second_32 -70;
+    pos @kc87_first_62 @kc87_second_33 -70;
+    pos @kc87_first_62 @kc87_second_35 -315;
+    pos @kc87_first_62 @kc87_second_36 -140;
+    pos @kc87_first_62 @kc87_second_37 -70;
+    pos @kc87_first_62 @kc87_second_39 -105;
+    pos @kc87_first_62 @kc87_second_48 1;
+    pos @kc87_first_62 @kc87_second_51 -35;
+    pos @kc87_first_62 @kc87_second_53 -50;
+    pos @kc87_first_62 @kc87_second_55 -210;
+    pos @kc87_first_62 @kc87_second_57 -175;
+    pos @kc87_first_62 @kc87_second_59 -210;
+    pos @kc87_first_62 @kc87_second_61 -35;
+    pos @kc87_first_62 @kc87_second_63 -70;
+    pos @kc87_first_62 @kc87_second_64 -35;
+    pos @kc87_first_62 @kc87_second_65 -140;
+    pos @kc87_first_62 @kc87_second_66 -210;
     pos @kc87_first_63 @kc87_second_6 -35;
-    pos @kc87_first_63 @kc87_second_8 1;
-    pos @kc87_first_63 @kc87_second_9 -245;
-    pos @kc87_first_63 @kc87_second_12 -210;
-    pos @kc87_first_63 @kc87_second_13 -210;
-    pos @kc87_first_63 @kc87_second_14 -210;
-    pos @kc87_first_63 @kc87_second_15 -175;
-    pos @kc87_first_63 @kc87_second_17 -70;
-    pos @kc87_first_63 @kc87_second_18 -180;
-    pos @kc87_first_63 @kc87_second_20 -140;
-    pos @kc87_first_63 @kc87_second_22 -105;
-    pos @kc87_first_63 @kc87_second_25 -140;
-    pos @kc87_first_63 @kc87_second_29 -105;
-    pos @kc87_first_63 @kc87_second_31 -140;
-    pos @kc87_first_63 @kc87_second_34 -35;
-    pos @kc87_first_63 @kc87_second_36 -35;
-    pos @kc87_first_63 @kc87_second_38 -175;
-    pos @kc87_first_63 @kc87_second_39 -142;
-    pos @kc87_first_63 @kc87_second_40 -245;
-    pos @kc87_first_63 @kc87_second_43 -210;
-    pos @kc87_first_63 @kc87_second_44 -105;
-    pos @kc87_first_63 @kc87_second_45 1;
-    pos @kc87_first_63 @kc87_second_46 -35;
-    pos @kc87_first_63 @kc87_second_47 -210;
-    pos @kc87_first_63 @kc87_second_48 -210;
+    pos @kc87_first_63 @kc87_second_12 -240;
+    pos @kc87_first_63 @kc87_second_13 -140;
+    pos @kc87_first_63 @kc87_second_14 -70;
+    pos @kc87_first_63 @kc87_second_15 -35;
+    pos @kc87_first_63 @kc87_second_20 -35;
+    pos @kc87_first_63 @kc87_second_22 -35;
+    pos @kc87_first_63 @kc87_second_35 -70;
+    pos @kc87_first_63 @kc87_second_39 -70;
+    pos @kc87_first_63 @kc87_second_40 -50;
+    pos @kc87_first_63 @kc87_second_48 1;
     pos @kc87_first_63 @kc87_second_51 -35;
-    pos @kc87_first_63 @kc87_second_58 -280;
-    pos @kc87_first_63 @kc87_second_60 -175;
-    pos @kc87_first_63 @kc87_second_61 -140;
-    pos @kc87_first_63 @kc87_second_62 -140;
-    pos @kc87_first_63 @kc87_second_63 -70;
-    pos @kc87_first_63 @kc87_second_64 -70;
-    pos @kc87_first_64 @kc87_second_1 -175;
-    pos @kc87_first_64 @kc87_second_2 -175;
+    pos @kc87_first_63 @kc87_second_65 -35;
+    pos @kc87_first_63 @kc87_second_66 -35;
     pos @kc87_first_64 @kc87_second_5 -70;
-    pos @kc87_first_64 @kc87_second_6 -105;
-    pos @kc87_first_64 @kc87_second_11 -105;
-    pos @kc87_first_64 @kc87_second_12 -175;
-    pos @kc87_first_64 @kc87_second_13 -140;
-    pos @kc87_first_64 @kc87_second_14 -70;
-    pos @kc87_first_64 @kc87_second_15 -35;
-    pos @kc87_first_64 @kc87_second_16 -140;
-    pos @kc87_first_64 @kc87_second_17 -70;
-    pos @kc87_first_64 @kc87_second_19 -175;
-    pos @kc87_first_64 @kc87_second_22 -70;
-    pos @kc87_first_64 @kc87_second_29 -35;
-    pos @kc87_first_64 @kc87_second_34 -105;
-    pos @kc87_first_64 @kc87_second_35 -175;
-    pos @kc87_first_64 @kc87_second_36 -35;
-    pos @kc87_first_64 @kc87_second_38 -70;
-    pos @kc87_first_64 @kc87_second_45 1;
-    pos @kc87_first_64 @kc87_second_51 -35;
-    pos @kc87_first_64 @kc87_second_53 -140;
-    pos @kc87_first_64 @kc87_second_55 -140;
-    pos @kc87_first_64 @kc87_second_57 -140;
-    pos @kc87_first_64 @kc87_second_63 -70;
+    pos @kc87_first_64 @kc87_second_9 -70;
+    pos @kc87_first_64 @kc87_second_11 -35;
+    pos @kc87_first_64 @kc87_second_12 -350;
+    pos @kc87_first_64 @kc87_second_13 -315;
+    pos @kc87_first_64 @kc87_second_14 -175;
+    pos @kc87_first_64 @kc87_second_15 -140;
+    pos @kc87_first_64 @kc87_second_16 -70;
+    pos @kc87_first_64 @kc87_second_18 -70;
+    pos @kc87_first_64 @kc87_second_27 -70;
+    pos @kc87_first_64 @kc87_second_31 -50;
+    pos @kc87_first_64 @kc87_second_40 -140;
+    pos @kc87_first_64 @kc87_second_41 -50;
+    pos @kc87_first_64 @kc87_second_43 -175;
+    pos @kc87_first_64 @kc87_second_45 -35;
+    pos @kc87_first_64 @kc87_second_48 1;
+    pos @kc87_first_64 @kc87_second_50 -70;
+    pos @kc87_first_64 @kc87_second_51 -175;
+    pos @kc87_first_64 @kc87_second_56 -70;
+    pos @kc87_first_64 @kc87_second_60 -70;
+    pos @kc87_first_64 @kc87_second_62 -50;
+    pos @kc87_first_64 @kc87_second_63 -140;
     pos @kc87_first_64 @kc87_second_64 -105;
-    pos @kc87_first_65 @kc87_second_1 -210;
-    pos @kc87_first_65 @kc87_second_2 -210;
-    pos @kc87_first_65 @kc87_second_3 -70;
-    pos @kc87_first_65 @kc87_second_4 -35;
-    pos @kc87_first_65 @kc87_second_6 -210;
-    pos @kc87_first_65 @kc87_second_7 -70;
-    pos @kc87_first_65 @kc87_second_8 -70;
-    pos @kc87_first_65 @kc87_second_16 -70;
-    pos @kc87_first_65 @kc87_second_17 -140;
-    pos @kc87_first_65 @kc87_second_19 -210;
+    pos @kc87_first_65 @kc87_second_4 -105;
+    pos @kc87_first_65 @kc87_second_6 -35;
+    pos @kc87_first_65 @kc87_second_8 1;
+    pos @kc87_first_65 @kc87_second_9 -245;
+    pos @kc87_first_65 @kc87_second_12 -210;
+    pos @kc87_first_65 @kc87_second_13 -210;
+    pos @kc87_first_65 @kc87_second_14 -210;
+    pos @kc87_first_65 @kc87_second_15 -175;
+    pos @kc87_first_65 @kc87_second_17 -70;
+    pos @kc87_first_65 @kc87_second_18 -180;
     pos @kc87_first_65 @kc87_second_20 -140;
-    pos @kc87_first_65 @kc87_second_21 -35;
-    pos @kc87_first_65 @kc87_second_22 -175;
-    pos @kc87_first_65 @kc87_second_23 -140;
-    pos @kc87_first_65 @kc87_second_24 -280;
-    pos @kc87_first_65 @kc87_second_29 -35;
-    pos @kc87_first_65 @kc87_second_30 -35;
-    pos @kc87_first_65 @kc87_second_32 -210;
-    pos @kc87_first_65 @kc87_second_34 -245;
-    pos @kc87_first_65 @kc87_second_35 -140;
-    pos @kc87_first_65 @kc87_second_36 -140;
-    pos @kc87_first_65 @kc87_second_37 -140;
-    pos @kc87_first_65 @kc87_second_38 -140;
-    pos @kc87_first_65 @kc87_second_39 -35;
-    pos @kc87_first_65 @kc87_second_44 -35;
-    pos @kc87_first_65 @kc87_second_45 1;
+    pos @kc87_first_65 @kc87_second_22 -105;
+    pos @kc87_first_65 @kc87_second_25 -140;
+    pos @kc87_first_65 @kc87_second_29 -105;
+    pos @kc87_first_65 @kc87_second_31 -140;
+    pos @kc87_first_65 @kc87_second_32 -105;
+    pos @kc87_first_65 @kc87_second_35 -35;
+    pos @kc87_first_65 @kc87_second_37 -35;
+    pos @kc87_first_65 @kc87_second_39 -175;
+    pos @kc87_first_65 @kc87_second_40 -142;
+    pos @kc87_first_65 @kc87_second_41 -245;
+    pos @kc87_first_65 @kc87_second_43 -210;
+    pos @kc87_first_65 @kc87_second_44 -175;
+    pos @kc87_first_65 @kc87_second_46 -105;
+    pos @kc87_first_65 @kc87_second_48 1;
     pos @kc87_first_65 @kc87_second_49 -35;
-    pos @kc87_first_65 @kc87_second_51 -140;
-    pos @kc87_first_65 @kc87_second_52 -70;
-    pos @kc87_first_65 @kc87_second_53 -210;
-    pos @kc87_first_65 @kc87_second_55 -210;
-    pos @kc87_first_65 @kc87_second_57 -210;
-    pos @kc87_first_65 @kc87_second_58 -35;
-    pos @kc87_first_65 @kc87_second_63 -175;
-    pos @kc87_first_65 @kc87_second_64 -245;
-    pos @kc87_first_66 @kc87_second_6 -35;
-    pos @kc87_first_66 @kc87_second_12 -240;
+    pos @kc87_first_65 @kc87_second_50 -210;
+    pos @kc87_first_65 @kc87_second_51 -210;
+    pos @kc87_first_65 @kc87_second_53 -35;
+    pos @kc87_first_65 @kc87_second_60 -280;
+    pos @kc87_first_65 @kc87_second_62 -175;
+    pos @kc87_first_65 @kc87_second_63 -140;
+    pos @kc87_first_65 @kc87_second_64 -140;
+    pos @kc87_first_65 @kc87_second_65 -70;
+    pos @kc87_first_65 @kc87_second_66 -70;
+    pos @kc87_first_66 @kc87_second_1 -175;
+    pos @kc87_first_66 @kc87_second_2 -175;
+    pos @kc87_first_66 @kc87_second_5 -70;
+    pos @kc87_first_66 @kc87_second_6 -105;
+    pos @kc87_first_66 @kc87_second_11 -105;
+    pos @kc87_first_66 @kc87_second_12 -175;
     pos @kc87_first_66 @kc87_second_13 -140;
     pos @kc87_first_66 @kc87_second_14 -70;
     pos @kc87_first_66 @kc87_second_15 -35;
-    pos @kc87_first_66 @kc87_second_20 -35;
-    pos @kc87_first_66 @kc87_second_22 -35;
-    pos @kc87_first_66 @kc87_second_34 -70;
-    pos @kc87_first_66 @kc87_second_38 -70;
-    pos @kc87_first_66 @kc87_second_39 -50;
-    pos @kc87_first_66 @kc87_second_45 1;
-    pos @kc87_first_66 @kc87_second_48 -35;
-    pos @kc87_first_66 @kc87_second_63 -35;
-    pos @kc87_first_66 @kc87_second_64 -35;
+    pos @kc87_first_66 @kc87_second_16 -140;
+    pos @kc87_first_66 @kc87_second_17 -70;
+    pos @kc87_first_66 @kc87_second_19 -175;
+    pos @kc87_first_66 @kc87_second_22 -70;
+    pos @kc87_first_66 @kc87_second_29 -35;
+    pos @kc87_first_66 @kc87_second_32 -70;
+    pos @kc87_first_66 @kc87_second_35 -105;
+    pos @kc87_first_66 @kc87_second_36 -175;
+    pos @kc87_first_66 @kc87_second_37 -35;
+    pos @kc87_first_66 @kc87_second_39 -70;
+    pos @kc87_first_66 @kc87_second_48 1;
+    pos @kc87_first_66 @kc87_second_53 -35;
+    pos @kc87_first_66 @kc87_second_55 -140;
+    pos @kc87_first_66 @kc87_second_57 -140;
+    pos @kc87_first_66 @kc87_second_59 -140;
+    pos @kc87_first_66 @kc87_second_65 -70;
+    pos @kc87_first_66 @kc87_second_66 -105;
     pos @kc87_first_67 @kc87_second_3 -100;
     pos @kc87_first_67 @kc87_second_4 -50;
     pos @kc87_first_67 @kc87_second_6 -50;
@@ -10063,23 +10133,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_67 @kc87_second_23 -70;
     pos @kc87_first_67 @kc87_second_29 -35;
     pos @kc87_first_67 @kc87_second_31 -70;
-    pos @kc87_first_67 @kc87_second_33 105;
-    pos @kc87_first_67 @kc87_second_34 -35;
-    pos @kc87_first_67 @kc87_second_38 -70;
-    pos @kc87_first_67 @kc87_second_39 -140;
+    pos @kc87_first_67 @kc87_second_32 -50;
+    pos @kc87_first_67 @kc87_second_34 105;
+    pos @kc87_first_67 @kc87_second_35 -35;
+    pos @kc87_first_67 @kc87_second_39 -70;
     pos @kc87_first_67 @kc87_second_40 -140;
+    pos @kc87_first_67 @kc87_second_41 -140;
     pos @kc87_first_67 @kc87_second_43 -140;
-    pos @kc87_first_67 @kc87_second_44 -35;
-    pos @kc87_first_67 @kc87_second_45 1;
-    pos @kc87_first_67 @kc87_second_47 -70;
-    pos @kc87_first_67 @kc87_second_48 -100;
-    pos @kc87_first_67 @kc87_second_50 105;
-    pos @kc87_first_67 @kc87_second_58 -140;
-    pos @kc87_first_67 @kc87_second_60 -70;
-    pos @kc87_first_67 @kc87_second_61 -70;
-    pos @kc87_first_67 @kc87_second_62 -50;
-    pos @kc87_first_67 @kc87_second_63 -35;
-    pos @kc87_first_67 @kc87_second_64 -35;
+    pos @kc87_first_67 @kc87_second_44 -50;
+    pos @kc87_first_67 @kc87_second_46 -35;
+    pos @kc87_first_67 @kc87_second_48 1;
+    pos @kc87_first_67 @kc87_second_50 -70;
+    pos @kc87_first_67 @kc87_second_51 -100;
+    pos @kc87_first_67 @kc87_second_52 105;
+    pos @kc87_first_67 @kc87_second_60 -140;
+    pos @kc87_first_67 @kc87_second_62 -70;
+    pos @kc87_first_67 @kc87_second_63 -70;
+    pos @kc87_first_67 @kc87_second_64 -50;
+    pos @kc87_first_67 @kc87_second_65 -35;
+    pos @kc87_first_67 @kc87_second_66 -35;
     pos @kc87_first_68 @kc87_second_3 -70;
     pos @kc87_first_68 @kc87_second_4 -50;
     pos @kc87_first_68 @kc87_second_6 -50;
@@ -10096,21 +10168,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_68 @kc87_second_23 -70;
     pos @kc87_first_68 @kc87_second_29 -35;
     pos @kc87_first_68 @kc87_second_31 -70;
-    pos @kc87_first_68 @kc87_second_34 -35;
-    pos @kc87_first_68 @kc87_second_38 -70;
-    pos @kc87_first_68 @kc87_second_39 -140;
+    pos @kc87_first_68 @kc87_second_35 -35;
+    pos @kc87_first_68 @kc87_second_39 -70;
     pos @kc87_first_68 @kc87_second_40 -140;
+    pos @kc87_first_68 @kc87_second_41 -140;
     pos @kc87_first_68 @kc87_second_43 -140;
-    pos @kc87_first_68 @kc87_second_44 -35;
-    pos @kc87_first_68 @kc87_second_45 1;
-    pos @kc87_first_68 @kc87_second_47 -70;
-    pos @kc87_first_68 @kc87_second_48 -140;
-    pos @kc87_first_68 @kc87_second_58 -140;
-    pos @kc87_first_68 @kc87_second_60 -70;
-    pos @kc87_first_68 @kc87_second_61 -105;
+    pos @kc87_first_68 @kc87_second_46 -35;
+    pos @kc87_first_68 @kc87_second_48 1;
+    pos @kc87_first_68 @kc87_second_50 -70;
+    pos @kc87_first_68 @kc87_second_51 -140;
+    pos @kc87_first_68 @kc87_second_60 -140;
     pos @kc87_first_68 @kc87_second_62 -70;
-    pos @kc87_first_68 @kc87_second_63 -35;
-    pos @kc87_first_68 @kc87_second_64 -35;
+    pos @kc87_first_68 @kc87_second_63 -105;
+    pos @kc87_first_68 @kc87_second_64 -70;
+    pos @kc87_first_68 @kc87_second_65 -35;
+    pos @kc87_first_68 @kc87_second_66 -35;
     pos @kc87_first_69 @kc87_second_3 -70;
     pos @kc87_first_69 @kc87_second_4 -50;
     pos @kc87_first_69 @kc87_second_6 -50;
@@ -10127,23 +10199,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_69 @kc87_second_23 -100;
     pos @kc87_first_69 @kc87_second_29 -35;
     pos @kc87_first_69 @kc87_second_31 -70;
-    pos @kc87_first_69 @kc87_second_33 105;
-    pos @kc87_first_69 @kc87_second_34 -35;
-    pos @kc87_first_69 @kc87_second_38 -70;
-    pos @kc87_first_69 @kc87_second_39 -140;
+    pos @kc87_first_69 @kc87_second_32 -50;
+    pos @kc87_first_69 @kc87_second_34 105;
+    pos @kc87_first_69 @kc87_second_35 -35;
+    pos @kc87_first_69 @kc87_second_39 -70;
     pos @kc87_first_69 @kc87_second_40 -140;
+    pos @kc87_first_69 @kc87_second_41 -140;
     pos @kc87_first_69 @kc87_second_43 -140;
-    pos @kc87_first_69 @kc87_second_44 -35;
-    pos @kc87_first_69 @kc87_second_45 1;
-    pos @kc87_first_69 @kc87_second_47 -70;
-    pos @kc87_first_69 @kc87_second_48 -140;
-    pos @kc87_first_69 @kc87_second_50 105;
-    pos @kc87_first_69 @kc87_second_58 -140;
-    pos @kc87_first_69 @kc87_second_60 -70;
-    pos @kc87_first_69 @kc87_second_61 -70;
-    pos @kc87_first_69 @kc87_second_62 -50;
-    pos @kc87_first_69 @kc87_second_63 -35;
-    pos @kc87_first_69 @kc87_second_64 -35;
+    pos @kc87_first_69 @kc87_second_44 -50;
+    pos @kc87_first_69 @kc87_second_46 -35;
+    pos @kc87_first_69 @kc87_second_48 1;
+    pos @kc87_first_69 @kc87_second_50 -70;
+    pos @kc87_first_69 @kc87_second_51 -140;
+    pos @kc87_first_69 @kc87_second_52 105;
+    pos @kc87_first_69 @kc87_second_60 -140;
+    pos @kc87_first_69 @kc87_second_62 -70;
+    pos @kc87_first_69 @kc87_second_63 -70;
+    pos @kc87_first_69 @kc87_second_64 -50;
+    pos @kc87_first_69 @kc87_second_65 -35;
+    pos @kc87_first_69 @kc87_second_66 -35;
     pos @kc87_first_70 @kc87_second_1 -210;
     pos @kc87_first_70 @kc87_second_2 -210;
     pos @kc87_first_70 @kc87_second_3 -35;
@@ -10157,24 +10231,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_70 @kc87_second_23 -105;
     pos @kc87_first_70 @kc87_second_24 -175;
     pos @kc87_first_70 @kc87_second_29 -105;
-    pos @kc87_first_70 @kc87_second_34 -175;
-    pos @kc87_first_70 @kc87_second_35 -140;
-    pos @kc87_first_70 @kc87_second_36 -70;
-    pos @kc87_first_70 @kc87_second_37 -105;
+    pos @kc87_first_70 @kc87_second_32 -140;
+    pos @kc87_first_70 @kc87_second_35 -175;
+    pos @kc87_first_70 @kc87_second_36 -140;
+    pos @kc87_first_70 @kc87_second_37 -70;
     pos @kc87_first_70 @kc87_second_38 -105;
-    pos @kc87_first_70 @kc87_second_39 -70;
-    pos @kc87_first_70 @kc87_second_44 -35;
-    pos @kc87_first_70 @kc87_second_45 1;
-    pos @kc87_first_70 @kc87_second_50 -35;
-    pos @kc87_first_70 @kc87_second_51 -70;
-    pos @kc87_first_70 @kc87_second_52 -70;
-    pos @kc87_first_70 @kc87_second_53 -175;
+    pos @kc87_first_70 @kc87_second_39 -105;
+    pos @kc87_first_70 @kc87_second_40 -70;
+    pos @kc87_first_70 @kc87_second_46 -35;
+    pos @kc87_first_70 @kc87_second_48 1;
+    pos @kc87_first_70 @kc87_second_52 -35;
+    pos @kc87_first_70 @kc87_second_53 -70;
+    pos @kc87_first_70 @kc87_second_54 -70;
     pos @kc87_first_70 @kc87_second_55 -175;
     pos @kc87_first_70 @kc87_second_57 -175;
-    pos @kc87_first_70 @kc87_second_58 -35;
-    pos @kc87_first_70 @kc87_second_59 -35;
-    pos @kc87_first_70 @kc87_second_63 -140;
-    pos @kc87_first_70 @kc87_second_64 -175;
+    pos @kc87_first_70 @kc87_second_59 -175;
+    pos @kc87_first_70 @kc87_second_60 -35;
+    pos @kc87_first_70 @kc87_second_61 -35;
+    pos @kc87_first_70 @kc87_second_65 -140;
+    pos @kc87_first_70 @kc87_second_66 -175;
     pos @kc87_first_71 @kc87_second_5 -70;
     pos @kc87_first_71 @kc87_second_8 -70;
     pos @kc87_first_71 @kc87_second_9 -105;
@@ -10189,22 +10264,23 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_71 @kc87_second_26 -35;
     pos @kc87_first_71 @kc87_second_27 -70;
     pos @kc87_first_71 @kc87_second_31 -70;
-    pos @kc87_first_71 @kc87_second_38 -35;
-    pos @kc87_first_71 @kc87_second_39 -245;
-    pos @kc87_first_71 @kc87_second_40 -70;
-    pos @kc87_first_71 @kc87_second_42 -35;
+    pos @kc87_first_71 @kc87_second_39 -35;
+    pos @kc87_first_71 @kc87_second_40 -245;
+    pos @kc87_first_71 @kc87_second_41 -70;
     pos @kc87_first_71 @kc87_second_43 -240;
-    pos @kc87_first_71 @kc87_second_45 1;
-    pos @kc87_first_71 @kc87_second_47 -105;
-    pos @kc87_first_71 @kc87_second_48 -280;
-    pos @kc87_first_71 @kc87_second_49 -35;
-    pos @kc87_first_71 @kc87_second_54 -35;
-    pos @kc87_first_71 @kc87_second_56 -70;
-    pos @kc87_first_71 @kc87_second_58 -105;
-    pos @kc87_first_71 @kc87_second_59 -35;
-    pos @kc87_first_71 @kc87_second_60 -70;
-    pos @kc87_first_71 @kc87_second_61 -175;
-    pos @kc87_first_71 @kc87_second_62 -140;
+    pos @kc87_first_71 @kc87_second_44 -210;
+    pos @kc87_first_71 @kc87_second_45 -35;
+    pos @kc87_first_71 @kc87_second_47 -35;
+    pos @kc87_first_71 @kc87_second_48 1;
+    pos @kc87_first_71 @kc87_second_50 -105;
+    pos @kc87_first_71 @kc87_second_51 -280;
+    pos @kc87_first_71 @kc87_second_56 -35;
+    pos @kc87_first_71 @kc87_second_58 -70;
+    pos @kc87_first_71 @kc87_second_60 -105;
+    pos @kc87_first_71 @kc87_second_61 -35;
+    pos @kc87_first_71 @kc87_second_62 -70;
+    pos @kc87_first_71 @kc87_second_63 -175;
+    pos @kc87_first_71 @kc87_second_64 -140;
     pos @kc87_first_72 @kc87_second_1 -140;
     pos @kc87_first_72 @kc87_second_2 -140;
     pos @kc87_first_72 @kc87_second_6 -140;
@@ -10217,20 +10293,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_72 @kc87_second_23 -70;
     pos @kc87_first_72 @kc87_second_24 -140;
     pos @kc87_first_72 @kc87_second_29 -70;
-    pos @kc87_first_72 @kc87_second_34 -175;
-    pos @kc87_first_72 @kc87_second_35 -105;
-    pos @kc87_first_72 @kc87_second_36 -70;
+    pos @kc87_first_72 @kc87_second_32 -35;
+    pos @kc87_first_72 @kc87_second_35 -175;
+    pos @kc87_first_72 @kc87_second_36 -105;
     pos @kc87_first_72 @kc87_second_37 -70;
     pos @kc87_first_72 @kc87_second_38 -70;
-    pos @kc87_first_72 @kc87_second_39 -35;
-    pos @kc87_first_72 @kc87_second_45 1;
-    pos @kc87_first_72 @kc87_second_50 -35;
-    pos @kc87_first_72 @kc87_second_51 -35;
-    pos @kc87_first_72 @kc87_second_53 -140;
+    pos @kc87_first_72 @kc87_second_39 -70;
+    pos @kc87_first_72 @kc87_second_40 -35;
+    pos @kc87_first_72 @kc87_second_48 1;
+    pos @kc87_first_72 @kc87_second_52 -35;
+    pos @kc87_first_72 @kc87_second_53 -35;
     pos @kc87_first_72 @kc87_second_55 -140;
     pos @kc87_first_72 @kc87_second_57 -140;
-    pos @kc87_first_72 @kc87_second_63 -105;
-    pos @kc87_first_72 @kc87_second_64 -105;
+    pos @kc87_first_72 @kc87_second_59 -140;
+    pos @kc87_first_72 @kc87_second_65 -105;
+    pos @kc87_first_72 @kc87_second_66 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -13116,6 +13193,7 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
+#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 

--- a/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ExtraBlackItalic.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/30 16:51:42</string>
+    <string>2026/07/30 22:05:24</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Italic.ufo/features.fea
+++ b/sources/Giphurs-Italic.ufo/features.fea
@@ -4090,8 +4090,8 @@ lookup ccmp_latn {
     sub \e \uni0302  by \ecircumflex;
     sub \e \uni0308  by \edieresis;
     sub \i \gravecomb  by \igrave;
-    sub \uni0456 \acutecomb  by \iacute;
     sub \i \acutecomb  by \iacute;
+    sub \uni0456 \acutecomb  by \iacute;
     sub \i \uni0302  by \icircumflex;
     sub \i \uni0308  by \idieresis;
     sub \n \tildecomb  by \ntilde;
@@ -4147,8 +4147,8 @@ lookup ccmp_latn {
     sub \I \uni0306  by \Ibreve;
     sub \i \uni0306  by \ibreve;
     sub \I \uni0328  by \Iogonek;
-    sub \i \uni0328  by \iogonek;
     sub \iogonek \gravecomb  by \iogonek;
+    sub \i \uni0328  by \iogonek;
     sub \I \uni0307  by \Idotaccent;
     sub \J \uni0302  by \Jcircumflex;
     sub \j \uni0302  by \jcircumflex;
@@ -4235,13 +4235,13 @@ lookup ccmp_latn {
     sub \U \uni0308 \uni030C  by \uni01D9;
     sub \u \uni0308 \uni030C  by \uni01DA;
     sub \U \uni0308 \gravecomb  by \uni01DB;
-    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \A \uni030A \acutecomb  by \uni01DC;
-    sub \A \uni0308 \uni0304  by \uni01DE;
+    sub \u \uni0308 \gravecomb  by \uni01DC;
     sub \AE \acutecomb  by \uni01DE;
+    sub \A \uni0308 \uni0304  by \uni01DE;
     sub \a \uni0308 \uni0304  by \uni01DF;
-    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \Oslash \acutecomb  by \uni01E0;
+    sub \A \uni0307 \uni0304  by \uni01E0;
     sub \a \uni0307 \uni0304  by \uni01E1;
     sub \AE \uni0304  by \uni01E2;
     sub \ae \uni0304  by \uni01E3;
@@ -5167,8 +5167,8 @@ lookup ccmp_cyrl {
     sub \uni043A \acutecomb  by \uni045C;
     sub \uni0438 \gravecomb  by \uni045D;
     sub \uni0443 \uni0306  by \uni045E;
-    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0456 \uni0307  by \uni0457;
+    sub \uni0456 \uni0308  by \uni0457;
     sub \uni0474 \uni030F  by \uni0476;
     sub \uni0475 \uni030F  by \uni0477;
     sub \W \gravecomb  by \uni0498;
@@ -6301,29 +6301,6 @@ lookup calt_Contextual_Alternates {
 	\uni2152.cv11.cv20.ss06.zero ] ;
 } calt_Contextual_Alternates;
 
-feature cv27 {
-
- script DFLT;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script copt;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script cyrl;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script grek;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-
- script latn;
-     language dflt ;
-      lookup locl_cv27_Localized_Eng;
-} cv27;
-
 feature locl {
 
  script cyrl;
@@ -6410,6 +6387,29 @@ feature locl {
      language WLF  exclude_dflt;
       lookup locl_cv27_Localized_Eng;
 } locl;
+
+feature cv27 {
+
+ script DFLT;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script copt;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script cyrl;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script grek;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+
+ script latn;
+     language dflt ;
+      lookup locl_cv27_Localized_Eng;
+} cv27;
 
 feature ss09 {
   featureNames {
@@ -6526,6 +6526,29 @@ feature smcp {
       lookup smcp_Small_caps_turkish_i_lookup;
 } smcp;
 
+feature cv01 {
+
+ script DFLT;
+     language dflt ;
+      lookup cv01_Alternative_digit_1_A;
+
+ script copt;
+     language dflt ;
+      lookup cv01_Alternative_digit_1_A;
+
+ script cyrl;
+     language dflt ;
+      lookup cv01_Alternative_digit_1_A;
+
+ script grek;
+     language dflt ;
+      lookup cv01_Alternative_digit_1_A;
+
+ script latn;
+     language dflt ;
+      lookup cv01_Alternative_digit_1_A;
+} cv01;
+
 feature ss01 {
   featureNames {
     name 3 1 0x409 "Alternative numbers set 1";
@@ -6596,29 +6619,6 @@ feature ss01 {
       lookup cv09_Alternative_digit_9_A;
       lookup cv10_Alternative_digit_0_A;
 } ss01;
-
-feature cv01 {
-
- script DFLT;
-     language dflt ;
-      lookup cv01_Alternative_digit_1_A;
-
- script copt;
-     language dflt ;
-      lookup cv01_Alternative_digit_1_A;
-
- script cyrl;
-     language dflt ;
-      lookup cv01_Alternative_digit_1_A;
-
- script grek;
-     language dflt ;
-      lookup cv01_Alternative_digit_1_A;
-
- script latn;
-     language dflt ;
-      lookup cv01_Alternative_digit_1_A;
-} cv01;
 
 feature cv02 {
 
@@ -6827,6 +6827,29 @@ feature cv10 {
       lookup cv10_Alternative_digit_0_A;
 } cv10;
 
+feature cv11 {
+
+ script DFLT;
+     language dflt ;
+      lookup cv11_Alternative_digit_1_B;
+
+ script copt;
+     language dflt ;
+      lookup cv11_Alternative_digit_1_B;
+
+ script cyrl;
+     language dflt ;
+      lookup cv11_Alternative_digit_1_B;
+
+ script grek;
+     language dflt ;
+      lookup cv11_Alternative_digit_1_B;
+
+ script latn;
+     language dflt ;
+      lookup cv11_Alternative_digit_1_B;
+} cv11;
+
 feature ss02 {
   featureNames {
     name 3 1 0x409 "Alternative numbers set 2";
@@ -6897,29 +6920,6 @@ feature ss02 {
       lookup cv19_Alternative_digit_9_B;
       lookup cv20_Alternative_digit_0_B;
 } ss02;
-
-feature cv11 {
-
- script DFLT;
-     language dflt ;
-      lookup cv11_Alternative_digit_1_B;
-
- script copt;
-     language dflt ;
-      lookup cv11_Alternative_digit_1_B;
-
- script cyrl;
-     language dflt ;
-      lookup cv11_Alternative_digit_1_B;
-
- script grek;
-     language dflt ;
-      lookup cv11_Alternative_digit_1_B;
-
- script latn;
-     language dflt ;
-      lookup cv11_Alternative_digit_1_B;
-} cv11;
 
 feature cv12 {
 
@@ -7920,16 +7920,17 @@ lookup kern_Horizontal_kerning {
     @kc87_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
 	\Gcommaaccent.cv21 \Gdotaccent.cv21 \O \Oacute \Obreve \Ocircumflex 
 	\Odieresis \Ograve \Ohungarumlaut \Omacron \Omicron \Omicrontonos 
-	\Oslash \Oslashacute \Otilde \Theta \uni0189 \uni018A \uni018F 
-	\uni0193.cv21 \uni019F \uni01D1 \uni01E4.cv21 \uni01EA \uni01EC 
-	\uni01F4.cv21 \uni020C \uni020E \uni022A \uni022C \uni022E \uni0230 
-	\uni0298 \uni03D8 \uni03F4 \uni03FD \uni03FF \uni041E \uni042E \uni0472 
-	\uni047A \uni04BC \uni04BE \uni04D8 \uni04DA \uni04E6 \uni04E8 \uni04EA 
-	\uni04EC \uni050C \uni1E0A \uni1E0C \uni1E0E \uni1E10 \uni1E12 
-	\uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE 
-	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
-	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
-	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
+	\Oslash \Oslashacute \Otilde \Theta \two.cv02.pnum \two.cv12.pnum 
+	\two.pnum \uni0189 \uni018A \uni018F \uni0193.cv21 \uni019F \uni01D1 
+	\uni01E4.cv21 \uni01EA \uni01EC \uni01F4.cv21 \uni020C \uni020E 
+	\uni022A \uni022C \uni022E \uni0230 \uni0298 \uni03D8 \uni03F4 \uni03FD 
+	\uni03FF \uni041E \uni042E \uni0472 \uni047A \uni04BC \uni04BE \uni04D8 
+	\uni04DA \uni04E6 \uni04E8 \uni04EA \uni04EC \uni050C \uni1E0A \uni1E0C 
+	\uni1E0E \uni1E10 \uni1E12 \uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 
+	\uni1E52 \uni1ECC \uni1ECE \uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 
+	\uni1EDA \uni1EDC \uni1EDE \uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A 
+	\uni1F4B \uni1F4C \uni1F4D \uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 
+	\uni2181 \uni2182 \uniA7C7 ];
     @kc87_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
 	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
 	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
@@ -7946,24 +7947,27 @@ lookup kern_Horizontal_kerning {
     @kc87_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc87_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
-	\uniA7AD ];
+    @kc87_first_9 = [\L \Lacute \one.cv01.ss06.pnum \one.cv11.ss06.pnum \one.ss06.pnum \uni023D 
+	\uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 \uniA7AD ];
     @kc87_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
     @kc87_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
     @kc87_first_12 = [\Psi \uni0470 ];
     @kc87_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
-	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
-	\uni2107 ];
+    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv08.onum 
+	\eight.cv08.pnum \eight.cv18.onum \eight.cv18.pnum \eight.onum 
+	\eight.pnum \three.cv03.pnum \three.pnum \uni0190 \uni01A7 \uni03E8 
+	\uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 \uni2107 ];
     @kc87_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
     @kc87_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc87_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
-	\uni2163 \uni2164 \universal ];
+    @kc87_first_17 = [\V \gradient \nine.cv19.pnum \seven.cv07.pnum \seven.cv07.ss07.pnum 
+	\seven.cv17.pnum \seven.cv17.ss07.pnum \seven.pnum \seven.ss07.pnum 
+	\slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE \uni2163 
+	\uni2164 \universal ];
     @kc87_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
     @kc87_first_19 = [\a \a.cv23 \aacute \aacute.cv23 \abreve \abreve.cv23 \acircumflex 
 	\acircumflex.cv23 \adieresis \adieresis.cv23 \agrave \agrave.cv23 
@@ -8059,16 +8063,17 @@ lookup kern_Horizontal_kerning {
     @kc87_first_22 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
-	\uni0207 \uni020D \uni020F \uni0229 \uni022B \uni022D \uni022F \uni0231 
-	\uni0247 \uni0254 \uni0258 \uni0259 \uni0275 \uni0278 \uni037B \uni037D 
-	\uni03D9 \uni03F6 \uni0435 \uni043E \uni044D \uni044E \uni0473 \uni04BD 
-	\uni04BF \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni04ED 
-	\uni050D \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni018D \uni01D2 \uni01DD 
+	\uni01E3 \uni01EB \uni01ED \uni0205 \uni0207 \uni020D \uni020F \uni0229 
+	\uni022B \uni022D \uni022F \uni0231 \uni0247 \uni0254 \uni0258 \uni0259 
+	\uni0275 \uni0278 \uni037B \uni037D \uni03D9 \uni03F6 \uni0435 \uni043E 
+	\uni044D \uni044E \uni0473 \uni04BD \uni04BF \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni04ED \uni050D \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni2184 ];
     @kc87_first_23 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
@@ -8153,18 +8158,21 @@ lookup kern_Horizontal_kerning {
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc87_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
-	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
-	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
-	\uni037B.sc \uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc 
-	\uni0473.sc \uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc 
-	\uni04E9.sc \uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc 
-	\uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc 
-	\uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc 
-	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
-	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
-	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
+    @kc87_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \nine.cv09.onum \nine.cv19.onum \nine.onum 
+	\o.sc \oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohungarumlaut.sc \omacron.sc \omicron.sc \oslash.sc \otilde.sc 
+	\uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc \uni022D.sc 
+	\uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc \uni037B.sc 
+	\uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc \uni0473.sc 
+	\uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc 
+	\uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc 
+	\uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_first_33 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
@@ -8223,73 +8231,82 @@ lookup kern_Horizontal_kerning {
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
     @kc87_first_37 = [\eth \uni1EFC \uni1EFD ];
-    @kc87_first_38 = [\fraction ];
-    @kc87_first_39 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc87_first_40 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
-	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_first_41 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc87_first_38 = [\four.cv04.onum \four.cv14.onum \four.onum \l.sc \lacute.sc \lcaron.sc 
+	\lcommaaccent.sc \ldot.sc \lslash.sc \one.cv01.ss06.onum 
+	\one.cv11.ss06.onum \one.ss06.onum \uni019A.sc \uni0234.sc 
+	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
+    @kc87_first_39 = [\four.cv04.pnum \four.cv14.pnum \four.pnum \phi.sc \thorn.sc \uni01A5.sc 
+	\uni0444.sc ];
+    @kc87_first_40 = [\fraction ];
+    @kc87_first_41 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \three.cv03.onum 
+	\three.onum \uni01E5 \uni1E21 ];
+    @kc87_first_42 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \two.cv02.onum \two.cv12.onum 
+	\two.onum \uni0260.sc \uni051B.sc \uni051B.sc.cv29 \uni1F60.sc 
+	\uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc 
+	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc 
+	\uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
+	\uni1FF6.sc \uni1FF7.sc ];
+    @kc87_first_43 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc87_first_42 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc87_first_44 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc87_first_43 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc87_first_45 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc87_first_44 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc87_first_46 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc87_first_45 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc87_first_47 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc87_first_46 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
-	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc87_first_47 = [\lambda \uni019B ];
-    @kc87_first_48 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc87_first_49 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc87_first_48 = [\lambda \uni019B ];
+    @kc87_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc87_first_50 = [\theta \uni047C \uniA7B6 \uniA64C \uni0424.loclBGR \zero.pnum \nine.pnum 
+	\nine.cv09.pnum \zero.cv10.pnum \zero.cv20.pnum \zero.zero.pnum 
+	\zero.cv10.zero.pnum \zero.cv20.zero.pnum ];
+    @kc87_first_51 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc87_first_50 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc87_first_51 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc87_first_52 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc87_first_52 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc87_first_53 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc87_first_54 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc87_first_53 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_first_54 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc87_first_55 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc87_first_56 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc87_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc87_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc87_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc87_first_57 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc87_first_58 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
-	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
-	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_first_59 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
-	\uni1E71 ];
-    @kc87_first_60 = [\tau \uni0491 \uni04A5 ];
-    @kc87_first_61 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc87_first_62 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc87_first_63 = [\uni0196 \uni01AA ];
-    @kc87_first_64 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
-	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
-	\ygrave ];
-    @kc87_first_65 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_first_59 = [\seven.cv07.onum \seven.cv07.ss07.onum \seven.cv17.onum 
+	\seven.cv17.ss07.onum \seven.onum \seven.ss07.onum \uni01B4.sc 
+	\uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_first_66 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
-	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
-	\zdotaccent ];
+    @kc87_first_60 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
+    @kc87_first_61 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+	\uni1E71 ];
+    @kc87_first_62 = [\tau \uni0491 \uni04A5 ];
+    @kc87_first_63 = [\three.cv13.onum \uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 
+	\uni02A3 \uni02AB \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z 
+	\zacute \zcaron \zdotaccent ];
+    @kc87_first_64 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc87_first_65 = [\uni0196 \uni01AA ];
+    @kc87_first_66 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
+	\ygrave ];
     @kc87_first_67 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
     @kc87_first_68 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
@@ -8330,15 +8347,19 @@ lookup kern_Horizontal_kerning {
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
     @kc87_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc87_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc87_second_7 = [\Omega \nine.cv19.pnum \two.cv02.pnum \two.cv12.pnum \two.pnum \uni03A9 
+	\uni1FFC ];
     @kc87_second_8 = [\Phi \uni0424 ];
     @kc87_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
-	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
-	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
-	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
+    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv08.onum 
+	\eight.cv08.pnum \eight.cv18.onum \eight.cv18.pnum \eight.onum 
+	\eight.tnum \three.cv03.pnum \three.tnum \uni01A7 \uni03E8 \uni0405 
+	\uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
+    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \three.cv13.pnum \uni01A9 \uni01B5 
+	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 ];
+    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \seven.cv07.pnum \seven.cv17.pnum \seven.pnum \uni0162 
+	\uni01AC \uni01AE \uni021A \uni0422 \uni042A \uni04AC \uni04B4 \uni050E 
+	\uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
     @kc87_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
@@ -8354,15 +8375,16 @@ lookup kern_Horizontal_kerning {
 	\agrave.cv23 \agrave.sc \alpha \alpha.sc \alphatonos \amacron 
 	\amacron.cv23 \amacron.sc \aogonek \aogonek.cv23 \aogonek.sc \aring 
 	\aring.cv23 \aring.sc \aringacute.cv23 \atilde \atilde.cv23 
-	\atilde.sc \d \dcaron \dcroat \delta.sc \dong \eth \g \g.cv24 \gbreve 
-	\gbreve.cv24 \gcaron.cv24 \gcircumflex \gcircumflex.cv24 
-	\gcommaaccent \gcommaaccent.cv24 \gdotaccent \gdotaccent.cv24 
-	\lambda.sc \phi \q \sigma \uni019B.sc \uni01CE.cv23 \uni01CE.sc 
-	\uni01DF \uni01DF.cv23 \uni01DF.sc \uni01E1 \uni01E1.cv23 \uni01E1.sc 
-	\uni01E3.cv23 \uni01E5 \uni01E5.cv24 \uni01F5.cv24 \uni0201 
-	\uni0201.cv23 \uni0201.sc \uni0203 \uni0203.cv23 \uni0203.sc \uni0227 
-	\uni0227.cv23 \uni0227.sc \uni0238 \uni0239 \uni024B \uni0260 \uni0261 
-	\uni0278 \uni0430 \uni0430.cv23 \uni0430.sc \uni0432 \uni0434 
+	\atilde.sc \d \dcaron \dcroat \delta.sc \dong \eth \four.cv04.onum 
+	\four.cv14.onum \four.onum \g \g.cv24 \gbreve \gbreve.cv24 
+	\gcaron.cv24 \gcircumflex \gcircumflex.cv24 \gcommaaccent 
+	\gcommaaccent.cv24 \gdotaccent \gdotaccent.cv24 \lambda.sc \phi \q 
+	\sigma \three.cv03.onum \three.onum \uni019B.sc \uni01CE.cv23 
+	\uni01CE.sc \uni01DF \uni01DF.cv23 \uni01DF.sc \uni01E1 \uni01E1.cv23 
+	\uni01E1.sc \uni01E3.cv23 \uni01E5 \uni01E5.cv24 \uni01F5.cv24 
+	\uni0201 \uni0201.cv23 \uni0201.sc \uni0203 \uni0203.cv23 \uni0203.sc 
+	\uni0227 \uni0227.cv23 \uni0227.sc \uni0238 \uni0239 \uni024B \uni0260 
+	\uni0261 \uni0278 \uni0430 \uni0430.cv23 \uni0430.sc \uni0432 \uni0434 
 	\uni0434.loclBGR \uni0434.loclBGR.sc \uni043B.loclBGR.sc \uni0444 
 	\uni0467.sc \uni0469.sc \uni04D1 \uni04D1.cv23 \uni04D1.sc \uni04D3 
 	\uni04D3.cv23 \uni04D3.sc \uni04D5.cv23 \uni0501 \uni0503 \uni051B 
@@ -8449,35 +8471,38 @@ lookup kern_Horizontal_kerning {
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni0188 \uni018D \uni01A3 \uni01D2 \uni01DD \uni01EB \uni020D 
-	\uni020F \uni022B \uni022D \uni022F \uni0231 \uni023C \uni0247 \uni0255 
-	\uni0258 \uni0259 \uni025A \uni0275 \uni0276 \uni029B \uni03D9 \uni03F2 
-	\uni03F5 \uni0435 \uni043E \uni0450 \uni0451 \uni0473 \uni047B \uni04A9 
-	\uni04AB \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni050D 
-	\uni1E09 \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni0188 \uni018D \uni01A3 
+	\uni01D2 \uni01DD \uni01EB \uni020D \uni020F \uni022B \uni022D \uni022F 
+	\uni0231 \uni023C \uni0247 \uni0255 \uni0258 \uni0259 \uni025A \uni0275 
+	\uni0276 \uni029B \uni03D9 \uni03F2 \uni03F5 \uni0435 \uni043E \uni0450 
+	\uni0451 \uni0473 \uni047B \uni04A9 \uni04AB \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni050D \uni1E09 \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni20C0 \uni217D ];
     @kc87_second_23 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
-	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
-	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \q.sc.cv29 \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc 
-	\uni01E5.sc \uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc 
-	\uni020F.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc 
-	\uni023C.sc \uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc 
-	\uni037C.sc \uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc 
-	\uni0444.loclBGR.sc \uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc 
-	\uni04AB.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
-	\uni04EB.sc \uni050D.sc \uni051B.sc \uni051B.sc.cv29 \uni1E09.sc 
-	\uni1E21.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
-	\uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc 
-	\uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
-	\uni1EE1.sc \uni1EE3.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc 
-	\uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc 
-	\uni217D.sc ];
+	\gdotaccent.sc \nine.cv09.onum \nine.cv19.onum \nine.onum \o.sc 
+	\oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohorn.sc \ohungarumlaut.sc \omacron.sc \omicron.sc \omicrontonos.sc 
+	\oslash.sc \oslashacute.sc \otilde.sc \q.sc \q.sc.cv29 \theta.sc 
+	\uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc \uni022B.sc 
+	\uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc \uni0259.sc 
+	\uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc \uni03D9.sc 
+	\uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc \uni0454.sc 
+	\uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc \uni04D9.sc 
+	\uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni050D.sc 
+	\uni051B.sc \uni051B.sc.cv29 \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
+	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
+	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
+	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_second_24 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
@@ -8540,14 +8565,15 @@ lookup kern_Horizontal_kerning {
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
     @kc87_second_27 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
-	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
-	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
-	\uni0457.sc \uni1E2D.sc \uni1E2F.sc \uni1EC9.sc \uni1ECB.sc 
-	\uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc 
-	\uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F76.sc \uni1F77.sc 
-	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2178.sc ];
+	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \one.cv01.ss06.onum 
+	\one.cv01.ss06.pnum \one.cv11.ss06.onum \one.cv11.ss06.pnum 
+	\one.ss06.onum \one.ss06.pnum \uni01D0.sc \uni0209.sc \uni020B.sc 
+	\uni0269.sc \uni026A.sc \uni0456.sc \uni0457.sc \uni1E2D.sc 
+	\uni1E2F.sc \uni1EC9.sc \uni1ECB.sc \uni1F30.sc \uni1F31.sc 
+	\uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
+	\uni1F37.sc \uni1F76.sc \uni1F77.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2178.sc ];
     @kc87_second_28 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
@@ -8590,97 +8616,105 @@ lookup kern_Horizontal_kerning {
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
     @kc87_second_30 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
-	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
-	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
-	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
-	\uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 \uni01D4.cv25 
-	\uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA \uni01DA.cv25 
-	\uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 \uni0215 
-	\uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 \uni0269 
-	\uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B \uni0299 
-	\uni029C \uni029F \uni0438 \uni0439 \uni043A \uni043C \uni043D \uni043F 
-	\uni0442 \uni0446 \uni0448 \uni0449 \uni044B \uni044C \uni044E \uni045C 
-	\uni045D \uni045F \uni0465 \uni0469 \uni046D \uni0491 \uni0495 \uni049B 
-	\uni049D \uni04A1 \uni04A3 \uni04A5 \uni04A7 \uni04AD \uni04C8 \uni04CA 
-	\uni04CE \uni0523 \uni0525 \uni0529 \uni1E3F \uni1E41 \uni1E43 \uni1E45 
-	\uni1E47 \uni1E49 \uni1E4B \uni1E59 \uni1E5B \uni1E5D \uni1E5F \uni1E73 
-	\uni1E73.cv25 \uni1E75 \uni1E75.cv25 \uni1E77 \uni1E77.cv25 \uni1E79 
-	\uni1E79.cv25 \uni1E7B \uni1E7B.cv25 \uni1EE5 \uni1EE5.cv25 \uni1EE7 
-	\uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 \uni1EED 
-	\uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 \uni1F50 
-	\uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F7A 
-	\uni1F7B \uni1FE6 \uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 
-	\upsilon \upsilondieresistonos \upsilontonos \uring \uring.cv25 
-	\utilde \utilde.cv25 ];
-    @kc87_second_31 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
-	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc87_second_32 = [\fraction ];
-    @kc87_second_33 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc87_second_34 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+	\ntilde \r \racute \rcaron \rcommaaccent \seven.cv07.ss07.onum 
+	\seven.cv17.ss07.onum \seven.ss07.onum \u \u.cv25 \uacute 
+	\uacute.cv25 \ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 
+	\udieresis \udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 
+	\uhungarumlaut \uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 
+	\uni01D4.cv25 \uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA 
+	\uni01DA.cv25 \uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 
+	\uni0215 \uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 
+	\uni0269 \uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B 
+	\uni0299 \uni029C \uni029F \uni0438 \uni0439 \uni043A \uni043C \uni043D 
+	\uni043F \uni0442 \uni0446 \uni0448 \uni0449 \uni044B \uni044C \uni044E 
+	\uni045C \uni045D \uni045F \uni0465 \uni0469 \uni046D \uni0491 \uni0495 
+	\uni049B \uni049D \uni04A1 \uni04A3 \uni04A5 \uni04A7 \uni04AD \uni04C8 
+	\uni04CA \uni04CE \uni0523 \uni0525 \uni0529 \uni1E3F \uni1E41 \uni1E43 
+	\uni1E45 \uni1E47 \uni1E49 \uni1E4B \uni1E59 \uni1E5B \uni1E5D \uni1E5F 
+	\uni1E73 \uni1E73.cv25 \uni1E75 \uni1E75.cv25 \uni1E77 \uni1E77.cv25 
+	\uni1E79 \uni1E79.cv25 \uni1E7B \uni1E7B.cv25 \uni1EE5 \uni1EE5.cv25 
+	\uni1EE7 \uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 
+	\uni1EED \uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 
+	\uni1F50 \uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 
+	\uni1F7A \uni1F7B \uni1FE6 \uni1FE7 \uni20AA \uniA657 \uogonek 
+	\uogonek.cv25 \upsilon \upsilondieresistonos \upsilontonos \uring 
+	\uring.cv25 \utilde \utilde.cv25 ];
+    @kc87_second_31 = [\f \florin \one.cv01.onum \one.cv01.pnum \one.cv11.onum \one.cv11.pnum 
+	\one.onum \one.pnum \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 
+	\uni1E1F \uni1E6B \uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
+    @kc87_second_32 = [\four.cv04.pnum \four.cv14.pnum \four.pnum ];
+    @kc87_second_33 = [\fraction ];
+    @kc87_second_34 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc87_second_35 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc87_second_35 = [\lambda \uni019B ];
-    @kc87_second_36 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc87_second_36 = [\lambda \uni019B ];
+    @kc87_second_37 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc87_second_37 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_second_38 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_second_39 = [\pi \tau \uni044A \uni04B5 ];
-    @kc87_second_40 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc87_second_38 = [\omega.sc \omegatonos.sc \two.cv02.onum \two.cv12.onum \two.onum.tnum 
+	\uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc 
+	\uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc 
+	\uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc 
+	\uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc 
+	\uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
+    @kc87_second_39 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc87_second_40 = [\pi \tau \uni044A \uni04B5 ];
+    @kc87_second_41 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc87_second_41 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_second_42 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc87_second_42 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc87_second_43 = [\seven.cv07.onum \seven.cv17.onum \seven.onum \t.sc \tau.sc \tbar.sc 
+	\tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc \uni021B.sc 
+	\uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc \uni0442.sc 
+	\uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc 
+	\uni1E71.sc \uni1E97.sc ];
+    @kc87_second_44 = [\seven.cv07.ss07.pnum \seven.cv17.ss07.pnum \seven.ss07.pnum ];
+    @kc87_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_second_43 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
-	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
-	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc87_second_44 = [\theta \uni0478 \uniA64C ];
-    @kc87_second_45 = [\tonos2 ];
-    @kc87_second_46 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc87_second_47 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc87_second_46 = [\six.cv06.onum \six.cv06.pnum \six.onum \six.pnum \theta \uni0478 \uniA64C 
+	\zero.cv10.pnum \zero.cv10.zero.pnum \zero.cv20.pnum 
+	\zero.cv20.zero.pnum \zero.pnum \zero.zero.pnum ];
+    @kc87_second_47 = [\three.cv13.onum \uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 
+	\uniA641 \uniA643 \z \zacute \zcaron \zdotaccent ];
+    @kc87_second_48 = [\tonos2 ];
+    @kc87_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc87_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc87_second_48 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_second_49 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
-	\z \zacute \zcaron \zdotaccent ];
-    @kc87_second_50 = [\uni0237 ];
-    @kc87_second_51 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc87_second_52 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc87_second_53 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc87_second_54 = [\uni042F \uni0518 ];
-    @kc87_second_55 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc87_second_52 = [\uni0237 ];
+    @kc87_second_53 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc87_second_54 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc87_second_55 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc87_second_56 = [\uni042F \uni0518 ];
+    @kc87_second_57 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc87_second_56 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc87_second_58 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc87_second_57 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
-    @kc87_second_58 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc87_second_59 = [\uni044F.sc \uni0519.sc ];
-    @kc87_second_60 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc87_second_59 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
+    @kc87_second_60 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc87_second_61 = [\uni044F.sc \uni0519.sc ];
+    @kc87_second_62 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc87_second_61 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc87_second_62 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc87_second_63 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc87_second_64 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc87_second_63 = [\uni0500 \uni0502 ];
-    @kc87_second_64 = [\uni0501.sc \uni0503.sc ];
-    @kc87_second_65 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
+    @kc87_second_65 = [\uni0500 \uni0502 ];
+    @kc87_second_66 = [\uni0501.sc \uni0503.sc ];
+    @kc87_second_67 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
 	\zero.cv20.zero.dnom.pnum \zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc87_second_66 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
+    @kc87_second_68 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
 	\zero.cv20.zero.numr.pnum \zero.numr.pnum \zero.zero.numr.pnum ];
     pos @kc87_first_1 @kc87_second_3 -70;
     pos @kc87_first_1 @kc87_second_8 -70;
     pos @kc87_first_1 @kc87_second_9 -140;
     pos @kc87_first_1 @kc87_second_10 -35;
-    pos @kc87_first_1 @kc87_second_12 -280;
+    pos @kc87_first_1 @kc87_second_12 -210;
     pos @kc87_first_1 @kc87_second_13 -280;
     pos @kc87_first_1 @kc87_second_14 -280;
     pos @kc87_first_1 @kc87_second_15 -210;
@@ -8688,26 +8722,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_1 @kc87_second_23 -35;
     pos @kc87_first_1 @kc87_second_25 -50;
     pos @kc87_first_1 @kc87_second_31 -70;
-    pos @kc87_first_1 @kc87_second_38 -35;
-    pos @kc87_first_1 @kc87_second_39 -140;
-    pos @kc87_first_1 @kc87_second_40 -105;
+    pos @kc87_first_1 @kc87_second_39 -35;
+    pos @kc87_first_1 @kc87_second_40 -140;
+    pos @kc87_first_1 @kc87_second_41 -105;
     pos @kc87_first_1 @kc87_second_43 -210;
-    pos @kc87_first_1 @kc87_second_44 -35;
-    pos @kc87_first_1 @kc87_second_45 1;
-    pos @kc87_first_1 @kc87_second_47 -175;
-    pos @kc87_first_1 @kc87_second_48 -210;
-    pos @kc87_first_1 @kc87_second_58 -140;
+    pos @kc87_first_1 @kc87_second_44 -175;
+    pos @kc87_first_1 @kc87_second_46 -35;
+    pos @kc87_first_1 @kc87_second_48 1;
+    pos @kc87_first_1 @kc87_second_50 -175;
+    pos @kc87_first_1 @kc87_second_51 -210;
     pos @kc87_first_1 @kc87_second_60 -140;
-    pos @kc87_first_1 @kc87_second_61 -210;
     pos @kc87_first_1 @kc87_second_62 -140;
+    pos @kc87_first_1 @kc87_second_63 -210;
+    pos @kc87_first_1 @kc87_second_64 -140;
     pos @kc87_first_2 @kc87_second_9 -35;
     pos @kc87_first_2 @kc87_second_12 -70;
     pos @kc87_first_2 @kc87_second_13 -70;
     pos @kc87_first_2 @kc87_second_14 -70;
     pos @kc87_first_2 @kc87_second_15 -35;
     pos @kc87_first_2 @kc87_second_16 -35;
-    pos @kc87_first_2 @kc87_second_39 -35;
-    pos @kc87_first_2 @kc87_second_45 1;
+    pos @kc87_first_2 @kc87_second_40 -35;
+    pos @kc87_first_2 @kc87_second_48 1;
     pos @kc87_first_3 @kc87_second_1 -35;
     pos @kc87_first_3 @kc87_second_2 -70;
     pos @kc87_first_3 @kc87_second_5 -35;
@@ -8717,8 +8752,8 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_3 @kc87_second_14 -35;
     pos @kc87_first_3 @kc87_second_16 -70;
     pos @kc87_first_3 @kc87_second_19 -70;
-    pos @kc87_first_3 @kc87_second_35 -35;
-    pos @kc87_first_3 @kc87_second_45 1;
+    pos @kc87_first_3 @kc87_second_36 -35;
+    pos @kc87_first_3 @kc87_second_48 1;
     pos @kc87_first_4 @kc87_second_1 -70;
     pos @kc87_first_4 @kc87_second_2 -140;
     pos @kc87_first_4 @kc87_second_4 70;
@@ -8733,23 +8768,23 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_4 @kc87_second_26 -70;
     pos @kc87_first_4 @kc87_second_27 -35;
     pos @kc87_first_4 @kc87_second_31 35;
-    pos @kc87_first_4 @kc87_second_34 -70;
     pos @kc87_first_4 @kc87_second_35 -70;
+    pos @kc87_first_4 @kc87_second_36 -70;
     pos @kc87_first_4 @kc87_second_43 -35;
-    pos @kc87_first_4 @kc87_second_45 1;
-    pos @kc87_first_4 @kc87_second_48 -70;
-    pos @kc87_first_4 @kc87_second_53 -70;
+    pos @kc87_first_4 @kc87_second_48 1;
+    pos @kc87_first_4 @kc87_second_51 -70;
     pos @kc87_first_4 @kc87_second_55 -70;
     pos @kc87_first_4 @kc87_second_57 -70;
-    pos @kc87_first_4 @kc87_second_61 -35;
+    pos @kc87_first_4 @kc87_second_59 -70;
+    pos @kc87_first_4 @kc87_second_63 -35;
     pos @kc87_first_5 @kc87_second_12 -70;
-    pos @kc87_first_5 @kc87_second_45 1;
+    pos @kc87_first_5 @kc87_second_48 1;
     pos @kc87_first_6 @kc87_second_1 -280;
     pos @kc87_first_6 @kc87_second_2 -350;
     pos @kc87_first_6 @kc87_second_3 -140;
     pos @kc87_first_6 @kc87_second_4 -70;
     pos @kc87_first_6 @kc87_second_6 -350;
-    pos @kc87_first_6 @kc87_second_7 -140;
+    pos @kc87_first_6 @kc87_second_7 -70;
     pos @kc87_first_6 @kc87_second_8 -210;
     pos @kc87_first_6 @kc87_second_10 -70;
     pos @kc87_first_6 @kc87_second_17 -240;
@@ -8764,44 +8799,46 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_6 @kc87_second_29 -240;
     pos @kc87_first_6 @kc87_second_30 -240;
     pos @kc87_first_6 @kc87_second_31 -175;
-    pos @kc87_first_6 @kc87_second_34 -350;
-    pos @kc87_first_6 @kc87_second_35 -105;
-    pos @kc87_first_6 @kc87_second_36 -240;
-    pos @kc87_first_6 @kc87_second_37 -210;
-    pos @kc87_first_6 @kc87_second_38 -240;
+    pos @kc87_first_6 @kc87_second_32 -175;
+    pos @kc87_first_6 @kc87_second_35 -350;
+    pos @kc87_first_6 @kc87_second_36 -105;
+    pos @kc87_first_6 @kc87_second_37 -240;
+    pos @kc87_first_6 @kc87_second_38 -210;
     pos @kc87_first_6 @kc87_second_39 -240;
-    pos @kc87_first_6 @kc87_second_41 -240;
-    pos @kc87_first_6 @kc87_second_44 -140;
-    pos @kc87_first_6 @kc87_second_45 1;
-    pos @kc87_first_6 @kc87_second_46 -35;
+    pos @kc87_first_6 @kc87_second_40 -240;
+    pos @kc87_first_6 @kc87_second_42 -240;
+    pos @kc87_first_6 @kc87_second_46 -70;
     pos @kc87_first_6 @kc87_second_47 -240;
-    pos @kc87_first_6 @kc87_second_49 -240;
+    pos @kc87_first_6 @kc87_second_48 1;
+    pos @kc87_first_6 @kc87_second_49 -35;
     pos @kc87_first_6 @kc87_second_50 -240;
-    pos @kc87_first_6 @kc87_second_51 -240;
     pos @kc87_first_6 @kc87_second_52 -240;
-    pos @kc87_first_6 @kc87_second_53 -280;
-    pos @kc87_first_6 @kc87_second_54 -70;
-    pos @kc87_first_6 @kc87_second_55 -240;
-    pos @kc87_first_6 @kc87_second_56 -175;
-    pos @kc87_first_6 @kc87_second_57 -280;
-    pos @kc87_first_6 @kc87_second_58 -240;
-    pos @kc87_first_6 @kc87_second_59 -210;
-    pos @kc87_first_6 @kc87_second_60 -175;
-    pos @kc87_first_6 @kc87_second_63 -175;
-    pos @kc87_first_6 @kc87_second_64 -175;
+    pos @kc87_first_6 @kc87_second_53 -240;
+    pos @kc87_first_6 @kc87_second_54 -240;
+    pos @kc87_first_6 @kc87_second_55 -280;
+    pos @kc87_first_6 @kc87_second_56 -70;
+    pos @kc87_first_6 @kc87_second_57 -240;
+    pos @kc87_first_6 @kc87_second_58 -175;
+    pos @kc87_first_6 @kc87_second_59 -280;
+    pos @kc87_first_6 @kc87_second_60 -240;
+    pos @kc87_first_6 @kc87_second_61 -210;
+    pos @kc87_first_6 @kc87_second_62 -175;
+    pos @kc87_first_6 @kc87_second_65 -175;
+    pos @kc87_first_6 @kc87_second_66 -175;
     pos @kc87_first_7 @kc87_second_3 -70;
     pos @kc87_first_7 @kc87_second_8 -105;
     pos @kc87_first_7 @kc87_second_17 -35;
     pos @kc87_first_7 @kc87_second_20 -105;
     pos @kc87_first_7 @kc87_second_22 -105;
     pos @kc87_first_7 @kc87_second_23 -70;
-    pos @kc87_first_7 @kc87_second_45 1;
-    pos @kc87_first_7 @kc87_second_46 -35;
-    pos @kc87_first_7 @kc87_second_47 -70;
-    pos @kc87_first_7 @kc87_second_51 -50;
-    pos @kc87_first_7 @kc87_second_60 -35;
-    pos @kc87_first_7 @kc87_second_63 -70;
-    pos @kc87_first_7 @kc87_second_64 -70;
+    pos @kc87_first_7 @kc87_second_32 -70;
+    pos @kc87_first_7 @kc87_second_48 1;
+    pos @kc87_first_7 @kc87_second_49 -35;
+    pos @kc87_first_7 @kc87_second_50 -70;
+    pos @kc87_first_7 @kc87_second_53 -50;
+    pos @kc87_first_7 @kc87_second_62 -35;
+    pos @kc87_first_7 @kc87_second_65 -70;
+    pos @kc87_first_7 @kc87_second_66 -70;
     pos @kc87_first_8 @kc87_second_3 -140;
     pos @kc87_first_8 @kc87_second_4 -70;
     pos @kc87_first_8 @kc87_second_6 -70;
@@ -8814,26 +8851,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_8 @kc87_second_25 -140;
     pos @kc87_first_8 @kc87_second_29 -35;
     pos @kc87_first_8 @kc87_second_31 -105;
-    pos @kc87_first_8 @kc87_second_34 -70;
-    pos @kc87_first_8 @kc87_second_36 -70;
-    pos @kc87_first_8 @kc87_second_38 -105;
-    pos @kc87_first_8 @kc87_second_39 -175;
-    pos @kc87_first_8 @kc87_second_40 -140;
-    pos @kc87_first_8 @kc87_second_41 -35;
+    pos @kc87_first_8 @kc87_second_32 -70;
+    pos @kc87_first_8 @kc87_second_35 -70;
+    pos @kc87_first_8 @kc87_second_37 -70;
+    pos @kc87_first_8 @kc87_second_39 -105;
+    pos @kc87_first_8 @kc87_second_40 -175;
+    pos @kc87_first_8 @kc87_second_41 -140;
+    pos @kc87_first_8 @kc87_second_42 -35;
     pos @kc87_first_8 @kc87_second_43 -140;
-    pos @kc87_first_8 @kc87_second_44 -105;
-    pos @kc87_first_8 @kc87_second_45 1;
-    pos @kc87_first_8 @kc87_second_46 -70;
-    pos @kc87_first_8 @kc87_second_47 -140;
-    pos @kc87_first_8 @kc87_second_48 -70;
-    pos @kc87_first_8 @kc87_second_51 -35;
-    pos @kc87_first_8 @kc87_second_52 -35;
-    pos @kc87_first_8 @kc87_second_58 -210;
-    pos @kc87_first_8 @kc87_second_60 -105;
-    pos @kc87_first_8 @kc87_second_61 -70;
-    pos @kc87_first_8 @kc87_second_62 -35;
+    pos @kc87_first_8 @kc87_second_46 -105;
+    pos @kc87_first_8 @kc87_second_48 1;
+    pos @kc87_first_8 @kc87_second_49 -70;
+    pos @kc87_first_8 @kc87_second_50 -140;
+    pos @kc87_first_8 @kc87_second_51 -70;
+    pos @kc87_first_8 @kc87_second_53 -35;
+    pos @kc87_first_8 @kc87_second_54 -35;
+    pos @kc87_first_8 @kc87_second_60 -210;
+    pos @kc87_first_8 @kc87_second_62 -105;
     pos @kc87_first_8 @kc87_second_63 -70;
     pos @kc87_first_8 @kc87_second_64 -35;
+    pos @kc87_first_8 @kc87_second_65 -70;
+    pos @kc87_first_8 @kc87_second_66 -35;
     pos @kc87_first_9 @kc87_second_3 -140;
     pos @kc87_first_9 @kc87_second_4 -70;
     pos @kc87_first_9 @kc87_second_6 -70;
@@ -8851,24 +8889,26 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_9 @kc87_second_23 -140;
     pos @kc87_first_9 @kc87_second_29 -50;
     pos @kc87_first_9 @kc87_second_31 -140;
-    pos @kc87_first_9 @kc87_second_34 -70;
-    pos @kc87_first_9 @kc87_second_38 -105;
-    pos @kc87_first_9 @kc87_second_39 -280;
-    pos @kc87_first_9 @kc87_second_40 -350;
-    pos @kc87_first_9 @kc87_second_41 -50;
+    pos @kc87_first_9 @kc87_second_32 -70;
+    pos @kc87_first_9 @kc87_second_35 -70;
+    pos @kc87_first_9 @kc87_second_39 -105;
+    pos @kc87_first_9 @kc87_second_40 -280;
+    pos @kc87_first_9 @kc87_second_41 -350;
+    pos @kc87_first_9 @kc87_second_42 -50;
     pos @kc87_first_9 @kc87_second_43 -350;
-    pos @kc87_first_9 @kc87_second_45 1;
-    pos @kc87_first_9 @kc87_second_46 -35;
-    pos @kc87_first_9 @kc87_second_47 -210;
-    pos @kc87_first_9 @kc87_second_48 -350;
-    pos @kc87_first_9 @kc87_second_51 -35;
-    pos @kc87_first_9 @kc87_second_52 -35;
-    pos @kc87_first_9 @kc87_second_58 -280;
-    pos @kc87_first_9 @kc87_second_60 -175;
-    pos @kc87_first_9 @kc87_second_61 -280;
-    pos @kc87_first_9 @kc87_second_62 -210;
-    pos @kc87_first_9 @kc87_second_63 -70;
-    pos @kc87_first_9 @kc87_second_64 -70;
+    pos @kc87_first_9 @kc87_second_44 -280;
+    pos @kc87_first_9 @kc87_second_48 1;
+    pos @kc87_first_9 @kc87_second_49 -35;
+    pos @kc87_first_9 @kc87_second_50 -210;
+    pos @kc87_first_9 @kc87_second_51 -350;
+    pos @kc87_first_9 @kc87_second_53 -35;
+    pos @kc87_first_9 @kc87_second_54 -35;
+    pos @kc87_first_9 @kc87_second_60 -280;
+    pos @kc87_first_9 @kc87_second_62 -175;
+    pos @kc87_first_9 @kc87_second_63 -280;
+    pos @kc87_first_9 @kc87_second_64 -210;
+    pos @kc87_first_9 @kc87_second_65 -70;
+    pos @kc87_first_9 @kc87_second_66 -70;
     pos @kc87_first_10 @kc87_second_1 -210;
     pos @kc87_first_10 @kc87_second_2 -350;
     pos @kc87_first_10 @kc87_second_5 -70;
@@ -8883,17 +8923,18 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_10 @kc87_second_22 -70;
     pos @kc87_first_10 @kc87_second_24 -350;
     pos @kc87_first_10 @kc87_second_29 -70;
-    pos @kc87_first_10 @kc87_second_32 -140;
-    pos @kc87_first_10 @kc87_second_34 -210;
-    pos @kc87_first_10 @kc87_second_35 -105;
-    pos @kc87_first_10 @kc87_second_38 -70;
-    pos @kc87_first_10 @kc87_second_45 1;
-    pos @kc87_first_10 @kc87_second_53 -210;
+    pos @kc87_first_10 @kc87_second_32 -35;
+    pos @kc87_first_10 @kc87_second_33 -140;
+    pos @kc87_first_10 @kc87_second_35 -210;
+    pos @kc87_first_10 @kc87_second_36 -105;
+    pos @kc87_first_10 @kc87_second_39 -70;
+    pos @kc87_first_10 @kc87_second_48 1;
     pos @kc87_first_10 @kc87_second_55 -210;
     pos @kc87_first_10 @kc87_second_57 -210;
-    pos @kc87_first_10 @kc87_second_61 -70;
+    pos @kc87_first_10 @kc87_second_59 -210;
     pos @kc87_first_10 @kc87_second_63 -70;
-    pos @kc87_first_10 @kc87_second_64 -105;
+    pos @kc87_first_10 @kc87_second_65 -70;
+    pos @kc87_first_10 @kc87_second_66 -105;
     pos @kc87_first_11 @kc87_second_1 -70;
     pos @kc87_first_11 @kc87_second_2 -140;
     pos @kc87_first_11 @kc87_second_5 -105;
@@ -8908,21 +8949,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_11 @kc87_second_24 -70;
     pos @kc87_first_11 @kc87_second_26 -70;
     pos @kc87_first_11 @kc87_second_27 -70;
-    pos @kc87_first_11 @kc87_second_34 -35;
-    pos @kc87_first_11 @kc87_second_35 -140;
-    pos @kc87_first_11 @kc87_second_39 -70;
-    pos @kc87_first_11 @kc87_second_42 -35;
+    pos @kc87_first_11 @kc87_second_35 -35;
+    pos @kc87_first_11 @kc87_second_36 -140;
+    pos @kc87_first_11 @kc87_second_40 -70;
     pos @kc87_first_11 @kc87_second_43 -35;
-    pos @kc87_first_11 @kc87_second_45 1;
-    pos @kc87_first_11 @kc87_second_48 -70;
-    pos @kc87_first_11 @kc87_second_53 -210;
-    pos @kc87_first_11 @kc87_second_55 -175;
-    pos @kc87_first_11 @kc87_second_56 -35;
+    pos @kc87_first_11 @kc87_second_45 -35;
+    pos @kc87_first_11 @kc87_second_48 1;
+    pos @kc87_first_11 @kc87_second_51 -70;
+    pos @kc87_first_11 @kc87_second_55 -210;
     pos @kc87_first_11 @kc87_second_57 -175;
-    pos @kc87_first_11 @kc87_second_61 -70;
-    pos @kc87_first_11 @kc87_second_62 -35;
-    pos @kc87_first_11 @kc87_second_63 -35;
-    pos @kc87_first_11 @kc87_second_64 -70;
+    pos @kc87_first_11 @kc87_second_58 -35;
+    pos @kc87_first_11 @kc87_second_59 -175;
+    pos @kc87_first_11 @kc87_second_63 -70;
+    pos @kc87_first_11 @kc87_second_64 -35;
+    pos @kc87_first_11 @kc87_second_65 -35;
+    pos @kc87_first_11 @kc87_second_66 -70;
     pos @kc87_first_12 @kc87_second_1 -140;
     pos @kc87_first_12 @kc87_second_2 -210;
     pos @kc87_first_12 @kc87_second_6 -140;
@@ -8931,28 +8972,30 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_12 @kc87_second_22 -70;
     pos @kc87_first_12 @kc87_second_24 -350;
     pos @kc87_first_12 @kc87_second_29 -35;
-    pos @kc87_first_12 @kc87_second_32 -140;
-    pos @kc87_first_12 @kc87_second_34 -140;
-    pos @kc87_first_12 @kc87_second_35 -70;
-    pos @kc87_first_12 @kc87_second_38 -70;
-    pos @kc87_first_12 @kc87_second_45 1;
-    pos @kc87_first_12 @kc87_second_51 -35;
-    pos @kc87_first_12 @kc87_second_53 -210;
+    pos @kc87_first_12 @kc87_second_32 -70;
+    pos @kc87_first_12 @kc87_second_33 -140;
+    pos @kc87_first_12 @kc87_second_35 -140;
+    pos @kc87_first_12 @kc87_second_36 -70;
+    pos @kc87_first_12 @kc87_second_39 -70;
+    pos @kc87_first_12 @kc87_second_48 1;
+    pos @kc87_first_12 @kc87_second_53 -35;
     pos @kc87_first_12 @kc87_second_55 -210;
     pos @kc87_first_12 @kc87_second_57 -210;
-    pos @kc87_first_12 @kc87_second_63 -70;
-    pos @kc87_first_12 @kc87_second_64 -105;
+    pos @kc87_first_12 @kc87_second_59 -210;
+    pos @kc87_first_12 @kc87_second_65 -70;
+    pos @kc87_first_12 @kc87_second_66 -105;
     pos @kc87_first_13 @kc87_second_6 -70;
     pos @kc87_first_13 @kc87_second_12 -70;
     pos @kc87_first_13 @kc87_second_13 -105;
     pos @kc87_first_13 @kc87_second_14 -35;
     pos @kc87_first_13 @kc87_second_22 -35;
     pos @kc87_first_13 @kc87_second_29 -35;
-    pos @kc87_first_13 @kc87_second_34 -70;
-    pos @kc87_first_13 @kc87_second_38 -70;
-    pos @kc87_first_13 @kc87_second_45 1;
-    pos @kc87_first_13 @kc87_second_63 -70;
-    pos @kc87_first_13 @kc87_second_64 -35;
+    pos @kc87_first_13 @kc87_second_32 -35;
+    pos @kc87_first_13 @kc87_second_35 -70;
+    pos @kc87_first_13 @kc87_second_39 -70;
+    pos @kc87_first_13 @kc87_second_48 1;
+    pos @kc87_first_13 @kc87_second_65 -70;
+    pos @kc87_first_13 @kc87_second_66 -35;
     pos @kc87_first_14 @kc87_second_2 -35;
     pos @kc87_first_14 @kc87_second_11 -35;
     pos @kc87_first_14 @kc87_second_12 -70;
@@ -8961,14 +9004,14 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_14 @kc87_second_16 -35;
     pos @kc87_first_14 @kc87_second_19 -35;
     pos @kc87_first_14 @kc87_second_25 -35;
-    pos @kc87_first_14 @kc87_second_39 -70;
-    pos @kc87_first_14 @kc87_second_45 1;
-    pos @kc87_first_14 @kc87_second_47 -70;
-    pos @kc87_first_14 @kc87_second_48 -35;
-    pos @kc87_first_14 @kc87_second_56 -35;
+    pos @kc87_first_14 @kc87_second_40 -70;
+    pos @kc87_first_14 @kc87_second_48 1;
+    pos @kc87_first_14 @kc87_second_50 -70;
+    pos @kc87_first_14 @kc87_second_51 -35;
     pos @kc87_first_14 @kc87_second_58 -35;
     pos @kc87_first_14 @kc87_second_60 -35;
     pos @kc87_first_14 @kc87_second_62 -35;
+    pos @kc87_first_14 @kc87_second_64 -35;
     pos @kc87_first_15 @kc87_second_3 -70;
     pos @kc87_first_15 @kc87_second_4 -70;
     pos @kc87_first_15 @kc87_second_6 -35;
@@ -8980,20 +9023,20 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_15 @kc87_second_25 -70;
     pos @kc87_first_15 @kc87_second_29 -35;
     pos @kc87_first_15 @kc87_second_31 -35;
-    pos @kc87_first_15 @kc87_second_36 -35;
-    pos @kc87_first_15 @kc87_second_38 -70;
-    pos @kc87_first_15 @kc87_second_39 -142;
-    pos @kc87_first_15 @kc87_second_40 -35;
-    pos @kc87_first_15 @kc87_second_44 -35;
-    pos @kc87_first_15 @kc87_second_45 1;
+    pos @kc87_first_15 @kc87_second_37 -35;
+    pos @kc87_first_15 @kc87_second_39 -70;
+    pos @kc87_first_15 @kc87_second_40 -142;
+    pos @kc87_first_15 @kc87_second_41 -35;
     pos @kc87_first_15 @kc87_second_46 -35;
-    pos @kc87_first_15 @kc87_second_47 -70;
-    pos @kc87_first_15 @kc87_second_51 -35;
-    pos @kc87_first_15 @kc87_second_52 -35;
-    pos @kc87_first_15 @kc87_second_58 -105;
-    pos @kc87_first_15 @kc87_second_60 -35;
-    pos @kc87_first_15 @kc87_second_63 -35;
-    pos @kc87_first_15 @kc87_second_64 -35;
+    pos @kc87_first_15 @kc87_second_48 1;
+    pos @kc87_first_15 @kc87_second_49 -35;
+    pos @kc87_first_15 @kc87_second_50 -70;
+    pos @kc87_first_15 @kc87_second_53 -35;
+    pos @kc87_first_15 @kc87_second_54 -35;
+    pos @kc87_first_15 @kc87_second_60 -105;
+    pos @kc87_first_15 @kc87_second_62 -35;
+    pos @kc87_first_15 @kc87_second_65 -35;
+    pos @kc87_first_15 @kc87_second_66 -35;
     pos @kc87_first_16 @kc87_second_1 -280;
     pos @kc87_first_16 @kc87_second_2 -280;
     pos @kc87_first_16 @kc87_second_3 -140;
@@ -9014,34 +9057,35 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_16 @kc87_second_29 -240;
     pos @kc87_first_16 @kc87_second_30 -140;
     pos @kc87_first_16 @kc87_second_31 -140;
-    pos @kc87_first_16 @kc87_second_32 -245;
-    pos @kc87_first_16 @kc87_second_34 -315;
-    pos @kc87_first_16 @kc87_second_35 -70;
-    pos @kc87_first_16 @kc87_second_36 -210;
+    pos @kc87_first_16 @kc87_second_32 -280;
+    pos @kc87_first_16 @kc87_second_33 -245;
+    pos @kc87_first_16 @kc87_second_35 -315;
+    pos @kc87_first_16 @kc87_second_36 -70;
     pos @kc87_first_16 @kc87_second_37 -210;
-    pos @kc87_first_16 @kc87_second_38 -245;
+    pos @kc87_first_16 @kc87_second_38 -210;
     pos @kc87_first_16 @kc87_second_39 -245;
-    pos @kc87_first_16 @kc87_second_40 -70;
-    pos @kc87_first_16 @kc87_second_42 -35;
+    pos @kc87_first_16 @kc87_second_40 -245;
+    pos @kc87_first_16 @kc87_second_41 -70;
     pos @kc87_first_16 @kc87_second_43 -140;
-    pos @kc87_first_16 @kc87_second_44 -140;
-    pos @kc87_first_16 @kc87_second_45 1;
-    pos @kc87_first_16 @kc87_second_46 -70;
+    pos @kc87_first_16 @kc87_second_45 -35;
+    pos @kc87_first_16 @kc87_second_46 -140;
     pos @kc87_first_16 @kc87_second_47 -140;
-    pos @kc87_first_16 @kc87_second_49 -140;
+    pos @kc87_first_16 @kc87_second_48 1;
+    pos @kc87_first_16 @kc87_second_49 -70;
     pos @kc87_first_16 @kc87_second_50 -140;
-    pos @kc87_first_16 @kc87_second_51 -240;
     pos @kc87_first_16 @kc87_second_52 -140;
-    pos @kc87_first_16 @kc87_second_53 -280;
-    pos @kc87_first_16 @kc87_second_54 -105;
+    pos @kc87_first_16 @kc87_second_53 -240;
+    pos @kc87_first_16 @kc87_second_54 -140;
     pos @kc87_first_16 @kc87_second_55 -280;
-    pos @kc87_first_16 @kc87_second_56 -140;
-    pos @kc87_first_16 @kc87_second_57 -315;
-    pos @kc87_first_16 @kc87_second_58 -210;
-    pos @kc87_first_16 @kc87_second_59 -210;
-    pos @kc87_first_16 @kc87_second_60 -105;
-    pos @kc87_first_16 @kc87_second_63 -315;
-    pos @kc87_first_16 @kc87_second_64 -350;
+    pos @kc87_first_16 @kc87_second_56 -105;
+    pos @kc87_first_16 @kc87_second_57 -280;
+    pos @kc87_first_16 @kc87_second_58 -140;
+    pos @kc87_first_16 @kc87_second_59 -315;
+    pos @kc87_first_16 @kc87_second_60 -210;
+    pos @kc87_first_16 @kc87_second_61 -210;
+    pos @kc87_first_16 @kc87_second_62 -105;
+    pos @kc87_first_16 @kc87_second_65 -315;
+    pos @kc87_first_16 @kc87_second_66 -350;
     pos @kc87_first_17 @kc87_second_1 -280;
     pos @kc87_first_17 @kc87_second_2 -280;
     pos @kc87_first_17 @kc87_second_3 -105;
@@ -9059,33 +9103,34 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_17 @kc87_second_27 -70;
     pos @kc87_first_17 @kc87_second_29 -140;
     pos @kc87_first_17 @kc87_second_30 -105;
-    pos @kc87_first_17 @kc87_second_32 -210;
-    pos @kc87_first_17 @kc87_second_34 -245;
-    pos @kc87_first_17 @kc87_second_35 -70;
-    pos @kc87_first_17 @kc87_second_36 -140;
+    pos @kc87_first_17 @kc87_second_32 -175;
+    pos @kc87_first_17 @kc87_second_33 -210;
+    pos @kc87_first_17 @kc87_second_35 -245;
+    pos @kc87_first_17 @kc87_second_36 -70;
     pos @kc87_first_17 @kc87_second_37 -140;
     pos @kc87_first_17 @kc87_second_38 -140;
-    pos @kc87_first_17 @kc87_second_39 -105;
-    pos @kc87_first_17 @kc87_second_40 -35;
+    pos @kc87_first_17 @kc87_second_39 -140;
+    pos @kc87_first_17 @kc87_second_40 -105;
+    pos @kc87_first_17 @kc87_second_41 -35;
     pos @kc87_first_17 @kc87_second_43 -35;
-    pos @kc87_first_17 @kc87_second_44 -70;
-    pos @kc87_first_17 @kc87_second_45 1;
-    pos @kc87_first_17 @kc87_second_46 -35;
-    pos @kc87_first_17 @kc87_second_47 -70;
-    pos @kc87_first_17 @kc87_second_49 -105;
+    pos @kc87_first_17 @kc87_second_46 -70;
+    pos @kc87_first_17 @kc87_second_47 -105;
+    pos @kc87_first_17 @kc87_second_48 1;
+    pos @kc87_first_17 @kc87_second_49 -35;
     pos @kc87_first_17 @kc87_second_50 -70;
-    pos @kc87_first_17 @kc87_second_51 -105;
     pos @kc87_first_17 @kc87_second_52 -70;
-    pos @kc87_first_17 @kc87_second_53 -210;
-    pos @kc87_first_17 @kc87_second_54 -35;
+    pos @kc87_first_17 @kc87_second_53 -105;
+    pos @kc87_first_17 @kc87_second_54 -70;
     pos @kc87_first_17 @kc87_second_55 -210;
-    pos @kc87_first_17 @kc87_second_56 -70;
-    pos @kc87_first_17 @kc87_second_57 -245;
-    pos @kc87_first_17 @kc87_second_58 -105;
-    pos @kc87_first_17 @kc87_second_59 -105;
-    pos @kc87_first_17 @kc87_second_60 -70;
-    pos @kc87_first_17 @kc87_second_63 -175;
-    pos @kc87_first_17 @kc87_second_64 -245;
+    pos @kc87_first_17 @kc87_second_56 -35;
+    pos @kc87_first_17 @kc87_second_57 -210;
+    pos @kc87_first_17 @kc87_second_58 -70;
+    pos @kc87_first_17 @kc87_second_59 -245;
+    pos @kc87_first_17 @kc87_second_60 -105;
+    pos @kc87_first_17 @kc87_second_61 -105;
+    pos @kc87_first_17 @kc87_second_62 -70;
+    pos @kc87_first_17 @kc87_second_65 -175;
+    pos @kc87_first_17 @kc87_second_66 -245;
     pos @kc87_first_18 @kc87_second_1 -210;
     pos @kc87_first_18 @kc87_second_2 -245;
     pos @kc87_first_18 @kc87_second_3 -35;
@@ -9099,33 +9144,34 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_18 @kc87_second_23 -70;
     pos @kc87_first_18 @kc87_second_24 -140;
     pos @kc87_first_18 @kc87_second_27 -35;
-    pos @kc87_first_18 @kc87_second_32 -140;
-    pos @kc87_first_18 @kc87_second_34 -140;
-    pos @kc87_first_18 @kc87_second_36 -105;
-    pos @kc87_first_18 @kc87_second_37 -70;
-    pos @kc87_first_18 @kc87_second_38 -105;
-    pos @kc87_first_18 @kc87_second_39 -70;
-    pos @kc87_first_18 @kc87_second_41 -35;
-    pos @kc87_first_18 @kc87_second_45 1;
-    pos @kc87_first_18 @kc87_second_50 -35;
-    pos @kc87_first_18 @kc87_second_51 -70;
-    pos @kc87_first_18 @kc87_second_53 -140;
+    pos @kc87_first_18 @kc87_second_32 -105;
+    pos @kc87_first_18 @kc87_second_33 -140;
+    pos @kc87_first_18 @kc87_second_35 -140;
+    pos @kc87_first_18 @kc87_second_37 -105;
+    pos @kc87_first_18 @kc87_second_38 -70;
+    pos @kc87_first_18 @kc87_second_39 -105;
+    pos @kc87_first_18 @kc87_second_40 -70;
+    pos @kc87_first_18 @kc87_second_42 -35;
+    pos @kc87_first_18 @kc87_second_48 1;
+    pos @kc87_first_18 @kc87_second_52 -35;
+    pos @kc87_first_18 @kc87_second_53 -70;
     pos @kc87_first_18 @kc87_second_55 -140;
-    pos @kc87_first_18 @kc87_second_57 -175;
-    pos @kc87_first_18 @kc87_second_58 -70;
-    pos @kc87_first_18 @kc87_second_63 -105;
-    pos @kc87_first_18 @kc87_second_64 -140;
+    pos @kc87_first_18 @kc87_second_57 -140;
+    pos @kc87_first_18 @kc87_second_59 -175;
+    pos @kc87_first_18 @kc87_second_60 -70;
+    pos @kc87_first_18 @kc87_second_65 -105;
+    pos @kc87_first_18 @kc87_second_66 -140;
     pos @kc87_first_19 @kc87_second_12 -280;
     pos @kc87_first_19 @kc87_second_14 -175;
     pos @kc87_first_19 @kc87_second_15 -140;
     pos @kc87_first_19 @kc87_second_29 -35;
-    pos @kc87_first_19 @kc87_second_45 1;
-    pos @kc87_first_19 @kc87_second_47 -70;
-    pos @kc87_first_19 @kc87_second_48 -140;
-    pos @kc87_first_19 @kc87_second_58 -70;
-    pos @kc87_first_19 @kc87_second_60 -35;
-    pos @kc87_first_19 @kc87_second_61 -105;
-    pos @kc87_first_19 @kc87_second_62 -70;
+    pos @kc87_first_19 @kc87_second_48 1;
+    pos @kc87_first_19 @kc87_second_50 -70;
+    pos @kc87_first_19 @kc87_second_51 -140;
+    pos @kc87_first_19 @kc87_second_60 -70;
+    pos @kc87_first_19 @kc87_second_62 -35;
+    pos @kc87_first_19 @kc87_second_63 -105;
+    pos @kc87_first_19 @kc87_second_64 -70;
     pos @kc87_first_20 @kc87_second_8 -35;
     pos @kc87_first_20 @kc87_second_9 -140;
     pos @kc87_first_20 @kc87_second_12 -280;
@@ -9136,24 +9182,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_20 @kc87_second_20 -70;
     pos @kc87_first_20 @kc87_second_25 -70;
     pos @kc87_first_20 @kc87_second_31 -50;
-    pos @kc87_first_20 @kc87_second_39 -140;
-    pos @kc87_first_20 @kc87_second_40 -105;
+    pos @kc87_first_20 @kc87_second_40 -140;
+    pos @kc87_first_20 @kc87_second_41 -105;
     pos @kc87_first_20 @kc87_second_43 -210;
-    pos @kc87_first_20 @kc87_second_45 1;
-    pos @kc87_first_20 @kc87_second_46 -35;
-    pos @kc87_first_20 @kc87_second_47 -140;
-    pos @kc87_first_20 @kc87_second_48 -210;
-    pos @kc87_first_20 @kc87_second_52 -35;
-    pos @kc87_first_20 @kc87_second_58 -105;
+    pos @kc87_first_20 @kc87_second_44 -175;
+    pos @kc87_first_20 @kc87_second_48 1;
+    pos @kc87_first_20 @kc87_second_49 -35;
+    pos @kc87_first_20 @kc87_second_50 -140;
+    pos @kc87_first_20 @kc87_second_51 -210;
+    pos @kc87_first_20 @kc87_second_54 -35;
     pos @kc87_first_20 @kc87_second_60 -105;
-    pos @kc87_first_20 @kc87_second_61 -210;
-    pos @kc87_first_20 @kc87_second_62 -140;
+    pos @kc87_first_20 @kc87_second_62 -105;
+    pos @kc87_first_20 @kc87_second_63 -210;
+    pos @kc87_first_20 @kc87_second_64 -140;
     pos @kc87_first_21 @kc87_second_1 -140;
     pos @kc87_first_21 @kc87_second_2 -350;
     pos @kc87_first_21 @kc87_second_19 -280;
-    pos @kc87_first_21 @kc87_second_38 -70;
-    pos @kc87_first_21 @kc87_second_45 1;
-    pos @kc87_first_21 @kc87_second_64 -210;
+    pos @kc87_first_21 @kc87_second_39 -70;
+    pos @kc87_first_21 @kc87_second_48 1;
+    pos @kc87_first_21 @kc87_second_66 -210;
     pos @kc87_first_22 @kc87_second_1 -35;
     pos @kc87_first_22 @kc87_second_5 -105;
     pos @kc87_first_22 @kc87_second_9 -70;
@@ -9166,20 +9213,20 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_22 @kc87_second_25 -35;
     pos @kc87_first_22 @kc87_second_26 -70;
     pos @kc87_first_22 @kc87_second_27 -105;
-    pos @kc87_first_22 @kc87_second_35 -70;
-    pos @kc87_first_22 @kc87_second_39 -70;
-    pos @kc87_first_22 @kc87_second_40 -35;
-    pos @kc87_first_22 @kc87_second_42 -35;
+    pos @kc87_first_22 @kc87_second_36 -70;
+    pos @kc87_first_22 @kc87_second_40 -70;
+    pos @kc87_first_22 @kc87_second_41 -35;
     pos @kc87_first_22 @kc87_second_43 -140;
-    pos @kc87_first_22 @kc87_second_45 1;
-    pos @kc87_first_22 @kc87_second_47 -70;
-    pos @kc87_first_22 @kc87_second_48 -175;
-    pos @kc87_first_22 @kc87_second_49 -35;
-    pos @kc87_first_22 @kc87_second_56 -105;
-    pos @kc87_first_22 @kc87_second_58 -35;
-    pos @kc87_first_22 @kc87_second_60 -50;
-    pos @kc87_first_22 @kc87_second_61 -105;
-    pos @kc87_first_22 @kc87_second_62 -70;
+    pos @kc87_first_22 @kc87_second_45 -35;
+    pos @kc87_first_22 @kc87_second_47 -35;
+    pos @kc87_first_22 @kc87_second_48 1;
+    pos @kc87_first_22 @kc87_second_50 -70;
+    pos @kc87_first_22 @kc87_second_51 -175;
+    pos @kc87_first_22 @kc87_second_58 -105;
+    pos @kc87_first_22 @kc87_second_60 -35;
+    pos @kc87_first_22 @kc87_second_62 -50;
+    pos @kc87_first_22 @kc87_second_63 -105;
+    pos @kc87_first_22 @kc87_second_64 -70;
     pos @kc87_first_23 @kc87_second_6 -35;
     pos @kc87_first_23 @kc87_second_12 -240;
     pos @kc87_first_23 @kc87_second_13 -175;
@@ -9187,17 +9234,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_23 @kc87_second_15 -70;
     pos @kc87_first_23 @kc87_second_22 -70;
     pos @kc87_first_23 @kc87_second_23 -35;
-    pos @kc87_first_23 @kc87_second_34 -35;
-    pos @kc87_first_23 @kc87_second_39 -35;
+    pos @kc87_first_23 @kc87_second_35 -35;
     pos @kc87_first_23 @kc87_second_40 -35;
+    pos @kc87_first_23 @kc87_second_41 -35;
     pos @kc87_first_23 @kc87_second_43 -70;
-    pos @kc87_first_23 @kc87_second_44 -35;
-    pos @kc87_first_23 @kc87_second_45 1;
-    pos @kc87_first_23 @kc87_second_48 -35;
-    pos @kc87_first_23 @kc87_second_58 -35;
-    pos @kc87_first_23 @kc87_second_62 -35;
-    pos @kc87_first_23 @kc87_second_63 -35;
+    pos @kc87_first_23 @kc87_second_46 -35;
+    pos @kc87_first_23 @kc87_second_48 1;
+    pos @kc87_first_23 @kc87_second_51 -35;
+    pos @kc87_first_23 @kc87_second_60 -35;
     pos @kc87_first_23 @kc87_second_64 -35;
+    pos @kc87_first_23 @kc87_second_65 -35;
+    pos @kc87_first_23 @kc87_second_66 -35;
     pos @kc87_first_24 @kc87_second_1 -70;
     pos @kc87_first_24 @kc87_second_2 -140;
     pos @kc87_first_24 @kc87_second_5 -105;
@@ -9210,19 +9257,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_24 @kc87_second_19 -70;
     pos @kc87_first_24 @kc87_second_26 -70;
     pos @kc87_first_24 @kc87_second_27 -70;
-    pos @kc87_first_24 @kc87_second_32 -70;
-    pos @kc87_first_24 @kc87_second_35 -70;
-    pos @kc87_first_24 @kc87_second_42 -35;
+    pos @kc87_first_24 @kc87_second_33 -70;
+    pos @kc87_first_24 @kc87_second_36 -70;
     pos @kc87_first_24 @kc87_second_43 -140;
-    pos @kc87_first_24 @kc87_second_45 1;
-    pos @kc87_first_24 @kc87_second_48 -140;
-    pos @kc87_first_24 @kc87_second_49 -35;
-    pos @kc87_first_24 @kc87_second_53 -140;
-    pos @kc87_first_24 @kc87_second_55 -105;
-    pos @kc87_first_24 @kc87_second_56 -70;
-    pos @kc87_first_24 @kc87_second_57 -70;
-    pos @kc87_first_24 @kc87_second_61 -70;
-    pos @kc87_first_24 @kc87_second_62 -35;
+    pos @kc87_first_24 @kc87_second_45 -35;
+    pos @kc87_first_24 @kc87_second_47 -35;
+    pos @kc87_first_24 @kc87_second_48 1;
+    pos @kc87_first_24 @kc87_second_51 -140;
+    pos @kc87_first_24 @kc87_second_55 -140;
+    pos @kc87_first_24 @kc87_second_57 -105;
+    pos @kc87_first_24 @kc87_second_58 -70;
+    pos @kc87_first_24 @kc87_second_59 -70;
+    pos @kc87_first_24 @kc87_second_63 -70;
+    pos @kc87_first_24 @kc87_second_64 -35;
     pos @kc87_first_25 @kc87_second_5 -70;
     pos @kc87_first_25 @kc87_second_9 -70;
     pos @kc87_first_25 @kc87_second_12 -240;
@@ -9233,32 +9280,33 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_25 @kc87_second_25 -35;
     pos @kc87_first_25 @kc87_second_26 -70;
     pos @kc87_first_25 @kc87_second_27 -70;
-    pos @kc87_first_25 @kc87_second_35 -70;
-    pos @kc87_first_25 @kc87_second_39 -70;
-    pos @kc87_first_25 @kc87_second_40 -35;
+    pos @kc87_first_25 @kc87_second_36 -70;
+    pos @kc87_first_25 @kc87_second_40 -70;
+    pos @kc87_first_25 @kc87_second_41 -35;
     pos @kc87_first_25 @kc87_second_43 -140;
-    pos @kc87_first_25 @kc87_second_45 1;
-    pos @kc87_first_25 @kc87_second_47 -70;
-    pos @kc87_first_25 @kc87_second_48 -140;
-    pos @kc87_first_25 @kc87_second_49 -35;
-    pos @kc87_first_25 @kc87_second_53 -50;
-    pos @kc87_first_25 @kc87_second_54 -35;
+    pos @kc87_first_25 @kc87_second_44 -105;
+    pos @kc87_first_25 @kc87_second_47 -35;
+    pos @kc87_first_25 @kc87_second_48 1;
+    pos @kc87_first_25 @kc87_second_50 -70;
+    pos @kc87_first_25 @kc87_second_51 -140;
     pos @kc87_first_25 @kc87_second_55 -50;
-    pos @kc87_first_25 @kc87_second_56 -105;
+    pos @kc87_first_25 @kc87_second_56 -35;
     pos @kc87_first_25 @kc87_second_57 -50;
-    pos @kc87_first_25 @kc87_second_58 -50;
-    pos @kc87_first_25 @kc87_second_60 -35;
-    pos @kc87_first_25 @kc87_second_61 -105;
-    pos @kc87_first_25 @kc87_second_62 -70;
+    pos @kc87_first_25 @kc87_second_58 -105;
+    pos @kc87_first_25 @kc87_second_59 -50;
+    pos @kc87_first_25 @kc87_second_60 -50;
+    pos @kc87_first_25 @kc87_second_62 -35;
+    pos @kc87_first_25 @kc87_second_63 -105;
+    pos @kc87_first_25 @kc87_second_64 -70;
     pos @kc87_first_26 @kc87_second_9 -35;
     pos @kc87_first_26 @kc87_second_12 -140;
     pos @kc87_first_26 @kc87_second_26 -70;
-    pos @kc87_first_26 @kc87_second_39 -35;
+    pos @kc87_first_26 @kc87_second_40 -35;
     pos @kc87_first_26 @kc87_second_43 -70;
-    pos @kc87_first_26 @kc87_second_45 1;
-    pos @kc87_first_26 @kc87_second_48 -70;
-    pos @kc87_first_26 @kc87_second_61 -70;
-    pos @kc87_first_26 @kc87_second_62 -35;
+    pos @kc87_first_26 @kc87_second_48 1;
+    pos @kc87_first_26 @kc87_second_51 -70;
+    pos @kc87_first_26 @kc87_second_63 -70;
+    pos @kc87_first_26 @kc87_second_64 -35;
     pos @kc87_first_27 @kc87_second_5 -50;
     pos @kc87_first_27 @kc87_second_9 -35;
     pos @kc87_first_27 @kc87_second_11 -35;
@@ -9269,17 +9317,18 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_27 @kc87_second_16 -35;
     pos @kc87_first_27 @kc87_second_26 -35;
     pos @kc87_first_27 @kc87_second_27 -35;
-    pos @kc87_first_27 @kc87_second_35 -35;
-    pos @kc87_first_27 @kc87_second_39 -50;
-    pos @kc87_first_27 @kc87_second_40 -35;
+    pos @kc87_first_27 @kc87_second_36 -35;
+    pos @kc87_first_27 @kc87_second_40 -50;
+    pos @kc87_first_27 @kc87_second_41 -35;
     pos @kc87_first_27 @kc87_second_43 -100;
-    pos @kc87_first_27 @kc87_second_45 1;
-    pos @kc87_first_27 @kc87_second_47 -35;
-    pos @kc87_first_27 @kc87_second_48 -140;
-    pos @kc87_first_27 @kc87_second_56 -35;
-    pos @kc87_first_27 @kc87_second_61 -70;
-    pos @kc87_first_27 @kc87_second_62 -35;
-    pos @kc87_first_28 @kc87_second_45 1;
+    pos @kc87_first_27 @kc87_second_44 -35;
+    pos @kc87_first_27 @kc87_second_48 1;
+    pos @kc87_first_27 @kc87_second_50 -35;
+    pos @kc87_first_27 @kc87_second_51 -140;
+    pos @kc87_first_27 @kc87_second_58 -35;
+    pos @kc87_first_27 @kc87_second_63 -70;
+    pos @kc87_first_27 @kc87_second_64 -35;
+    pos @kc87_first_28 @kc87_second_48 1;
     pos @kc87_first_29 @kc87_second_8 -70;
     pos @kc87_first_29 @kc87_second_9 -210;
     pos @kc87_first_29 @kc87_second_12 -350;
@@ -9287,17 +9336,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_29 @kc87_second_14 -210;
     pos @kc87_first_29 @kc87_second_15 -175;
     pos @kc87_first_29 @kc87_second_25 -70;
-    pos @kc87_first_29 @kc87_second_38 -35;
-    pos @kc87_first_29 @kc87_second_39 -210;
+    pos @kc87_first_29 @kc87_second_39 -35;
     pos @kc87_first_29 @kc87_second_40 -210;
+    pos @kc87_first_29 @kc87_second_41 -210;
     pos @kc87_first_29 @kc87_second_43 -210;
-    pos @kc87_first_29 @kc87_second_45 1;
-    pos @kc87_first_29 @kc87_second_47 -140;
-    pos @kc87_first_29 @kc87_second_48 -280;
-    pos @kc87_first_29 @kc87_second_58 -210;
-    pos @kc87_first_29 @kc87_second_60 -105;
-    pos @kc87_first_29 @kc87_second_61 -175;
-    pos @kc87_first_29 @kc87_second_62 -140;
+    pos @kc87_first_29 @kc87_second_48 1;
+    pos @kc87_first_29 @kc87_second_50 -140;
+    pos @kc87_first_29 @kc87_second_51 -280;
+    pos @kc87_first_29 @kc87_second_60 -210;
+    pos @kc87_first_29 @kc87_second_62 -105;
+    pos @kc87_first_29 @kc87_second_63 -175;
+    pos @kc87_first_29 @kc87_second_64 -140;
     pos @kc87_first_30 @kc87_second_1 -175;
     pos @kc87_first_30 @kc87_second_2 -175;
     pos @kc87_first_30 @kc87_second_5 -70;
@@ -9313,16 +9362,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_30 @kc87_second_19 -175;
     pos @kc87_first_30 @kc87_second_22 -70;
     pos @kc87_first_30 @kc87_second_29 -105;
-    pos @kc87_first_30 @kc87_second_33 105;
-    pos @kc87_first_30 @kc87_second_34 -105;
-    pos @kc87_first_30 @kc87_second_35 -175;
-    pos @kc87_first_30 @kc87_second_36 -35;
-    pos @kc87_first_30 @kc87_second_38 -70;
-    pos @kc87_first_30 @kc87_second_45 1;
-    pos @kc87_first_30 @kc87_second_50 105;
-    pos @kc87_first_30 @kc87_second_51 -35;
-    pos @kc87_first_30 @kc87_second_63 -70;
-    pos @kc87_first_30 @kc87_second_64 -105;
+    pos @kc87_first_30 @kc87_second_34 105;
+    pos @kc87_first_30 @kc87_second_35 -105;
+    pos @kc87_first_30 @kc87_second_36 -175;
+    pos @kc87_first_30 @kc87_second_37 -35;
+    pos @kc87_first_30 @kc87_second_39 -70;
+    pos @kc87_first_30 @kc87_second_48 1;
+    pos @kc87_first_30 @kc87_second_52 105;
+    pos @kc87_first_30 @kc87_second_53 -35;
+    pos @kc87_first_30 @kc87_second_65 -70;
+    pos @kc87_first_30 @kc87_second_66 -105;
     pos @kc87_first_31 @kc87_second_3 -70;
     pos @kc87_first_31 @kc87_second_4 -35;
     pos @kc87_first_31 @kc87_second_6 -70;
@@ -9332,16 +9381,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_31 @kc87_second_22 -70;
     pos @kc87_first_31 @kc87_second_23 -140;
     pos @kc87_first_31 @kc87_second_29 -35;
-    pos @kc87_first_31 @kc87_second_34 -70;
-    pos @kc87_first_31 @kc87_second_36 -35;
-    pos @kc87_first_31 @kc87_second_38 -140;
-    pos @kc87_first_31 @kc87_second_39 -70;
-    pos @kc87_first_31 @kc87_second_45 1;
-    pos @kc87_first_31 @kc87_second_51 -35;
-    pos @kc87_first_31 @kc87_second_52 -35;
-    pos @kc87_first_31 @kc87_second_58 -140;
-    pos @kc87_first_31 @kc87_second_63 -70;
-    pos @kc87_first_31 @kc87_second_64 -70;
+    pos @kc87_first_31 @kc87_second_32 -70;
+    pos @kc87_first_31 @kc87_second_35 -70;
+    pos @kc87_first_31 @kc87_second_37 -35;
+    pos @kc87_first_31 @kc87_second_39 -140;
+    pos @kc87_first_31 @kc87_second_40 -70;
+    pos @kc87_first_31 @kc87_second_48 1;
+    pos @kc87_first_31 @kc87_second_53 -35;
+    pos @kc87_first_31 @kc87_second_54 -35;
+    pos @kc87_first_31 @kc87_second_60 -140;
+    pos @kc87_first_31 @kc87_second_65 -70;
+    pos @kc87_first_31 @kc87_second_66 -70;
     pos @kc87_first_32 @kc87_second_1 -35;
     pos @kc87_first_32 @kc87_second_2 -105;
     pos @kc87_first_32 @kc87_second_3 -70;
@@ -9355,20 +9405,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_32 @kc87_second_16 -70;
     pos @kc87_first_32 @kc87_second_24 -35;
     pos @kc87_first_32 @kc87_second_27 -70;
-    pos @kc87_first_32 @kc87_second_35 -35;
-    pos @kc87_first_32 @kc87_second_39 -35;
+    pos @kc87_first_32 @kc87_second_36 -35;
     pos @kc87_first_32 @kc87_second_40 -35;
-    pos @kc87_first_32 @kc87_second_42 -35;
+    pos @kc87_first_32 @kc87_second_41 -35;
     pos @kc87_first_32 @kc87_second_43 -140;
-    pos @kc87_first_32 @kc87_second_45 1;
-    pos @kc87_first_32 @kc87_second_47 -50;
-    pos @kc87_first_32 @kc87_second_48 -140;
-    pos @kc87_first_32 @kc87_second_49 -35;
-    pos @kc87_first_32 @kc87_second_53 -70;
+    pos @kc87_first_32 @kc87_second_44 -70;
+    pos @kc87_first_32 @kc87_second_45 -35;
+    pos @kc87_first_32 @kc87_second_47 -35;
+    pos @kc87_first_32 @kc87_second_48 1;
+    pos @kc87_first_32 @kc87_second_50 -50;
+    pos @kc87_first_32 @kc87_second_51 -140;
     pos @kc87_first_32 @kc87_second_55 -70;
     pos @kc87_first_32 @kc87_second_57 -70;
-    pos @kc87_first_32 @kc87_second_61 -70;
-    pos @kc87_first_32 @kc87_second_62 -35;
+    pos @kc87_first_32 @kc87_second_59 -70;
+    pos @kc87_first_32 @kc87_second_63 -70;
+    pos @kc87_first_32 @kc87_second_64 -35;
     pos @kc87_first_33 @kc87_second_3 -35;
     pos @kc87_first_33 @kc87_second_4 -70;
     pos @kc87_first_33 @kc87_second_6 -70;
@@ -9381,33 +9432,34 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_33 @kc87_second_22 -105;
     pos @kc87_first_33 @kc87_second_23 -70;
     pos @kc87_first_33 @kc87_second_29 -35;
-    pos @kc87_first_33 @kc87_second_34 -70;
-    pos @kc87_first_33 @kc87_second_36 -70;
-    pos @kc87_first_33 @kc87_second_38 -105;
-    pos @kc87_first_33 @kc87_second_39 -70;
-    pos @kc87_first_33 @kc87_second_44 -70;
-    pos @kc87_first_33 @kc87_second_45 1;
-    pos @kc87_first_33 @kc87_second_51 -35;
-    pos @kc87_first_33 @kc87_second_52 -35;
-    pos @kc87_first_33 @kc87_second_63 -70;
-    pos @kc87_first_33 @kc87_second_64 -70;
-    pos @kc87_first_34 @kc87_second_32 -315;
-    pos @kc87_first_34 @kc87_second_45 1;
+    pos @kc87_first_33 @kc87_second_32 -70;
+    pos @kc87_first_33 @kc87_second_35 -70;
+    pos @kc87_first_33 @kc87_second_37 -70;
+    pos @kc87_first_33 @kc87_second_39 -105;
+    pos @kc87_first_33 @kc87_second_40 -70;
+    pos @kc87_first_33 @kc87_second_46 -70;
+    pos @kc87_first_33 @kc87_second_48 1;
+    pos @kc87_first_33 @kc87_second_53 -35;
+    pos @kc87_first_33 @kc87_second_54 -35;
+    pos @kc87_first_33 @kc87_second_65 -70;
+    pos @kc87_first_33 @kc87_second_66 -70;
+    pos @kc87_first_34 @kc87_second_33 -315;
+    pos @kc87_first_34 @kc87_second_48 1;
     pos @kc87_first_35 @kc87_second_9 -70;
     pos @kc87_first_35 @kc87_second_12 -240;
     pos @kc87_first_35 @kc87_second_13 -210;
     pos @kc87_first_35 @kc87_second_14 -140;
     pos @kc87_first_35 @kc87_second_15 -105;
-    pos @kc87_first_35 @kc87_second_39 -70;
-    pos @kc87_first_35 @kc87_second_40 -35;
+    pos @kc87_first_35 @kc87_second_40 -70;
+    pos @kc87_first_35 @kc87_second_41 -35;
     pos @kc87_first_35 @kc87_second_43 -140;
-    pos @kc87_first_35 @kc87_second_45 1;
-    pos @kc87_first_35 @kc87_second_47 -50;
-    pos @kc87_first_35 @kc87_second_48 -140;
-    pos @kc87_first_35 @kc87_second_58 -35;
+    pos @kc87_first_35 @kc87_second_48 1;
+    pos @kc87_first_35 @kc87_second_50 -50;
+    pos @kc87_first_35 @kc87_second_51 -140;
     pos @kc87_first_35 @kc87_second_60 -35;
-    pos @kc87_first_35 @kc87_second_61 -70;
-    pos @kc87_first_35 @kc87_second_62 -70;
+    pos @kc87_first_35 @kc87_second_62 -35;
+    pos @kc87_first_35 @kc87_second_63 -70;
+    pos @kc87_first_35 @kc87_second_64 -70;
     pos @kc87_first_36 @kc87_second_9 -35;
     pos @kc87_first_36 @kc87_second_12 -240;
     pos @kc87_first_36 @kc87_second_13 -240;
@@ -9416,15 +9468,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_36 @kc87_second_16 -35;
     pos @kc87_first_36 @kc87_second_26 -35;
     pos @kc87_first_36 @kc87_second_27 -35;
-    pos @kc87_first_36 @kc87_second_39 -70;
-    pos @kc87_first_36 @kc87_second_40 -35;
+    pos @kc87_first_36 @kc87_second_40 -70;
+    pos @kc87_first_36 @kc87_second_41 -35;
     pos @kc87_first_36 @kc87_second_43 -70;
-    pos @kc87_first_36 @kc87_second_45 1;
-    pos @kc87_first_36 @kc87_second_47 -35;
-    pos @kc87_first_36 @kc87_second_48 -70;
-    pos @kc87_first_36 @kc87_second_60 -35;
-    pos @kc87_first_36 @kc87_second_61 -70;
-    pos @kc87_first_36 @kc87_second_62 -70;
+    pos @kc87_first_36 @kc87_second_44 -35;
+    pos @kc87_first_36 @kc87_second_48 1;
+    pos @kc87_first_36 @kc87_second_50 -35;
+    pos @kc87_first_36 @kc87_second_51 -70;
+    pos @kc87_first_36 @kc87_second_62 -35;
+    pos @kc87_first_36 @kc87_second_63 -70;
+    pos @kc87_first_36 @kc87_second_64 -70;
     pos @kc87_first_37 @kc87_second_5 -70;
     pos @kc87_first_37 @kc87_second_9 -70;
     pos @kc87_first_37 @kc87_second_12 -140;
@@ -9434,619 +9487,636 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_37 @kc87_second_16 -70;
     pos @kc87_first_37 @kc87_second_26 -70;
     pos @kc87_first_37 @kc87_second_27 -70;
-    pos @kc87_first_37 @kc87_second_35 -50;
-    pos @kc87_first_37 @kc87_second_39 -50;
-    pos @kc87_first_37 @kc87_second_40 -35;
-    pos @kc87_first_37 @kc87_second_45 1;
-    pos @kc87_first_37 @kc87_second_47 -35;
-    pos @kc87_first_37 @kc87_second_48 -140;
-    pos @kc87_first_37 @kc87_second_56 -35;
-    pos @kc87_first_37 @kc87_second_61 -70;
-    pos @kc87_first_37 @kc87_second_62 -35;
-    pos @kc87_first_38 @kc87_second_1 -210;
-    pos @kc87_first_38 @kc87_second_2 -280;
-    pos @kc87_first_38 @kc87_second_6 -280;
-    pos @kc87_first_38 @kc87_second_8 -70;
-    pos @kc87_first_38 @kc87_second_17 -140;
-    pos @kc87_first_38 @kc87_second_19 -350;
-    pos @kc87_first_38 @kc87_second_20 -140;
-    pos @kc87_first_38 @kc87_second_22 -140;
-    pos @kc87_first_38 @kc87_second_23 -70;
-    pos @kc87_first_38 @kc87_second_24 -280;
-    pos @kc87_first_38 @kc87_second_28 -315;
-    pos @kc87_first_38 @kc87_second_29 -140;
-    pos @kc87_first_38 @kc87_second_32 -385;
-    pos @kc87_first_38 @kc87_second_34 -210;
+    pos @kc87_first_37 @kc87_second_36 -50;
+    pos @kc87_first_37 @kc87_second_40 -50;
+    pos @kc87_first_37 @kc87_second_41 -35;
+    pos @kc87_first_37 @kc87_second_48 1;
+    pos @kc87_first_37 @kc87_second_50 -35;
+    pos @kc87_first_37 @kc87_second_51 -140;
+    pos @kc87_first_37 @kc87_second_58 -35;
+    pos @kc87_first_37 @kc87_second_63 -70;
+    pos @kc87_first_37 @kc87_second_64 -35;
+    pos @kc87_first_38 @kc87_second_3 -140;
+    pos @kc87_first_38 @kc87_second_4 -70;
+    pos @kc87_first_38 @kc87_second_6 -70;
+    pos @kc87_first_38 @kc87_second_8 -210;
+    pos @kc87_first_38 @kc87_second_9 -420;
+    pos @kc87_first_38 @kc87_second_12 -350;
+    pos @kc87_first_38 @kc87_second_13 -420;
+    pos @kc87_first_38 @kc87_second_14 -350;
+    pos @kc87_first_38 @kc87_second_15 -280;
+    pos @kc87_first_38 @kc87_second_17 -70;
+    pos @kc87_first_38 @kc87_second_18 -210;
+    pos @kc87_first_38 @kc87_second_20 -210;
+    pos @kc87_first_38 @kc87_second_22 -70;
+    pos @kc87_first_38 @kc87_second_23 -140;
+    pos @kc87_first_38 @kc87_second_29 -35;
+    pos @kc87_first_38 @kc87_second_31 -140;
+    pos @kc87_first_38 @kc87_second_32 -70;
     pos @kc87_first_38 @kc87_second_35 -70;
-    pos @kc87_first_38 @kc87_second_36 -140;
-    pos @kc87_first_38 @kc87_second_37 -140;
-    pos @kc87_first_38 @kc87_second_38 -140;
-    pos @kc87_first_38 @kc87_second_41 -70;
-    pos @kc87_first_38 @kc87_second_45 1;
-    pos @kc87_first_38 @kc87_second_51 -140;
-    pos @kc87_first_38 @kc87_second_52 -70;
-    pos @kc87_first_38 @kc87_second_53 -140;
-    pos @kc87_first_38 @kc87_second_55 -245;
-    pos @kc87_first_38 @kc87_second_58 -70;
-    pos @kc87_first_38 @kc87_second_59 -70;
-    pos @kc87_first_38 @kc87_second_63 -245;
-    pos @kc87_first_38 @kc87_second_64 -280;
-    pos @kc87_first_38 @kc87_second_65 -315;
+    pos @kc87_first_38 @kc87_second_37 -70;
+    pos @kc87_first_38 @kc87_second_39 -210;
+    pos @kc87_first_38 @kc87_second_40 -280;
+    pos @kc87_first_38 @kc87_second_41 -420;
+    pos @kc87_first_38 @kc87_second_43 -350;
+    pos @kc87_first_38 @kc87_second_44 -280;
+    pos @kc87_first_38 @kc87_second_48 1;
+    pos @kc87_first_38 @kc87_second_49 -35;
+    pos @kc87_first_38 @kc87_second_50 -210;
+    pos @kc87_first_38 @kc87_second_51 -350;
+    pos @kc87_first_38 @kc87_second_53 -35;
+    pos @kc87_first_38 @kc87_second_54 -35;
+    pos @kc87_first_38 @kc87_second_60 -280;
+    pos @kc87_first_38 @kc87_second_62 -175;
+    pos @kc87_first_38 @kc87_second_63 -280;
+    pos @kc87_first_38 @kc87_second_64 -210;
+    pos @kc87_first_38 @kc87_second_65 -70;
+    pos @kc87_first_39 @kc87_second_1 -35;
+    pos @kc87_first_39 @kc87_second_2 -70;
+    pos @kc87_first_39 @kc87_second_5 -105;
     pos @kc87_first_39 @kc87_second_6 -35;
+    pos @kc87_first_39 @kc87_second_9 -70;
+    pos @kc87_first_39 @kc87_second_11 -70;
     pos @kc87_first_39 @kc87_second_12 -240;
-    pos @kc87_first_39 @kc87_second_13 -140;
-    pos @kc87_first_39 @kc87_second_14 -35;
-    pos @kc87_first_39 @kc87_second_15 -35;
-    pos @kc87_first_39 @kc87_second_34 -35;
-    pos @kc87_first_39 @kc87_second_45 1;
-    pos @kc87_first_39 @kc87_second_63 -35;
-    pos @kc87_first_39 @kc87_second_64 -35;
-    pos @kc87_first_40 @kc87_second_12 -210;
-    pos @kc87_first_40 @kc87_second_13 -175;
-    pos @kc87_first_40 @kc87_second_14 -105;
-    pos @kc87_first_40 @kc87_second_15 -70;
-    pos @kc87_first_40 @kc87_second_43 -70;
-    pos @kc87_first_40 @kc87_second_45 1;
-    pos @kc87_first_40 @kc87_second_48 -105;
+    pos @kc87_first_39 @kc87_second_13 -245;
+    pos @kc87_first_39 @kc87_second_14 -140;
+    pos @kc87_first_39 @kc87_second_15 -105;
+    pos @kc87_first_39 @kc87_second_16 -105;
+    pos @kc87_first_39 @kc87_second_18 -70;
+    pos @kc87_first_39 @kc87_second_19 -70;
+    pos @kc87_first_39 @kc87_second_24 -35;
+    pos @kc87_first_39 @kc87_second_25 -70;
+    pos @kc87_first_39 @kc87_second_26 -140;
+    pos @kc87_first_39 @kc87_second_27 -105;
+    pos @kc87_first_39 @kc87_second_35 -35;
+    pos @kc87_first_39 @kc87_second_36 -140;
+    pos @kc87_first_39 @kc87_second_40 -105;
+    pos @kc87_first_39 @kc87_second_41 -70;
+    pos @kc87_first_39 @kc87_second_43 -175;
+    pos @kc87_first_39 @kc87_second_45 -105;
+    pos @kc87_first_39 @kc87_second_47 -70;
+    pos @kc87_first_39 @kc87_second_48 1;
+    pos @kc87_first_39 @kc87_second_50 -70;
+    pos @kc87_first_39 @kc87_second_51 -140;
+    pos @kc87_first_39 @kc87_second_55 -210;
+    pos @kc87_first_39 @kc87_second_56 -70;
+    pos @kc87_first_39 @kc87_second_57 -175;
+    pos @kc87_first_39 @kc87_second_58 -105;
+    pos @kc87_first_39 @kc87_second_59 -175;
+    pos @kc87_first_39 @kc87_second_62 -50;
+    pos @kc87_first_39 @kc87_second_63 -105;
+    pos @kc87_first_39 @kc87_second_64 -70;
+    pos @kc87_first_39 @kc87_second_66 -35;
+    pos @kc87_first_40 @kc87_second_1 -210;
+    pos @kc87_first_40 @kc87_second_2 -280;
+    pos @kc87_first_40 @kc87_second_6 -280;
+    pos @kc87_first_40 @kc87_second_8 -70;
+    pos @kc87_first_40 @kc87_second_17 -140;
+    pos @kc87_first_40 @kc87_second_19 -350;
+    pos @kc87_first_40 @kc87_second_20 -140;
+    pos @kc87_first_40 @kc87_second_22 -140;
+    pos @kc87_first_40 @kc87_second_23 -70;
+    pos @kc87_first_40 @kc87_second_24 -280;
+    pos @kc87_first_40 @kc87_second_28 -315;
+    pos @kc87_first_40 @kc87_second_29 -140;
+    pos @kc87_first_40 @kc87_second_33 -385;
+    pos @kc87_first_40 @kc87_second_35 -210;
+    pos @kc87_first_40 @kc87_second_36 -70;
+    pos @kc87_first_40 @kc87_second_37 -140;
+    pos @kc87_first_40 @kc87_second_38 -140;
+    pos @kc87_first_40 @kc87_second_39 -140;
+    pos @kc87_first_40 @kc87_second_42 -70;
+    pos @kc87_first_40 @kc87_second_48 1;
+    pos @kc87_first_40 @kc87_second_53 -140;
+    pos @kc87_first_40 @kc87_second_54 -70;
+    pos @kc87_first_40 @kc87_second_55 -140;
+    pos @kc87_first_40 @kc87_second_57 -245;
+    pos @kc87_first_40 @kc87_second_60 -70;
     pos @kc87_first_40 @kc87_second_61 -70;
-    pos @kc87_first_41 @kc87_second_1 -140;
-    pos @kc87_first_41 @kc87_second_2 -175;
-    pos @kc87_first_41 @kc87_second_5 -105;
-    pos @kc87_first_41 @kc87_second_6 -70;
-    pos @kc87_first_41 @kc87_second_11 -70;
-    pos @kc87_first_41 @kc87_second_12 -175;
-    pos @kc87_first_41 @kc87_second_13 -105;
-    pos @kc87_first_41 @kc87_second_14 -70;
+    pos @kc87_first_40 @kc87_second_65 -245;
+    pos @kc87_first_40 @kc87_second_66 -280;
+    pos @kc87_first_40 @kc87_second_67 -315;
+    pos @kc87_first_41 @kc87_second_6 -35;
+    pos @kc87_first_41 @kc87_second_12 -240;
+    pos @kc87_first_41 @kc87_second_13 -140;
+    pos @kc87_first_41 @kc87_second_14 -35;
     pos @kc87_first_41 @kc87_second_15 -35;
-    pos @kc87_first_41 @kc87_second_16 -105;
-    pos @kc87_first_41 @kc87_second_17 -35;
-    pos @kc87_first_41 @kc87_second_19 -175;
-    pos @kc87_first_41 @kc87_second_22 -50;
-    pos @kc87_first_41 @kc87_second_24 -105;
-    pos @kc87_first_41 @kc87_second_29 -35;
-    pos @kc87_first_41 @kc87_second_34 -70;
-    pos @kc87_first_41 @kc87_second_35 -140;
-    pos @kc87_first_41 @kc87_second_36 -35;
-    pos @kc87_first_41 @kc87_second_38 -50;
-    pos @kc87_first_41 @kc87_second_45 1;
-    pos @kc87_first_41 @kc87_second_51 -35;
-    pos @kc87_first_41 @kc87_second_53 -105;
-    pos @kc87_first_41 @kc87_second_55 -105;
-    pos @kc87_first_41 @kc87_second_57 -105;
-    pos @kc87_first_41 @kc87_second_63 -50;
-    pos @kc87_first_41 @kc87_second_64 -70;
-    pos @kc87_first_42 @kc87_second_1 -210;
-    pos @kc87_first_42 @kc87_second_2 -280;
-    pos @kc87_first_42 @kc87_second_3 -70;
-    pos @kc87_first_42 @kc87_second_6 -280;
-    pos @kc87_first_42 @kc87_second_8 -35;
-    pos @kc87_first_42 @kc87_second_11 -70;
-    pos @kc87_first_42 @kc87_second_13 -140;
-    pos @kc87_first_42 @kc87_second_14 -35;
-    pos @kc87_first_42 @kc87_second_15 -35;
-    pos @kc87_first_42 @kc87_second_16 -140;
-    pos @kc87_first_42 @kc87_second_17 -105;
-    pos @kc87_first_42 @kc87_second_19 -280;
-    pos @kc87_first_42 @kc87_second_20 -140;
-    pos @kc87_first_42 @kc87_second_22 -140;
-    pos @kc87_first_42 @kc87_second_23 -140;
-    pos @kc87_first_42 @kc87_second_24 -210;
-    pos @kc87_first_42 @kc87_second_34 -280;
-    pos @kc87_first_42 @kc87_second_35 -140;
-    pos @kc87_first_42 @kc87_second_36 -70;
-    pos @kc87_first_42 @kc87_second_37 -140;
-    pos @kc87_first_42 @kc87_second_38 -175;
-    pos @kc87_first_42 @kc87_second_44 -70;
-    pos @kc87_first_42 @kc87_second_45 1;
-    pos @kc87_first_42 @kc87_second_53 -210;
-    pos @kc87_first_42 @kc87_second_55 -175;
-    pos @kc87_first_42 @kc87_second_57 -210;
-    pos @kc87_first_42 @kc87_second_59 -70;
-    pos @kc87_first_42 @kc87_second_63 -175;
-    pos @kc87_first_42 @kc87_second_64 -175;
-    pos @kc87_first_43 @kc87_second_9 -70;
-    pos @kc87_first_43 @kc87_second_12 -240;
-    pos @kc87_first_43 @kc87_second_13 -210;
-    pos @kc87_first_43 @kc87_second_14 -140;
-    pos @kc87_first_43 @kc87_second_15 -105;
-    pos @kc87_first_43 @kc87_second_39 -70;
-    pos @kc87_first_43 @kc87_second_40 -35;
-    pos @kc87_first_43 @kc87_second_43 -140;
-    pos @kc87_first_43 @kc87_second_45 1;
-    pos @kc87_first_43 @kc87_second_47 -50;
-    pos @kc87_first_43 @kc87_second_48 -140;
-    pos @kc87_first_43 @kc87_second_58 -35;
-    pos @kc87_first_43 @kc87_second_60 -35;
-    pos @kc87_first_43 @kc87_second_61 -70;
-    pos @kc87_first_43 @kc87_second_62 -70;
+    pos @kc87_first_41 @kc87_second_35 -35;
+    pos @kc87_first_41 @kc87_second_48 1;
+    pos @kc87_first_41 @kc87_second_65 -35;
+    pos @kc87_first_41 @kc87_second_66 -35;
+    pos @kc87_first_42 @kc87_second_12 -210;
+    pos @kc87_first_42 @kc87_second_13 -175;
+    pos @kc87_first_42 @kc87_second_14 -105;
+    pos @kc87_first_42 @kc87_second_15 -70;
+    pos @kc87_first_42 @kc87_second_43 -70;
+    pos @kc87_first_42 @kc87_second_44 -35;
+    pos @kc87_first_42 @kc87_second_48 1;
+    pos @kc87_first_42 @kc87_second_51 -105;
+    pos @kc87_first_42 @kc87_second_63 -70;
+    pos @kc87_first_43 @kc87_second_1 -140;
+    pos @kc87_first_43 @kc87_second_2 -175;
+    pos @kc87_first_43 @kc87_second_5 -105;
+    pos @kc87_first_43 @kc87_second_6 -70;
+    pos @kc87_first_43 @kc87_second_11 -70;
+    pos @kc87_first_43 @kc87_second_12 -175;
+    pos @kc87_first_43 @kc87_second_13 -105;
+    pos @kc87_first_43 @kc87_second_14 -70;
+    pos @kc87_first_43 @kc87_second_15 -35;
+    pos @kc87_first_43 @kc87_second_16 -105;
+    pos @kc87_first_43 @kc87_second_17 -35;
+    pos @kc87_first_43 @kc87_second_19 -175;
+    pos @kc87_first_43 @kc87_second_22 -50;
+    pos @kc87_first_43 @kc87_second_24 -105;
+    pos @kc87_first_43 @kc87_second_29 -35;
+    pos @kc87_first_43 @kc87_second_32 -70;
+    pos @kc87_first_43 @kc87_second_35 -70;
+    pos @kc87_first_43 @kc87_second_36 -140;
+    pos @kc87_first_43 @kc87_second_37 -35;
+    pos @kc87_first_43 @kc87_second_39 -50;
+    pos @kc87_first_43 @kc87_second_48 1;
+    pos @kc87_first_43 @kc87_second_53 -35;
+    pos @kc87_first_43 @kc87_second_55 -105;
+    pos @kc87_first_43 @kc87_second_57 -105;
+    pos @kc87_first_43 @kc87_second_59 -105;
+    pos @kc87_first_43 @kc87_second_65 -50;
+    pos @kc87_first_43 @kc87_second_66 -70;
+    pos @kc87_first_44 @kc87_second_1 -210;
+    pos @kc87_first_44 @kc87_second_2 -280;
+    pos @kc87_first_44 @kc87_second_3 -70;
+    pos @kc87_first_44 @kc87_second_6 -280;
     pos @kc87_first_44 @kc87_second_8 -35;
-    pos @kc87_first_44 @kc87_second_9 -70;
-    pos @kc87_first_44 @kc87_second_12 -240;
-    pos @kc87_first_44 @kc87_second_13 -210;
-    pos @kc87_first_44 @kc87_second_14 -70;
-    pos @kc87_first_44 @kc87_second_15 -105;
-    pos @kc87_first_44 @kc87_second_22 -35;
-    pos @kc87_first_44 @kc87_second_38 -70;
-    pos @kc87_first_44 @kc87_second_39 -105;
-    pos @kc87_first_44 @kc87_second_40 -70;
-    pos @kc87_first_44 @kc87_second_43 -70;
-    pos @kc87_first_44 @kc87_second_44 -35;
-    pos @kc87_first_44 @kc87_second_45 1;
-    pos @kc87_first_44 @kc87_second_47 -70;
-    pos @kc87_first_44 @kc87_second_48 -70;
-    pos @kc87_first_44 @kc87_second_58 -70;
-    pos @kc87_first_44 @kc87_second_60 -50;
-    pos @kc87_first_44 @kc87_second_62 -70;
-    pos @kc87_first_44 @kc87_second_63 -35;
-    pos @kc87_first_44 @kc87_second_64 -35;
-    pos @kc87_first_45 @kc87_second_6 -70;
-    pos @kc87_first_45 @kc87_second_8 -35;
-    pos @kc87_first_45 @kc87_second_12 -175;
-    pos @kc87_first_45 @kc87_second_13 -140;
-    pos @kc87_first_45 @kc87_second_14 -70;
-    pos @kc87_first_45 @kc87_second_15 -35;
-    pos @kc87_first_45 @kc87_second_17 -70;
-    pos @kc87_first_45 @kc87_second_20 -70;
-    pos @kc87_first_45 @kc87_second_22 -105;
-    pos @kc87_first_45 @kc87_second_29 -35;
-    pos @kc87_first_45 @kc87_second_34 -70;
-    pos @kc87_first_45 @kc87_second_36 -35;
-    pos @kc87_first_45 @kc87_second_38 -105;
-    pos @kc87_first_45 @kc87_second_45 1;
-    pos @kc87_first_45 @kc87_second_51 -35;
+    pos @kc87_first_44 @kc87_second_11 -70;
+    pos @kc87_first_44 @kc87_second_13 -140;
+    pos @kc87_first_44 @kc87_second_14 -35;
+    pos @kc87_first_44 @kc87_second_15 -35;
+    pos @kc87_first_44 @kc87_second_16 -140;
+    pos @kc87_first_44 @kc87_second_17 -105;
+    pos @kc87_first_44 @kc87_second_19 -280;
+    pos @kc87_first_44 @kc87_second_20 -140;
+    pos @kc87_first_44 @kc87_second_22 -140;
+    pos @kc87_first_44 @kc87_second_23 -140;
+    pos @kc87_first_44 @kc87_second_24 -210;
+    pos @kc87_first_44 @kc87_second_32 -70;
+    pos @kc87_first_44 @kc87_second_35 -280;
+    pos @kc87_first_44 @kc87_second_36 -140;
+    pos @kc87_first_44 @kc87_second_37 -70;
+    pos @kc87_first_44 @kc87_second_38 -140;
+    pos @kc87_first_44 @kc87_second_39 -175;
+    pos @kc87_first_44 @kc87_second_46 -70;
+    pos @kc87_first_44 @kc87_second_48 1;
+    pos @kc87_first_44 @kc87_second_55 -210;
+    pos @kc87_first_44 @kc87_second_57 -175;
+    pos @kc87_first_44 @kc87_second_59 -210;
+    pos @kc87_first_44 @kc87_second_61 -70;
+    pos @kc87_first_44 @kc87_second_65 -175;
+    pos @kc87_first_44 @kc87_second_66 -175;
+    pos @kc87_first_45 @kc87_second_9 -70;
+    pos @kc87_first_45 @kc87_second_12 -240;
+    pos @kc87_first_45 @kc87_second_13 -210;
+    pos @kc87_first_45 @kc87_second_14 -140;
+    pos @kc87_first_45 @kc87_second_15 -105;
+    pos @kc87_first_45 @kc87_second_40 -70;
+    pos @kc87_first_45 @kc87_second_41 -35;
+    pos @kc87_first_45 @kc87_second_43 -140;
+    pos @kc87_first_45 @kc87_second_44 -70;
+    pos @kc87_first_45 @kc87_second_48 1;
+    pos @kc87_first_45 @kc87_second_50 -50;
+    pos @kc87_first_45 @kc87_second_51 -140;
+    pos @kc87_first_45 @kc87_second_60 -35;
+    pos @kc87_first_45 @kc87_second_62 -35;
     pos @kc87_first_45 @kc87_second_63 -70;
     pos @kc87_first_45 @kc87_second_64 -70;
-    pos @kc87_first_46 @kc87_second_3 -140;
-    pos @kc87_first_46 @kc87_second_4 -70;
-    pos @kc87_first_46 @kc87_second_6 -70;
-    pos @kc87_first_46 @kc87_second_8 -210;
-    pos @kc87_first_46 @kc87_second_9 -420;
-    pos @kc87_first_46 @kc87_second_12 -350;
-    pos @kc87_first_46 @kc87_second_13 -420;
-    pos @kc87_first_46 @kc87_second_14 -350;
-    pos @kc87_first_46 @kc87_second_15 -280;
-    pos @kc87_first_46 @kc87_second_17 -70;
-    pos @kc87_first_46 @kc87_second_18 -210;
-    pos @kc87_first_46 @kc87_second_20 -210;
-    pos @kc87_first_46 @kc87_second_22 -70;
-    pos @kc87_first_46 @kc87_second_23 -140;
-    pos @kc87_first_46 @kc87_second_29 -35;
-    pos @kc87_first_46 @kc87_second_31 -140;
-    pos @kc87_first_46 @kc87_second_34 -70;
-    pos @kc87_first_46 @kc87_second_36 -70;
-    pos @kc87_first_46 @kc87_second_38 -210;
-    pos @kc87_first_46 @kc87_second_39 -280;
-    pos @kc87_first_46 @kc87_second_40 -420;
-    pos @kc87_first_46 @kc87_second_43 -350;
-    pos @kc87_first_46 @kc87_second_45 1;
+    pos @kc87_first_46 @kc87_second_8 -35;
+    pos @kc87_first_46 @kc87_second_9 -70;
+    pos @kc87_first_46 @kc87_second_12 -240;
+    pos @kc87_first_46 @kc87_second_13 -210;
+    pos @kc87_first_46 @kc87_second_14 -70;
+    pos @kc87_first_46 @kc87_second_15 -105;
+    pos @kc87_first_46 @kc87_second_22 -35;
+    pos @kc87_first_46 @kc87_second_39 -70;
+    pos @kc87_first_46 @kc87_second_40 -105;
+    pos @kc87_first_46 @kc87_second_41 -70;
+    pos @kc87_first_46 @kc87_second_43 -70;
     pos @kc87_first_46 @kc87_second_46 -35;
-    pos @kc87_first_46 @kc87_second_47 -210;
-    pos @kc87_first_46 @kc87_second_48 -350;
-    pos @kc87_first_46 @kc87_second_51 -35;
-    pos @kc87_first_46 @kc87_second_52 -35;
-    pos @kc87_first_46 @kc87_second_58 -280;
-    pos @kc87_first_46 @kc87_second_60 -175;
-    pos @kc87_first_46 @kc87_second_61 -280;
-    pos @kc87_first_46 @kc87_second_62 -210;
-    pos @kc87_first_46 @kc87_second_63 -70;
-    pos @kc87_first_47 @kc87_second_3 -140;
-    pos @kc87_first_47 @kc87_second_4 -105;
+    pos @kc87_first_46 @kc87_second_48 1;
+    pos @kc87_first_46 @kc87_second_50 -70;
+    pos @kc87_first_46 @kc87_second_51 -70;
+    pos @kc87_first_46 @kc87_second_60 -70;
+    pos @kc87_first_46 @kc87_second_62 -50;
+    pos @kc87_first_46 @kc87_second_64 -70;
+    pos @kc87_first_46 @kc87_second_65 -35;
+    pos @kc87_first_46 @kc87_second_66 -35;
     pos @kc87_first_47 @kc87_second_6 -70;
-    pos @kc87_first_47 @kc87_second_8 -210;
-    pos @kc87_first_47 @kc87_second_9 -280;
-    pos @kc87_first_47 @kc87_second_12 -350;
-    pos @kc87_first_47 @kc87_second_13 -385;
-    pos @kc87_first_47 @kc87_second_14 -350;
-    pos @kc87_first_47 @kc87_second_15 -280;
-    pos @kc87_first_47 @kc87_second_18 -210;
-    pos @kc87_first_47 @kc87_second_20 -140;
+    pos @kc87_first_47 @kc87_second_8 -35;
+    pos @kc87_first_47 @kc87_second_12 -175;
+    pos @kc87_first_47 @kc87_second_13 -140;
+    pos @kc87_first_47 @kc87_second_14 -70;
+    pos @kc87_first_47 @kc87_second_15 -35;
+    pos @kc87_first_47 @kc87_second_17 -70;
+    pos @kc87_first_47 @kc87_second_20 -70;
     pos @kc87_first_47 @kc87_second_22 -105;
-    pos @kc87_first_47 @kc87_second_23 -140;
-    pos @kc87_first_47 @kc87_second_29 -70;
-    pos @kc87_first_47 @kc87_second_31 -175;
-    pos @kc87_first_47 @kc87_second_34 -70;
-    pos @kc87_first_47 @kc87_second_36 -35;
-    pos @kc87_first_47 @kc87_second_38 -175;
-    pos @kc87_first_47 @kc87_second_39 -280;
-    pos @kc87_first_47 @kc87_second_40 -280;
-    pos @kc87_first_47 @kc87_second_43 -280;
-    pos @kc87_first_47 @kc87_second_44 -140;
-    pos @kc87_first_47 @kc87_second_45 1;
-    pos @kc87_first_47 @kc87_second_46 -70;
-    pos @kc87_first_47 @kc87_second_47 -280;
-    pos @kc87_first_47 @kc87_second_48 -350;
-    pos @kc87_first_47 @kc87_second_51 -35;
-    pos @kc87_first_47 @kc87_second_52 -70;
-    pos @kc87_first_47 @kc87_second_58 -245;
-    pos @kc87_first_47 @kc87_second_60 -245;
-    pos @kc87_first_47 @kc87_second_61 -280;
-    pos @kc87_first_47 @kc87_second_62 -210;
-    pos @kc87_first_47 @kc87_second_63 -70;
-    pos @kc87_first_47 @kc87_second_64 -70;
-    pos @kc87_first_48 @kc87_second_3 -70;
+    pos @kc87_first_47 @kc87_second_29 -35;
+    pos @kc87_first_47 @kc87_second_32 -70;
+    pos @kc87_first_47 @kc87_second_35 -70;
+    pos @kc87_first_47 @kc87_second_37 -35;
+    pos @kc87_first_47 @kc87_second_39 -105;
+    pos @kc87_first_47 @kc87_second_48 1;
+    pos @kc87_first_47 @kc87_second_53 -35;
+    pos @kc87_first_47 @kc87_second_65 -70;
+    pos @kc87_first_47 @kc87_second_66 -70;
+    pos @kc87_first_48 @kc87_second_3 -140;
     pos @kc87_first_48 @kc87_second_4 -105;
-    pos @kc87_first_48 @kc87_second_6 -210;
-    pos @kc87_first_48 @kc87_second_7 -70;
-    pos @kc87_first_48 @kc87_second_8 -175;
-    pos @kc87_first_48 @kc87_second_17 -210;
+    pos @kc87_first_48 @kc87_second_6 -70;
+    pos @kc87_first_48 @kc87_second_8 -210;
+    pos @kc87_first_48 @kc87_second_9 -280;
+    pos @kc87_first_48 @kc87_second_12 -350;
+    pos @kc87_first_48 @kc87_second_13 -385;
+    pos @kc87_first_48 @kc87_second_14 -350;
+    pos @kc87_first_48 @kc87_second_15 -280;
+    pos @kc87_first_48 @kc87_second_18 -210;
     pos @kc87_first_48 @kc87_second_20 -140;
-    pos @kc87_first_48 @kc87_second_21 -210;
-    pos @kc87_first_48 @kc87_second_22 -210;
-    pos @kc87_first_48 @kc87_second_23 -210;
-    pos @kc87_first_48 @kc87_second_24 -140;
-    pos @kc87_first_48 @kc87_second_25 -140;
-    pos @kc87_first_48 @kc87_second_27 -140;
-    pos @kc87_first_48 @kc87_second_29 -210;
-    pos @kc87_first_48 @kc87_second_30 -210;
-    pos @kc87_first_48 @kc87_second_31 -140;
-    pos @kc87_first_48 @kc87_second_34 -210;
+    pos @kc87_first_48 @kc87_second_22 -105;
+    pos @kc87_first_48 @kc87_second_23 -140;
+    pos @kc87_first_48 @kc87_second_29 -70;
+    pos @kc87_first_48 @kc87_second_31 -175;
     pos @kc87_first_48 @kc87_second_35 -70;
-    pos @kc87_first_48 @kc87_second_36 -175;
-    pos @kc87_first_48 @kc87_second_37 -210;
-    pos @kc87_first_48 @kc87_second_38 -175;
-    pos @kc87_first_48 @kc87_second_39 -210;
-    pos @kc87_first_48 @kc87_second_40 -105;
-    pos @kc87_first_48 @kc87_second_43 -70;
-    pos @kc87_first_48 @kc87_second_44 -105;
-    pos @kc87_first_48 @kc87_second_45 1;
-    pos @kc87_first_48 @kc87_second_46 -35;
-    pos @kc87_first_48 @kc87_second_47 -210;
-    pos @kc87_first_48 @kc87_second_50 -210;
-    pos @kc87_first_48 @kc87_second_51 -210;
-    pos @kc87_first_48 @kc87_second_52 -175;
-    pos @kc87_first_48 @kc87_second_53 -175;
-    pos @kc87_first_48 @kc87_second_55 -210;
-    pos @kc87_first_48 @kc87_second_56 -140;
-    pos @kc87_first_48 @kc87_second_57 -210;
-    pos @kc87_first_48 @kc87_second_58 -210;
-    pos @kc87_first_48 @kc87_second_59 -175;
-    pos @kc87_first_48 @kc87_second_60 -175;
-    pos @kc87_first_48 @kc87_second_63 -210;
+    pos @kc87_first_48 @kc87_second_37 -35;
+    pos @kc87_first_48 @kc87_second_39 -175;
+    pos @kc87_first_48 @kc87_second_40 -280;
+    pos @kc87_first_48 @kc87_second_41 -280;
+    pos @kc87_first_48 @kc87_second_43 -280;
+    pos @kc87_first_48 @kc87_second_44 -210;
+    pos @kc87_first_48 @kc87_second_46 -140;
+    pos @kc87_first_48 @kc87_second_48 1;
+    pos @kc87_first_48 @kc87_second_49 -70;
+    pos @kc87_first_48 @kc87_second_50 -280;
+    pos @kc87_first_48 @kc87_second_51 -350;
+    pos @kc87_first_48 @kc87_second_53 -35;
+    pos @kc87_first_48 @kc87_second_54 -70;
+    pos @kc87_first_48 @kc87_second_60 -245;
+    pos @kc87_first_48 @kc87_second_62 -245;
+    pos @kc87_first_48 @kc87_second_63 -280;
     pos @kc87_first_48 @kc87_second_64 -210;
-    pos @kc87_first_49 @kc87_second_5 -70;
-    pos @kc87_first_49 @kc87_second_11 -35;
-    pos @kc87_first_49 @kc87_second_12 -240;
-    pos @kc87_first_49 @kc87_second_13 -70;
-    pos @kc87_first_49 @kc87_second_14 -140;
-    pos @kc87_first_49 @kc87_second_15 -105;
-    pos @kc87_first_49 @kc87_second_16 -70;
-    pos @kc87_first_49 @kc87_second_26 -70;
-    pos @kc87_first_49 @kc87_second_27 -70;
-    pos @kc87_first_49 @kc87_second_35 -35;
-    pos @kc87_first_49 @kc87_second_39 -70;
-    pos @kc87_first_49 @kc87_second_42 -35;
+    pos @kc87_first_48 @kc87_second_65 -70;
+    pos @kc87_first_48 @kc87_second_66 -70;
+    pos @kc87_first_49 @kc87_second_3 -70;
+    pos @kc87_first_49 @kc87_second_4 -105;
+    pos @kc87_first_49 @kc87_second_6 -210;
+    pos @kc87_first_49 @kc87_second_7 -70;
+    pos @kc87_first_49 @kc87_second_8 -175;
+    pos @kc87_first_49 @kc87_second_17 -210;
+    pos @kc87_first_49 @kc87_second_20 -140;
+    pos @kc87_first_49 @kc87_second_21 -210;
+    pos @kc87_first_49 @kc87_second_22 -210;
+    pos @kc87_first_49 @kc87_second_23 -210;
+    pos @kc87_first_49 @kc87_second_24 -140;
+    pos @kc87_first_49 @kc87_second_25 -140;
+    pos @kc87_first_49 @kc87_second_27 -140;
+    pos @kc87_first_49 @kc87_second_29 -210;
+    pos @kc87_first_49 @kc87_second_30 -210;
+    pos @kc87_first_49 @kc87_second_31 -140;
+    pos @kc87_first_49 @kc87_second_32 -140;
+    pos @kc87_first_49 @kc87_second_35 -210;
+    pos @kc87_first_49 @kc87_second_36 -70;
+    pos @kc87_first_49 @kc87_second_37 -175;
+    pos @kc87_first_49 @kc87_second_38 -210;
+    pos @kc87_first_49 @kc87_second_39 -175;
+    pos @kc87_first_49 @kc87_second_40 -210;
+    pos @kc87_first_49 @kc87_second_41 -105;
     pos @kc87_first_49 @kc87_second_43 -70;
-    pos @kc87_first_49 @kc87_second_45 1;
-    pos @kc87_first_49 @kc87_second_47 -35;
-    pos @kc87_first_49 @kc87_second_48 -140;
-    pos @kc87_first_49 @kc87_second_51 1;
-    pos @kc87_first_49 @kc87_second_56 -35;
-    pos @kc87_first_49 @kc87_second_60 -35;
-    pos @kc87_first_49 @kc87_second_61 -105;
-    pos @kc87_first_49 @kc87_second_62 -70;
-    pos @kc87_first_50 @kc87_second_65 -140;
-    pos @kc87_first_51 @kc87_second_32 -315;
-    pos @kc87_first_51 @kc87_second_66 -140;
-    pos @kc87_first_52 @kc87_second_1 -105;
-    pos @kc87_first_52 @kc87_second_2 -210;
-    pos @kc87_first_52 @kc87_second_6 -140;
-    pos @kc87_first_52 @kc87_second_11 -70;
-    pos @kc87_first_52 @kc87_second_12 -210;
-    pos @kc87_first_52 @kc87_second_13 -210;
-    pos @kc87_first_52 @kc87_second_14 -105;
-    pos @kc87_first_52 @kc87_second_15 -70;
-    pos @kc87_first_52 @kc87_second_16 -140;
-    pos @kc87_first_52 @kc87_second_17 -35;
-    pos @kc87_first_52 @kc87_second_22 -35;
-    pos @kc87_first_52 @kc87_second_24 -210;
-    pos @kc87_first_52 @kc87_second_26 -70;
-    pos @kc87_first_52 @kc87_second_27 -70;
-    pos @kc87_first_52 @kc87_second_29 -35;
-    pos @kc87_first_52 @kc87_second_34 -210;
-    pos @kc87_first_52 @kc87_second_35 -140;
-    pos @kc87_first_52 @kc87_second_42 -35;
-    pos @kc87_first_52 @kc87_second_43 -70;
-    pos @kc87_first_52 @kc87_second_45 1;
-    pos @kc87_first_52 @kc87_second_47 -35;
-    pos @kc87_first_52 @kc87_second_48 -105;
-    pos @kc87_first_52 @kc87_second_53 -210;
-    pos @kc87_first_52 @kc87_second_55 -140;
-    pos @kc87_first_52 @kc87_second_57 -175;
-    pos @kc87_first_52 @kc87_second_61 -35;
-    pos @kc87_first_52 @kc87_second_62 -35;
-    pos @kc87_first_52 @kc87_second_63 -35;
-    pos @kc87_first_52 @kc87_second_64 -70;
-    pos @kc87_first_53 @kc87_second_1 -35;
-    pos @kc87_first_53 @kc87_second_2 -70;
-    pos @kc87_first_53 @kc87_second_5 -105;
-    pos @kc87_first_53 @kc87_second_6 -35;
-    pos @kc87_first_53 @kc87_second_9 -70;
-    pos @kc87_first_53 @kc87_second_11 -70;
-    pos @kc87_first_53 @kc87_second_12 -240;
-    pos @kc87_first_53 @kc87_second_13 -245;
-    pos @kc87_first_53 @kc87_second_14 -140;
-    pos @kc87_first_53 @kc87_second_15 -105;
-    pos @kc87_first_53 @kc87_second_16 -105;
-    pos @kc87_first_53 @kc87_second_18 -70;
-    pos @kc87_first_53 @kc87_second_19 -70;
-    pos @kc87_first_53 @kc87_second_24 -35;
-    pos @kc87_first_53 @kc87_second_25 -70;
-    pos @kc87_first_53 @kc87_second_26 -140;
-    pos @kc87_first_53 @kc87_second_27 -105;
-    pos @kc87_first_53 @kc87_second_34 -35;
-    pos @kc87_first_53 @kc87_second_35 -140;
-    pos @kc87_first_53 @kc87_second_39 -105;
-    pos @kc87_first_53 @kc87_second_40 -70;
-    pos @kc87_first_53 @kc87_second_42 -105;
-    pos @kc87_first_53 @kc87_second_43 -175;
-    pos @kc87_first_53 @kc87_second_45 1;
-    pos @kc87_first_53 @kc87_second_47 -70;
-    pos @kc87_first_53 @kc87_second_48 -140;
-    pos @kc87_first_53 @kc87_second_49 -70;
-    pos @kc87_first_53 @kc87_second_53 -210;
-    pos @kc87_first_53 @kc87_second_54 -70;
-    pos @kc87_first_53 @kc87_second_55 -175;
-    pos @kc87_first_53 @kc87_second_56 -105;
-    pos @kc87_first_53 @kc87_second_57 -175;
-    pos @kc87_first_53 @kc87_second_60 -50;
-    pos @kc87_first_53 @kc87_second_61 -105;
-    pos @kc87_first_53 @kc87_second_62 -70;
-    pos @kc87_first_53 @kc87_second_64 -35;
+    pos @kc87_first_49 @kc87_second_46 -105;
+    pos @kc87_first_49 @kc87_second_48 1;
+    pos @kc87_first_49 @kc87_second_49 -35;
+    pos @kc87_first_49 @kc87_second_50 -210;
+    pos @kc87_first_49 @kc87_second_52 -210;
+    pos @kc87_first_49 @kc87_second_53 -210;
+    pos @kc87_first_49 @kc87_second_54 -175;
+    pos @kc87_first_49 @kc87_second_55 -175;
+    pos @kc87_first_49 @kc87_second_57 -210;
+    pos @kc87_first_49 @kc87_second_58 -140;
+    pos @kc87_first_49 @kc87_second_59 -210;
+    pos @kc87_first_49 @kc87_second_60 -210;
+    pos @kc87_first_49 @kc87_second_61 -175;
+    pos @kc87_first_49 @kc87_second_62 -175;
+    pos @kc87_first_49 @kc87_second_65 -210;
+    pos @kc87_first_49 @kc87_second_66 -210;
+    pos @kc87_first_50 @kc87_second_1 -35;
+    pos @kc87_first_50 @kc87_second_2 -70;
+    pos @kc87_first_50 @kc87_second_5 -70;
+    pos @kc87_first_50 @kc87_second_11 -35;
+    pos @kc87_first_50 @kc87_second_12 -70;
+    pos @kc87_first_50 @kc87_second_13 -140;
+    pos @kc87_first_50 @kc87_second_14 -70;
+    pos @kc87_first_50 @kc87_second_15 -35;
+    pos @kc87_first_50 @kc87_second_16 -105;
+    pos @kc87_first_50 @kc87_second_26 -35;
+    pos @kc87_first_50 @kc87_second_27 -70;
+    pos @kc87_first_50 @kc87_second_36 -70;
+    pos @kc87_first_50 @kc87_second_43 -70;
+    pos @kc87_first_50 @kc87_second_48 1;
+    pos @kc87_first_50 @kc87_second_55 -175;
+    pos @kc87_first_50 @kc87_second_57 -140;
+    pos @kc87_first_50 @kc87_second_59 -140;
+    pos @kc87_first_50 @kc87_second_63 -35;
+    pos @kc87_first_51 @kc87_second_5 -70;
+    pos @kc87_first_51 @kc87_second_11 -35;
+    pos @kc87_first_51 @kc87_second_12 -240;
+    pos @kc87_first_51 @kc87_second_13 -70;
+    pos @kc87_first_51 @kc87_second_14 -140;
+    pos @kc87_first_51 @kc87_second_15 -105;
+    pos @kc87_first_51 @kc87_second_16 -70;
+    pos @kc87_first_51 @kc87_second_26 -70;
+    pos @kc87_first_51 @kc87_second_27 -70;
+    pos @kc87_first_51 @kc87_second_36 -35;
+    pos @kc87_first_51 @kc87_second_40 -70;
+    pos @kc87_first_51 @kc87_second_43 -70;
+    pos @kc87_first_51 @kc87_second_45 -35;
+    pos @kc87_first_51 @kc87_second_48 1;
+    pos @kc87_first_51 @kc87_second_50 -35;
+    pos @kc87_first_51 @kc87_second_51 -140;
+    pos @kc87_first_51 @kc87_second_53 1;
+    pos @kc87_first_51 @kc87_second_58 -35;
+    pos @kc87_first_51 @kc87_second_62 -35;
+    pos @kc87_first_51 @kc87_second_63 -105;
+    pos @kc87_first_51 @kc87_second_64 -70;
+    pos @kc87_first_52 @kc87_second_67 -140;
+    pos @kc87_first_53 @kc87_second_33 -315;
+    pos @kc87_first_53 @kc87_second_68 -140;
     pos @kc87_first_54 @kc87_second_1 -105;
     pos @kc87_first_54 @kc87_second_2 -210;
-    pos @kc87_first_54 @kc87_second_5 -70;
-    pos @kc87_first_54 @kc87_second_6 -105;
-    pos @kc87_first_54 @kc87_second_13 -70;
-    pos @kc87_first_54 @kc87_second_14 -35;
+    pos @kc87_first_54 @kc87_second_6 -140;
+    pos @kc87_first_54 @kc87_second_11 -70;
+    pos @kc87_first_54 @kc87_second_12 -210;
+    pos @kc87_first_54 @kc87_second_13 -210;
+    pos @kc87_first_54 @kc87_second_14 -105;
+    pos @kc87_first_54 @kc87_second_15 -70;
     pos @kc87_first_54 @kc87_second_16 -140;
-    pos @kc87_first_54 @kc87_second_17 -70;
-    pos @kc87_first_54 @kc87_second_19 -210;
+    pos @kc87_first_54 @kc87_second_17 -35;
     pos @kc87_first_54 @kc87_second_22 -35;
     pos @kc87_first_54 @kc87_second_24 -210;
+    pos @kc87_first_54 @kc87_second_26 -70;
+    pos @kc87_first_54 @kc87_second_27 -70;
     pos @kc87_first_54 @kc87_second_29 -35;
-    pos @kc87_first_54 @kc87_second_32 -105;
-    pos @kc87_first_54 @kc87_second_34 -105;
-    pos @kc87_first_54 @kc87_second_35 -140;
-    pos @kc87_first_54 @kc87_second_38 -70;
-    pos @kc87_first_54 @kc87_second_45 1;
-    pos @kc87_first_54 @kc87_second_51 -35;
-    pos @kc87_first_54 @kc87_second_53 -245;
+    pos @kc87_first_54 @kc87_second_35 -210;
+    pos @kc87_first_54 @kc87_second_36 -140;
+    pos @kc87_first_54 @kc87_second_43 -70;
+    pos @kc87_first_54 @kc87_second_45 -35;
+    pos @kc87_first_54 @kc87_second_48 1;
+    pos @kc87_first_54 @kc87_second_50 -35;
+    pos @kc87_first_54 @kc87_second_51 -105;
     pos @kc87_first_54 @kc87_second_55 -210;
-    pos @kc87_first_54 @kc87_second_57 -210;
-    pos @kc87_first_54 @kc87_second_63 -70;
-    pos @kc87_first_54 @kc87_second_64 -105;
-    pos @kc87_first_55 @kc87_second_12 -240;
-    pos @kc87_first_55 @kc87_second_13 -140;
-    pos @kc87_first_55 @kc87_second_14 -105;
-    pos @kc87_first_55 @kc87_second_15 -35;
-    pos @kc87_first_55 @kc87_second_33 44;
-    pos @kc87_first_55 @kc87_second_45 1;
-    pos @kc87_first_55 @kc87_second_50 44;
-    pos @kc87_first_56 @kc87_second_1 -140;
-    pos @kc87_first_56 @kc87_second_2 -210;
-    pos @kc87_first_56 @kc87_second_6 -140;
-    pos @kc87_first_56 @kc87_second_12 -175;
+    pos @kc87_first_54 @kc87_second_57 -140;
+    pos @kc87_first_54 @kc87_second_59 -175;
+    pos @kc87_first_54 @kc87_second_63 -35;
+    pos @kc87_first_54 @kc87_second_64 -35;
+    pos @kc87_first_54 @kc87_second_65 -35;
+    pos @kc87_first_54 @kc87_second_66 -70;
+    pos @kc87_first_55 @kc87_second_1 -105;
+    pos @kc87_first_55 @kc87_second_2 -210;
+    pos @kc87_first_55 @kc87_second_5 -70;
+    pos @kc87_first_55 @kc87_second_6 -105;
+    pos @kc87_first_55 @kc87_second_13 -70;
+    pos @kc87_first_55 @kc87_second_14 -35;
+    pos @kc87_first_55 @kc87_second_16 -140;
+    pos @kc87_first_55 @kc87_second_17 -70;
+    pos @kc87_first_55 @kc87_second_19 -210;
+    pos @kc87_first_55 @kc87_second_22 -35;
+    pos @kc87_first_55 @kc87_second_24 -210;
+    pos @kc87_first_55 @kc87_second_29 -35;
+    pos @kc87_first_55 @kc87_second_32 -70;
+    pos @kc87_first_55 @kc87_second_33 -105;
+    pos @kc87_first_55 @kc87_second_35 -105;
+    pos @kc87_first_55 @kc87_second_36 -140;
+    pos @kc87_first_55 @kc87_second_39 -70;
+    pos @kc87_first_55 @kc87_second_48 1;
+    pos @kc87_first_55 @kc87_second_53 -35;
+    pos @kc87_first_55 @kc87_second_55 -245;
+    pos @kc87_first_55 @kc87_second_57 -210;
+    pos @kc87_first_55 @kc87_second_59 -210;
+    pos @kc87_first_55 @kc87_second_65 -70;
+    pos @kc87_first_55 @kc87_second_66 -105;
+    pos @kc87_first_56 @kc87_second_12 -240;
     pos @kc87_first_56 @kc87_second_13 -140;
-    pos @kc87_first_56 @kc87_second_16 -140;
-    pos @kc87_first_56 @kc87_second_19 -210;
-    pos @kc87_first_56 @kc87_second_24 -210;
-    pos @kc87_first_56 @kc87_second_32 -140;
-    pos @kc87_first_56 @kc87_second_34 -140;
-    pos @kc87_first_56 @kc87_second_35 -210;
-    pos @kc87_first_56 @kc87_second_36 -35;
-    pos @kc87_first_56 @kc87_second_45 1;
-    pos @kc87_first_56 @kc87_second_53 -210;
-    pos @kc87_first_56 @kc87_second_55 -175;
-    pos @kc87_first_56 @kc87_second_57 -175;
-    pos @kc87_first_56 @kc87_second_63 -105;
-    pos @kc87_first_56 @kc87_second_64 -210;
-    pos @kc87_first_57 @kc87_second_12 -240;
-    pos @kc87_first_57 @kc87_second_13 -175;
-    pos @kc87_first_57 @kc87_second_14 -70;
-    pos @kc87_first_57 @kc87_second_15 -35;
-    pos @kc87_first_57 @kc87_second_19 -35;
-    pos @kc87_first_57 @kc87_second_26 -35;
-    pos @kc87_first_57 @kc87_second_39 -35;
-    pos @kc87_first_57 @kc87_second_40 -35;
-    pos @kc87_first_57 @kc87_second_43 -70;
-    pos @kc87_first_57 @kc87_second_45 1;
-    pos @kc87_first_57 @kc87_second_47 -35;
-    pos @kc87_first_57 @kc87_second_48 -70;
-    pos @kc87_first_57 @kc87_second_58 -35;
-    pos @kc87_first_57 @kc87_second_60 -35;
-    pos @kc87_first_57 @kc87_second_61 -70;
-    pos @kc87_first_57 @kc87_second_62 -35;
-    pos @kc87_first_58 @kc87_second_13 -35;
-    pos @kc87_first_58 @kc87_second_58 -35;
+    pos @kc87_first_56 @kc87_second_14 -105;
+    pos @kc87_first_56 @kc87_second_15 -35;
+    pos @kc87_first_56 @kc87_second_34 44;
+    pos @kc87_first_56 @kc87_second_48 1;
+    pos @kc87_first_56 @kc87_second_52 44;
+    pos @kc87_first_57 @kc87_second_1 -140;
+    pos @kc87_first_57 @kc87_second_2 -210;
+    pos @kc87_first_57 @kc87_second_6 -140;
+    pos @kc87_first_57 @kc87_second_12 -175;
+    pos @kc87_first_57 @kc87_second_13 -140;
+    pos @kc87_first_57 @kc87_second_16 -140;
+    pos @kc87_first_57 @kc87_second_19 -210;
+    pos @kc87_first_57 @kc87_second_24 -210;
+    pos @kc87_first_57 @kc87_second_32 -35;
+    pos @kc87_first_57 @kc87_second_33 -140;
+    pos @kc87_first_57 @kc87_second_35 -140;
+    pos @kc87_first_57 @kc87_second_36 -210;
+    pos @kc87_first_57 @kc87_second_37 -35;
+    pos @kc87_first_57 @kc87_second_48 1;
+    pos @kc87_first_57 @kc87_second_55 -210;
+    pos @kc87_first_57 @kc87_second_57 -175;
+    pos @kc87_first_57 @kc87_second_59 -175;
+    pos @kc87_first_57 @kc87_second_65 -105;
+    pos @kc87_first_57 @kc87_second_66 -210;
+    pos @kc87_first_58 @kc87_second_12 -240;
+    pos @kc87_first_58 @kc87_second_13 -175;
+    pos @kc87_first_58 @kc87_second_14 -70;
+    pos @kc87_first_58 @kc87_second_15 -35;
+    pos @kc87_first_58 @kc87_second_19 -35;
+    pos @kc87_first_58 @kc87_second_26 -35;
+    pos @kc87_first_58 @kc87_second_40 -35;
+    pos @kc87_first_58 @kc87_second_41 -35;
+    pos @kc87_first_58 @kc87_second_43 -70;
+    pos @kc87_first_58 @kc87_second_48 1;
+    pos @kc87_first_58 @kc87_second_50 -35;
+    pos @kc87_first_58 @kc87_second_51 -70;
+    pos @kc87_first_58 @kc87_second_60 -35;
+    pos @kc87_first_58 @kc87_second_62 -35;
+    pos @kc87_first_58 @kc87_second_63 -70;
     pos @kc87_first_58 @kc87_second_64 -35;
-    pos @kc87_first_59 @kc87_second_12 -175;
-    pos @kc87_first_59 @kc87_second_13 -140;
-    pos @kc87_first_59 @kc87_second_14 -35;
-    pos @kc87_first_59 @kc87_second_45 1;
-    pos @kc87_first_60 @kc87_second_1 -140;
-    pos @kc87_first_60 @kc87_second_2 -280;
-    pos @kc87_first_60 @kc87_second_5 -140;
-    pos @kc87_first_60 @kc87_second_6 -280;
-    pos @kc87_first_60 @kc87_second_8 -70;
-    pos @kc87_first_60 @kc87_second_10 -70;
-    pos @kc87_first_60 @kc87_second_11 -175;
-    pos @kc87_first_60 @kc87_second_12 -240;
-    pos @kc87_first_60 @kc87_second_13 -140;
-    pos @kc87_first_60 @kc87_second_14 -105;
-    pos @kc87_first_60 @kc87_second_15 -70;
-    pos @kc87_first_60 @kc87_second_16 -175;
-    pos @kc87_first_60 @kc87_second_17 -70;
-    pos @kc87_first_60 @kc87_second_19 -280;
-    pos @kc87_first_60 @kc87_second_22 -70;
-    pos @kc87_first_60 @kc87_second_23 -70;
-    pos @kc87_first_60 @kc87_second_24 -210;
-    pos @kc87_first_60 @kc87_second_26 -70;
-    pos @kc87_first_60 @kc87_second_27 -70;
-    pos @kc87_first_60 @kc87_second_29 -70;
+    pos @kc87_first_59 @kc87_second_1 -210;
+    pos @kc87_first_59 @kc87_second_2 -210;
+    pos @kc87_first_59 @kc87_second_3 -70;
+    pos @kc87_first_59 @kc87_second_4 -35;
+    pos @kc87_first_59 @kc87_second_6 -210;
+    pos @kc87_first_59 @kc87_second_7 -70;
+    pos @kc87_first_59 @kc87_second_8 -70;
+    pos @kc87_first_59 @kc87_second_16 -70;
+    pos @kc87_first_59 @kc87_second_17 -140;
+    pos @kc87_first_59 @kc87_second_19 -210;
+    pos @kc87_first_59 @kc87_second_20 -140;
+    pos @kc87_first_59 @kc87_second_21 -35;
+    pos @kc87_first_59 @kc87_second_22 -175;
+    pos @kc87_first_59 @kc87_second_23 -140;
+    pos @kc87_first_59 @kc87_second_24 -280;
+    pos @kc87_first_59 @kc87_second_29 -35;
+    pos @kc87_first_59 @kc87_second_30 -35;
+    pos @kc87_first_59 @kc87_second_32 -140;
+    pos @kc87_first_59 @kc87_second_33 -210;
+    pos @kc87_first_59 @kc87_second_35 -245;
+    pos @kc87_first_59 @kc87_second_36 -140;
+    pos @kc87_first_59 @kc87_second_37 -140;
+    pos @kc87_first_59 @kc87_second_38 -140;
+    pos @kc87_first_59 @kc87_second_39 -140;
+    pos @kc87_first_59 @kc87_second_40 -35;
+    pos @kc87_first_59 @kc87_second_46 -35;
+    pos @kc87_first_59 @kc87_second_47 -35;
+    pos @kc87_first_59 @kc87_second_48 1;
+    pos @kc87_first_59 @kc87_second_53 -140;
+    pos @kc87_first_59 @kc87_second_54 -70;
+    pos @kc87_first_59 @kc87_second_55 -210;
+    pos @kc87_first_59 @kc87_second_57 -210;
+    pos @kc87_first_59 @kc87_second_59 -210;
+    pos @kc87_first_59 @kc87_second_60 -35;
+    pos @kc87_first_59 @kc87_second_65 -175;
+    pos @kc87_first_59 @kc87_second_66 -245;
+    pos @kc87_first_60 @kc87_second_13 -35;
     pos @kc87_first_60 @kc87_second_32 -70;
-    pos @kc87_first_60 @kc87_second_34 -315;
-    pos @kc87_first_60 @kc87_second_35 -140;
-    pos @kc87_first_60 @kc87_second_36 -70;
-    pos @kc87_first_60 @kc87_second_38 -105;
-    pos @kc87_first_60 @kc87_second_45 1;
-    pos @kc87_first_60 @kc87_second_48 -35;
-    pos @kc87_first_60 @kc87_second_51 -50;
-    pos @kc87_first_60 @kc87_second_53 -210;
-    pos @kc87_first_60 @kc87_second_55 -175;
-    pos @kc87_first_60 @kc87_second_57 -210;
-    pos @kc87_first_60 @kc87_second_59 -35;
-    pos @kc87_first_60 @kc87_second_61 -70;
-    pos @kc87_first_60 @kc87_second_62 -35;
-    pos @kc87_first_60 @kc87_second_63 -140;
-    pos @kc87_first_60 @kc87_second_64 -210;
-    pos @kc87_first_61 @kc87_second_1 -35;
-    pos @kc87_first_61 @kc87_second_2 -70;
-    pos @kc87_first_61 @kc87_second_5 -70;
-    pos @kc87_first_61 @kc87_second_11 -35;
-    pos @kc87_first_61 @kc87_second_12 -140;
+    pos @kc87_first_60 @kc87_second_60 -35;
+    pos @kc87_first_60 @kc87_second_66 -35;
+    pos @kc87_first_61 @kc87_second_12 -175;
     pos @kc87_first_61 @kc87_second_13 -140;
-    pos @kc87_first_61 @kc87_second_14 -70;
-    pos @kc87_first_61 @kc87_second_15 -35;
-    pos @kc87_first_61 @kc87_second_16 -105;
-    pos @kc87_first_61 @kc87_second_26 -35;
-    pos @kc87_first_61 @kc87_second_27 -70;
-    pos @kc87_first_61 @kc87_second_35 -70;
-    pos @kc87_first_61 @kc87_second_43 -70;
-    pos @kc87_first_61 @kc87_second_45 1;
-    pos @kc87_first_61 @kc87_second_53 -175;
-    pos @kc87_first_61 @kc87_second_55 -140;
-    pos @kc87_first_61 @kc87_second_57 -140;
-    pos @kc87_first_61 @kc87_second_61 -35;
-    pos @kc87_first_62 @kc87_second_5 -70;
-    pos @kc87_first_62 @kc87_second_9 -70;
-    pos @kc87_first_62 @kc87_second_11 -35;
-    pos @kc87_first_62 @kc87_second_12 -350;
-    pos @kc87_first_62 @kc87_second_13 -315;
-    pos @kc87_first_62 @kc87_second_14 -175;
-    pos @kc87_first_62 @kc87_second_15 -140;
-    pos @kc87_first_62 @kc87_second_16 -70;
-    pos @kc87_first_62 @kc87_second_18 -70;
+    pos @kc87_first_61 @kc87_second_14 -35;
+    pos @kc87_first_61 @kc87_second_48 1;
+    pos @kc87_first_62 @kc87_second_1 -140;
+    pos @kc87_first_62 @kc87_second_2 -280;
+    pos @kc87_first_62 @kc87_second_5 -140;
+    pos @kc87_first_62 @kc87_second_6 -280;
+    pos @kc87_first_62 @kc87_second_8 -70;
+    pos @kc87_first_62 @kc87_second_10 -70;
+    pos @kc87_first_62 @kc87_second_11 -175;
+    pos @kc87_first_62 @kc87_second_12 -240;
+    pos @kc87_first_62 @kc87_second_13 -140;
+    pos @kc87_first_62 @kc87_second_14 -105;
+    pos @kc87_first_62 @kc87_second_15 -70;
+    pos @kc87_first_62 @kc87_second_16 -175;
+    pos @kc87_first_62 @kc87_second_17 -70;
+    pos @kc87_first_62 @kc87_second_19 -280;
+    pos @kc87_first_62 @kc87_second_22 -70;
+    pos @kc87_first_62 @kc87_second_23 -70;
+    pos @kc87_first_62 @kc87_second_24 -210;
+    pos @kc87_first_62 @kc87_second_26 -70;
     pos @kc87_first_62 @kc87_second_27 -70;
-    pos @kc87_first_62 @kc87_second_31 -50;
-    pos @kc87_first_62 @kc87_second_39 -140;
-    pos @kc87_first_62 @kc87_second_40 -50;
-    pos @kc87_first_62 @kc87_second_42 -35;
-    pos @kc87_first_62 @kc87_second_43 -175;
-    pos @kc87_first_62 @kc87_second_45 1;
-    pos @kc87_first_62 @kc87_second_47 -70;
-    pos @kc87_first_62 @kc87_second_48 -175;
-    pos @kc87_first_62 @kc87_second_54 -70;
-    pos @kc87_first_62 @kc87_second_58 -70;
-    pos @kc87_first_62 @kc87_second_60 -50;
-    pos @kc87_first_62 @kc87_second_61 -140;
-    pos @kc87_first_62 @kc87_second_62 -105;
-    pos @kc87_first_63 @kc87_second_4 -105;
+    pos @kc87_first_62 @kc87_second_29 -70;
+    pos @kc87_first_62 @kc87_second_32 -70;
+    pos @kc87_first_62 @kc87_second_33 -70;
+    pos @kc87_first_62 @kc87_second_35 -315;
+    pos @kc87_first_62 @kc87_second_36 -140;
+    pos @kc87_first_62 @kc87_second_37 -70;
+    pos @kc87_first_62 @kc87_second_39 -105;
+    pos @kc87_first_62 @kc87_second_48 1;
+    pos @kc87_first_62 @kc87_second_51 -35;
+    pos @kc87_first_62 @kc87_second_53 -50;
+    pos @kc87_first_62 @kc87_second_55 -210;
+    pos @kc87_first_62 @kc87_second_57 -175;
+    pos @kc87_first_62 @kc87_second_59 -210;
+    pos @kc87_first_62 @kc87_second_61 -35;
+    pos @kc87_first_62 @kc87_second_63 -70;
+    pos @kc87_first_62 @kc87_second_64 -35;
+    pos @kc87_first_62 @kc87_second_65 -140;
+    pos @kc87_first_62 @kc87_second_66 -210;
     pos @kc87_first_63 @kc87_second_6 -35;
-    pos @kc87_first_63 @kc87_second_8 1;
-    pos @kc87_first_63 @kc87_second_9 -245;
-    pos @kc87_first_63 @kc87_second_12 -210;
-    pos @kc87_first_63 @kc87_second_13 -210;
-    pos @kc87_first_63 @kc87_second_14 -210;
-    pos @kc87_first_63 @kc87_second_15 -175;
-    pos @kc87_first_63 @kc87_second_17 -70;
-    pos @kc87_first_63 @kc87_second_18 -180;
-    pos @kc87_first_63 @kc87_second_20 -140;
-    pos @kc87_first_63 @kc87_second_22 -105;
-    pos @kc87_first_63 @kc87_second_25 -140;
-    pos @kc87_first_63 @kc87_second_29 -105;
-    pos @kc87_first_63 @kc87_second_31 -140;
-    pos @kc87_first_63 @kc87_second_34 -35;
-    pos @kc87_first_63 @kc87_second_36 -35;
-    pos @kc87_first_63 @kc87_second_38 -175;
-    pos @kc87_first_63 @kc87_second_39 -142;
-    pos @kc87_first_63 @kc87_second_40 -245;
-    pos @kc87_first_63 @kc87_second_43 -210;
-    pos @kc87_first_63 @kc87_second_44 -105;
-    pos @kc87_first_63 @kc87_second_45 1;
-    pos @kc87_first_63 @kc87_second_46 -35;
-    pos @kc87_first_63 @kc87_second_47 -210;
-    pos @kc87_first_63 @kc87_second_48 -210;
+    pos @kc87_first_63 @kc87_second_12 -240;
+    pos @kc87_first_63 @kc87_second_13 -140;
+    pos @kc87_first_63 @kc87_second_14 -70;
+    pos @kc87_first_63 @kc87_second_15 -35;
+    pos @kc87_first_63 @kc87_second_20 -35;
+    pos @kc87_first_63 @kc87_second_22 -35;
+    pos @kc87_first_63 @kc87_second_35 -70;
+    pos @kc87_first_63 @kc87_second_39 -70;
+    pos @kc87_first_63 @kc87_second_40 -50;
+    pos @kc87_first_63 @kc87_second_48 1;
     pos @kc87_first_63 @kc87_second_51 -35;
-    pos @kc87_first_63 @kc87_second_58 -280;
-    pos @kc87_first_63 @kc87_second_60 -175;
-    pos @kc87_first_63 @kc87_second_61 -140;
-    pos @kc87_first_63 @kc87_second_62 -140;
-    pos @kc87_first_63 @kc87_second_63 -70;
-    pos @kc87_first_63 @kc87_second_64 -70;
-    pos @kc87_first_64 @kc87_second_1 -175;
-    pos @kc87_first_64 @kc87_second_2 -175;
+    pos @kc87_first_63 @kc87_second_65 -35;
+    pos @kc87_first_63 @kc87_second_66 -35;
     pos @kc87_first_64 @kc87_second_5 -70;
-    pos @kc87_first_64 @kc87_second_6 -105;
-    pos @kc87_first_64 @kc87_second_11 -105;
-    pos @kc87_first_64 @kc87_second_12 -175;
-    pos @kc87_first_64 @kc87_second_13 -140;
-    pos @kc87_first_64 @kc87_second_14 -70;
-    pos @kc87_first_64 @kc87_second_15 -35;
-    pos @kc87_first_64 @kc87_second_16 -140;
-    pos @kc87_first_64 @kc87_second_17 -70;
-    pos @kc87_first_64 @kc87_second_19 -175;
-    pos @kc87_first_64 @kc87_second_22 -70;
-    pos @kc87_first_64 @kc87_second_29 -35;
-    pos @kc87_first_64 @kc87_second_34 -105;
-    pos @kc87_first_64 @kc87_second_35 -175;
-    pos @kc87_first_64 @kc87_second_36 -35;
-    pos @kc87_first_64 @kc87_second_38 -70;
-    pos @kc87_first_64 @kc87_second_45 1;
-    pos @kc87_first_64 @kc87_second_51 -35;
-    pos @kc87_first_64 @kc87_second_53 -140;
-    pos @kc87_first_64 @kc87_second_55 -140;
-    pos @kc87_first_64 @kc87_second_57 -140;
-    pos @kc87_first_64 @kc87_second_63 -70;
+    pos @kc87_first_64 @kc87_second_9 -70;
+    pos @kc87_first_64 @kc87_second_11 -35;
+    pos @kc87_first_64 @kc87_second_12 -350;
+    pos @kc87_first_64 @kc87_second_13 -315;
+    pos @kc87_first_64 @kc87_second_14 -175;
+    pos @kc87_first_64 @kc87_second_15 -140;
+    pos @kc87_first_64 @kc87_second_16 -70;
+    pos @kc87_first_64 @kc87_second_18 -70;
+    pos @kc87_first_64 @kc87_second_27 -70;
+    pos @kc87_first_64 @kc87_second_31 -50;
+    pos @kc87_first_64 @kc87_second_40 -140;
+    pos @kc87_first_64 @kc87_second_41 -50;
+    pos @kc87_first_64 @kc87_second_43 -175;
+    pos @kc87_first_64 @kc87_second_45 -35;
+    pos @kc87_first_64 @kc87_second_48 1;
+    pos @kc87_first_64 @kc87_second_50 -70;
+    pos @kc87_first_64 @kc87_second_51 -175;
+    pos @kc87_first_64 @kc87_second_56 -70;
+    pos @kc87_first_64 @kc87_second_60 -70;
+    pos @kc87_first_64 @kc87_second_62 -50;
+    pos @kc87_first_64 @kc87_second_63 -140;
     pos @kc87_first_64 @kc87_second_64 -105;
-    pos @kc87_first_65 @kc87_second_1 -210;
-    pos @kc87_first_65 @kc87_second_2 -210;
-    pos @kc87_first_65 @kc87_second_3 -70;
-    pos @kc87_first_65 @kc87_second_4 -35;
-    pos @kc87_first_65 @kc87_second_6 -210;
-    pos @kc87_first_65 @kc87_second_7 -70;
-    pos @kc87_first_65 @kc87_second_8 -70;
-    pos @kc87_first_65 @kc87_second_16 -70;
-    pos @kc87_first_65 @kc87_second_17 -140;
-    pos @kc87_first_65 @kc87_second_19 -210;
+    pos @kc87_first_65 @kc87_second_4 -105;
+    pos @kc87_first_65 @kc87_second_6 -35;
+    pos @kc87_first_65 @kc87_second_8 1;
+    pos @kc87_first_65 @kc87_second_9 -245;
+    pos @kc87_first_65 @kc87_second_12 -210;
+    pos @kc87_first_65 @kc87_second_13 -210;
+    pos @kc87_first_65 @kc87_second_14 -210;
+    pos @kc87_first_65 @kc87_second_15 -175;
+    pos @kc87_first_65 @kc87_second_17 -70;
+    pos @kc87_first_65 @kc87_second_18 -180;
     pos @kc87_first_65 @kc87_second_20 -140;
-    pos @kc87_first_65 @kc87_second_21 -35;
-    pos @kc87_first_65 @kc87_second_22 -175;
-    pos @kc87_first_65 @kc87_second_23 -140;
-    pos @kc87_first_65 @kc87_second_24 -280;
-    pos @kc87_first_65 @kc87_second_29 -35;
-    pos @kc87_first_65 @kc87_second_30 -35;
-    pos @kc87_first_65 @kc87_second_32 -210;
-    pos @kc87_first_65 @kc87_second_34 -245;
-    pos @kc87_first_65 @kc87_second_35 -140;
-    pos @kc87_first_65 @kc87_second_36 -140;
-    pos @kc87_first_65 @kc87_second_37 -140;
-    pos @kc87_first_65 @kc87_second_38 -140;
-    pos @kc87_first_65 @kc87_second_39 -35;
-    pos @kc87_first_65 @kc87_second_44 -35;
-    pos @kc87_first_65 @kc87_second_45 1;
+    pos @kc87_first_65 @kc87_second_22 -105;
+    pos @kc87_first_65 @kc87_second_25 -140;
+    pos @kc87_first_65 @kc87_second_29 -105;
+    pos @kc87_first_65 @kc87_second_31 -140;
+    pos @kc87_first_65 @kc87_second_32 -105;
+    pos @kc87_first_65 @kc87_second_35 -35;
+    pos @kc87_first_65 @kc87_second_37 -35;
+    pos @kc87_first_65 @kc87_second_39 -175;
+    pos @kc87_first_65 @kc87_second_40 -142;
+    pos @kc87_first_65 @kc87_second_41 -245;
+    pos @kc87_first_65 @kc87_second_43 -210;
+    pos @kc87_first_65 @kc87_second_44 -175;
+    pos @kc87_first_65 @kc87_second_46 -105;
+    pos @kc87_first_65 @kc87_second_48 1;
     pos @kc87_first_65 @kc87_second_49 -35;
-    pos @kc87_first_65 @kc87_second_51 -140;
-    pos @kc87_first_65 @kc87_second_52 -70;
-    pos @kc87_first_65 @kc87_second_53 -210;
-    pos @kc87_first_65 @kc87_second_55 -210;
-    pos @kc87_first_65 @kc87_second_57 -210;
-    pos @kc87_first_65 @kc87_second_58 -35;
-    pos @kc87_first_65 @kc87_second_63 -175;
-    pos @kc87_first_65 @kc87_second_64 -245;
-    pos @kc87_first_66 @kc87_second_6 -35;
-    pos @kc87_first_66 @kc87_second_12 -240;
+    pos @kc87_first_65 @kc87_second_50 -210;
+    pos @kc87_first_65 @kc87_second_51 -210;
+    pos @kc87_first_65 @kc87_second_53 -35;
+    pos @kc87_first_65 @kc87_second_60 -280;
+    pos @kc87_first_65 @kc87_second_62 -175;
+    pos @kc87_first_65 @kc87_second_63 -140;
+    pos @kc87_first_65 @kc87_second_64 -140;
+    pos @kc87_first_65 @kc87_second_65 -70;
+    pos @kc87_first_65 @kc87_second_66 -70;
+    pos @kc87_first_66 @kc87_second_1 -175;
+    pos @kc87_first_66 @kc87_second_2 -175;
+    pos @kc87_first_66 @kc87_second_5 -70;
+    pos @kc87_first_66 @kc87_second_6 -105;
+    pos @kc87_first_66 @kc87_second_11 -105;
+    pos @kc87_first_66 @kc87_second_12 -175;
     pos @kc87_first_66 @kc87_second_13 -140;
     pos @kc87_first_66 @kc87_second_14 -70;
     pos @kc87_first_66 @kc87_second_15 -35;
-    pos @kc87_first_66 @kc87_second_20 -35;
-    pos @kc87_first_66 @kc87_second_22 -35;
-    pos @kc87_first_66 @kc87_second_34 -70;
-    pos @kc87_first_66 @kc87_second_38 -70;
-    pos @kc87_first_66 @kc87_second_39 -50;
-    pos @kc87_first_66 @kc87_second_45 1;
-    pos @kc87_first_66 @kc87_second_48 -35;
-    pos @kc87_first_66 @kc87_second_63 -35;
-    pos @kc87_first_66 @kc87_second_64 -35;
+    pos @kc87_first_66 @kc87_second_16 -140;
+    pos @kc87_first_66 @kc87_second_17 -70;
+    pos @kc87_first_66 @kc87_second_19 -175;
+    pos @kc87_first_66 @kc87_second_22 -70;
+    pos @kc87_first_66 @kc87_second_29 -35;
+    pos @kc87_first_66 @kc87_second_32 -70;
+    pos @kc87_first_66 @kc87_second_35 -105;
+    pos @kc87_first_66 @kc87_second_36 -175;
+    pos @kc87_first_66 @kc87_second_37 -35;
+    pos @kc87_first_66 @kc87_second_39 -70;
+    pos @kc87_first_66 @kc87_second_48 1;
+    pos @kc87_first_66 @kc87_second_53 -35;
+    pos @kc87_first_66 @kc87_second_55 -140;
+    pos @kc87_first_66 @kc87_second_57 -140;
+    pos @kc87_first_66 @kc87_second_59 -140;
+    pos @kc87_first_66 @kc87_second_65 -70;
+    pos @kc87_first_66 @kc87_second_66 -105;
     pos @kc87_first_67 @kc87_second_3 -100;
     pos @kc87_first_67 @kc87_second_4 -50;
     pos @kc87_first_67 @kc87_second_6 -50;
@@ -10063,23 +10133,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_67 @kc87_second_23 -70;
     pos @kc87_first_67 @kc87_second_29 -35;
     pos @kc87_first_67 @kc87_second_31 -70;
-    pos @kc87_first_67 @kc87_second_33 105;
-    pos @kc87_first_67 @kc87_second_34 -35;
-    pos @kc87_first_67 @kc87_second_38 -70;
-    pos @kc87_first_67 @kc87_second_39 -140;
+    pos @kc87_first_67 @kc87_second_32 -50;
+    pos @kc87_first_67 @kc87_second_34 105;
+    pos @kc87_first_67 @kc87_second_35 -35;
+    pos @kc87_first_67 @kc87_second_39 -70;
     pos @kc87_first_67 @kc87_second_40 -140;
+    pos @kc87_first_67 @kc87_second_41 -140;
     pos @kc87_first_67 @kc87_second_43 -140;
-    pos @kc87_first_67 @kc87_second_44 -35;
-    pos @kc87_first_67 @kc87_second_45 1;
-    pos @kc87_first_67 @kc87_second_47 -70;
-    pos @kc87_first_67 @kc87_second_48 -100;
-    pos @kc87_first_67 @kc87_second_50 105;
-    pos @kc87_first_67 @kc87_second_58 -140;
-    pos @kc87_first_67 @kc87_second_60 -70;
-    pos @kc87_first_67 @kc87_second_61 -70;
-    pos @kc87_first_67 @kc87_second_62 -50;
-    pos @kc87_first_67 @kc87_second_63 -35;
-    pos @kc87_first_67 @kc87_second_64 -35;
+    pos @kc87_first_67 @kc87_second_44 -50;
+    pos @kc87_first_67 @kc87_second_46 -35;
+    pos @kc87_first_67 @kc87_second_48 1;
+    pos @kc87_first_67 @kc87_second_50 -70;
+    pos @kc87_first_67 @kc87_second_51 -100;
+    pos @kc87_first_67 @kc87_second_52 105;
+    pos @kc87_first_67 @kc87_second_60 -140;
+    pos @kc87_first_67 @kc87_second_62 -70;
+    pos @kc87_first_67 @kc87_second_63 -70;
+    pos @kc87_first_67 @kc87_second_64 -50;
+    pos @kc87_first_67 @kc87_second_65 -35;
+    pos @kc87_first_67 @kc87_second_66 -35;
     pos @kc87_first_68 @kc87_second_3 -70;
     pos @kc87_first_68 @kc87_second_4 -50;
     pos @kc87_first_68 @kc87_second_6 -50;
@@ -10096,21 +10168,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_68 @kc87_second_23 -70;
     pos @kc87_first_68 @kc87_second_29 -35;
     pos @kc87_first_68 @kc87_second_31 -70;
-    pos @kc87_first_68 @kc87_second_34 -35;
-    pos @kc87_first_68 @kc87_second_38 -70;
-    pos @kc87_first_68 @kc87_second_39 -140;
+    pos @kc87_first_68 @kc87_second_35 -35;
+    pos @kc87_first_68 @kc87_second_39 -70;
     pos @kc87_first_68 @kc87_second_40 -140;
+    pos @kc87_first_68 @kc87_second_41 -140;
     pos @kc87_first_68 @kc87_second_43 -140;
-    pos @kc87_first_68 @kc87_second_44 -35;
-    pos @kc87_first_68 @kc87_second_45 1;
-    pos @kc87_first_68 @kc87_second_47 -70;
-    pos @kc87_first_68 @kc87_second_48 -140;
-    pos @kc87_first_68 @kc87_second_58 -140;
-    pos @kc87_first_68 @kc87_second_60 -70;
-    pos @kc87_first_68 @kc87_second_61 -105;
+    pos @kc87_first_68 @kc87_second_46 -35;
+    pos @kc87_first_68 @kc87_second_48 1;
+    pos @kc87_first_68 @kc87_second_50 -70;
+    pos @kc87_first_68 @kc87_second_51 -140;
+    pos @kc87_first_68 @kc87_second_60 -140;
     pos @kc87_first_68 @kc87_second_62 -70;
-    pos @kc87_first_68 @kc87_second_63 -35;
-    pos @kc87_first_68 @kc87_second_64 -35;
+    pos @kc87_first_68 @kc87_second_63 -105;
+    pos @kc87_first_68 @kc87_second_64 -70;
+    pos @kc87_first_68 @kc87_second_65 -35;
+    pos @kc87_first_68 @kc87_second_66 -35;
     pos @kc87_first_69 @kc87_second_3 -70;
     pos @kc87_first_69 @kc87_second_4 -50;
     pos @kc87_first_69 @kc87_second_6 -50;
@@ -10127,23 +10199,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_69 @kc87_second_23 -100;
     pos @kc87_first_69 @kc87_second_29 -35;
     pos @kc87_first_69 @kc87_second_31 -70;
-    pos @kc87_first_69 @kc87_second_33 105;
-    pos @kc87_first_69 @kc87_second_34 -35;
-    pos @kc87_first_69 @kc87_second_38 -70;
-    pos @kc87_first_69 @kc87_second_39 -140;
+    pos @kc87_first_69 @kc87_second_32 -50;
+    pos @kc87_first_69 @kc87_second_34 105;
+    pos @kc87_first_69 @kc87_second_35 -35;
+    pos @kc87_first_69 @kc87_second_39 -70;
     pos @kc87_first_69 @kc87_second_40 -140;
+    pos @kc87_first_69 @kc87_second_41 -140;
     pos @kc87_first_69 @kc87_second_43 -140;
-    pos @kc87_first_69 @kc87_second_44 -35;
-    pos @kc87_first_69 @kc87_second_45 1;
-    pos @kc87_first_69 @kc87_second_47 -70;
-    pos @kc87_first_69 @kc87_second_48 -140;
-    pos @kc87_first_69 @kc87_second_50 105;
-    pos @kc87_first_69 @kc87_second_58 -140;
-    pos @kc87_first_69 @kc87_second_60 -70;
-    pos @kc87_first_69 @kc87_second_61 -70;
-    pos @kc87_first_69 @kc87_second_62 -50;
-    pos @kc87_first_69 @kc87_second_63 -35;
-    pos @kc87_first_69 @kc87_second_64 -35;
+    pos @kc87_first_69 @kc87_second_44 -50;
+    pos @kc87_first_69 @kc87_second_46 -35;
+    pos @kc87_first_69 @kc87_second_48 1;
+    pos @kc87_first_69 @kc87_second_50 -70;
+    pos @kc87_first_69 @kc87_second_51 -140;
+    pos @kc87_first_69 @kc87_second_52 105;
+    pos @kc87_first_69 @kc87_second_60 -140;
+    pos @kc87_first_69 @kc87_second_62 -70;
+    pos @kc87_first_69 @kc87_second_63 -70;
+    pos @kc87_first_69 @kc87_second_64 -50;
+    pos @kc87_first_69 @kc87_second_65 -35;
+    pos @kc87_first_69 @kc87_second_66 -35;
     pos @kc87_first_70 @kc87_second_1 -210;
     pos @kc87_first_70 @kc87_second_2 -210;
     pos @kc87_first_70 @kc87_second_3 -35;
@@ -10157,24 +10231,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_70 @kc87_second_23 -105;
     pos @kc87_first_70 @kc87_second_24 -175;
     pos @kc87_first_70 @kc87_second_29 -105;
-    pos @kc87_first_70 @kc87_second_34 -175;
-    pos @kc87_first_70 @kc87_second_35 -140;
-    pos @kc87_first_70 @kc87_second_36 -70;
-    pos @kc87_first_70 @kc87_second_37 -105;
+    pos @kc87_first_70 @kc87_second_32 -140;
+    pos @kc87_first_70 @kc87_second_35 -175;
+    pos @kc87_first_70 @kc87_second_36 -140;
+    pos @kc87_first_70 @kc87_second_37 -70;
     pos @kc87_first_70 @kc87_second_38 -105;
-    pos @kc87_first_70 @kc87_second_39 -70;
-    pos @kc87_first_70 @kc87_second_44 -35;
-    pos @kc87_first_70 @kc87_second_45 1;
-    pos @kc87_first_70 @kc87_second_50 -35;
-    pos @kc87_first_70 @kc87_second_51 -70;
-    pos @kc87_first_70 @kc87_second_52 -70;
-    pos @kc87_first_70 @kc87_second_53 -175;
+    pos @kc87_first_70 @kc87_second_39 -105;
+    pos @kc87_first_70 @kc87_second_40 -70;
+    pos @kc87_first_70 @kc87_second_46 -35;
+    pos @kc87_first_70 @kc87_second_48 1;
+    pos @kc87_first_70 @kc87_second_52 -35;
+    pos @kc87_first_70 @kc87_second_53 -70;
+    pos @kc87_first_70 @kc87_second_54 -70;
     pos @kc87_first_70 @kc87_second_55 -175;
     pos @kc87_first_70 @kc87_second_57 -175;
-    pos @kc87_first_70 @kc87_second_58 -35;
-    pos @kc87_first_70 @kc87_second_59 -35;
-    pos @kc87_first_70 @kc87_second_63 -140;
-    pos @kc87_first_70 @kc87_second_64 -175;
+    pos @kc87_first_70 @kc87_second_59 -175;
+    pos @kc87_first_70 @kc87_second_60 -35;
+    pos @kc87_first_70 @kc87_second_61 -35;
+    pos @kc87_first_70 @kc87_second_65 -140;
+    pos @kc87_first_70 @kc87_second_66 -175;
     pos @kc87_first_71 @kc87_second_5 -70;
     pos @kc87_first_71 @kc87_second_8 -70;
     pos @kc87_first_71 @kc87_second_9 -105;
@@ -10189,22 +10264,23 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_71 @kc87_second_26 -35;
     pos @kc87_first_71 @kc87_second_27 -70;
     pos @kc87_first_71 @kc87_second_31 -70;
-    pos @kc87_first_71 @kc87_second_38 -35;
-    pos @kc87_first_71 @kc87_second_39 -245;
-    pos @kc87_first_71 @kc87_second_40 -70;
-    pos @kc87_first_71 @kc87_second_42 -35;
+    pos @kc87_first_71 @kc87_second_39 -35;
+    pos @kc87_first_71 @kc87_second_40 -245;
+    pos @kc87_first_71 @kc87_second_41 -70;
     pos @kc87_first_71 @kc87_second_43 -240;
-    pos @kc87_first_71 @kc87_second_45 1;
-    pos @kc87_first_71 @kc87_second_47 -105;
-    pos @kc87_first_71 @kc87_second_48 -280;
-    pos @kc87_first_71 @kc87_second_49 -35;
-    pos @kc87_first_71 @kc87_second_54 -35;
-    pos @kc87_first_71 @kc87_second_56 -70;
-    pos @kc87_first_71 @kc87_second_58 -105;
-    pos @kc87_first_71 @kc87_second_59 -35;
-    pos @kc87_first_71 @kc87_second_60 -70;
-    pos @kc87_first_71 @kc87_second_61 -175;
-    pos @kc87_first_71 @kc87_second_62 -140;
+    pos @kc87_first_71 @kc87_second_44 -210;
+    pos @kc87_first_71 @kc87_second_45 -35;
+    pos @kc87_first_71 @kc87_second_47 -35;
+    pos @kc87_first_71 @kc87_second_48 1;
+    pos @kc87_first_71 @kc87_second_50 -105;
+    pos @kc87_first_71 @kc87_second_51 -280;
+    pos @kc87_first_71 @kc87_second_56 -35;
+    pos @kc87_first_71 @kc87_second_58 -70;
+    pos @kc87_first_71 @kc87_second_60 -105;
+    pos @kc87_first_71 @kc87_second_61 -35;
+    pos @kc87_first_71 @kc87_second_62 -70;
+    pos @kc87_first_71 @kc87_second_63 -175;
+    pos @kc87_first_71 @kc87_second_64 -140;
     pos @kc87_first_72 @kc87_second_1 -140;
     pos @kc87_first_72 @kc87_second_2 -140;
     pos @kc87_first_72 @kc87_second_6 -140;
@@ -10217,20 +10293,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_72 @kc87_second_23 -70;
     pos @kc87_first_72 @kc87_second_24 -140;
     pos @kc87_first_72 @kc87_second_29 -70;
-    pos @kc87_first_72 @kc87_second_34 -175;
-    pos @kc87_first_72 @kc87_second_35 -105;
-    pos @kc87_first_72 @kc87_second_36 -70;
+    pos @kc87_first_72 @kc87_second_32 -35;
+    pos @kc87_first_72 @kc87_second_35 -175;
+    pos @kc87_first_72 @kc87_second_36 -105;
     pos @kc87_first_72 @kc87_second_37 -70;
     pos @kc87_first_72 @kc87_second_38 -70;
-    pos @kc87_first_72 @kc87_second_39 -35;
-    pos @kc87_first_72 @kc87_second_45 1;
-    pos @kc87_first_72 @kc87_second_50 -35;
-    pos @kc87_first_72 @kc87_second_51 -35;
-    pos @kc87_first_72 @kc87_second_53 -140;
+    pos @kc87_first_72 @kc87_second_39 -70;
+    pos @kc87_first_72 @kc87_second_40 -35;
+    pos @kc87_first_72 @kc87_second_48 1;
+    pos @kc87_first_72 @kc87_second_52 -35;
+    pos @kc87_first_72 @kc87_second_53 -35;
     pos @kc87_first_72 @kc87_second_55 -140;
     pos @kc87_first_72 @kc87_second_57 -140;
-    pos @kc87_first_72 @kc87_second_63 -105;
-    pos @kc87_first_72 @kc87_second_64 -105;
+    pos @kc87_first_72 @kc87_second_59 -140;
+    pos @kc87_first_72 @kc87_second_65 -105;
+    pos @kc87_first_72 @kc87_second_66 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -12891,6 +12968,7 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
+#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 

--- a/sources/Giphurs-Italic.ufo/fontinfo.plist
+++ b/sources/Giphurs-Italic.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/30 16:15:48</string>
+    <string>2026/07/30 21:58:22</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Regular.ufo/features.fea
+++ b/sources/Giphurs-Regular.ufo/features.fea
@@ -7931,10 +7931,11 @@ lookup kern_Horizontal_kerning {
 	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
 	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
     @kc87_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
-	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
-	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
-	\uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA 
-	\uni1FFB \uni1FFC \uni20B2 \uni20B2.ss05 ];
+	\Q.cv29 \two.cv02.pnum \two.cv12.pnum \two.pnum \uni01E4 \uni03A9 
+	\uni051A \uni051A.cv29 \uni1E20 \uni1F68 \uni1F69 \uni1F6A \uni1F6B 
+	\uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 \uni1FA9 \uni1FAA \uni1FAB 
+	\uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA \uni1FFB \uni1FFC \uni20B2 
+	\uni20B2.ss05 ];
     @kc87_first_6 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
 	\uni0422 \uni0490 \uni0492 \uni04A4 \uni04AC \uni1E6A \uni1E6C \uni1E6E 
 	\uni1E70 ];
@@ -7946,24 +7947,27 @@ lookup kern_Horizontal_kerning {
     @kc87_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc87_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
-	\uniA7AD ];
+    @kc87_first_9 = [\L \Lacute \one.cv01.ss06.pnum \one.cv11.ss06.pnum \one.ss06.pnum \uni023D 
+	\uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 \uniA7AD ];
     @kc87_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
     @kc87_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
     @kc87_first_12 = [\Psi \uni0470 ];
     @kc87_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
-	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
-	\uni2107 ];
+    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv08.onum 
+	\eight.cv08.pnum \eight.cv18.onum \eight.cv18.pnum \three.cv03.pnum 
+	\three.pnum \uni0190 \uni01A7 \uni03E8 \uni0405 \uni0510 \uni1E60 
+	\uni1E62 \uni1E64 \uni1E66 \uni1E68 \uni2107 ];
     @kc87_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
     @kc87_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc87_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
-	\uni2163 \uni2164 \uni2C6F \universal ];
+    @kc87_first_17 = [\V \gradient \nine.cv19.pnum \seven.cv07.pnum \seven.cv07.ss07.pnum 
+	\seven.cv17.pnum \seven.cv17.ss07.pnum \seven.pnum \seven.ss07.pnum 
+	\slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE \uni2163 
+	\uni2164 \uni2C6F \universal ];
     @kc87_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
     @kc87_first_19 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
 	\atilde \uni01DF \uni01E1 \uni0201 \uni0203 \uni0227 \uni0430 \uni04D1 
@@ -8060,16 +8064,17 @@ lookup kern_Horizontal_kerning {
     @kc87_first_23 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
-	\uni0207 \uni020D \uni020F \uni0229 \uni022B \uni022D \uni022F \uni0231 
-	\uni0247 \uni0254 \uni0258 \uni0259 \uni0275 \uni0278 \uni037B \uni037D 
-	\uni03D9 \uni03F6 \uni0435 \uni043E \uni044D \uni044E \uni0473 \uni04BD 
-	\uni04BF \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni04ED 
-	\uni050D \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni018D \uni01D2 \uni01DD 
+	\uni01E3 \uni01EB \uni01ED \uni0205 \uni0207 \uni020D \uni020F \uni0229 
+	\uni022B \uni022D \uni022F \uni0231 \uni0247 \uni0254 \uni0258 \uni0259 
+	\uni0275 \uni0278 \uni037B \uni037D \uni03D9 \uni03F6 \uni0435 \uni043E 
+	\uni044D \uni044E \uni0473 \uni04BD \uni04BF \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni04ED \uni050D \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni2184 ];
     @kc87_first_24 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
@@ -8154,18 +8159,21 @@ lookup kern_Horizontal_kerning {
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc87_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
-	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
-	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
-	\uni037B.sc \uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc 
-	\uni0473.sc \uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc 
-	\uni04E9.sc \uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc 
-	\uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc 
-	\uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc 
-	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
-	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
-	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
+    @kc87_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \nine.cv09.onum \nine.cv19.onum \nine.onum 
+	\o.sc \oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohungarumlaut.sc \omacron.sc \omicron.sc \oslash.sc \otilde.sc 
+	\uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc \uni022D.sc 
+	\uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc \uni037B.sc 
+	\uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc \uni0473.sc 
+	\uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc 
+	\uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc 
+	\uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_first_34 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
@@ -8224,73 +8232,81 @@ lookup kern_Horizontal_kerning {
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
     @kc87_first_38 = [\eth \uni1EFC \uni1EFD ];
-    @kc87_first_39 = [\fraction ];
-    @kc87_first_40 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc87_first_41 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
-	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_first_42 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc87_first_39 = [\four.cv04.onum \four.cv14.onum \four.onum \l.sc \lacute.sc \lcaron.sc 
+	\lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc \uni0234.sc 
+	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
+    @kc87_first_40 = [\four.cv04.pnum \four.cv14.pnum \four.pnum \phi.sc \thorn.sc \uni01A5.sc 
+	\uni0444.sc ];
+    @kc87_first_41 = [\fraction ];
+    @kc87_first_42 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \three.cv03.onum 
+	\three.onum \uni01E5 \uni1E21 ];
+    @kc87_first_43 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \two.cv02.onum \two.cv12.onum 
+	\two.onum \uni0260.sc \uni051B.sc \uni051B.sc.cv29 \uni1F60.sc 
+	\uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc 
+	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc 
+	\uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
+	\uni1FF6.sc \uni1FF7.sc ];
+    @kc87_first_44 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc87_first_43 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc87_first_45 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc87_first_44 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc87_first_46 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc87_first_45 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc87_first_47 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc87_first_46 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc87_first_48 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc87_first_47 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
-	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc87_first_48 = [\lambda \uni019B ];
-    @kc87_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc87_first_50 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc87_first_49 = [\lambda \uni019B ];
+    @kc87_first_50 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc87_first_51 = [\theta \uni047C \uniA7B6 \uniA64C \uni0424.loclBGR \zero.pnum \nine.pnum 
+	\nine.cv09.pnum \zero.cv10.pnum \zero.cv20.pnum \zero.zero.pnum 
+	\zero.cv10.zero.pnum \zero.cv20.zero.pnum ];
+    @kc87_first_52 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc87_first_51 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc87_first_52 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc87_first_53 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc87_first_53 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc87_first_54 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc87_first_55 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc87_first_54 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc87_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc87_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc87_first_56 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc87_first_57 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc87_first_58 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc87_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_first_59 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc87_first_59 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
-	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
-	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_first_60 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
-	\uni1E71 ];
-    @kc87_first_61 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
-    @kc87_first_62 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc87_first_63 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc87_first_64 = [\uni0196 \uni01AA ];
-    @kc87_first_65 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
-	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
-	\ygrave ];
-    @kc87_first_66 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_first_60 = [\seven.cv07.onum \seven.cv07.ss07.onum \seven.cv17.ss07.onum 
+	\seven.cv17.tnum \seven.onum \seven.ss07.onum \uni01B4.sc 
+	\uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_first_67 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
-	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
-	\zdotaccent ];
+    @kc87_first_61 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
+    @kc87_first_62 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+	\uni1E71 ];
+    @kc87_first_63 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
+    @kc87_first_64 = [\three.cv13.onum \uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 
+	\uni02A3 \uni02AB \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z 
+	\zacute \zcaron \zdotaccent ];
+    @kc87_first_65 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc87_first_66 = [\uni0196 \uni01AA ];
+    @kc87_first_67 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
+	\ygrave ];
     @kc87_first_68 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
     @kc87_first_69 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
@@ -8331,15 +8347,19 @@ lookup kern_Horizontal_kerning {
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
     @kc87_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc87_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc87_second_7 = [\Omega \nine.cv19.pnum \two.cv02.pnum \two.cv12.pnum \two.pnum \uni03A9 
+	\uni1FFC ];
     @kc87_second_8 = [\Phi \uni0424 ];
     @kc87_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
-	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
-	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
-	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
+    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv18.onum 
+	\eight.cv18.pnum \eight.onum \three.cv03.pnum \three.pnum \uni01A7 
+	\uni03E8 \uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 
+	\uni1E68 ];
+    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \three.cv13.pnum \uni01A9 \uni01B5 
+	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 ];
+    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \seven.cv07.pnum \seven.cv17.pnum \seven.pnum \uni0162 
+	\uni01AC \uni01AE \uni021A \uni0422 \uni042A \uni04AC \uni04B4 \uni050E 
+	\uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
     @kc87_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
@@ -8371,18 +8391,19 @@ lookup kern_Horizontal_kerning {
 	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 
 	\uni1FB4 \uni1FB6 \uni1FB7 \uni217E \uniA64D \uniA7C8 ];
     @kc87_second_19 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
-	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
-	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
-	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
-	\uni043B.loclBGR.sc \uni0467.sc \uni0469.sc \uni04D1.sc \uni04D3.sc 
-	\uni1E01.sc \uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc 
-	\uni1EA9.sc \uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc 
-	\uni1EB3.sc \uni1EB5.sc \uni1EB7.sc \uni1F00.sc \uni1F01.sc 
-	\uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc 
-	\uni1F07.sc \uni1F70.sc \uni1F71.sc \uni1F80.sc \uni1F81.sc 
-	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
-	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
-	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
+	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc 
+	\four.cv04.onum \four.cv14.onum \four.onum \lambda.sc \uni019B.sc 
+	\uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc \uni0203.sc 
+	\uni0227.sc \uni0430.sc \uni0434.loclBGR.sc \uni043B.loclBGR.sc 
+	\uni0467.sc \uni0469.sc \uni04D1.sc \uni04D3.sc \uni1E01.sc 
+	\uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc \uni1EA9.sc 
+	\uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc \uni1EB3.sc 
+	\uni1EB5.sc \uni1EB7.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc 
+	\uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc 
+	\uni1F70.sc \uni1F71.sc \uni1F80.sc \uni1F81.sc \uni1F82.sc 
+	\uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc \uni1F87.sc 
+	\uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc \uni1FB4.sc 
+	\uni1FB6.sc \uni1FB7.sc ];
     @kc87_second_20 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
@@ -8450,35 +8471,38 @@ lookup kern_Horizontal_kerning {
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni0188 \uni018D \uni01A3 \uni01D2 \uni01DD \uni01EB \uni020D 
-	\uni020F \uni022B \uni022D \uni022F \uni0231 \uni023C \uni0247 \uni0255 
-	\uni0258 \uni0259 \uni025A \uni0275 \uni0276 \uni029B \uni03D9 \uni03F2 
-	\uni03F5 \uni0435 \uni043E \uni0450 \uni0451 \uni0473 \uni047B \uni04A9 
-	\uni04AB \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni050D 
-	\uni1E09 \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni0188 \uni018D \uni01A3 
+	\uni01D2 \uni01DD \uni01EB \uni020D \uni020F \uni022B \uni022D \uni022F 
+	\uni0231 \uni023C \uni0247 \uni0255 \uni0258 \uni0259 \uni025A \uni0275 
+	\uni0276 \uni029B \uni03D9 \uni03F2 \uni03F5 \uni0435 \uni043E \uni0450 
+	\uni0451 \uni0473 \uni047B \uni04A9 \uni04AB \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni050D \uni1E09 \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni20C0 \uni217D ];
     @kc87_second_25 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
-	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
-	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \q.sc.cv29 \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc 
-	\uni01E5.sc \uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc 
-	\uni020F.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc 
-	\uni023C.sc \uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc 
-	\uni037C.sc \uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc 
-	\uni0444.loclBGR.sc \uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc 
-	\uni04AB.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
-	\uni04EB.sc \uni050D.sc \uni051B.sc \uni051B.sc.cv29 \uni1E09.sc 
-	\uni1E21.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
-	\uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc 
-	\uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
-	\uni1EE1.sc \uni1EE3.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc 
-	\uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc 
-	\uni217D.sc ];
+	\gdotaccent.sc \nine.cv09.onum \nine.cv19.onum \nine.onum \o.sc 
+	\oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohorn.sc \ohungarumlaut.sc \omacron.sc \omicron.sc \omicrontonos.sc 
+	\oslash.sc \oslashacute.sc \otilde.sc \q.sc \q.sc.cv29 \theta.sc 
+	\uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc \uni022B.sc 
+	\uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc \uni0259.sc 
+	\uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc \uni03D9.sc 
+	\uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc \uni0454.sc 
+	\uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc \uni04D9.sc 
+	\uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni050D.sc 
+	\uni051B.sc \uni051B.sc.cv29 \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
+	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
+	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
+	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_second_26 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
@@ -8541,14 +8565,15 @@ lookup kern_Horizontal_kerning {
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
     @kc87_second_29 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
-	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
-	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
-	\uni0457.sc \uni1E2D.sc \uni1E2F.sc \uni1EC9.sc \uni1ECB.sc 
-	\uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc 
-	\uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F76.sc \uni1F77.sc 
-	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2178.sc ];
+	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \one.cv01.ss06.onum 
+	\one.cv01.ss06.pnum \one.cv11.ss06.onum \one.cv11.ss06.pnum 
+	\one.ss06.onum \one.ss06.pnum \uni01D0.sc \uni0209.sc \uni020B.sc 
+	\uni0269.sc \uni026A.sc \uni0456.sc \uni0457.sc \uni1E2D.sc 
+	\uni1E2F.sc \uni1EC9.sc \uni1ECB.sc \uni1F30.sc \uni1F31.sc 
+	\uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
+	\uni1F37.sc \uni1F76.sc \uni1F77.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2178.sc ];
     @kc87_second_30 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
@@ -8591,21 +8616,22 @@ lookup kern_Horizontal_kerning {
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
     @kc87_second_32 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
-	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
-	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
-	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
-	\uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 \uni01D4.cv25 
-	\uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA \uni01DA.cv25 
-	\uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 \uni0215 
-	\uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 \uni0269 
-	\uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B \uni0299 
-	\uni029C \uni029F \uni0432 \uni0433 \uni0438 \uni0439 \uni043A \uni043C 
-	\uni043D \uni043F \uni0446 \uni0448 \uni0449 \uni044B \uni044C \uni044E 
-	\uni0453 \uni045C \uni045D \uni045F \uni0465 \uni0469 \uni046D \uni0491 
-	\uni0493 \uni0495 \uni049B \uni049D \uni04A1 \uni04A3 \uni04A5 \uni04A7 
-	\uni04C8 \uni04CA \uni04CE \uni04F7 \uni04FB \uni0523 \uni0525 \uni0529 
-	\uni1E3F \uni1E41 \uni1E43 \uni1E45 \uni1E47 \uni1E49 \uni1E4B \uni1E59 
-	\uni1E5B \uni1E5D \uni1E5F \uni1E73 \uni1E73.cv25 \uni1E75 
+	\ntilde \r \racute \rcaron \rcommaaccent \seven.cv07.ss07.onum 
+	\seven.cv17.ss07.onum \seven.ss07.onum \u \u.cv25 \uacute 
+	\uacute.cv25 \ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 
+	\udieresis \udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 
+	\uhungarumlaut \uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 
+	\uni01D4.cv25 \uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA 
+	\uni01DA.cv25 \uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 
+	\uni0215 \uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 
+	\uni0269 \uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B 
+	\uni0299 \uni029C \uni029F \uni0432 \uni0433 \uni0438 \uni0439 \uni043A 
+	\uni043C \uni043D \uni043F \uni0446 \uni0448 \uni0449 \uni044B \uni044C 
+	\uni044E \uni0453 \uni045C \uni045D \uni045F \uni0465 \uni0469 \uni046D 
+	\uni0491 \uni0493 \uni0495 \uni049B \uni049D \uni04A1 \uni04A3 \uni04A5 
+	\uni04A7 \uni04C8 \uni04CA \uni04CE \uni04F7 \uni04FB \uni0523 \uni0525 
+	\uni0529 \uni1E3F \uni1E41 \uni1E43 \uni1E45 \uni1E47 \uni1E49 \uni1E4B 
+	\uni1E59 \uni1E5B \uni1E5D \uni1E5F \uni1E73 \uni1E73.cv25 \uni1E75 
 	\uni1E75.cv25 \uni1E77 \uni1E77.cv25 \uni1E79 \uni1E79.cv25 \uni1E7B 
 	\uni1E7B.cv25 \uni1EE5 \uni1EE5.cv25 \uni1EE7 \uni1EE7.cv25 \uni1EE9 
 	\uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 \uni1EED \uni1EED.cv25 \uni1EEF 
@@ -8614,75 +8640,83 @@ lookup kern_Horizontal_kerning {
 	\uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 \upsilon 
 	\upsilondieresistonos \upsilontonos \uring \uring.cv25 \utilde 
 	\utilde.cv25 ];
-    @kc87_second_33 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
-	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc87_second_34 = [\fraction ];
-    @kc87_second_35 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \uni01E5 \uni1E21 ];
-    @kc87_second_36 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc87_second_37 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+    @kc87_second_33 = [\f \florin \one.cv01.onum \one.cv01.pnum \one.cv11.onum \one.cv11.pnum 
+	\one.onum \one.pnum \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 
+	\uni1E1F \uni1E6B \uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
+    @kc87_second_34 = [\four.cv04.pnum \four.cv14.pnum \four.pnum ];
+    @kc87_second_35 = [\fraction ];
+    @kc87_second_36 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \three.cv03.onum \three.onum 
+	\uni01E5 \uni1E21 ];
+    @kc87_second_37 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc87_second_38 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc87_second_38 = [\lambda \uni019B ];
-    @kc87_second_39 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc87_second_39 = [\lambda \uni019B ];
+    @kc87_second_40 = [\nine.cv09.pnum \nine.pnum \six.cv06.onum \six.cv06.pnum \six.onum \six.pnum 
+	\theta \uni0478 \uniA64C \zero.cv10.pnum \zero.cv10.zero.pnum 
+	\zero.cv20.pnum \zero.cv20.zero.pnum \zero.pnum \zero.zero.pnum ];
+    @kc87_second_41 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc87_second_40 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_second_41 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_second_42 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
-    @kc87_second_43 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc87_second_42 = [\omega.sc \omegatonos.sc \two.cv02.onum \two.cv12.onum \two.onum \uni1F60.sc 
+	\uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc 
+	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc 
+	\uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
+	\uni1FF6.sc \uni1FF7.sc ];
+    @kc87_second_43 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc87_second_44 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
+    @kc87_second_45 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc87_second_44 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_second_46 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc87_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc87_second_47 = [\seven.cv07.onum \seven.cv17.onum \seven.onum \t.sc \tau.sc \tbar.sc 
+	\tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc \uni021B.sc 
+	\uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc \uni0442.sc 
+	\uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc 
+	\uni1E71.sc \uni1E97.sc ];
+    @kc87_second_48 = [\seven.cv07.ss07.pnum \seven.cv17.ss07.pnum \seven.ss07.pnum ];
+    @kc87_second_49 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_second_46 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
-	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
-	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc87_second_47 = [\theta \uni0478 \uniA64C ];
-    @kc87_second_48 = [\tonos2 ];
-    @kc87_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc87_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc87_second_50 = [\three.cv13.onum \uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 
+	\uniA641 \uniA643 \z \zacute \zcaron \zdotaccent ];
+    @kc87_second_51 = [\tonos2 ];
+    @kc87_second_52 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc87_second_53 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc87_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_second_54 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_second_52 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
-	\z \zacute \zcaron \zdotaccent ];
-    @kc87_second_53 = [\uni0237 ];
-    @kc87_second_54 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc87_second_55 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc87_second_56 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc87_second_57 = [\uni042F \uni0518 ];
-    @kc87_second_58 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
+    @kc87_second_55 = [\uni0237 ];
+    @kc87_second_56 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc87_second_57 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc87_second_58 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc87_second_59 = [\uni042F \uni0518 ];
+    @kc87_second_60 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
 	\uni052F ];
-    @kc87_second_59 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc87_second_61 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc87_second_60 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc87_second_62 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc87_second_61 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc87_second_62 = [\uni044F.sc \uni0519.sc ];
-    @kc87_second_63 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc87_second_63 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc87_second_64 = [\uni044F.sc \uni0519.sc ];
+    @kc87_second_65 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc87_second_64 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc87_second_65 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc87_second_66 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc87_second_67 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc87_second_66 = [\uni0500 \uni0502 ];
-    @kc87_second_67 = [\uni0501.sc \uni0503.sc ];
-    @kc87_second_68 = [\zero.cv10.zero.dnom.pnum \zero.cv20.zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc87_second_69 = [\zero.cv10.zero.numr.pnum \zero.cv20.zero.numr.pnum \zero.zero.numr.pnum ];
+    @kc87_second_68 = [\uni0500 \uni0502 ];
+    @kc87_second_69 = [\uni0501.sc \uni0503.sc ];
+    @kc87_second_70 = [\zero.cv10.zero.dnom.pnum \zero.cv20.zero.dnom.pnum \zero.zero.dnom.pnum ];
+    @kc87_second_71 = [\zero.cv10.zero.numr.pnum \zero.cv20.zero.numr.pnum \zero.zero.numr.pnum ];
     pos @kc87_first_1 @kc87_second_3 -70;
     pos @kc87_first_1 @kc87_second_8 -70;
     pos @kc87_first_1 @kc87_second_9 -140;
     pos @kc87_first_1 @kc87_second_10 -35;
-    pos @kc87_first_1 @kc87_second_12 -280;
+    pos @kc87_first_1 @kc87_second_12 -210;
     pos @kc87_first_1 @kc87_second_13 -280;
     pos @kc87_first_1 @kc87_second_14 -280;
     pos @kc87_first_1 @kc87_second_15 -210;
@@ -8690,26 +8724,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_1 @kc87_second_25 -35;
     pos @kc87_first_1 @kc87_second_27 -50;
     pos @kc87_first_1 @kc87_second_33 -70;
-    pos @kc87_first_1 @kc87_second_41 -35;
-    pos @kc87_first_1 @kc87_second_42 -140;
-    pos @kc87_first_1 @kc87_second_43 -105;
-    pos @kc87_first_1 @kc87_second_46 -210;
-    pos @kc87_first_1 @kc87_second_47 -35;
-    pos @kc87_first_1 @kc87_second_48 1;
-    pos @kc87_first_1 @kc87_second_50 -175;
-    pos @kc87_first_1 @kc87_second_51 -210;
-    pos @kc87_first_1 @kc87_second_61 -140;
+    pos @kc87_first_1 @kc87_second_40 -35;
+    pos @kc87_first_1 @kc87_second_43 -35;
+    pos @kc87_first_1 @kc87_second_44 -140;
+    pos @kc87_first_1 @kc87_second_45 -105;
+    pos @kc87_first_1 @kc87_second_47 -210;
+    pos @kc87_first_1 @kc87_second_48 -175;
+    pos @kc87_first_1 @kc87_second_51 1;
+    pos @kc87_first_1 @kc87_second_53 -175;
+    pos @kc87_first_1 @kc87_second_54 -210;
     pos @kc87_first_1 @kc87_second_63 -140;
-    pos @kc87_first_1 @kc87_second_64 -210;
     pos @kc87_first_1 @kc87_second_65 -140;
+    pos @kc87_first_1 @kc87_second_66 -210;
+    pos @kc87_first_1 @kc87_second_67 -140;
     pos @kc87_first_2 @kc87_second_9 -35;
     pos @kc87_first_2 @kc87_second_12 -70;
     pos @kc87_first_2 @kc87_second_13 -70;
     pos @kc87_first_2 @kc87_second_14 -70;
     pos @kc87_first_2 @kc87_second_15 -35;
     pos @kc87_first_2 @kc87_second_16 -35;
-    pos @kc87_first_2 @kc87_second_42 -35;
-    pos @kc87_first_2 @kc87_second_48 1;
+    pos @kc87_first_2 @kc87_second_44 -35;
+    pos @kc87_first_2 @kc87_second_51 1;
     pos @kc87_first_3 @kc87_second_1 -35;
     pos @kc87_first_3 @kc87_second_2 -70;
     pos @kc87_first_3 @kc87_second_5 -35;
@@ -8720,8 +8755,8 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_3 @kc87_second_16 -70;
     pos @kc87_first_3 @kc87_second_19 -35;
     pos @kc87_first_3 @kc87_second_21 -70;
-    pos @kc87_first_3 @kc87_second_38 -35;
-    pos @kc87_first_3 @kc87_second_48 1;
+    pos @kc87_first_3 @kc87_second_39 -35;
+    pos @kc87_first_3 @kc87_second_51 1;
     pos @kc87_first_4 @kc87_second_1 -70;
     pos @kc87_first_4 @kc87_second_2 -140;
     pos @kc87_first_4 @kc87_second_4 70;
@@ -8737,24 +8772,24 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_4 @kc87_second_28 -70;
     pos @kc87_first_4 @kc87_second_29 -35;
     pos @kc87_first_4 @kc87_second_33 35;
-    pos @kc87_first_4 @kc87_second_35 -35;
-    pos @kc87_first_4 @kc87_second_37 -70;
+    pos @kc87_first_4 @kc87_second_36 -35;
     pos @kc87_first_4 @kc87_second_38 -70;
-    pos @kc87_first_4 @kc87_second_46 -35;
-    pos @kc87_first_4 @kc87_second_48 1;
-    pos @kc87_first_4 @kc87_second_51 -70;
-    pos @kc87_first_4 @kc87_second_56 -70;
+    pos @kc87_first_4 @kc87_second_39 -70;
+    pos @kc87_first_4 @kc87_second_47 -35;
+    pos @kc87_first_4 @kc87_second_51 1;
+    pos @kc87_first_4 @kc87_second_54 -70;
     pos @kc87_first_4 @kc87_second_58 -70;
-    pos @kc87_first_4 @kc87_second_59 -70;
-    pos @kc87_first_4 @kc87_second_64 -35;
+    pos @kc87_first_4 @kc87_second_60 -70;
+    pos @kc87_first_4 @kc87_second_61 -70;
+    pos @kc87_first_4 @kc87_second_66 -35;
     pos @kc87_first_5 @kc87_second_12 -70;
-    pos @kc87_first_5 @kc87_second_48 1;
+    pos @kc87_first_5 @kc87_second_51 1;
     pos @kc87_first_6 @kc87_second_1 -280;
     pos @kc87_first_6 @kc87_second_2 -350;
     pos @kc87_first_6 @kc87_second_3 -140;
     pos @kc87_first_6 @kc87_second_4 -70;
     pos @kc87_first_6 @kc87_second_6 -350;
-    pos @kc87_first_6 @kc87_second_7 -140;
+    pos @kc87_first_6 @kc87_second_7 -70;
     pos @kc87_first_6 @kc87_second_8 -210;
     pos @kc87_first_6 @kc87_second_10 -70;
     pos @kc87_first_6 @kc87_second_17 -240;
@@ -8771,32 +8806,33 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_6 @kc87_second_31 -240;
     pos @kc87_first_6 @kc87_second_32 -240;
     pos @kc87_first_6 @kc87_second_33 -175;
-    pos @kc87_first_6 @kc87_second_35 -240;
-    pos @kc87_first_6 @kc87_second_37 -350;
-    pos @kc87_first_6 @kc87_second_38 -105;
-    pos @kc87_first_6 @kc87_second_39 -240;
-    pos @kc87_first_6 @kc87_second_40 -210;
+    pos @kc87_first_6 @kc87_second_34 -175;
+    pos @kc87_first_6 @kc87_second_36 -240;
+    pos @kc87_first_6 @kc87_second_38 -350;
+    pos @kc87_first_6 @kc87_second_39 -105;
+    pos @kc87_first_6 @kc87_second_40 -70;
     pos @kc87_first_6 @kc87_second_41 -240;
-    pos @kc87_first_6 @kc87_second_42 -240;
+    pos @kc87_first_6 @kc87_second_42 -210;
+    pos @kc87_first_6 @kc87_second_43 -240;
     pos @kc87_first_6 @kc87_second_44 -240;
-    pos @kc87_first_6 @kc87_second_47 -140;
-    pos @kc87_first_6 @kc87_second_48 1;
-    pos @kc87_first_6 @kc87_second_49 -35;
+    pos @kc87_first_6 @kc87_second_46 -240;
     pos @kc87_first_6 @kc87_second_50 -240;
-    pos @kc87_first_6 @kc87_second_52 -240;
+    pos @kc87_first_6 @kc87_second_51 1;
+    pos @kc87_first_6 @kc87_second_52 -35;
     pos @kc87_first_6 @kc87_second_53 -240;
-    pos @kc87_first_6 @kc87_second_54 -240;
     pos @kc87_first_6 @kc87_second_55 -240;
-    pos @kc87_first_6 @kc87_second_56 -280;
-    pos @kc87_first_6 @kc87_second_57 -70;
+    pos @kc87_first_6 @kc87_second_56 -240;
+    pos @kc87_first_6 @kc87_second_57 -240;
     pos @kc87_first_6 @kc87_second_58 -280;
-    pos @kc87_first_6 @kc87_second_59 -240;
-    pos @kc87_first_6 @kc87_second_60 -175;
+    pos @kc87_first_6 @kc87_second_59 -70;
+    pos @kc87_first_6 @kc87_second_60 -280;
     pos @kc87_first_6 @kc87_second_61 -240;
-    pos @kc87_first_6 @kc87_second_62 -210;
-    pos @kc87_first_6 @kc87_second_63 -175;
-    pos @kc87_first_6 @kc87_second_66 -175;
-    pos @kc87_first_6 @kc87_second_67 -175;
+    pos @kc87_first_6 @kc87_second_62 -175;
+    pos @kc87_first_6 @kc87_second_63 -240;
+    pos @kc87_first_6 @kc87_second_64 -210;
+    pos @kc87_first_6 @kc87_second_65 -175;
+    pos @kc87_first_6 @kc87_second_68 -175;
+    pos @kc87_first_6 @kc87_second_69 -175;
     pos @kc87_first_7 @kc87_second_3 -70;
     pos @kc87_first_7 @kc87_second_8 -105;
     pos @kc87_first_7 @kc87_second_17 -35;
@@ -8804,13 +8840,14 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_7 @kc87_second_22 -105;
     pos @kc87_first_7 @kc87_second_24 -105;
     pos @kc87_first_7 @kc87_second_25 -70;
-    pos @kc87_first_7 @kc87_second_48 1;
-    pos @kc87_first_7 @kc87_second_49 -35;
-    pos @kc87_first_7 @kc87_second_50 -70;
-    pos @kc87_first_7 @kc87_second_54 -50;
-    pos @kc87_first_7 @kc87_second_63 -35;
-    pos @kc87_first_7 @kc87_second_66 -70;
-    pos @kc87_first_7 @kc87_second_67 -70;
+    pos @kc87_first_7 @kc87_second_34 -70;
+    pos @kc87_first_7 @kc87_second_51 1;
+    pos @kc87_first_7 @kc87_second_52 -35;
+    pos @kc87_first_7 @kc87_second_53 -70;
+    pos @kc87_first_7 @kc87_second_56 -50;
+    pos @kc87_first_7 @kc87_second_65 -35;
+    pos @kc87_first_7 @kc87_second_68 -70;
+    pos @kc87_first_7 @kc87_second_69 -70;
     pos @kc87_first_8 @kc87_second_3 -140;
     pos @kc87_first_8 @kc87_second_4 -70;
     pos @kc87_first_8 @kc87_second_6 -70;
@@ -8824,26 +8861,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_8 @kc87_second_27 -140;
     pos @kc87_first_8 @kc87_second_31 -35;
     pos @kc87_first_8 @kc87_second_33 -105;
-    pos @kc87_first_8 @kc87_second_37 -70;
-    pos @kc87_first_8 @kc87_second_39 -70;
-    pos @kc87_first_8 @kc87_second_41 -105;
-    pos @kc87_first_8 @kc87_second_42 -175;
-    pos @kc87_first_8 @kc87_second_43 -140;
-    pos @kc87_first_8 @kc87_second_44 -35;
-    pos @kc87_first_8 @kc87_second_46 -140;
-    pos @kc87_first_8 @kc87_second_47 -105;
-    pos @kc87_first_8 @kc87_second_48 1;
-    pos @kc87_first_8 @kc87_second_49 -70;
-    pos @kc87_first_8 @kc87_second_50 -140;
-    pos @kc87_first_8 @kc87_second_51 -70;
-    pos @kc87_first_8 @kc87_second_54 -35;
-    pos @kc87_first_8 @kc87_second_55 -35;
-    pos @kc87_first_8 @kc87_second_61 -210;
-    pos @kc87_first_8 @kc87_second_63 -105;
-    pos @kc87_first_8 @kc87_second_64 -70;
-    pos @kc87_first_8 @kc87_second_65 -35;
+    pos @kc87_first_8 @kc87_second_34 -70;
+    pos @kc87_first_8 @kc87_second_38 -70;
+    pos @kc87_first_8 @kc87_second_40 -105;
+    pos @kc87_first_8 @kc87_second_41 -70;
+    pos @kc87_first_8 @kc87_second_43 -105;
+    pos @kc87_first_8 @kc87_second_44 -175;
+    pos @kc87_first_8 @kc87_second_45 -140;
+    pos @kc87_first_8 @kc87_second_46 -35;
+    pos @kc87_first_8 @kc87_second_47 -140;
+    pos @kc87_first_8 @kc87_second_51 1;
+    pos @kc87_first_8 @kc87_second_52 -70;
+    pos @kc87_first_8 @kc87_second_53 -140;
+    pos @kc87_first_8 @kc87_second_54 -70;
+    pos @kc87_first_8 @kc87_second_56 -35;
+    pos @kc87_first_8 @kc87_second_57 -35;
+    pos @kc87_first_8 @kc87_second_63 -210;
+    pos @kc87_first_8 @kc87_second_65 -105;
     pos @kc87_first_8 @kc87_second_66 -70;
     pos @kc87_first_8 @kc87_second_67 -35;
+    pos @kc87_first_8 @kc87_second_68 -70;
+    pos @kc87_first_8 @kc87_second_69 -35;
     pos @kc87_first_9 @kc87_second_3 -140;
     pos @kc87_first_9 @kc87_second_4 -70;
     pos @kc87_first_9 @kc87_second_6 -70;
@@ -8862,24 +8900,26 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_9 @kc87_second_25 -140;
     pos @kc87_first_9 @kc87_second_31 -50;
     pos @kc87_first_9 @kc87_second_33 -140;
-    pos @kc87_first_9 @kc87_second_37 -70;
-    pos @kc87_first_9 @kc87_second_41 -105;
-    pos @kc87_first_9 @kc87_second_42 -280;
-    pos @kc87_first_9 @kc87_second_43 -350;
-    pos @kc87_first_9 @kc87_second_44 -50;
-    pos @kc87_first_9 @kc87_second_46 -350;
-    pos @kc87_first_9 @kc87_second_48 1;
-    pos @kc87_first_9 @kc87_second_49 -35;
-    pos @kc87_first_9 @kc87_second_50 -210;
-    pos @kc87_first_9 @kc87_second_51 -350;
-    pos @kc87_first_9 @kc87_second_54 -35;
-    pos @kc87_first_9 @kc87_second_55 -35;
-    pos @kc87_first_9 @kc87_second_61 -280;
-    pos @kc87_first_9 @kc87_second_63 -175;
-    pos @kc87_first_9 @kc87_second_64 -280;
-    pos @kc87_first_9 @kc87_second_65 -210;
-    pos @kc87_first_9 @kc87_second_66 -70;
-    pos @kc87_first_9 @kc87_second_67 -70;
+    pos @kc87_first_9 @kc87_second_34 -70;
+    pos @kc87_first_9 @kc87_second_38 -70;
+    pos @kc87_first_9 @kc87_second_43 -105;
+    pos @kc87_first_9 @kc87_second_44 -280;
+    pos @kc87_first_9 @kc87_second_45 -350;
+    pos @kc87_first_9 @kc87_second_46 -50;
+    pos @kc87_first_9 @kc87_second_47 -350;
+    pos @kc87_first_9 @kc87_second_48 -280;
+    pos @kc87_first_9 @kc87_second_51 1;
+    pos @kc87_first_9 @kc87_second_52 -35;
+    pos @kc87_first_9 @kc87_second_53 -210;
+    pos @kc87_first_9 @kc87_second_54 -350;
+    pos @kc87_first_9 @kc87_second_56 -35;
+    pos @kc87_first_9 @kc87_second_57 -35;
+    pos @kc87_first_9 @kc87_second_63 -280;
+    pos @kc87_first_9 @kc87_second_65 -175;
+    pos @kc87_first_9 @kc87_second_66 -280;
+    pos @kc87_first_9 @kc87_second_67 -210;
+    pos @kc87_first_9 @kc87_second_68 -70;
+    pos @kc87_first_9 @kc87_second_69 -70;
     pos @kc87_first_10 @kc87_second_1 -210;
     pos @kc87_first_10 @kc87_second_2 -350;
     pos @kc87_first_10 @kc87_second_5 -70;
@@ -8896,18 +8936,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_10 @kc87_second_24 -70;
     pos @kc87_first_10 @kc87_second_26 -350;
     pos @kc87_first_10 @kc87_second_31 -70;
-    pos @kc87_first_10 @kc87_second_34 -140;
-    pos @kc87_first_10 @kc87_second_35 -70;
-    pos @kc87_first_10 @kc87_second_37 -210;
-    pos @kc87_first_10 @kc87_second_38 -105;
-    pos @kc87_first_10 @kc87_second_41 -70;
-    pos @kc87_first_10 @kc87_second_48 1;
-    pos @kc87_first_10 @kc87_second_56 -210;
+    pos @kc87_first_10 @kc87_second_34 -35;
+    pos @kc87_first_10 @kc87_second_35 -140;
+    pos @kc87_first_10 @kc87_second_36 -70;
+    pos @kc87_first_10 @kc87_second_38 -210;
+    pos @kc87_first_10 @kc87_second_39 -105;
+    pos @kc87_first_10 @kc87_second_43 -70;
+    pos @kc87_first_10 @kc87_second_51 1;
     pos @kc87_first_10 @kc87_second_58 -210;
-    pos @kc87_first_10 @kc87_second_59 -210;
-    pos @kc87_first_10 @kc87_second_64 -70;
+    pos @kc87_first_10 @kc87_second_60 -210;
+    pos @kc87_first_10 @kc87_second_61 -210;
     pos @kc87_first_10 @kc87_second_66 -70;
-    pos @kc87_first_10 @kc87_second_67 -105;
+    pos @kc87_first_10 @kc87_second_68 -70;
+    pos @kc87_first_10 @kc87_second_69 -105;
     pos @kc87_first_11 @kc87_second_1 -70;
     pos @kc87_first_11 @kc87_second_2 -140;
     pos @kc87_first_11 @kc87_second_5 -105;
@@ -8923,22 +8964,22 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_11 @kc87_second_26 -70;
     pos @kc87_first_11 @kc87_second_28 -70;
     pos @kc87_first_11 @kc87_second_29 -70;
-    pos @kc87_first_11 @kc87_second_35 -35;
-    pos @kc87_first_11 @kc87_second_37 -35;
-    pos @kc87_first_11 @kc87_second_38 -140;
-    pos @kc87_first_11 @kc87_second_42 -70;
-    pos @kc87_first_11 @kc87_second_45 -35;
-    pos @kc87_first_11 @kc87_second_46 -35;
-    pos @kc87_first_11 @kc87_second_48 1;
-    pos @kc87_first_11 @kc87_second_51 -70;
-    pos @kc87_first_11 @kc87_second_56 -210;
-    pos @kc87_first_11 @kc87_second_58 -175;
-    pos @kc87_first_11 @kc87_second_59 -175;
-    pos @kc87_first_11 @kc87_second_60 -35;
-    pos @kc87_first_11 @kc87_second_64 -70;
-    pos @kc87_first_11 @kc87_second_65 -35;
-    pos @kc87_first_11 @kc87_second_66 -35;
-    pos @kc87_first_11 @kc87_second_67 -70;
+    pos @kc87_first_11 @kc87_second_36 -35;
+    pos @kc87_first_11 @kc87_second_38 -35;
+    pos @kc87_first_11 @kc87_second_39 -140;
+    pos @kc87_first_11 @kc87_second_44 -70;
+    pos @kc87_first_11 @kc87_second_47 -35;
+    pos @kc87_first_11 @kc87_second_49 -35;
+    pos @kc87_first_11 @kc87_second_51 1;
+    pos @kc87_first_11 @kc87_second_54 -70;
+    pos @kc87_first_11 @kc87_second_58 -210;
+    pos @kc87_first_11 @kc87_second_60 -175;
+    pos @kc87_first_11 @kc87_second_61 -175;
+    pos @kc87_first_11 @kc87_second_62 -35;
+    pos @kc87_first_11 @kc87_second_66 -70;
+    pos @kc87_first_11 @kc87_second_67 -35;
+    pos @kc87_first_11 @kc87_second_68 -35;
+    pos @kc87_first_11 @kc87_second_69 -70;
     pos @kc87_first_12 @kc87_second_1 -140;
     pos @kc87_first_12 @kc87_second_2 -210;
     pos @kc87_first_12 @kc87_second_6 -140;
@@ -8949,18 +8990,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_12 @kc87_second_24 -70;
     pos @kc87_first_12 @kc87_second_26 -350;
     pos @kc87_first_12 @kc87_second_31 -35;
-    pos @kc87_first_12 @kc87_second_34 -140;
-    pos @kc87_first_12 @kc87_second_35 -70;
-    pos @kc87_first_12 @kc87_second_37 -140;
-    pos @kc87_first_12 @kc87_second_38 -70;
-    pos @kc87_first_12 @kc87_second_41 -70;
-    pos @kc87_first_12 @kc87_second_48 1;
-    pos @kc87_first_12 @kc87_second_54 -35;
-    pos @kc87_first_12 @kc87_second_56 -210;
+    pos @kc87_first_12 @kc87_second_34 -70;
+    pos @kc87_first_12 @kc87_second_35 -140;
+    pos @kc87_first_12 @kc87_second_36 -70;
+    pos @kc87_first_12 @kc87_second_38 -140;
+    pos @kc87_first_12 @kc87_second_39 -70;
+    pos @kc87_first_12 @kc87_second_43 -70;
+    pos @kc87_first_12 @kc87_second_51 1;
+    pos @kc87_first_12 @kc87_second_56 -35;
     pos @kc87_first_12 @kc87_second_58 -210;
-    pos @kc87_first_12 @kc87_second_59 -210;
-    pos @kc87_first_12 @kc87_second_66 -70;
-    pos @kc87_first_12 @kc87_second_67 -105;
+    pos @kc87_first_12 @kc87_second_60 -210;
+    pos @kc87_first_12 @kc87_second_61 -210;
+    pos @kc87_first_12 @kc87_second_68 -70;
+    pos @kc87_first_12 @kc87_second_69 -105;
     pos @kc87_first_13 @kc87_second_6 -70;
     pos @kc87_first_13 @kc87_second_12 -70;
     pos @kc87_first_13 @kc87_second_13 -105;
@@ -8968,11 +9010,12 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_13 @kc87_second_18 -35;
     pos @kc87_first_13 @kc87_second_24 -35;
     pos @kc87_first_13 @kc87_second_31 -35;
-    pos @kc87_first_13 @kc87_second_37 -70;
-    pos @kc87_first_13 @kc87_second_41 -70;
-    pos @kc87_first_13 @kc87_second_48 1;
-    pos @kc87_first_13 @kc87_second_66 -70;
-    pos @kc87_first_13 @kc87_second_67 -35;
+    pos @kc87_first_13 @kc87_second_34 -35;
+    pos @kc87_first_13 @kc87_second_38 -70;
+    pos @kc87_first_13 @kc87_second_43 -70;
+    pos @kc87_first_13 @kc87_second_51 1;
+    pos @kc87_first_13 @kc87_second_68 -70;
+    pos @kc87_first_13 @kc87_second_69 -35;
     pos @kc87_first_14 @kc87_second_2 -35;
     pos @kc87_first_14 @kc87_second_11 -35;
     pos @kc87_first_14 @kc87_second_12 -70;
@@ -8981,15 +9024,15 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_14 @kc87_second_16 -35;
     pos @kc87_first_14 @kc87_second_21 -35;
     pos @kc87_first_14 @kc87_second_27 -35;
-    pos @kc87_first_14 @kc87_second_35 -35;
-    pos @kc87_first_14 @kc87_second_42 -70;
-    pos @kc87_first_14 @kc87_second_48 1;
-    pos @kc87_first_14 @kc87_second_50 -70;
-    pos @kc87_first_14 @kc87_second_51 -35;
-    pos @kc87_first_14 @kc87_second_60 -35;
-    pos @kc87_first_14 @kc87_second_61 -35;
+    pos @kc87_first_14 @kc87_second_36 -35;
+    pos @kc87_first_14 @kc87_second_44 -70;
+    pos @kc87_first_14 @kc87_second_51 1;
+    pos @kc87_first_14 @kc87_second_53 -70;
+    pos @kc87_first_14 @kc87_second_54 -35;
+    pos @kc87_first_14 @kc87_second_62 -35;
     pos @kc87_first_14 @kc87_second_63 -35;
     pos @kc87_first_14 @kc87_second_65 -35;
+    pos @kc87_first_14 @kc87_second_67 -35;
     pos @kc87_first_15 @kc87_second_3 -70;
     pos @kc87_first_15 @kc87_second_4 -70;
     pos @kc87_first_15 @kc87_second_6 -35;
@@ -9002,20 +9045,20 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_15 @kc87_second_27 -70;
     pos @kc87_first_15 @kc87_second_31 -35;
     pos @kc87_first_15 @kc87_second_33 -35;
-    pos @kc87_first_15 @kc87_second_39 -35;
-    pos @kc87_first_15 @kc87_second_41 -70;
-    pos @kc87_first_15 @kc87_second_42 -142;
-    pos @kc87_first_15 @kc87_second_43 -35;
-    pos @kc87_first_15 @kc87_second_47 -35;
-    pos @kc87_first_15 @kc87_second_48 1;
-    pos @kc87_first_15 @kc87_second_49 -35;
-    pos @kc87_first_15 @kc87_second_50 -70;
-    pos @kc87_first_15 @kc87_second_54 -35;
-    pos @kc87_first_15 @kc87_second_55 -35;
-    pos @kc87_first_15 @kc87_second_61 -105;
-    pos @kc87_first_15 @kc87_second_63 -35;
-    pos @kc87_first_15 @kc87_second_66 -35;
-    pos @kc87_first_15 @kc87_second_67 -35;
+    pos @kc87_first_15 @kc87_second_40 -35;
+    pos @kc87_first_15 @kc87_second_41 -35;
+    pos @kc87_first_15 @kc87_second_43 -70;
+    pos @kc87_first_15 @kc87_second_44 -142;
+    pos @kc87_first_15 @kc87_second_45 -35;
+    pos @kc87_first_15 @kc87_second_51 1;
+    pos @kc87_first_15 @kc87_second_52 -35;
+    pos @kc87_first_15 @kc87_second_53 -70;
+    pos @kc87_first_15 @kc87_second_56 -35;
+    pos @kc87_first_15 @kc87_second_57 -35;
+    pos @kc87_first_15 @kc87_second_63 -105;
+    pos @kc87_first_15 @kc87_second_65 -35;
+    pos @kc87_first_15 @kc87_second_68 -35;
+    pos @kc87_first_15 @kc87_second_69 -35;
     pos @kc87_first_16 @kc87_second_1 -280;
     pos @kc87_first_16 @kc87_second_2 -280;
     pos @kc87_first_16 @kc87_second_3 -140;
@@ -9038,35 +9081,36 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_16 @kc87_second_31 -240;
     pos @kc87_first_16 @kc87_second_32 -140;
     pos @kc87_first_16 @kc87_second_33 -140;
-    pos @kc87_first_16 @kc87_second_34 -245;
-    pos @kc87_first_16 @kc87_second_35 -315;
-    pos @kc87_first_16 @kc87_second_37 -315;
-    pos @kc87_first_16 @kc87_second_38 -70;
-    pos @kc87_first_16 @kc87_second_39 -210;
-    pos @kc87_first_16 @kc87_second_40 -210;
-    pos @kc87_first_16 @kc87_second_41 -245;
-    pos @kc87_first_16 @kc87_second_42 -245;
-    pos @kc87_first_16 @kc87_second_43 -70;
-    pos @kc87_first_16 @kc87_second_45 -35;
-    pos @kc87_first_16 @kc87_second_46 -140;
+    pos @kc87_first_16 @kc87_second_34 -280;
+    pos @kc87_first_16 @kc87_second_35 -245;
+    pos @kc87_first_16 @kc87_second_36 -315;
+    pos @kc87_first_16 @kc87_second_38 -315;
+    pos @kc87_first_16 @kc87_second_39 -70;
+    pos @kc87_first_16 @kc87_second_40 -140;
+    pos @kc87_first_16 @kc87_second_41 -210;
+    pos @kc87_first_16 @kc87_second_42 -210;
+    pos @kc87_first_16 @kc87_second_43 -245;
+    pos @kc87_first_16 @kc87_second_44 -245;
+    pos @kc87_first_16 @kc87_second_45 -70;
     pos @kc87_first_16 @kc87_second_47 -140;
-    pos @kc87_first_16 @kc87_second_48 1;
-    pos @kc87_first_16 @kc87_second_49 -70;
+    pos @kc87_first_16 @kc87_second_49 -35;
     pos @kc87_first_16 @kc87_second_50 -140;
-    pos @kc87_first_16 @kc87_second_52 -140;
+    pos @kc87_first_16 @kc87_second_51 1;
+    pos @kc87_first_16 @kc87_second_52 -70;
     pos @kc87_first_16 @kc87_second_53 -140;
-    pos @kc87_first_16 @kc87_second_54 -240;
     pos @kc87_first_16 @kc87_second_55 -140;
-    pos @kc87_first_16 @kc87_second_56 -280;
-    pos @kc87_first_16 @kc87_second_57 -105;
-    pos @kc87_first_16 @kc87_second_58 -315;
-    pos @kc87_first_16 @kc87_second_59 -280;
-    pos @kc87_first_16 @kc87_second_60 -140;
-    pos @kc87_first_16 @kc87_second_61 -210;
-    pos @kc87_first_16 @kc87_second_62 -210;
-    pos @kc87_first_16 @kc87_second_63 -105;
-    pos @kc87_first_16 @kc87_second_66 -315;
-    pos @kc87_first_16 @kc87_second_67 -350;
+    pos @kc87_first_16 @kc87_second_56 -240;
+    pos @kc87_first_16 @kc87_second_57 -140;
+    pos @kc87_first_16 @kc87_second_58 -280;
+    pos @kc87_first_16 @kc87_second_59 -105;
+    pos @kc87_first_16 @kc87_second_60 -315;
+    pos @kc87_first_16 @kc87_second_61 -280;
+    pos @kc87_first_16 @kc87_second_62 -140;
+    pos @kc87_first_16 @kc87_second_63 -210;
+    pos @kc87_first_16 @kc87_second_64 -210;
+    pos @kc87_first_16 @kc87_second_65 -105;
+    pos @kc87_first_16 @kc87_second_68 -315;
+    pos @kc87_first_16 @kc87_second_69 -350;
     pos @kc87_first_17 @kc87_second_1 -280;
     pos @kc87_first_17 @kc87_second_2 -280;
     pos @kc87_first_17 @kc87_second_3 -105;
@@ -9086,34 +9130,35 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_17 @kc87_second_29 -70;
     pos @kc87_first_17 @kc87_second_31 -140;
     pos @kc87_first_17 @kc87_second_32 -105;
-    pos @kc87_first_17 @kc87_second_34 -210;
-    pos @kc87_first_17 @kc87_second_35 -175;
-    pos @kc87_first_17 @kc87_second_37 -245;
-    pos @kc87_first_17 @kc87_second_38 -70;
-    pos @kc87_first_17 @kc87_second_39 -140;
-    pos @kc87_first_17 @kc87_second_40 -140;
+    pos @kc87_first_17 @kc87_second_34 -175;
+    pos @kc87_first_17 @kc87_second_35 -210;
+    pos @kc87_first_17 @kc87_second_36 -175;
+    pos @kc87_first_17 @kc87_second_38 -245;
+    pos @kc87_first_17 @kc87_second_39 -70;
+    pos @kc87_first_17 @kc87_second_40 -70;
     pos @kc87_first_17 @kc87_second_41 -140;
-    pos @kc87_first_17 @kc87_second_42 -105;
-    pos @kc87_first_17 @kc87_second_43 -35;
-    pos @kc87_first_17 @kc87_second_46 -35;
-    pos @kc87_first_17 @kc87_second_47 -70;
-    pos @kc87_first_17 @kc87_second_48 1;
-    pos @kc87_first_17 @kc87_second_49 -35;
-    pos @kc87_first_17 @kc87_second_50 -70;
-    pos @kc87_first_17 @kc87_second_52 -105;
+    pos @kc87_first_17 @kc87_second_42 -140;
+    pos @kc87_first_17 @kc87_second_43 -140;
+    pos @kc87_first_17 @kc87_second_44 -105;
+    pos @kc87_first_17 @kc87_second_45 -35;
+    pos @kc87_first_17 @kc87_second_47 -35;
+    pos @kc87_first_17 @kc87_second_50 -105;
+    pos @kc87_first_17 @kc87_second_51 1;
+    pos @kc87_first_17 @kc87_second_52 -35;
     pos @kc87_first_17 @kc87_second_53 -70;
-    pos @kc87_first_17 @kc87_second_54 -105;
     pos @kc87_first_17 @kc87_second_55 -70;
-    pos @kc87_first_17 @kc87_second_56 -210;
-    pos @kc87_first_17 @kc87_second_57 -35;
-    pos @kc87_first_17 @kc87_second_58 -245;
-    pos @kc87_first_17 @kc87_second_59 -210;
-    pos @kc87_first_17 @kc87_second_60 -70;
-    pos @kc87_first_17 @kc87_second_61 -105;
-    pos @kc87_first_17 @kc87_second_62 -105;
-    pos @kc87_first_17 @kc87_second_63 -70;
-    pos @kc87_first_17 @kc87_second_66 -175;
-    pos @kc87_first_17 @kc87_second_67 -245;
+    pos @kc87_first_17 @kc87_second_56 -105;
+    pos @kc87_first_17 @kc87_second_57 -70;
+    pos @kc87_first_17 @kc87_second_58 -210;
+    pos @kc87_first_17 @kc87_second_59 -35;
+    pos @kc87_first_17 @kc87_second_60 -245;
+    pos @kc87_first_17 @kc87_second_61 -210;
+    pos @kc87_first_17 @kc87_second_62 -70;
+    pos @kc87_first_17 @kc87_second_63 -105;
+    pos @kc87_first_17 @kc87_second_64 -105;
+    pos @kc87_first_17 @kc87_second_65 -70;
+    pos @kc87_first_17 @kc87_second_68 -175;
+    pos @kc87_first_17 @kc87_second_69 -245;
     pos @kc87_first_18 @kc87_second_1 -210;
     pos @kc87_first_18 @kc87_second_2 -245;
     pos @kc87_first_18 @kc87_second_3 -35;
@@ -9129,41 +9174,42 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_18 @kc87_second_25 -70;
     pos @kc87_first_18 @kc87_second_26 -140;
     pos @kc87_first_18 @kc87_second_29 -35;
-    pos @kc87_first_18 @kc87_second_34 -140;
-    pos @kc87_first_18 @kc87_second_35 -105;
-    pos @kc87_first_18 @kc87_second_37 -140;
-    pos @kc87_first_18 @kc87_second_39 -105;
-    pos @kc87_first_18 @kc87_second_40 -70;
+    pos @kc87_first_18 @kc87_second_34 -105;
+    pos @kc87_first_18 @kc87_second_35 -140;
+    pos @kc87_first_18 @kc87_second_36 -105;
+    pos @kc87_first_18 @kc87_second_38 -140;
     pos @kc87_first_18 @kc87_second_41 -105;
     pos @kc87_first_18 @kc87_second_42 -70;
-    pos @kc87_first_18 @kc87_second_44 -35;
-    pos @kc87_first_18 @kc87_second_48 1;
-    pos @kc87_first_18 @kc87_second_53 -35;
-    pos @kc87_first_18 @kc87_second_54 -70;
-    pos @kc87_first_18 @kc87_second_56 -140;
-    pos @kc87_first_18 @kc87_second_58 -175;
-    pos @kc87_first_18 @kc87_second_59 -140;
-    pos @kc87_first_18 @kc87_second_61 -70;
-    pos @kc87_first_18 @kc87_second_66 -105;
-    pos @kc87_first_18 @kc87_second_67 -140;
+    pos @kc87_first_18 @kc87_second_43 -105;
+    pos @kc87_first_18 @kc87_second_44 -70;
+    pos @kc87_first_18 @kc87_second_46 -35;
+    pos @kc87_first_18 @kc87_second_51 1;
+    pos @kc87_first_18 @kc87_second_55 -35;
+    pos @kc87_first_18 @kc87_second_56 -70;
+    pos @kc87_first_18 @kc87_second_58 -140;
+    pos @kc87_first_18 @kc87_second_60 -175;
+    pos @kc87_first_18 @kc87_second_61 -140;
+    pos @kc87_first_18 @kc87_second_63 -70;
+    pos @kc87_first_18 @kc87_second_68 -105;
+    pos @kc87_first_18 @kc87_second_69 -140;
     pos @kc87_first_19 @kc87_second_12 -280;
     pos @kc87_first_19 @kc87_second_14 -175;
     pos @kc87_first_19 @kc87_second_15 -140;
     pos @kc87_first_19 @kc87_second_18 -35;
     pos @kc87_first_19 @kc87_second_31 -35;
     pos @kc87_first_19 @kc87_second_33 -50;
-    pos @kc87_first_19 @kc87_second_48 1;
-    pos @kc87_first_19 @kc87_second_50 -70;
-    pos @kc87_first_19 @kc87_second_51 -140;
-    pos @kc87_first_19 @kc87_second_61 -70;
-    pos @kc87_first_19 @kc87_second_63 -35;
-    pos @kc87_first_19 @kc87_second_64 -105;
-    pos @kc87_first_19 @kc87_second_65 -70;
+    pos @kc87_first_19 @kc87_second_51 1;
+    pos @kc87_first_19 @kc87_second_53 -70;
+    pos @kc87_first_19 @kc87_second_54 -140;
+    pos @kc87_first_19 @kc87_second_63 -70;
+    pos @kc87_first_19 @kc87_second_65 -35;
+    pos @kc87_first_19 @kc87_second_66 -105;
+    pos @kc87_first_19 @kc87_second_67 -70;
     pos @kc87_first_20 @kc87_second_12 -240;
     pos @kc87_first_20 @kc87_second_13 -140;
     pos @kc87_first_20 @kc87_second_14 -105;
     pos @kc87_first_20 @kc87_second_15 -35;
-    pos @kc87_first_20 @kc87_second_48 1;
+    pos @kc87_first_20 @kc87_second_51 1;
     pos @kc87_first_21 @kc87_second_8 -35;
     pos @kc87_first_21 @kc87_second_9 -140;
     pos @kc87_first_21 @kc87_second_12 -280;
@@ -9174,25 +9220,26 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_21 @kc87_second_22 -70;
     pos @kc87_first_21 @kc87_second_27 -70;
     pos @kc87_first_21 @kc87_second_33 -50;
-    pos @kc87_first_21 @kc87_second_42 -140;
-    pos @kc87_first_21 @kc87_second_43 -105;
-    pos @kc87_first_21 @kc87_second_46 -210;
-    pos @kc87_first_21 @kc87_second_48 1;
-    pos @kc87_first_21 @kc87_second_49 -35;
-    pos @kc87_first_21 @kc87_second_50 -140;
-    pos @kc87_first_21 @kc87_second_51 -210;
-    pos @kc87_first_21 @kc87_second_55 -35;
-    pos @kc87_first_21 @kc87_second_61 -105;
+    pos @kc87_first_21 @kc87_second_44 -140;
+    pos @kc87_first_21 @kc87_second_45 -105;
+    pos @kc87_first_21 @kc87_second_47 -210;
+    pos @kc87_first_21 @kc87_second_48 -175;
+    pos @kc87_first_21 @kc87_second_51 1;
+    pos @kc87_first_21 @kc87_second_52 -35;
+    pos @kc87_first_21 @kc87_second_53 -140;
+    pos @kc87_first_21 @kc87_second_54 -210;
+    pos @kc87_first_21 @kc87_second_57 -35;
     pos @kc87_first_21 @kc87_second_63 -105;
-    pos @kc87_first_21 @kc87_second_64 -210;
-    pos @kc87_first_21 @kc87_second_65 -140;
+    pos @kc87_first_21 @kc87_second_65 -105;
+    pos @kc87_first_21 @kc87_second_66 -210;
+    pos @kc87_first_21 @kc87_second_67 -140;
     pos @kc87_first_22 @kc87_second_1 -140;
     pos @kc87_first_22 @kc87_second_2 -350;
     pos @kc87_first_22 @kc87_second_19 -140;
     pos @kc87_first_22 @kc87_second_21 -280;
-    pos @kc87_first_22 @kc87_second_41 -70;
-    pos @kc87_first_22 @kc87_second_48 1;
-    pos @kc87_first_22 @kc87_second_67 -210;
+    pos @kc87_first_22 @kc87_second_43 -70;
+    pos @kc87_first_22 @kc87_second_51 1;
+    pos @kc87_first_22 @kc87_second_69 -210;
     pos @kc87_first_23 @kc87_second_1 -35;
     pos @kc87_first_23 @kc87_second_5 -105;
     pos @kc87_first_23 @kc87_second_9 -70;
@@ -9205,21 +9252,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_23 @kc87_second_27 -35;
     pos @kc87_first_23 @kc87_second_28 -70;
     pos @kc87_first_23 @kc87_second_29 -105;
-    pos @kc87_first_23 @kc87_second_35 -35;
-    pos @kc87_first_23 @kc87_second_38 -70;
-    pos @kc87_first_23 @kc87_second_42 -70;
-    pos @kc87_first_23 @kc87_second_43 -35;
+    pos @kc87_first_23 @kc87_second_36 -35;
+    pos @kc87_first_23 @kc87_second_39 -70;
+    pos @kc87_first_23 @kc87_second_44 -70;
     pos @kc87_first_23 @kc87_second_45 -35;
-    pos @kc87_first_23 @kc87_second_46 -140;
-    pos @kc87_first_23 @kc87_second_48 1;
-    pos @kc87_first_23 @kc87_second_50 -70;
-    pos @kc87_first_23 @kc87_second_51 -175;
-    pos @kc87_first_23 @kc87_second_52 -35;
-    pos @kc87_first_23 @kc87_second_60 -105;
-    pos @kc87_first_23 @kc87_second_61 -35;
-    pos @kc87_first_23 @kc87_second_63 -50;
-    pos @kc87_first_23 @kc87_second_64 -105;
-    pos @kc87_first_23 @kc87_second_65 -70;
+    pos @kc87_first_23 @kc87_second_47 -140;
+    pos @kc87_first_23 @kc87_second_49 -35;
+    pos @kc87_first_23 @kc87_second_50 -35;
+    pos @kc87_first_23 @kc87_second_51 1;
+    pos @kc87_first_23 @kc87_second_53 -70;
+    pos @kc87_first_23 @kc87_second_54 -175;
+    pos @kc87_first_23 @kc87_second_62 -105;
+    pos @kc87_first_23 @kc87_second_63 -35;
+    pos @kc87_first_23 @kc87_second_65 -50;
+    pos @kc87_first_23 @kc87_second_66 -105;
+    pos @kc87_first_23 @kc87_second_67 -70;
     pos @kc87_first_24 @kc87_second_6 -35;
     pos @kc87_first_24 @kc87_second_12 -240;
     pos @kc87_first_24 @kc87_second_13 -175;
@@ -9228,17 +9275,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_24 @kc87_second_18 -70;
     pos @kc87_first_24 @kc87_second_24 -70;
     pos @kc87_first_24 @kc87_second_25 -35;
-    pos @kc87_first_24 @kc87_second_37 -35;
-    pos @kc87_first_24 @kc87_second_42 -35;
-    pos @kc87_first_24 @kc87_second_43 -35;
-    pos @kc87_first_24 @kc87_second_46 -70;
-    pos @kc87_first_24 @kc87_second_47 -35;
-    pos @kc87_first_24 @kc87_second_48 1;
-    pos @kc87_first_24 @kc87_second_51 -35;
-    pos @kc87_first_24 @kc87_second_61 -35;
-    pos @kc87_first_24 @kc87_second_65 -35;
-    pos @kc87_first_24 @kc87_second_66 -35;
+    pos @kc87_first_24 @kc87_second_38 -35;
+    pos @kc87_first_24 @kc87_second_40 -35;
+    pos @kc87_first_24 @kc87_second_44 -35;
+    pos @kc87_first_24 @kc87_second_45 -35;
+    pos @kc87_first_24 @kc87_second_47 -70;
+    pos @kc87_first_24 @kc87_second_51 1;
+    pos @kc87_first_24 @kc87_second_54 -35;
+    pos @kc87_first_24 @kc87_second_63 -35;
     pos @kc87_first_24 @kc87_second_67 -35;
+    pos @kc87_first_24 @kc87_second_68 -35;
+    pos @kc87_first_24 @kc87_second_69 -35;
     pos @kc87_first_25 @kc87_second_1 -70;
     pos @kc87_first_25 @kc87_second_2 -140;
     pos @kc87_first_25 @kc87_second_5 -105;
@@ -9251,19 +9298,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_25 @kc87_second_21 -70;
     pos @kc87_first_25 @kc87_second_28 -70;
     pos @kc87_first_25 @kc87_second_29 -70;
-    pos @kc87_first_25 @kc87_second_34 -70;
-    pos @kc87_first_25 @kc87_second_38 -70;
-    pos @kc87_first_25 @kc87_second_45 -35;
-    pos @kc87_first_25 @kc87_second_46 -140;
-    pos @kc87_first_25 @kc87_second_48 1;
-    pos @kc87_first_25 @kc87_second_51 -140;
-    pos @kc87_first_25 @kc87_second_52 -35;
-    pos @kc87_first_25 @kc87_second_56 -140;
-    pos @kc87_first_25 @kc87_second_58 -70;
-    pos @kc87_first_25 @kc87_second_59 -105;
+    pos @kc87_first_25 @kc87_second_35 -70;
+    pos @kc87_first_25 @kc87_second_39 -70;
+    pos @kc87_first_25 @kc87_second_47 -140;
+    pos @kc87_first_25 @kc87_second_49 -35;
+    pos @kc87_first_25 @kc87_second_50 -35;
+    pos @kc87_first_25 @kc87_second_51 1;
+    pos @kc87_first_25 @kc87_second_54 -140;
+    pos @kc87_first_25 @kc87_second_58 -140;
     pos @kc87_first_25 @kc87_second_60 -70;
-    pos @kc87_first_25 @kc87_second_64 -70;
-    pos @kc87_first_25 @kc87_second_65 -35;
+    pos @kc87_first_25 @kc87_second_61 -105;
+    pos @kc87_first_25 @kc87_second_62 -70;
+    pos @kc87_first_25 @kc87_second_66 -70;
+    pos @kc87_first_25 @kc87_second_67 -35;
     pos @kc87_first_26 @kc87_second_5 -70;
     pos @kc87_first_26 @kc87_second_9 -70;
     pos @kc87_first_26 @kc87_second_12 -240;
@@ -9274,32 +9321,33 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_26 @kc87_second_27 -35;
     pos @kc87_first_26 @kc87_second_28 -70;
     pos @kc87_first_26 @kc87_second_29 -70;
-    pos @kc87_first_26 @kc87_second_38 -70;
-    pos @kc87_first_26 @kc87_second_42 -70;
-    pos @kc87_first_26 @kc87_second_43 -35;
-    pos @kc87_first_26 @kc87_second_46 -140;
-    pos @kc87_first_26 @kc87_second_48 1;
-    pos @kc87_first_26 @kc87_second_50 -70;
-    pos @kc87_first_26 @kc87_second_51 -140;
-    pos @kc87_first_26 @kc87_second_52 -35;
-    pos @kc87_first_26 @kc87_second_56 -50;
-    pos @kc87_first_26 @kc87_second_57 -35;
+    pos @kc87_first_26 @kc87_second_39 -70;
+    pos @kc87_first_26 @kc87_second_44 -70;
+    pos @kc87_first_26 @kc87_second_45 -35;
+    pos @kc87_first_26 @kc87_second_47 -140;
+    pos @kc87_first_26 @kc87_second_48 -105;
+    pos @kc87_first_26 @kc87_second_50 -35;
+    pos @kc87_first_26 @kc87_second_51 1;
+    pos @kc87_first_26 @kc87_second_53 -70;
+    pos @kc87_first_26 @kc87_second_54 -140;
     pos @kc87_first_26 @kc87_second_58 -50;
-    pos @kc87_first_26 @kc87_second_59 -50;
-    pos @kc87_first_26 @kc87_second_60 -105;
+    pos @kc87_first_26 @kc87_second_59 -35;
+    pos @kc87_first_26 @kc87_second_60 -50;
     pos @kc87_first_26 @kc87_second_61 -50;
-    pos @kc87_first_26 @kc87_second_63 -35;
-    pos @kc87_first_26 @kc87_second_64 -105;
-    pos @kc87_first_26 @kc87_second_65 -70;
+    pos @kc87_first_26 @kc87_second_62 -105;
+    pos @kc87_first_26 @kc87_second_63 -50;
+    pos @kc87_first_26 @kc87_second_65 -35;
+    pos @kc87_first_26 @kc87_second_66 -105;
+    pos @kc87_first_26 @kc87_second_67 -70;
     pos @kc87_first_27 @kc87_second_9 -35;
     pos @kc87_first_27 @kc87_second_12 -140;
     pos @kc87_first_27 @kc87_second_28 -70;
-    pos @kc87_first_27 @kc87_second_42 -35;
-    pos @kc87_first_27 @kc87_second_46 -70;
-    pos @kc87_first_27 @kc87_second_48 1;
-    pos @kc87_first_27 @kc87_second_51 -70;
-    pos @kc87_first_27 @kc87_second_64 -70;
-    pos @kc87_first_27 @kc87_second_65 -35;
+    pos @kc87_first_27 @kc87_second_44 -35;
+    pos @kc87_first_27 @kc87_second_47 -70;
+    pos @kc87_first_27 @kc87_second_51 1;
+    pos @kc87_first_27 @kc87_second_54 -70;
+    pos @kc87_first_27 @kc87_second_66 -70;
+    pos @kc87_first_27 @kc87_second_67 -35;
     pos @kc87_first_28 @kc87_second_5 -50;
     pos @kc87_first_28 @kc87_second_9 -35;
     pos @kc87_first_28 @kc87_second_11 -35;
@@ -9310,18 +9358,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_28 @kc87_second_16 -35;
     pos @kc87_first_28 @kc87_second_28 -35;
     pos @kc87_first_28 @kc87_second_29 -35;
-    pos @kc87_first_28 @kc87_second_35 -35;
-    pos @kc87_first_28 @kc87_second_38 -35;
-    pos @kc87_first_28 @kc87_second_42 -50;
-    pos @kc87_first_28 @kc87_second_43 -35;
-    pos @kc87_first_28 @kc87_second_46 -100;
-    pos @kc87_first_28 @kc87_second_48 1;
-    pos @kc87_first_28 @kc87_second_50 -35;
-    pos @kc87_first_28 @kc87_second_51 -140;
-    pos @kc87_first_28 @kc87_second_60 -35;
-    pos @kc87_first_28 @kc87_second_64 -70;
-    pos @kc87_first_28 @kc87_second_65 -35;
-    pos @kc87_first_29 @kc87_second_48 1;
+    pos @kc87_first_28 @kc87_second_36 -35;
+    pos @kc87_first_28 @kc87_second_39 -35;
+    pos @kc87_first_28 @kc87_second_44 -50;
+    pos @kc87_first_28 @kc87_second_45 -35;
+    pos @kc87_first_28 @kc87_second_47 -100;
+    pos @kc87_first_28 @kc87_second_48 -35;
+    pos @kc87_first_28 @kc87_second_51 1;
+    pos @kc87_first_28 @kc87_second_53 -35;
+    pos @kc87_first_28 @kc87_second_54 -140;
+    pos @kc87_first_28 @kc87_second_62 -35;
+    pos @kc87_first_28 @kc87_second_66 -70;
+    pos @kc87_first_28 @kc87_second_67 -35;
+    pos @kc87_first_29 @kc87_second_51 1;
     pos @kc87_first_30 @kc87_second_8 -70;
     pos @kc87_first_30 @kc87_second_9 -210;
     pos @kc87_first_30 @kc87_second_12 -350;
@@ -9329,17 +9378,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_30 @kc87_second_14 -210;
     pos @kc87_first_30 @kc87_second_15 -175;
     pos @kc87_first_30 @kc87_second_27 -70;
-    pos @kc87_first_30 @kc87_second_41 -35;
-    pos @kc87_first_30 @kc87_second_42 -210;
-    pos @kc87_first_30 @kc87_second_43 -210;
-    pos @kc87_first_30 @kc87_second_46 -210;
-    pos @kc87_first_30 @kc87_second_48 1;
-    pos @kc87_first_30 @kc87_second_50 -140;
-    pos @kc87_first_30 @kc87_second_51 -280;
-    pos @kc87_first_30 @kc87_second_61 -210;
-    pos @kc87_first_30 @kc87_second_63 -105;
-    pos @kc87_first_30 @kc87_second_64 -175;
-    pos @kc87_first_30 @kc87_second_65 -140;
+    pos @kc87_first_30 @kc87_second_43 -35;
+    pos @kc87_first_30 @kc87_second_44 -210;
+    pos @kc87_first_30 @kc87_second_45 -210;
+    pos @kc87_first_30 @kc87_second_47 -210;
+    pos @kc87_first_30 @kc87_second_51 1;
+    pos @kc87_first_30 @kc87_second_53 -140;
+    pos @kc87_first_30 @kc87_second_54 -280;
+    pos @kc87_first_30 @kc87_second_63 -210;
+    pos @kc87_first_30 @kc87_second_65 -105;
+    pos @kc87_first_30 @kc87_second_66 -175;
+    pos @kc87_first_30 @kc87_second_67 -140;
     pos @kc87_first_31 @kc87_second_1 -175;
     pos @kc87_first_31 @kc87_second_2 -175;
     pos @kc87_first_31 @kc87_second_5 -70;
@@ -9357,16 +9406,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_31 @kc87_second_21 -175;
     pos @kc87_first_31 @kc87_second_24 -70;
     pos @kc87_first_31 @kc87_second_31 -105;
-    pos @kc87_first_31 @kc87_second_36 105;
-    pos @kc87_first_31 @kc87_second_37 -105;
-    pos @kc87_first_31 @kc87_second_38 -175;
-    pos @kc87_first_31 @kc87_second_39 -35;
-    pos @kc87_first_31 @kc87_second_41 -70;
-    pos @kc87_first_31 @kc87_second_48 1;
-    pos @kc87_first_31 @kc87_second_53 105;
-    pos @kc87_first_31 @kc87_second_54 -35;
-    pos @kc87_first_31 @kc87_second_66 -70;
-    pos @kc87_first_31 @kc87_second_67 -105;
+    pos @kc87_first_31 @kc87_second_37 105;
+    pos @kc87_first_31 @kc87_second_38 -105;
+    pos @kc87_first_31 @kc87_second_39 -175;
+    pos @kc87_first_31 @kc87_second_41 -35;
+    pos @kc87_first_31 @kc87_second_43 -70;
+    pos @kc87_first_31 @kc87_second_51 1;
+    pos @kc87_first_31 @kc87_second_55 105;
+    pos @kc87_first_31 @kc87_second_56 -35;
+    pos @kc87_first_31 @kc87_second_68 -70;
+    pos @kc87_first_31 @kc87_second_69 -105;
     pos @kc87_first_32 @kc87_second_3 -70;
     pos @kc87_first_32 @kc87_second_4 -35;
     pos @kc87_first_32 @kc87_second_6 -70;
@@ -9377,16 +9426,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_32 @kc87_second_24 -70;
     pos @kc87_first_32 @kc87_second_25 -140;
     pos @kc87_first_32 @kc87_second_31 -35;
-    pos @kc87_first_32 @kc87_second_37 -70;
-    pos @kc87_first_32 @kc87_second_39 -35;
-    pos @kc87_first_32 @kc87_second_41 -140;
-    pos @kc87_first_32 @kc87_second_42 -70;
-    pos @kc87_first_32 @kc87_second_48 1;
-    pos @kc87_first_32 @kc87_second_54 -35;
-    pos @kc87_first_32 @kc87_second_55 -35;
-    pos @kc87_first_32 @kc87_second_61 -140;
-    pos @kc87_first_32 @kc87_second_66 -70;
-    pos @kc87_first_32 @kc87_second_67 -70;
+    pos @kc87_first_32 @kc87_second_38 -70;
+    pos @kc87_first_32 @kc87_second_41 -35;
+    pos @kc87_first_32 @kc87_second_43 -140;
+    pos @kc87_first_32 @kc87_second_44 -70;
+    pos @kc87_first_32 @kc87_second_51 1;
+    pos @kc87_first_32 @kc87_second_56 -35;
+    pos @kc87_first_32 @kc87_second_57 -35;
+    pos @kc87_first_32 @kc87_second_63 -140;
+    pos @kc87_first_32 @kc87_second_68 -70;
+    pos @kc87_first_32 @kc87_second_69 -70;
     pos @kc87_first_33 @kc87_second_1 -35;
     pos @kc87_first_33 @kc87_second_2 -105;
     pos @kc87_first_33 @kc87_second_3 -70;
@@ -9401,21 +9450,22 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_33 @kc87_second_19 -70;
     pos @kc87_first_33 @kc87_second_26 -35;
     pos @kc87_first_33 @kc87_second_29 -70;
-    pos @kc87_first_33 @kc87_second_35 -35;
-    pos @kc87_first_33 @kc87_second_38 -35;
-    pos @kc87_first_33 @kc87_second_42 -35;
-    pos @kc87_first_33 @kc87_second_43 -35;
+    pos @kc87_first_33 @kc87_second_36 -35;
+    pos @kc87_first_33 @kc87_second_39 -35;
+    pos @kc87_first_33 @kc87_second_44 -35;
     pos @kc87_first_33 @kc87_second_45 -35;
-    pos @kc87_first_33 @kc87_second_46 -140;
-    pos @kc87_first_33 @kc87_second_48 1;
-    pos @kc87_first_33 @kc87_second_50 -50;
-    pos @kc87_first_33 @kc87_second_51 -140;
-    pos @kc87_first_33 @kc87_second_52 -35;
-    pos @kc87_first_33 @kc87_second_56 -70;
+    pos @kc87_first_33 @kc87_second_47 -140;
+    pos @kc87_first_33 @kc87_second_48 -70;
+    pos @kc87_first_33 @kc87_second_49 -35;
+    pos @kc87_first_33 @kc87_second_50 -35;
+    pos @kc87_first_33 @kc87_second_51 1;
+    pos @kc87_first_33 @kc87_second_53 -50;
+    pos @kc87_first_33 @kc87_second_54 -140;
     pos @kc87_first_33 @kc87_second_58 -70;
-    pos @kc87_first_33 @kc87_second_59 -70;
-    pos @kc87_first_33 @kc87_second_64 -70;
-    pos @kc87_first_33 @kc87_second_65 -35;
+    pos @kc87_first_33 @kc87_second_60 -70;
+    pos @kc87_first_33 @kc87_second_61 -70;
+    pos @kc87_first_33 @kc87_second_66 -70;
+    pos @kc87_first_33 @kc87_second_67 -35;
     pos @kc87_first_34 @kc87_second_3 -35;
     pos @kc87_first_34 @kc87_second_4 -70;
     pos @kc87_first_34 @kc87_second_6 -70;
@@ -9429,35 +9479,36 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_34 @kc87_second_24 -105;
     pos @kc87_first_34 @kc87_second_25 -70;
     pos @kc87_first_34 @kc87_second_31 -35;
-    pos @kc87_first_34 @kc87_second_37 -70;
-    pos @kc87_first_34 @kc87_second_39 -70;
-    pos @kc87_first_34 @kc87_second_41 -105;
-    pos @kc87_first_34 @kc87_second_42 -70;
-    pos @kc87_first_34 @kc87_second_47 -70;
-    pos @kc87_first_34 @kc87_second_48 1;
-    pos @kc87_first_34 @kc87_second_54 -35;
-    pos @kc87_first_34 @kc87_second_55 -35;
-    pos @kc87_first_34 @kc87_second_66 -70;
-    pos @kc87_first_34 @kc87_second_67 -70;
-    pos @kc87_first_35 @kc87_second_34 -315;
-    pos @kc87_first_35 @kc87_second_48 1;
+    pos @kc87_first_34 @kc87_second_34 -70;
+    pos @kc87_first_34 @kc87_second_38 -70;
+    pos @kc87_first_34 @kc87_second_40 -70;
+    pos @kc87_first_34 @kc87_second_41 -70;
+    pos @kc87_first_34 @kc87_second_43 -105;
+    pos @kc87_first_34 @kc87_second_44 -70;
+    pos @kc87_first_34 @kc87_second_51 1;
+    pos @kc87_first_34 @kc87_second_56 -35;
+    pos @kc87_first_34 @kc87_second_57 -35;
+    pos @kc87_first_34 @kc87_second_68 -70;
+    pos @kc87_first_34 @kc87_second_69 -70;
+    pos @kc87_first_35 @kc87_second_35 -315;
+    pos @kc87_first_35 @kc87_second_51 1;
     pos @kc87_first_36 @kc87_second_9 -70;
     pos @kc87_first_36 @kc87_second_12 -240;
     pos @kc87_first_36 @kc87_second_13 -210;
     pos @kc87_first_36 @kc87_second_14 -140;
     pos @kc87_first_36 @kc87_second_15 -105;
-    pos @kc87_first_36 @kc87_second_36 44;
-    pos @kc87_first_36 @kc87_second_42 -70;
-    pos @kc87_first_36 @kc87_second_43 -35;
-    pos @kc87_first_36 @kc87_second_46 -140;
-    pos @kc87_first_36 @kc87_second_48 1;
-    pos @kc87_first_36 @kc87_second_50 -50;
-    pos @kc87_first_36 @kc87_second_51 -140;
-    pos @kc87_first_36 @kc87_second_53 44;
-    pos @kc87_first_36 @kc87_second_61 -35;
+    pos @kc87_first_36 @kc87_second_37 44;
+    pos @kc87_first_36 @kc87_second_44 -70;
+    pos @kc87_first_36 @kc87_second_45 -35;
+    pos @kc87_first_36 @kc87_second_47 -140;
+    pos @kc87_first_36 @kc87_second_51 1;
+    pos @kc87_first_36 @kc87_second_53 -50;
+    pos @kc87_first_36 @kc87_second_54 -140;
+    pos @kc87_first_36 @kc87_second_55 44;
     pos @kc87_first_36 @kc87_second_63 -35;
-    pos @kc87_first_36 @kc87_second_64 -70;
-    pos @kc87_first_36 @kc87_second_65 -70;
+    pos @kc87_first_36 @kc87_second_65 -35;
+    pos @kc87_first_36 @kc87_second_66 -70;
+    pos @kc87_first_36 @kc87_second_67 -70;
     pos @kc87_first_37 @kc87_second_9 -35;
     pos @kc87_first_37 @kc87_second_12 -240;
     pos @kc87_first_37 @kc87_second_13 -240;
@@ -9466,15 +9517,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_37 @kc87_second_16 -35;
     pos @kc87_first_37 @kc87_second_28 -35;
     pos @kc87_first_37 @kc87_second_29 -35;
-    pos @kc87_first_37 @kc87_second_42 -70;
-    pos @kc87_first_37 @kc87_second_43 -35;
-    pos @kc87_first_37 @kc87_second_46 -70;
-    pos @kc87_first_37 @kc87_second_48 1;
-    pos @kc87_first_37 @kc87_second_50 -35;
-    pos @kc87_first_37 @kc87_second_51 -70;
-    pos @kc87_first_37 @kc87_second_63 -35;
-    pos @kc87_first_37 @kc87_second_64 -70;
-    pos @kc87_first_37 @kc87_second_65 -70;
+    pos @kc87_first_37 @kc87_second_44 -70;
+    pos @kc87_first_37 @kc87_second_45 -35;
+    pos @kc87_first_37 @kc87_second_47 -70;
+    pos @kc87_first_37 @kc87_second_48 -35;
+    pos @kc87_first_37 @kc87_second_51 1;
+    pos @kc87_first_37 @kc87_second_53 -35;
+    pos @kc87_first_37 @kc87_second_54 -70;
+    pos @kc87_first_37 @kc87_second_65 -35;
+    pos @kc87_first_37 @kc87_second_66 -70;
+    pos @kc87_first_37 @kc87_second_67 -70;
     pos @kc87_first_38 @kc87_second_5 -70;
     pos @kc87_first_38 @kc87_second_9 -70;
     pos @kc87_first_38 @kc87_second_12 -140;
@@ -9484,669 +9536,685 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_38 @kc87_second_16 -70;
     pos @kc87_first_38 @kc87_second_28 -70;
     pos @kc87_first_38 @kc87_second_29 -70;
-    pos @kc87_first_38 @kc87_second_38 -50;
-    pos @kc87_first_38 @kc87_second_42 -50;
-    pos @kc87_first_38 @kc87_second_43 -35;
-    pos @kc87_first_38 @kc87_second_48 1;
-    pos @kc87_first_38 @kc87_second_50 -35;
-    pos @kc87_first_38 @kc87_second_51 -140;
-    pos @kc87_first_38 @kc87_second_60 -35;
-    pos @kc87_first_38 @kc87_second_64 -70;
-    pos @kc87_first_38 @kc87_second_65 -35;
-    pos @kc87_first_39 @kc87_second_1 -210;
-    pos @kc87_first_39 @kc87_second_2 -280;
-    pos @kc87_first_39 @kc87_second_6 -280;
-    pos @kc87_first_39 @kc87_second_8 -70;
-    pos @kc87_first_39 @kc87_second_9 3;
-    pos @kc87_first_39 @kc87_second_17 -140;
-    pos @kc87_first_39 @kc87_second_18 -140;
-    pos @kc87_first_39 @kc87_second_19 -245;
-    pos @kc87_first_39 @kc87_second_21 -350;
-    pos @kc87_first_39 @kc87_second_22 -140;
-    pos @kc87_first_39 @kc87_second_24 -140;
-    pos @kc87_first_39 @kc87_second_25 -70;
-    pos @kc87_first_39 @kc87_second_26 -280;
-    pos @kc87_first_39 @kc87_second_30 -315;
-    pos @kc87_first_39 @kc87_second_31 -140;
-    pos @kc87_first_39 @kc87_second_34 -385;
-    pos @kc87_first_39 @kc87_second_35 -140;
-    pos @kc87_first_39 @kc87_second_37 -210;
+    pos @kc87_first_38 @kc87_second_39 -50;
+    pos @kc87_first_38 @kc87_second_44 -50;
+    pos @kc87_first_38 @kc87_second_45 -35;
+    pos @kc87_first_38 @kc87_second_51 1;
+    pos @kc87_first_38 @kc87_second_53 -35;
+    pos @kc87_first_38 @kc87_second_54 -140;
+    pos @kc87_first_38 @kc87_second_62 -35;
+    pos @kc87_first_38 @kc87_second_66 -70;
+    pos @kc87_first_38 @kc87_second_67 -35;
+    pos @kc87_first_39 @kc87_second_3 -140;
+    pos @kc87_first_39 @kc87_second_4 -70;
+    pos @kc87_first_39 @kc87_second_6 -70;
+    pos @kc87_first_39 @kc87_second_8 -210;
+    pos @kc87_first_39 @kc87_second_9 -420;
+    pos @kc87_first_39 @kc87_second_12 -350;
+    pos @kc87_first_39 @kc87_second_13 -420;
+    pos @kc87_first_39 @kc87_second_14 -350;
+    pos @kc87_first_39 @kc87_second_15 -280;
+    pos @kc87_first_39 @kc87_second_17 -70;
+    pos @kc87_first_39 @kc87_second_18 -70;
+    pos @kc87_first_39 @kc87_second_20 -210;
+    pos @kc87_first_39 @kc87_second_22 -210;
+    pos @kc87_first_39 @kc87_second_24 -70;
+    pos @kc87_first_39 @kc87_second_25 -140;
+    pos @kc87_first_39 @kc87_second_31 -35;
+    pos @kc87_first_39 @kc87_second_33 -140;
     pos @kc87_first_39 @kc87_second_38 -70;
-    pos @kc87_first_39 @kc87_second_39 -140;
-    pos @kc87_first_39 @kc87_second_40 -140;
-    pos @kc87_first_39 @kc87_second_41 -140;
-    pos @kc87_first_39 @kc87_second_42 -70;
-    pos @kc87_first_39 @kc87_second_44 -70;
-    pos @kc87_first_39 @kc87_second_48 1;
-    pos @kc87_first_39 @kc87_second_54 -140;
-    pos @kc87_first_39 @kc87_second_55 -70;
-    pos @kc87_first_39 @kc87_second_56 -140;
-    pos @kc87_first_39 @kc87_second_58 -245;
-    pos @kc87_first_39 @kc87_second_59 -210;
-    pos @kc87_first_39 @kc87_second_60 -70;
-    pos @kc87_first_39 @kc87_second_61 -70;
-    pos @kc87_first_39 @kc87_second_62 -70;
-    pos @kc87_first_39 @kc87_second_63 -70;
-    pos @kc87_first_39 @kc87_second_66 -245;
-    pos @kc87_first_39 @kc87_second_67 -280;
-    pos @kc87_first_39 @kc87_second_68 -315;
+    pos @kc87_first_39 @kc87_second_41 -70;
+    pos @kc87_first_39 @kc87_second_43 -210;
+    pos @kc87_first_39 @kc87_second_44 -280;
+    pos @kc87_first_39 @kc87_second_45 -420;
+    pos @kc87_first_39 @kc87_second_47 -350;
+    pos @kc87_first_39 @kc87_second_48 -280;
+    pos @kc87_first_39 @kc87_second_51 1;
+    pos @kc87_first_39 @kc87_second_52 -35;
+    pos @kc87_first_39 @kc87_second_53 -210;
+    pos @kc87_first_39 @kc87_second_54 -350;
+    pos @kc87_first_39 @kc87_second_56 -35;
+    pos @kc87_first_39 @kc87_second_57 -35;
+    pos @kc87_first_39 @kc87_second_63 -280;
+    pos @kc87_first_39 @kc87_second_65 -175;
+    pos @kc87_first_39 @kc87_second_66 -280;
+    pos @kc87_first_39 @kc87_second_67 -210;
+    pos @kc87_first_39 @kc87_second_68 -70;
+    pos @kc87_first_40 @kc87_second_1 -35;
+    pos @kc87_first_40 @kc87_second_2 -70;
+    pos @kc87_first_40 @kc87_second_5 -105;
     pos @kc87_first_40 @kc87_second_6 -35;
+    pos @kc87_first_40 @kc87_second_9 -70;
+    pos @kc87_first_40 @kc87_second_11 -70;
     pos @kc87_first_40 @kc87_second_12 -240;
-    pos @kc87_first_40 @kc87_second_13 -140;
-    pos @kc87_first_40 @kc87_second_14 -35;
-    pos @kc87_first_40 @kc87_second_15 -35;
-    pos @kc87_first_40 @kc87_second_35 35;
-    pos @kc87_first_40 @kc87_second_36 100;
-    pos @kc87_first_40 @kc87_second_37 -35;
-    pos @kc87_first_40 @kc87_second_48 1;
-    pos @kc87_first_40 @kc87_second_66 -35;
-    pos @kc87_first_40 @kc87_second_67 -35;
-    pos @kc87_first_41 @kc87_second_12 -210;
-    pos @kc87_first_41 @kc87_second_13 -175;
-    pos @kc87_first_41 @kc87_second_14 -105;
-    pos @kc87_first_41 @kc87_second_15 -70;
+    pos @kc87_first_40 @kc87_second_13 -245;
+    pos @kc87_first_40 @kc87_second_14 -140;
+    pos @kc87_first_40 @kc87_second_15 -105;
+    pos @kc87_first_40 @kc87_second_16 -105;
+    pos @kc87_first_40 @kc87_second_19 -35;
+    pos @kc87_first_40 @kc87_second_20 -70;
+    pos @kc87_first_40 @kc87_second_21 -70;
+    pos @kc87_first_40 @kc87_second_26 -35;
+    pos @kc87_first_40 @kc87_second_27 -70;
+    pos @kc87_first_40 @kc87_second_28 -140;
+    pos @kc87_first_40 @kc87_second_29 -105;
+    pos @kc87_first_40 @kc87_second_36 -35;
+    pos @kc87_first_40 @kc87_second_38 -35;
+    pos @kc87_first_40 @kc87_second_39 -140;
+    pos @kc87_first_40 @kc87_second_44 -105;
+    pos @kc87_first_40 @kc87_second_45 -70;
+    pos @kc87_first_40 @kc87_second_47 -175;
+    pos @kc87_first_40 @kc87_second_49 -105;
+    pos @kc87_first_40 @kc87_second_50 -70;
+    pos @kc87_first_40 @kc87_second_51 1;
+    pos @kc87_first_40 @kc87_second_53 -70;
+    pos @kc87_first_40 @kc87_second_54 -140;
+    pos @kc87_first_40 @kc87_second_58 -210;
+    pos @kc87_first_40 @kc87_second_59 -70;
+    pos @kc87_first_40 @kc87_second_60 -175;
+    pos @kc87_first_40 @kc87_second_61 -175;
+    pos @kc87_first_40 @kc87_second_62 -105;
+    pos @kc87_first_40 @kc87_second_65 -50;
+    pos @kc87_first_40 @kc87_second_66 -105;
+    pos @kc87_first_40 @kc87_second_67 -70;
+    pos @kc87_first_40 @kc87_second_69 -35;
+    pos @kc87_first_41 @kc87_second_1 -210;
+    pos @kc87_first_41 @kc87_second_2 -280;
+    pos @kc87_first_41 @kc87_second_6 -280;
+    pos @kc87_first_41 @kc87_second_8 -70;
+    pos @kc87_first_41 @kc87_second_9 3;
+    pos @kc87_first_41 @kc87_second_17 -140;
+    pos @kc87_first_41 @kc87_second_18 -140;
+    pos @kc87_first_41 @kc87_second_19 -245;
+    pos @kc87_first_41 @kc87_second_21 -350;
+    pos @kc87_first_41 @kc87_second_22 -140;
+    pos @kc87_first_41 @kc87_second_24 -140;
+    pos @kc87_first_41 @kc87_second_25 -70;
+    pos @kc87_first_41 @kc87_second_26 -280;
+    pos @kc87_first_41 @kc87_second_30 -315;
+    pos @kc87_first_41 @kc87_second_31 -140;
+    pos @kc87_first_41 @kc87_second_35 -385;
+    pos @kc87_first_41 @kc87_second_36 -140;
+    pos @kc87_first_41 @kc87_second_38 -210;
+    pos @kc87_first_41 @kc87_second_39 -70;
+    pos @kc87_first_41 @kc87_second_41 -140;
+    pos @kc87_first_41 @kc87_second_42 -140;
+    pos @kc87_first_41 @kc87_second_43 -140;
+    pos @kc87_first_41 @kc87_second_44 -70;
     pos @kc87_first_41 @kc87_second_46 -70;
-    pos @kc87_first_41 @kc87_second_48 1;
-    pos @kc87_first_41 @kc87_second_51 -105;
+    pos @kc87_first_41 @kc87_second_51 1;
+    pos @kc87_first_41 @kc87_second_56 -140;
+    pos @kc87_first_41 @kc87_second_57 -70;
+    pos @kc87_first_41 @kc87_second_58 -140;
+    pos @kc87_first_41 @kc87_second_60 -245;
+    pos @kc87_first_41 @kc87_second_61 -210;
+    pos @kc87_first_41 @kc87_second_62 -70;
+    pos @kc87_first_41 @kc87_second_63 -70;
     pos @kc87_first_41 @kc87_second_64 -70;
-    pos @kc87_first_42 @kc87_second_1 -140;
-    pos @kc87_first_42 @kc87_second_2 -175;
-    pos @kc87_first_42 @kc87_second_5 -105;
-    pos @kc87_first_42 @kc87_second_6 -70;
-    pos @kc87_first_42 @kc87_second_11 -70;
-    pos @kc87_first_42 @kc87_second_12 -175;
-    pos @kc87_first_42 @kc87_second_13 -105;
-    pos @kc87_first_42 @kc87_second_14 -70;
+    pos @kc87_first_41 @kc87_second_65 -70;
+    pos @kc87_first_41 @kc87_second_68 -245;
+    pos @kc87_first_41 @kc87_second_69 -280;
+    pos @kc87_first_41 @kc87_second_70 -315;
+    pos @kc87_first_42 @kc87_second_6 -35;
+    pos @kc87_first_42 @kc87_second_12 -240;
+    pos @kc87_first_42 @kc87_second_13 -140;
+    pos @kc87_first_42 @kc87_second_14 -35;
     pos @kc87_first_42 @kc87_second_15 -35;
-    pos @kc87_first_42 @kc87_second_16 -105;
-    pos @kc87_first_42 @kc87_second_17 -35;
-    pos @kc87_first_42 @kc87_second_18 -50;
-    pos @kc87_first_42 @kc87_second_19 -140;
-    pos @kc87_first_42 @kc87_second_21 -175;
-    pos @kc87_first_42 @kc87_second_24 -50;
-    pos @kc87_first_42 @kc87_second_26 -105;
-    pos @kc87_first_42 @kc87_second_31 -35;
-    pos @kc87_first_42 @kc87_second_34 -70;
-    pos @kc87_first_42 @kc87_second_35 -50;
-    pos @kc87_first_42 @kc87_second_37 -70;
-    pos @kc87_first_42 @kc87_second_38 -140;
-    pos @kc87_first_42 @kc87_second_39 -35;
-    pos @kc87_first_42 @kc87_second_41 -50;
-    pos @kc87_first_42 @kc87_second_48 1;
-    pos @kc87_first_42 @kc87_second_54 -35;
-    pos @kc87_first_42 @kc87_second_56 -105;
-    pos @kc87_first_42 @kc87_second_58 -105;
-    pos @kc87_first_42 @kc87_second_59 -105;
-    pos @kc87_first_42 @kc87_second_66 -50;
-    pos @kc87_first_42 @kc87_second_67 -70;
-    pos @kc87_first_43 @kc87_second_1 -210;
-    pos @kc87_first_43 @kc87_second_2 -280;
-    pos @kc87_first_43 @kc87_second_3 -70;
-    pos @kc87_first_43 @kc87_second_6 -280;
-    pos @kc87_first_43 @kc87_second_8 -35;
-    pos @kc87_first_43 @kc87_second_11 -70;
-    pos @kc87_first_43 @kc87_second_13 -140;
-    pos @kc87_first_43 @kc87_second_14 -35;
-    pos @kc87_first_43 @kc87_second_15 -35;
-    pos @kc87_first_43 @kc87_second_16 -140;
-    pos @kc87_first_43 @kc87_second_17 -105;
-    pos @kc87_first_43 @kc87_second_18 -140;
-    pos @kc87_first_43 @kc87_second_19 -210;
-    pos @kc87_first_43 @kc87_second_21 -280;
-    pos @kc87_first_43 @kc87_second_22 -140;
-    pos @kc87_first_43 @kc87_second_24 -140;
-    pos @kc87_first_43 @kc87_second_25 -140;
-    pos @kc87_first_43 @kc87_second_26 -210;
-    pos @kc87_first_43 @kc87_second_34 -140;
-    pos @kc87_first_43 @kc87_second_35 -140;
-    pos @kc87_first_43 @kc87_second_37 -280;
-    pos @kc87_first_43 @kc87_second_38 -140;
-    pos @kc87_first_43 @kc87_second_39 -70;
-    pos @kc87_first_43 @kc87_second_40 -140;
-    pos @kc87_first_43 @kc87_second_41 -175;
+    pos @kc87_first_42 @kc87_second_36 35;
+    pos @kc87_first_42 @kc87_second_37 100;
+    pos @kc87_first_42 @kc87_second_38 -35;
+    pos @kc87_first_42 @kc87_second_51 1;
+    pos @kc87_first_42 @kc87_second_68 -35;
+    pos @kc87_first_42 @kc87_second_69 -35;
+    pos @kc87_first_43 @kc87_second_12 -210;
+    pos @kc87_first_43 @kc87_second_13 -175;
+    pos @kc87_first_43 @kc87_second_14 -105;
+    pos @kc87_first_43 @kc87_second_15 -70;
     pos @kc87_first_43 @kc87_second_47 -70;
-    pos @kc87_first_43 @kc87_second_48 1;
-    pos @kc87_first_43 @kc87_second_56 -210;
-    pos @kc87_first_43 @kc87_second_58 -210;
-    pos @kc87_first_43 @kc87_second_59 -175;
-    pos @kc87_first_43 @kc87_second_62 -70;
-    pos @kc87_first_43 @kc87_second_66 -175;
-    pos @kc87_first_43 @kc87_second_67 -175;
-    pos @kc87_first_44 @kc87_second_9 -70;
-    pos @kc87_first_44 @kc87_second_12 -240;
-    pos @kc87_first_44 @kc87_second_13 -210;
-    pos @kc87_first_44 @kc87_second_14 -140;
-    pos @kc87_first_44 @kc87_second_15 -105;
-    pos @kc87_first_44 @kc87_second_42 -70;
-    pos @kc87_first_44 @kc87_second_43 -35;
-    pos @kc87_first_44 @kc87_second_46 -140;
-    pos @kc87_first_44 @kc87_second_48 1;
-    pos @kc87_first_44 @kc87_second_50 -50;
-    pos @kc87_first_44 @kc87_second_51 -140;
-    pos @kc87_first_44 @kc87_second_61 -35;
-    pos @kc87_first_44 @kc87_second_63 -35;
-    pos @kc87_first_44 @kc87_second_64 -70;
-    pos @kc87_first_44 @kc87_second_65 -70;
+    pos @kc87_first_43 @kc87_second_48 -35;
+    pos @kc87_first_43 @kc87_second_51 1;
+    pos @kc87_first_43 @kc87_second_54 -105;
+    pos @kc87_first_43 @kc87_second_66 -70;
+    pos @kc87_first_44 @kc87_second_1 -140;
+    pos @kc87_first_44 @kc87_second_2 -175;
+    pos @kc87_first_44 @kc87_second_5 -105;
+    pos @kc87_first_44 @kc87_second_6 -70;
+    pos @kc87_first_44 @kc87_second_11 -70;
+    pos @kc87_first_44 @kc87_second_12 -175;
+    pos @kc87_first_44 @kc87_second_13 -105;
+    pos @kc87_first_44 @kc87_second_14 -70;
+    pos @kc87_first_44 @kc87_second_15 -35;
+    pos @kc87_first_44 @kc87_second_16 -105;
+    pos @kc87_first_44 @kc87_second_17 -35;
+    pos @kc87_first_44 @kc87_second_18 -50;
+    pos @kc87_first_44 @kc87_second_19 -140;
+    pos @kc87_first_44 @kc87_second_21 -175;
+    pos @kc87_first_44 @kc87_second_24 -50;
+    pos @kc87_first_44 @kc87_second_26 -105;
+    pos @kc87_first_44 @kc87_second_31 -35;
+    pos @kc87_first_44 @kc87_second_34 -70;
+    pos @kc87_first_44 @kc87_second_35 -70;
+    pos @kc87_first_44 @kc87_second_36 -50;
+    pos @kc87_first_44 @kc87_second_38 -70;
+    pos @kc87_first_44 @kc87_second_39 -140;
+    pos @kc87_first_44 @kc87_second_41 -35;
+    pos @kc87_first_44 @kc87_second_43 -50;
+    pos @kc87_first_44 @kc87_second_51 1;
+    pos @kc87_first_44 @kc87_second_56 -35;
+    pos @kc87_first_44 @kc87_second_58 -105;
+    pos @kc87_first_44 @kc87_second_60 -105;
+    pos @kc87_first_44 @kc87_second_61 -105;
+    pos @kc87_first_44 @kc87_second_68 -50;
+    pos @kc87_first_44 @kc87_second_69 -70;
+    pos @kc87_first_45 @kc87_second_1 -210;
+    pos @kc87_first_45 @kc87_second_2 -280;
+    pos @kc87_first_45 @kc87_second_3 -70;
+    pos @kc87_first_45 @kc87_second_6 -280;
     pos @kc87_first_45 @kc87_second_8 -35;
-    pos @kc87_first_45 @kc87_second_9 -70;
-    pos @kc87_first_45 @kc87_second_12 -240;
-    pos @kc87_first_45 @kc87_second_13 -210;
-    pos @kc87_first_45 @kc87_second_14 -70;
-    pos @kc87_first_45 @kc87_second_15 -105;
-    pos @kc87_first_45 @kc87_second_18 -35;
-    pos @kc87_first_45 @kc87_second_24 -35;
+    pos @kc87_first_45 @kc87_second_11 -70;
+    pos @kc87_first_45 @kc87_second_13 -140;
+    pos @kc87_first_45 @kc87_second_14 -35;
+    pos @kc87_first_45 @kc87_second_15 -35;
+    pos @kc87_first_45 @kc87_second_16 -140;
+    pos @kc87_first_45 @kc87_second_17 -105;
+    pos @kc87_first_45 @kc87_second_18 -140;
+    pos @kc87_first_45 @kc87_second_19 -210;
+    pos @kc87_first_45 @kc87_second_21 -280;
+    pos @kc87_first_45 @kc87_second_22 -140;
+    pos @kc87_first_45 @kc87_second_24 -140;
+    pos @kc87_first_45 @kc87_second_25 -140;
+    pos @kc87_first_45 @kc87_second_26 -210;
+    pos @kc87_first_45 @kc87_second_34 -70;
+    pos @kc87_first_45 @kc87_second_35 -140;
+    pos @kc87_first_45 @kc87_second_36 -140;
+    pos @kc87_first_45 @kc87_second_38 -280;
+    pos @kc87_first_45 @kc87_second_39 -140;
+    pos @kc87_first_45 @kc87_second_40 -70;
     pos @kc87_first_45 @kc87_second_41 -70;
-    pos @kc87_first_45 @kc87_second_42 -105;
-    pos @kc87_first_45 @kc87_second_43 -70;
-    pos @kc87_first_45 @kc87_second_46 -70;
-    pos @kc87_first_45 @kc87_second_47 -35;
-    pos @kc87_first_45 @kc87_second_48 1;
-    pos @kc87_first_45 @kc87_second_50 -70;
-    pos @kc87_first_45 @kc87_second_51 -70;
-    pos @kc87_first_45 @kc87_second_61 -70;
-    pos @kc87_first_45 @kc87_second_63 -50;
-    pos @kc87_first_45 @kc87_second_65 -70;
-    pos @kc87_first_45 @kc87_second_66 -35;
-    pos @kc87_first_45 @kc87_second_67 -35;
-    pos @kc87_first_46 @kc87_second_6 -70;
-    pos @kc87_first_46 @kc87_second_8 -35;
-    pos @kc87_first_46 @kc87_second_12 -175;
-    pos @kc87_first_46 @kc87_second_13 -140;
-    pos @kc87_first_46 @kc87_second_14 -70;
-    pos @kc87_first_46 @kc87_second_15 -35;
-    pos @kc87_first_46 @kc87_second_17 -70;
-    pos @kc87_first_46 @kc87_second_18 -105;
-    pos @kc87_first_46 @kc87_second_22 -70;
-    pos @kc87_first_46 @kc87_second_24 -105;
-    pos @kc87_first_46 @kc87_second_31 -35;
-    pos @kc87_first_46 @kc87_second_37 -70;
-    pos @kc87_first_46 @kc87_second_39 -35;
-    pos @kc87_first_46 @kc87_second_41 -105;
-    pos @kc87_first_46 @kc87_second_48 1;
-    pos @kc87_first_46 @kc87_second_54 -35;
+    pos @kc87_first_45 @kc87_second_42 -140;
+    pos @kc87_first_45 @kc87_second_43 -175;
+    pos @kc87_first_45 @kc87_second_51 1;
+    pos @kc87_first_45 @kc87_second_58 -210;
+    pos @kc87_first_45 @kc87_second_60 -210;
+    pos @kc87_first_45 @kc87_second_61 -175;
+    pos @kc87_first_45 @kc87_second_64 -70;
+    pos @kc87_first_45 @kc87_second_68 -175;
+    pos @kc87_first_45 @kc87_second_69 -175;
+    pos @kc87_first_46 @kc87_second_9 -70;
+    pos @kc87_first_46 @kc87_second_12 -240;
+    pos @kc87_first_46 @kc87_second_13 -210;
+    pos @kc87_first_46 @kc87_second_14 -140;
+    pos @kc87_first_46 @kc87_second_15 -105;
+    pos @kc87_first_46 @kc87_second_44 -70;
+    pos @kc87_first_46 @kc87_second_45 -35;
+    pos @kc87_first_46 @kc87_second_47 -140;
+    pos @kc87_first_46 @kc87_second_48 -70;
+    pos @kc87_first_46 @kc87_second_51 1;
+    pos @kc87_first_46 @kc87_second_53 -50;
+    pos @kc87_first_46 @kc87_second_54 -140;
+    pos @kc87_first_46 @kc87_second_63 -35;
+    pos @kc87_first_46 @kc87_second_65 -35;
     pos @kc87_first_46 @kc87_second_66 -70;
     pos @kc87_first_46 @kc87_second_67 -70;
-    pos @kc87_first_47 @kc87_second_3 -140;
-    pos @kc87_first_47 @kc87_second_4 -70;
-    pos @kc87_first_47 @kc87_second_6 -70;
-    pos @kc87_first_47 @kc87_second_8 -210;
-    pos @kc87_first_47 @kc87_second_9 -420;
-    pos @kc87_first_47 @kc87_second_12 -350;
-    pos @kc87_first_47 @kc87_second_13 -420;
-    pos @kc87_first_47 @kc87_second_14 -350;
-    pos @kc87_first_47 @kc87_second_15 -280;
-    pos @kc87_first_47 @kc87_second_17 -70;
-    pos @kc87_first_47 @kc87_second_18 -70;
-    pos @kc87_first_47 @kc87_second_20 -210;
-    pos @kc87_first_47 @kc87_second_22 -210;
-    pos @kc87_first_47 @kc87_second_24 -70;
-    pos @kc87_first_47 @kc87_second_25 -140;
-    pos @kc87_first_47 @kc87_second_31 -35;
-    pos @kc87_first_47 @kc87_second_33 -140;
-    pos @kc87_first_47 @kc87_second_37 -70;
-    pos @kc87_first_47 @kc87_second_39 -70;
-    pos @kc87_first_47 @kc87_second_41 -210;
-    pos @kc87_first_47 @kc87_second_42 -280;
-    pos @kc87_first_47 @kc87_second_43 -420;
-    pos @kc87_first_47 @kc87_second_46 -350;
-    pos @kc87_first_47 @kc87_second_48 1;
-    pos @kc87_first_47 @kc87_second_49 -35;
-    pos @kc87_first_47 @kc87_second_50 -210;
-    pos @kc87_first_47 @kc87_second_51 -350;
-    pos @kc87_first_47 @kc87_second_54 -35;
-    pos @kc87_first_47 @kc87_second_55 -35;
-    pos @kc87_first_47 @kc87_second_61 -280;
-    pos @kc87_first_47 @kc87_second_63 -175;
-    pos @kc87_first_47 @kc87_second_64 -280;
-    pos @kc87_first_47 @kc87_second_65 -210;
-    pos @kc87_first_47 @kc87_second_66 -70;
-    pos @kc87_first_48 @kc87_second_3 -140;
-    pos @kc87_first_48 @kc87_second_4 -105;
+    pos @kc87_first_47 @kc87_second_8 -35;
+    pos @kc87_first_47 @kc87_second_9 -70;
+    pos @kc87_first_47 @kc87_second_12 -240;
+    pos @kc87_first_47 @kc87_second_13 -210;
+    pos @kc87_first_47 @kc87_second_14 -70;
+    pos @kc87_first_47 @kc87_second_15 -105;
+    pos @kc87_first_47 @kc87_second_18 -35;
+    pos @kc87_first_47 @kc87_second_24 -35;
+    pos @kc87_first_47 @kc87_second_40 -35;
+    pos @kc87_first_47 @kc87_second_43 -70;
+    pos @kc87_first_47 @kc87_second_44 -105;
+    pos @kc87_first_47 @kc87_second_45 -70;
+    pos @kc87_first_47 @kc87_second_47 -70;
+    pos @kc87_first_47 @kc87_second_51 1;
+    pos @kc87_first_47 @kc87_second_53 -70;
+    pos @kc87_first_47 @kc87_second_54 -70;
+    pos @kc87_first_47 @kc87_second_63 -70;
+    pos @kc87_first_47 @kc87_second_65 -50;
+    pos @kc87_first_47 @kc87_second_67 -70;
+    pos @kc87_first_47 @kc87_second_68 -35;
+    pos @kc87_first_47 @kc87_second_69 -35;
     pos @kc87_first_48 @kc87_second_6 -70;
-    pos @kc87_first_48 @kc87_second_8 -210;
-    pos @kc87_first_48 @kc87_second_9 -280;
-    pos @kc87_first_48 @kc87_second_12 -350;
-    pos @kc87_first_48 @kc87_second_13 -385;
-    pos @kc87_first_48 @kc87_second_14 -350;
-    pos @kc87_first_48 @kc87_second_15 -280;
+    pos @kc87_first_48 @kc87_second_8 -35;
+    pos @kc87_first_48 @kc87_second_12 -175;
+    pos @kc87_first_48 @kc87_second_13 -140;
+    pos @kc87_first_48 @kc87_second_14 -70;
+    pos @kc87_first_48 @kc87_second_15 -35;
+    pos @kc87_first_48 @kc87_second_17 -70;
     pos @kc87_first_48 @kc87_second_18 -105;
-    pos @kc87_first_48 @kc87_second_20 -210;
-    pos @kc87_first_48 @kc87_second_22 -140;
+    pos @kc87_first_48 @kc87_second_22 -70;
     pos @kc87_first_48 @kc87_second_24 -105;
-    pos @kc87_first_48 @kc87_second_25 -140;
-    pos @kc87_first_48 @kc87_second_31 -70;
-    pos @kc87_first_48 @kc87_second_33 -175;
-    pos @kc87_first_48 @kc87_second_37 -70;
-    pos @kc87_first_48 @kc87_second_39 -35;
-    pos @kc87_first_48 @kc87_second_41 -175;
-    pos @kc87_first_48 @kc87_second_42 -280;
-    pos @kc87_first_48 @kc87_second_43 -280;
-    pos @kc87_first_48 @kc87_second_46 -280;
-    pos @kc87_first_48 @kc87_second_47 -140;
-    pos @kc87_first_48 @kc87_second_48 1;
-    pos @kc87_first_48 @kc87_second_49 -70;
-    pos @kc87_first_48 @kc87_second_50 -280;
-    pos @kc87_first_48 @kc87_second_51 -350;
-    pos @kc87_first_48 @kc87_second_54 -35;
-    pos @kc87_first_48 @kc87_second_55 -70;
-    pos @kc87_first_48 @kc87_second_61 -245;
-    pos @kc87_first_48 @kc87_second_63 -245;
-    pos @kc87_first_48 @kc87_second_64 -280;
-    pos @kc87_first_48 @kc87_second_65 -210;
-    pos @kc87_first_48 @kc87_second_66 -70;
-    pos @kc87_first_48 @kc87_second_67 -70;
-    pos @kc87_first_49 @kc87_second_3 -70;
+    pos @kc87_first_48 @kc87_second_31 -35;
+    pos @kc87_first_48 @kc87_second_34 -70;
+    pos @kc87_first_48 @kc87_second_38 -70;
+    pos @kc87_first_48 @kc87_second_41 -35;
+    pos @kc87_first_48 @kc87_second_43 -105;
+    pos @kc87_first_48 @kc87_second_51 1;
+    pos @kc87_first_48 @kc87_second_56 -35;
+    pos @kc87_first_48 @kc87_second_68 -70;
+    pos @kc87_first_48 @kc87_second_69 -70;
+    pos @kc87_first_49 @kc87_second_3 -140;
     pos @kc87_first_49 @kc87_second_4 -105;
-    pos @kc87_first_49 @kc87_second_6 -210;
-    pos @kc87_first_49 @kc87_second_7 -70;
-    pos @kc87_first_49 @kc87_second_8 -175;
-    pos @kc87_first_49 @kc87_second_17 -210;
-    pos @kc87_first_49 @kc87_second_18 -210;
+    pos @kc87_first_49 @kc87_second_6 -70;
+    pos @kc87_first_49 @kc87_second_8 -210;
+    pos @kc87_first_49 @kc87_second_9 -280;
+    pos @kc87_first_49 @kc87_second_12 -350;
+    pos @kc87_first_49 @kc87_second_13 -385;
+    pos @kc87_first_49 @kc87_second_14 -350;
+    pos @kc87_first_49 @kc87_second_15 -280;
+    pos @kc87_first_49 @kc87_second_18 -105;
+    pos @kc87_first_49 @kc87_second_20 -210;
     pos @kc87_first_49 @kc87_second_22 -140;
-    pos @kc87_first_49 @kc87_second_23 -210;
-    pos @kc87_first_49 @kc87_second_24 -210;
-    pos @kc87_first_49 @kc87_second_25 -210;
-    pos @kc87_first_49 @kc87_second_26 -140;
-    pos @kc87_first_49 @kc87_second_27 -140;
-    pos @kc87_first_49 @kc87_second_29 -140;
-    pos @kc87_first_49 @kc87_second_31 -210;
-    pos @kc87_first_49 @kc87_second_32 -210;
-    pos @kc87_first_49 @kc87_second_33 -140;
-    pos @kc87_first_49 @kc87_second_35 -210;
-    pos @kc87_first_49 @kc87_second_37 -210;
+    pos @kc87_first_49 @kc87_second_24 -105;
+    pos @kc87_first_49 @kc87_second_25 -140;
+    pos @kc87_first_49 @kc87_second_31 -70;
+    pos @kc87_first_49 @kc87_second_33 -175;
     pos @kc87_first_49 @kc87_second_38 -70;
-    pos @kc87_first_49 @kc87_second_39 -175;
-    pos @kc87_first_49 @kc87_second_40 -210;
-    pos @kc87_first_49 @kc87_second_41 -175;
-    pos @kc87_first_49 @kc87_second_42 -210;
-    pos @kc87_first_49 @kc87_second_43 -105;
-    pos @kc87_first_49 @kc87_second_46 -70;
-    pos @kc87_first_49 @kc87_second_47 -105;
-    pos @kc87_first_49 @kc87_second_48 1;
-    pos @kc87_first_49 @kc87_second_49 -35;
-    pos @kc87_first_49 @kc87_second_50 -210;
-    pos @kc87_first_49 @kc87_second_53 -210;
-    pos @kc87_first_49 @kc87_second_54 -210;
-    pos @kc87_first_49 @kc87_second_55 -175;
-    pos @kc87_first_49 @kc87_second_56 -175;
-    pos @kc87_first_49 @kc87_second_58 -210;
-    pos @kc87_first_49 @kc87_second_59 -210;
-    pos @kc87_first_49 @kc87_second_60 -140;
-    pos @kc87_first_49 @kc87_second_61 -210;
-    pos @kc87_first_49 @kc87_second_62 -175;
-    pos @kc87_first_49 @kc87_second_63 -175;
-    pos @kc87_first_49 @kc87_second_66 -210;
+    pos @kc87_first_49 @kc87_second_40 -140;
+    pos @kc87_first_49 @kc87_second_41 -35;
+    pos @kc87_first_49 @kc87_second_43 -175;
+    pos @kc87_first_49 @kc87_second_44 -280;
+    pos @kc87_first_49 @kc87_second_45 -280;
+    pos @kc87_first_49 @kc87_second_47 -280;
+    pos @kc87_first_49 @kc87_second_48 -210;
+    pos @kc87_first_49 @kc87_second_51 1;
+    pos @kc87_first_49 @kc87_second_52 -70;
+    pos @kc87_first_49 @kc87_second_53 -280;
+    pos @kc87_first_49 @kc87_second_54 -350;
+    pos @kc87_first_49 @kc87_second_56 -35;
+    pos @kc87_first_49 @kc87_second_57 -70;
+    pos @kc87_first_49 @kc87_second_63 -245;
+    pos @kc87_first_49 @kc87_second_65 -245;
+    pos @kc87_first_49 @kc87_second_66 -280;
     pos @kc87_first_49 @kc87_second_67 -210;
-    pos @kc87_first_50 @kc87_second_5 -70;
-    pos @kc87_first_50 @kc87_second_11 -35;
-    pos @kc87_first_50 @kc87_second_12 -240;
-    pos @kc87_first_50 @kc87_second_13 -70;
-    pos @kc87_first_50 @kc87_second_14 -140;
-    pos @kc87_first_50 @kc87_second_15 -105;
-    pos @kc87_first_50 @kc87_second_16 -70;
-    pos @kc87_first_50 @kc87_second_28 -70;
-    pos @kc87_first_50 @kc87_second_29 -70;
-    pos @kc87_first_50 @kc87_second_38 -35;
-    pos @kc87_first_50 @kc87_second_42 -70;
-    pos @kc87_first_50 @kc87_second_45 -35;
-    pos @kc87_first_50 @kc87_second_46 -70;
-    pos @kc87_first_50 @kc87_second_48 1;
-    pos @kc87_first_50 @kc87_second_50 -35;
-    pos @kc87_first_50 @kc87_second_51 -140;
-    pos @kc87_first_50 @kc87_second_54 1;
-    pos @kc87_first_50 @kc87_second_60 -35;
-    pos @kc87_first_50 @kc87_second_63 -35;
-    pos @kc87_first_50 @kc87_second_64 -105;
-    pos @kc87_first_50 @kc87_second_65 -70;
-    pos @kc87_first_51 @kc87_second_48 1;
-    pos @kc87_first_51 @kc87_second_68 -140;
-    pos @kc87_first_52 @kc87_second_34 -315;
-    pos @kc87_first_52 @kc87_second_48 1;
-    pos @kc87_first_52 @kc87_second_69 -140;
-    pos @kc87_first_53 @kc87_second_1 -105;
-    pos @kc87_first_53 @kc87_second_2 -210;
-    pos @kc87_first_53 @kc87_second_6 -140;
-    pos @kc87_first_53 @kc87_second_11 -70;
-    pos @kc87_first_53 @kc87_second_12 -210;
-    pos @kc87_first_53 @kc87_second_13 -210;
-    pos @kc87_first_53 @kc87_second_14 -105;
-    pos @kc87_first_53 @kc87_second_15 -70;
-    pos @kc87_first_53 @kc87_second_16 -140;
-    pos @kc87_first_53 @kc87_second_17 -35;
-    pos @kc87_first_53 @kc87_second_18 -35;
-    pos @kc87_first_53 @kc87_second_19 -105;
-    pos @kc87_first_53 @kc87_second_24 -35;
-    pos @kc87_first_53 @kc87_second_26 -210;
-    pos @kc87_first_53 @kc87_second_28 -70;
-    pos @kc87_first_53 @kc87_second_29 -70;
-    pos @kc87_first_53 @kc87_second_31 -35;
-    pos @kc87_first_53 @kc87_second_35 -70;
-    pos @kc87_first_53 @kc87_second_37 -210;
-    pos @kc87_first_53 @kc87_second_38 -140;
-    pos @kc87_first_53 @kc87_second_45 -35;
-    pos @kc87_first_53 @kc87_second_46 -70;
-    pos @kc87_first_53 @kc87_second_48 1;
-    pos @kc87_first_53 @kc87_second_50 -35;
-    pos @kc87_first_53 @kc87_second_51 -105;
-    pos @kc87_first_53 @kc87_second_56 -210;
-    pos @kc87_first_53 @kc87_second_58 -175;
-    pos @kc87_first_53 @kc87_second_59 -140;
-    pos @kc87_first_53 @kc87_second_64 -35;
-    pos @kc87_first_53 @kc87_second_65 -35;
-    pos @kc87_first_53 @kc87_second_66 -35;
-    pos @kc87_first_53 @kc87_second_67 -70;
-    pos @kc87_first_54 @kc87_second_1 -35;
-    pos @kc87_first_54 @kc87_second_2 -70;
-    pos @kc87_first_54 @kc87_second_5 -105;
-    pos @kc87_first_54 @kc87_second_6 -35;
-    pos @kc87_first_54 @kc87_second_9 -70;
-    pos @kc87_first_54 @kc87_second_11 -70;
-    pos @kc87_first_54 @kc87_second_12 -240;
-    pos @kc87_first_54 @kc87_second_13 -245;
-    pos @kc87_first_54 @kc87_second_14 -140;
-    pos @kc87_first_54 @kc87_second_15 -105;
-    pos @kc87_first_54 @kc87_second_16 -105;
-    pos @kc87_first_54 @kc87_second_19 -35;
-    pos @kc87_first_54 @kc87_second_20 -70;
-    pos @kc87_first_54 @kc87_second_21 -70;
-    pos @kc87_first_54 @kc87_second_26 -35;
-    pos @kc87_first_54 @kc87_second_27 -70;
-    pos @kc87_first_54 @kc87_second_28 -140;
-    pos @kc87_first_54 @kc87_second_29 -105;
-    pos @kc87_first_54 @kc87_second_35 -35;
-    pos @kc87_first_54 @kc87_second_37 -35;
-    pos @kc87_first_54 @kc87_second_38 -140;
-    pos @kc87_first_54 @kc87_second_42 -105;
-    pos @kc87_first_54 @kc87_second_43 -70;
-    pos @kc87_first_54 @kc87_second_45 -105;
-    pos @kc87_first_54 @kc87_second_46 -175;
-    pos @kc87_first_54 @kc87_second_48 1;
-    pos @kc87_first_54 @kc87_second_50 -70;
-    pos @kc87_first_54 @kc87_second_51 -140;
-    pos @kc87_first_54 @kc87_second_52 -70;
-    pos @kc87_first_54 @kc87_second_56 -210;
-    pos @kc87_first_54 @kc87_second_57 -70;
-    pos @kc87_first_54 @kc87_second_58 -175;
-    pos @kc87_first_54 @kc87_second_59 -175;
-    pos @kc87_first_54 @kc87_second_60 -105;
-    pos @kc87_first_54 @kc87_second_63 -50;
-    pos @kc87_first_54 @kc87_second_64 -105;
-    pos @kc87_first_54 @kc87_second_65 -70;
-    pos @kc87_first_54 @kc87_second_67 -35;
+    pos @kc87_first_49 @kc87_second_68 -70;
+    pos @kc87_first_49 @kc87_second_69 -70;
+    pos @kc87_first_50 @kc87_second_3 -70;
+    pos @kc87_first_50 @kc87_second_4 -105;
+    pos @kc87_first_50 @kc87_second_6 -210;
+    pos @kc87_first_50 @kc87_second_7 -70;
+    pos @kc87_first_50 @kc87_second_8 -175;
+    pos @kc87_first_50 @kc87_second_17 -210;
+    pos @kc87_first_50 @kc87_second_18 -210;
+    pos @kc87_first_50 @kc87_second_22 -140;
+    pos @kc87_first_50 @kc87_second_23 -210;
+    pos @kc87_first_50 @kc87_second_24 -210;
+    pos @kc87_first_50 @kc87_second_25 -210;
+    pos @kc87_first_50 @kc87_second_26 -140;
+    pos @kc87_first_50 @kc87_second_27 -140;
+    pos @kc87_first_50 @kc87_second_29 -140;
+    pos @kc87_first_50 @kc87_second_31 -210;
+    pos @kc87_first_50 @kc87_second_32 -210;
+    pos @kc87_first_50 @kc87_second_33 -140;
+    pos @kc87_first_50 @kc87_second_34 -140;
+    pos @kc87_first_50 @kc87_second_36 -210;
+    pos @kc87_first_50 @kc87_second_38 -210;
+    pos @kc87_first_50 @kc87_second_39 -70;
+    pos @kc87_first_50 @kc87_second_40 -105;
+    pos @kc87_first_50 @kc87_second_41 -175;
+    pos @kc87_first_50 @kc87_second_42 -210;
+    pos @kc87_first_50 @kc87_second_43 -175;
+    pos @kc87_first_50 @kc87_second_44 -210;
+    pos @kc87_first_50 @kc87_second_45 -105;
+    pos @kc87_first_50 @kc87_second_47 -70;
+    pos @kc87_first_50 @kc87_second_51 1;
+    pos @kc87_first_50 @kc87_second_52 -35;
+    pos @kc87_first_50 @kc87_second_53 -210;
+    pos @kc87_first_50 @kc87_second_55 -210;
+    pos @kc87_first_50 @kc87_second_56 -210;
+    pos @kc87_first_50 @kc87_second_57 -175;
+    pos @kc87_first_50 @kc87_second_58 -175;
+    pos @kc87_first_50 @kc87_second_60 -210;
+    pos @kc87_first_50 @kc87_second_61 -210;
+    pos @kc87_first_50 @kc87_second_62 -140;
+    pos @kc87_first_50 @kc87_second_63 -210;
+    pos @kc87_first_50 @kc87_second_64 -175;
+    pos @kc87_first_50 @kc87_second_65 -175;
+    pos @kc87_first_50 @kc87_second_68 -210;
+    pos @kc87_first_50 @kc87_second_69 -210;
+    pos @kc87_first_51 @kc87_second_1 -35;
+    pos @kc87_first_51 @kc87_second_2 -70;
+    pos @kc87_first_51 @kc87_second_5 -70;
+    pos @kc87_first_51 @kc87_second_11 -35;
+    pos @kc87_first_51 @kc87_second_12 -70;
+    pos @kc87_first_51 @kc87_second_13 -140;
+    pos @kc87_first_51 @kc87_second_14 -70;
+    pos @kc87_first_51 @kc87_second_15 -35;
+    pos @kc87_first_51 @kc87_second_16 -105;
+    pos @kc87_first_51 @kc87_second_28 -35;
+    pos @kc87_first_51 @kc87_second_29 -70;
+    pos @kc87_first_51 @kc87_second_36 -35;
+    pos @kc87_first_51 @kc87_second_39 -70;
+    pos @kc87_first_51 @kc87_second_47 -70;
+    pos @kc87_first_51 @kc87_second_51 1;
+    pos @kc87_first_51 @kc87_second_58 -175;
+    pos @kc87_first_51 @kc87_second_60 -140;
+    pos @kc87_first_51 @kc87_second_61 -140;
+    pos @kc87_first_51 @kc87_second_66 -35;
+    pos @kc87_first_52 @kc87_second_5 -70;
+    pos @kc87_first_52 @kc87_second_11 -35;
+    pos @kc87_first_52 @kc87_second_12 -240;
+    pos @kc87_first_52 @kc87_second_13 -70;
+    pos @kc87_first_52 @kc87_second_14 -140;
+    pos @kc87_first_52 @kc87_second_15 -105;
+    pos @kc87_first_52 @kc87_second_16 -70;
+    pos @kc87_first_52 @kc87_second_28 -70;
+    pos @kc87_first_52 @kc87_second_29 -70;
+    pos @kc87_first_52 @kc87_second_39 -35;
+    pos @kc87_first_52 @kc87_second_44 -70;
+    pos @kc87_first_52 @kc87_second_47 -70;
+    pos @kc87_first_52 @kc87_second_49 -35;
+    pos @kc87_first_52 @kc87_second_51 1;
+    pos @kc87_first_52 @kc87_second_53 -35;
+    pos @kc87_first_52 @kc87_second_54 -140;
+    pos @kc87_first_52 @kc87_second_56 1;
+    pos @kc87_first_52 @kc87_second_62 -35;
+    pos @kc87_first_52 @kc87_second_65 -35;
+    pos @kc87_first_52 @kc87_second_66 -105;
+    pos @kc87_first_52 @kc87_second_67 -70;
+    pos @kc87_first_53 @kc87_second_51 1;
+    pos @kc87_first_53 @kc87_second_70 -140;
+    pos @kc87_first_54 @kc87_second_35 -315;
+    pos @kc87_first_54 @kc87_second_51 1;
+    pos @kc87_first_54 @kc87_second_71 -140;
     pos @kc87_first_55 @kc87_second_1 -105;
     pos @kc87_first_55 @kc87_second_2 -210;
-    pos @kc87_first_55 @kc87_second_5 -70;
-    pos @kc87_first_55 @kc87_second_6 -105;
-    pos @kc87_first_55 @kc87_second_13 -70;
-    pos @kc87_first_55 @kc87_second_14 -35;
+    pos @kc87_first_55 @kc87_second_6 -140;
+    pos @kc87_first_55 @kc87_second_11 -70;
+    pos @kc87_first_55 @kc87_second_12 -210;
+    pos @kc87_first_55 @kc87_second_13 -210;
+    pos @kc87_first_55 @kc87_second_14 -105;
+    pos @kc87_first_55 @kc87_second_15 -70;
     pos @kc87_first_55 @kc87_second_16 -140;
-    pos @kc87_first_55 @kc87_second_17 -70;
+    pos @kc87_first_55 @kc87_second_17 -35;
     pos @kc87_first_55 @kc87_second_18 -35;
     pos @kc87_first_55 @kc87_second_19 -105;
-    pos @kc87_first_55 @kc87_second_21 -210;
     pos @kc87_first_55 @kc87_second_24 -35;
     pos @kc87_first_55 @kc87_second_26 -210;
+    pos @kc87_first_55 @kc87_second_28 -70;
+    pos @kc87_first_55 @kc87_second_29 -70;
     pos @kc87_first_55 @kc87_second_31 -35;
-    pos @kc87_first_55 @kc87_second_34 -105;
-    pos @kc87_first_55 @kc87_second_35 -35;
-    pos @kc87_first_55 @kc87_second_37 -105;
-    pos @kc87_first_55 @kc87_second_38 -140;
-    pos @kc87_first_55 @kc87_second_41 -70;
-    pos @kc87_first_55 @kc87_second_48 1;
-    pos @kc87_first_55 @kc87_second_54 -35;
-    pos @kc87_first_55 @kc87_second_56 -245;
+    pos @kc87_first_55 @kc87_second_36 -70;
+    pos @kc87_first_55 @kc87_second_38 -210;
+    pos @kc87_first_55 @kc87_second_39 -140;
+    pos @kc87_first_55 @kc87_second_47 -70;
+    pos @kc87_first_55 @kc87_second_49 -35;
+    pos @kc87_first_55 @kc87_second_51 1;
+    pos @kc87_first_55 @kc87_second_53 -35;
+    pos @kc87_first_55 @kc87_second_54 -105;
     pos @kc87_first_55 @kc87_second_58 -210;
-    pos @kc87_first_55 @kc87_second_59 -210;
-    pos @kc87_first_55 @kc87_second_66 -70;
-    pos @kc87_first_55 @kc87_second_67 -105;
-    pos @kc87_first_56 @kc87_second_12 -240;
-    pos @kc87_first_56 @kc87_second_13 -140;
-    pos @kc87_first_56 @kc87_second_14 -105;
-    pos @kc87_first_56 @kc87_second_15 -35;
-    pos @kc87_first_56 @kc87_second_35 35;
-    pos @kc87_first_56 @kc87_second_36 44;
-    pos @kc87_first_56 @kc87_second_48 1;
-    pos @kc87_first_56 @kc87_second_53 44;
-    pos @kc87_first_57 @kc87_second_1 -140;
-    pos @kc87_first_57 @kc87_second_2 -210;
-    pos @kc87_first_57 @kc87_second_6 -140;
-    pos @kc87_first_57 @kc87_second_12 -175;
+    pos @kc87_first_55 @kc87_second_60 -175;
+    pos @kc87_first_55 @kc87_second_61 -140;
+    pos @kc87_first_55 @kc87_second_66 -35;
+    pos @kc87_first_55 @kc87_second_67 -35;
+    pos @kc87_first_55 @kc87_second_68 -35;
+    pos @kc87_first_55 @kc87_second_69 -70;
+    pos @kc87_first_56 @kc87_second_1 -105;
+    pos @kc87_first_56 @kc87_second_2 -210;
+    pos @kc87_first_56 @kc87_second_5 -70;
+    pos @kc87_first_56 @kc87_second_6 -105;
+    pos @kc87_first_56 @kc87_second_13 -70;
+    pos @kc87_first_56 @kc87_second_14 -35;
+    pos @kc87_first_56 @kc87_second_16 -140;
+    pos @kc87_first_56 @kc87_second_17 -70;
+    pos @kc87_first_56 @kc87_second_18 -35;
+    pos @kc87_first_56 @kc87_second_19 -105;
+    pos @kc87_first_56 @kc87_second_21 -210;
+    pos @kc87_first_56 @kc87_second_24 -35;
+    pos @kc87_first_56 @kc87_second_26 -210;
+    pos @kc87_first_56 @kc87_second_31 -35;
+    pos @kc87_first_56 @kc87_second_34 -70;
+    pos @kc87_first_56 @kc87_second_35 -105;
+    pos @kc87_first_56 @kc87_second_36 -35;
+    pos @kc87_first_56 @kc87_second_38 -105;
+    pos @kc87_first_56 @kc87_second_39 -140;
+    pos @kc87_first_56 @kc87_second_43 -70;
+    pos @kc87_first_56 @kc87_second_51 1;
+    pos @kc87_first_56 @kc87_second_56 -35;
+    pos @kc87_first_56 @kc87_second_58 -245;
+    pos @kc87_first_56 @kc87_second_60 -210;
+    pos @kc87_first_56 @kc87_second_61 -210;
+    pos @kc87_first_56 @kc87_second_68 -70;
+    pos @kc87_first_56 @kc87_second_69 -105;
+    pos @kc87_first_57 @kc87_second_12 -240;
     pos @kc87_first_57 @kc87_second_13 -140;
-    pos @kc87_first_57 @kc87_second_16 -140;
-    pos @kc87_first_57 @kc87_second_19 -140;
-    pos @kc87_first_57 @kc87_second_21 -210;
-    pos @kc87_first_57 @kc87_second_26 -210;
-    pos @kc87_first_57 @kc87_second_34 -140;
-    pos @kc87_first_57 @kc87_second_35 -50;
-    pos @kc87_first_57 @kc87_second_37 -140;
-    pos @kc87_first_57 @kc87_second_38 -210;
-    pos @kc87_first_57 @kc87_second_39 -35;
-    pos @kc87_first_57 @kc87_second_48 1;
-    pos @kc87_first_57 @kc87_second_56 -210;
-    pos @kc87_first_57 @kc87_second_58 -175;
-    pos @kc87_first_57 @kc87_second_59 -175;
-    pos @kc87_first_57 @kc87_second_66 -105;
-    pos @kc87_first_57 @kc87_second_67 -210;
-    pos @kc87_first_58 @kc87_second_12 -240;
-    pos @kc87_first_58 @kc87_second_13 -175;
-    pos @kc87_first_58 @kc87_second_14 -70;
-    pos @kc87_first_58 @kc87_second_15 -35;
-    pos @kc87_first_58 @kc87_second_21 -35;
-    pos @kc87_first_58 @kc87_second_28 -35;
-    pos @kc87_first_58 @kc87_second_42 -35;
-    pos @kc87_first_58 @kc87_second_43 -35;
-    pos @kc87_first_58 @kc87_second_46 -70;
-    pos @kc87_first_58 @kc87_second_48 1;
-    pos @kc87_first_58 @kc87_second_50 -35;
-    pos @kc87_first_58 @kc87_second_51 -70;
-    pos @kc87_first_58 @kc87_second_61 -35;
-    pos @kc87_first_58 @kc87_second_63 -35;
-    pos @kc87_first_58 @kc87_second_64 -70;
-    pos @kc87_first_58 @kc87_second_65 -35;
-    pos @kc87_first_59 @kc87_second_13 -35;
-    pos @kc87_first_59 @kc87_second_18 -70;
-    pos @kc87_first_59 @kc87_second_61 -35;
+    pos @kc87_first_57 @kc87_second_14 -105;
+    pos @kc87_first_57 @kc87_second_15 -35;
+    pos @kc87_first_57 @kc87_second_36 35;
+    pos @kc87_first_57 @kc87_second_37 44;
+    pos @kc87_first_57 @kc87_second_51 1;
+    pos @kc87_first_57 @kc87_second_55 44;
+    pos @kc87_first_58 @kc87_second_1 -140;
+    pos @kc87_first_58 @kc87_second_2 -210;
+    pos @kc87_first_58 @kc87_second_6 -140;
+    pos @kc87_first_58 @kc87_second_12 -175;
+    pos @kc87_first_58 @kc87_second_13 -140;
+    pos @kc87_first_58 @kc87_second_16 -140;
+    pos @kc87_first_58 @kc87_second_19 -140;
+    pos @kc87_first_58 @kc87_second_21 -210;
+    pos @kc87_first_58 @kc87_second_26 -210;
+    pos @kc87_first_58 @kc87_second_34 -35;
+    pos @kc87_first_58 @kc87_second_35 -140;
+    pos @kc87_first_58 @kc87_second_36 -50;
+    pos @kc87_first_58 @kc87_second_38 -140;
+    pos @kc87_first_58 @kc87_second_39 -210;
+    pos @kc87_first_58 @kc87_second_41 -35;
+    pos @kc87_first_58 @kc87_second_51 1;
+    pos @kc87_first_58 @kc87_second_58 -210;
+    pos @kc87_first_58 @kc87_second_60 -175;
+    pos @kc87_first_58 @kc87_second_61 -175;
+    pos @kc87_first_58 @kc87_second_68 -105;
+    pos @kc87_first_58 @kc87_second_69 -210;
+    pos @kc87_first_59 @kc87_second_12 -240;
+    pos @kc87_first_59 @kc87_second_13 -175;
+    pos @kc87_first_59 @kc87_second_14 -70;
+    pos @kc87_first_59 @kc87_second_15 -35;
+    pos @kc87_first_59 @kc87_second_21 -35;
+    pos @kc87_first_59 @kc87_second_28 -35;
+    pos @kc87_first_59 @kc87_second_44 -35;
+    pos @kc87_first_59 @kc87_second_45 -35;
+    pos @kc87_first_59 @kc87_second_47 -70;
+    pos @kc87_first_59 @kc87_second_51 1;
+    pos @kc87_first_59 @kc87_second_53 -35;
+    pos @kc87_first_59 @kc87_second_54 -70;
+    pos @kc87_first_59 @kc87_second_63 -35;
+    pos @kc87_first_59 @kc87_second_65 -35;
+    pos @kc87_first_59 @kc87_second_66 -70;
     pos @kc87_first_59 @kc87_second_67 -35;
-    pos @kc87_first_60 @kc87_second_12 -175;
-    pos @kc87_first_60 @kc87_second_13 -140;
-    pos @kc87_first_60 @kc87_second_14 -35;
-    pos @kc87_first_60 @kc87_second_48 1;
-    pos @kc87_first_61 @kc87_second_1 -140;
-    pos @kc87_first_61 @kc87_second_2 -280;
-    pos @kc87_first_61 @kc87_second_5 -140;
-    pos @kc87_first_61 @kc87_second_6 -280;
-    pos @kc87_first_61 @kc87_second_8 -70;
-    pos @kc87_first_61 @kc87_second_10 -70;
-    pos @kc87_first_61 @kc87_second_11 -175;
-    pos @kc87_first_61 @kc87_second_12 -240;
-    pos @kc87_first_61 @kc87_second_13 -140;
-    pos @kc87_first_61 @kc87_second_14 -105;
-    pos @kc87_first_61 @kc87_second_15 -70;
-    pos @kc87_first_61 @kc87_second_16 -175;
-    pos @kc87_first_61 @kc87_second_17 -70;
+    pos @kc87_first_60 @kc87_second_1 -210;
+    pos @kc87_first_60 @kc87_second_2 -210;
+    pos @kc87_first_60 @kc87_second_3 -70;
+    pos @kc87_first_60 @kc87_second_4 -35;
+    pos @kc87_first_60 @kc87_second_6 -210;
+    pos @kc87_first_60 @kc87_second_7 -70;
+    pos @kc87_first_60 @kc87_second_8 -70;
+    pos @kc87_first_60 @kc87_second_16 -70;
+    pos @kc87_first_60 @kc87_second_17 -70;
+    pos @kc87_first_60 @kc87_second_18 -175;
+    pos @kc87_first_60 @kc87_second_19 -210;
+    pos @kc87_first_60 @kc87_second_21 -210;
+    pos @kc87_first_60 @kc87_second_22 -140;
+    pos @kc87_first_60 @kc87_second_23 -35;
+    pos @kc87_first_60 @kc87_second_24 -175;
+    pos @kc87_first_60 @kc87_second_25 -140;
+    pos @kc87_first_60 @kc87_second_26 -280;
+    pos @kc87_first_60 @kc87_second_31 -35;
+    pos @kc87_first_60 @kc87_second_32 -35;
+    pos @kc87_first_60 @kc87_second_34 -140;
+    pos @kc87_first_60 @kc87_second_35 -210;
+    pos @kc87_first_60 @kc87_second_36 -175;
+    pos @kc87_first_60 @kc87_second_38 -245;
+    pos @kc87_first_60 @kc87_second_39 -140;
+    pos @kc87_first_60 @kc87_second_40 -35;
+    pos @kc87_first_60 @kc87_second_41 -140;
+    pos @kc87_first_60 @kc87_second_42 -140;
+    pos @kc87_first_60 @kc87_second_43 -140;
+    pos @kc87_first_60 @kc87_second_44 -35;
+    pos @kc87_first_60 @kc87_second_50 -35;
+    pos @kc87_first_60 @kc87_second_51 1;
+    pos @kc87_first_60 @kc87_second_56 -140;
+    pos @kc87_first_60 @kc87_second_57 -70;
+    pos @kc87_first_60 @kc87_second_58 -210;
+    pos @kc87_first_60 @kc87_second_60 -210;
+    pos @kc87_first_60 @kc87_second_61 -210;
+    pos @kc87_first_60 @kc87_second_63 -35;
+    pos @kc87_first_60 @kc87_second_68 -175;
+    pos @kc87_first_60 @kc87_second_69 -245;
+    pos @kc87_first_61 @kc87_second_13 -35;
     pos @kc87_first_61 @kc87_second_18 -70;
-    pos @kc87_first_61 @kc87_second_19 -140;
-    pos @kc87_first_61 @kc87_second_21 -280;
-    pos @kc87_first_61 @kc87_second_24 -70;
-    pos @kc87_first_61 @kc87_second_25 -70;
-    pos @kc87_first_61 @kc87_second_26 -210;
-    pos @kc87_first_61 @kc87_second_28 -70;
-    pos @kc87_first_61 @kc87_second_29 -70;
-    pos @kc87_first_61 @kc87_second_31 -70;
     pos @kc87_first_61 @kc87_second_34 -70;
-    pos @kc87_first_61 @kc87_second_35 -70;
-    pos @kc87_first_61 @kc87_second_37 -315;
-    pos @kc87_first_61 @kc87_second_38 -140;
-    pos @kc87_first_61 @kc87_second_39 -70;
-    pos @kc87_first_61 @kc87_second_41 -105;
-    pos @kc87_first_61 @kc87_second_48 1;
-    pos @kc87_first_61 @kc87_second_51 -35;
-    pos @kc87_first_61 @kc87_second_54 -50;
-    pos @kc87_first_61 @kc87_second_56 -210;
-    pos @kc87_first_61 @kc87_second_58 -210;
-    pos @kc87_first_61 @kc87_second_59 -175;
-    pos @kc87_first_61 @kc87_second_62 -35;
-    pos @kc87_first_61 @kc87_second_64 -70;
-    pos @kc87_first_61 @kc87_second_65 -35;
-    pos @kc87_first_61 @kc87_second_66 -140;
-    pos @kc87_first_61 @kc87_second_67 -210;
-    pos @kc87_first_62 @kc87_second_1 -35;
-    pos @kc87_first_62 @kc87_second_2 -70;
-    pos @kc87_first_62 @kc87_second_5 -70;
-    pos @kc87_first_62 @kc87_second_11 -35;
-    pos @kc87_first_62 @kc87_second_12 -140;
+    pos @kc87_first_61 @kc87_second_63 -35;
+    pos @kc87_first_61 @kc87_second_69 -35;
+    pos @kc87_first_62 @kc87_second_12 -175;
     pos @kc87_first_62 @kc87_second_13 -140;
-    pos @kc87_first_62 @kc87_second_14 -70;
-    pos @kc87_first_62 @kc87_second_15 -35;
-    pos @kc87_first_62 @kc87_second_16 -105;
-    pos @kc87_first_62 @kc87_second_28 -35;
-    pos @kc87_first_62 @kc87_second_29 -70;
-    pos @kc87_first_62 @kc87_second_35 -35;
-    pos @kc87_first_62 @kc87_second_38 -70;
-    pos @kc87_first_62 @kc87_second_46 -70;
-    pos @kc87_first_62 @kc87_second_48 1;
-    pos @kc87_first_62 @kc87_second_56 -175;
-    pos @kc87_first_62 @kc87_second_58 -140;
-    pos @kc87_first_62 @kc87_second_59 -140;
-    pos @kc87_first_62 @kc87_second_64 -35;
-    pos @kc87_first_63 @kc87_second_5 -70;
-    pos @kc87_first_63 @kc87_second_9 -70;
-    pos @kc87_first_63 @kc87_second_11 -35;
-    pos @kc87_first_63 @kc87_second_12 -350;
-    pos @kc87_first_63 @kc87_second_13 -315;
-    pos @kc87_first_63 @kc87_second_14 -175;
-    pos @kc87_first_63 @kc87_second_15 -140;
-    pos @kc87_first_63 @kc87_second_16 -70;
-    pos @kc87_first_63 @kc87_second_20 -70;
+    pos @kc87_first_62 @kc87_second_14 -35;
+    pos @kc87_first_62 @kc87_second_51 1;
+    pos @kc87_first_63 @kc87_second_1 -140;
+    pos @kc87_first_63 @kc87_second_2 -280;
+    pos @kc87_first_63 @kc87_second_5 -140;
+    pos @kc87_first_63 @kc87_second_6 -280;
+    pos @kc87_first_63 @kc87_second_8 -70;
+    pos @kc87_first_63 @kc87_second_10 -70;
+    pos @kc87_first_63 @kc87_second_11 -175;
+    pos @kc87_first_63 @kc87_second_12 -240;
+    pos @kc87_first_63 @kc87_second_13 -140;
+    pos @kc87_first_63 @kc87_second_14 -105;
+    pos @kc87_first_63 @kc87_second_15 -70;
+    pos @kc87_first_63 @kc87_second_16 -175;
+    pos @kc87_first_63 @kc87_second_17 -70;
+    pos @kc87_first_63 @kc87_second_18 -70;
+    pos @kc87_first_63 @kc87_second_19 -140;
+    pos @kc87_first_63 @kc87_second_21 -280;
+    pos @kc87_first_63 @kc87_second_24 -70;
+    pos @kc87_first_63 @kc87_second_25 -70;
+    pos @kc87_first_63 @kc87_second_26 -210;
+    pos @kc87_first_63 @kc87_second_28 -70;
     pos @kc87_first_63 @kc87_second_29 -70;
-    pos @kc87_first_63 @kc87_second_33 -50;
-    pos @kc87_first_63 @kc87_second_42 -140;
-    pos @kc87_first_63 @kc87_second_43 -50;
-    pos @kc87_first_63 @kc87_second_45 -35;
-    pos @kc87_first_63 @kc87_second_46 -175;
-    pos @kc87_first_63 @kc87_second_48 1;
-    pos @kc87_first_63 @kc87_second_50 -70;
-    pos @kc87_first_63 @kc87_second_51 -175;
-    pos @kc87_first_63 @kc87_second_57 -70;
-    pos @kc87_first_63 @kc87_second_61 -70;
-    pos @kc87_first_63 @kc87_second_63 -50;
-    pos @kc87_first_63 @kc87_second_64 -140;
-    pos @kc87_first_63 @kc87_second_65 -105;
-    pos @kc87_first_64 @kc87_second_4 -105;
+    pos @kc87_first_63 @kc87_second_31 -70;
+    pos @kc87_first_63 @kc87_second_34 -70;
+    pos @kc87_first_63 @kc87_second_35 -70;
+    pos @kc87_first_63 @kc87_second_36 -70;
+    pos @kc87_first_63 @kc87_second_38 -315;
+    pos @kc87_first_63 @kc87_second_39 -140;
+    pos @kc87_first_63 @kc87_second_41 -70;
+    pos @kc87_first_63 @kc87_second_43 -105;
+    pos @kc87_first_63 @kc87_second_51 1;
+    pos @kc87_first_63 @kc87_second_54 -35;
+    pos @kc87_first_63 @kc87_second_56 -50;
+    pos @kc87_first_63 @kc87_second_58 -210;
+    pos @kc87_first_63 @kc87_second_60 -210;
+    pos @kc87_first_63 @kc87_second_61 -175;
+    pos @kc87_first_63 @kc87_second_64 -35;
+    pos @kc87_first_63 @kc87_second_66 -70;
+    pos @kc87_first_63 @kc87_second_67 -35;
+    pos @kc87_first_63 @kc87_second_68 -140;
+    pos @kc87_first_63 @kc87_second_69 -210;
     pos @kc87_first_64 @kc87_second_6 -35;
-    pos @kc87_first_64 @kc87_second_8 1;
-    pos @kc87_first_64 @kc87_second_9 -245;
-    pos @kc87_first_64 @kc87_second_12 -210;
-    pos @kc87_first_64 @kc87_second_13 -210;
-    pos @kc87_first_64 @kc87_second_14 -210;
-    pos @kc87_first_64 @kc87_second_15 -175;
-    pos @kc87_first_64 @kc87_second_17 -70;
-    pos @kc87_first_64 @kc87_second_18 -105;
-    pos @kc87_first_64 @kc87_second_20 -180;
-    pos @kc87_first_64 @kc87_second_22 -140;
-    pos @kc87_first_64 @kc87_second_24 -105;
-    pos @kc87_first_64 @kc87_second_27 -140;
-    pos @kc87_first_64 @kc87_second_31 -105;
-    pos @kc87_first_64 @kc87_second_33 -140;
-    pos @kc87_first_64 @kc87_second_37 -35;
-    pos @kc87_first_64 @kc87_second_39 -35;
-    pos @kc87_first_64 @kc87_second_41 -175;
-    pos @kc87_first_64 @kc87_second_42 -142;
-    pos @kc87_first_64 @kc87_second_43 -245;
-    pos @kc87_first_64 @kc87_second_46 -210;
-    pos @kc87_first_64 @kc87_second_47 -105;
-    pos @kc87_first_64 @kc87_second_48 1;
-    pos @kc87_first_64 @kc87_second_49 -35;
-    pos @kc87_first_64 @kc87_second_50 -210;
-    pos @kc87_first_64 @kc87_second_51 -210;
+    pos @kc87_first_64 @kc87_second_12 -240;
+    pos @kc87_first_64 @kc87_second_13 -140;
+    pos @kc87_first_64 @kc87_second_14 -70;
+    pos @kc87_first_64 @kc87_second_15 -35;
+    pos @kc87_first_64 @kc87_second_18 -35;
+    pos @kc87_first_64 @kc87_second_22 -35;
+    pos @kc87_first_64 @kc87_second_24 -35;
+    pos @kc87_first_64 @kc87_second_38 -70;
+    pos @kc87_first_64 @kc87_second_43 -70;
+    pos @kc87_first_64 @kc87_second_44 -50;
+    pos @kc87_first_64 @kc87_second_51 1;
     pos @kc87_first_64 @kc87_second_54 -35;
-    pos @kc87_first_64 @kc87_second_61 -280;
-    pos @kc87_first_64 @kc87_second_63 -175;
-    pos @kc87_first_64 @kc87_second_64 -140;
-    pos @kc87_first_64 @kc87_second_65 -140;
-    pos @kc87_first_64 @kc87_second_66 -70;
-    pos @kc87_first_64 @kc87_second_67 -70;
-    pos @kc87_first_65 @kc87_second_1 -175;
-    pos @kc87_first_65 @kc87_second_2 -175;
+    pos @kc87_first_64 @kc87_second_68 -35;
+    pos @kc87_first_64 @kc87_second_69 -35;
     pos @kc87_first_65 @kc87_second_5 -70;
-    pos @kc87_first_65 @kc87_second_6 -105;
-    pos @kc87_first_65 @kc87_second_11 -105;
-    pos @kc87_first_65 @kc87_second_12 -175;
-    pos @kc87_first_65 @kc87_second_13 -140;
-    pos @kc87_first_65 @kc87_second_14 -70;
-    pos @kc87_first_65 @kc87_second_15 -35;
-    pos @kc87_first_65 @kc87_second_16 -140;
-    pos @kc87_first_65 @kc87_second_17 -70;
-    pos @kc87_first_65 @kc87_second_18 -70;
-    pos @kc87_first_65 @kc87_second_19 -140;
-    pos @kc87_first_65 @kc87_second_21 -175;
-    pos @kc87_first_65 @kc87_second_24 -70;
-    pos @kc87_first_65 @kc87_second_31 -35;
-    pos @kc87_first_65 @kc87_second_35 -70;
-    pos @kc87_first_65 @kc87_second_37 -105;
-    pos @kc87_first_65 @kc87_second_38 -175;
-    pos @kc87_first_65 @kc87_second_39 -35;
-    pos @kc87_first_65 @kc87_second_41 -70;
-    pos @kc87_first_65 @kc87_second_48 1;
-    pos @kc87_first_65 @kc87_second_54 -35;
-    pos @kc87_first_65 @kc87_second_56 -140;
-    pos @kc87_first_65 @kc87_second_58 -140;
-    pos @kc87_first_65 @kc87_second_59 -140;
-    pos @kc87_first_65 @kc87_second_66 -70;
+    pos @kc87_first_65 @kc87_second_9 -70;
+    pos @kc87_first_65 @kc87_second_11 -35;
+    pos @kc87_first_65 @kc87_second_12 -350;
+    pos @kc87_first_65 @kc87_second_13 -315;
+    pos @kc87_first_65 @kc87_second_14 -175;
+    pos @kc87_first_65 @kc87_second_15 -140;
+    pos @kc87_first_65 @kc87_second_16 -70;
+    pos @kc87_first_65 @kc87_second_20 -70;
+    pos @kc87_first_65 @kc87_second_29 -70;
+    pos @kc87_first_65 @kc87_second_33 -50;
+    pos @kc87_first_65 @kc87_second_44 -140;
+    pos @kc87_first_65 @kc87_second_45 -50;
+    pos @kc87_first_65 @kc87_second_47 -175;
+    pos @kc87_first_65 @kc87_second_49 -35;
+    pos @kc87_first_65 @kc87_second_51 1;
+    pos @kc87_first_65 @kc87_second_53 -70;
+    pos @kc87_first_65 @kc87_second_54 -175;
+    pos @kc87_first_65 @kc87_second_59 -70;
+    pos @kc87_first_65 @kc87_second_63 -70;
+    pos @kc87_first_65 @kc87_second_65 -50;
+    pos @kc87_first_65 @kc87_second_66 -140;
     pos @kc87_first_65 @kc87_second_67 -105;
-    pos @kc87_first_66 @kc87_second_1 -210;
-    pos @kc87_first_66 @kc87_second_2 -210;
-    pos @kc87_first_66 @kc87_second_3 -70;
-    pos @kc87_first_66 @kc87_second_4 -35;
-    pos @kc87_first_66 @kc87_second_6 -210;
-    pos @kc87_first_66 @kc87_second_7 -70;
-    pos @kc87_first_66 @kc87_second_8 -70;
-    pos @kc87_first_66 @kc87_second_16 -70;
-    pos @kc87_first_66 @kc87_second_17 -140;
-    pos @kc87_first_66 @kc87_second_18 -175;
-    pos @kc87_first_66 @kc87_second_19 -210;
-    pos @kc87_first_66 @kc87_second_21 -210;
+    pos @kc87_first_66 @kc87_second_4 -105;
+    pos @kc87_first_66 @kc87_second_6 -35;
+    pos @kc87_first_66 @kc87_second_8 1;
+    pos @kc87_first_66 @kc87_second_9 -245;
+    pos @kc87_first_66 @kc87_second_12 -210;
+    pos @kc87_first_66 @kc87_second_13 -210;
+    pos @kc87_first_66 @kc87_second_14 -210;
+    pos @kc87_first_66 @kc87_second_15 -175;
+    pos @kc87_first_66 @kc87_second_17 -70;
+    pos @kc87_first_66 @kc87_second_18 -105;
+    pos @kc87_first_66 @kc87_second_20 -180;
     pos @kc87_first_66 @kc87_second_22 -140;
-    pos @kc87_first_66 @kc87_second_23 -35;
-    pos @kc87_first_66 @kc87_second_24 -175;
-    pos @kc87_first_66 @kc87_second_25 -140;
-    pos @kc87_first_66 @kc87_second_26 -280;
-    pos @kc87_first_66 @kc87_second_31 -35;
-    pos @kc87_first_66 @kc87_second_32 -35;
-    pos @kc87_first_66 @kc87_second_34 -210;
-    pos @kc87_first_66 @kc87_second_35 -175;
-    pos @kc87_first_66 @kc87_second_37 -245;
-    pos @kc87_first_66 @kc87_second_38 -140;
-    pos @kc87_first_66 @kc87_second_39 -140;
-    pos @kc87_first_66 @kc87_second_40 -140;
-    pos @kc87_first_66 @kc87_second_41 -140;
-    pos @kc87_first_66 @kc87_second_42 -35;
-    pos @kc87_first_66 @kc87_second_47 -35;
-    pos @kc87_first_66 @kc87_second_48 1;
+    pos @kc87_first_66 @kc87_second_24 -105;
+    pos @kc87_first_66 @kc87_second_27 -140;
+    pos @kc87_first_66 @kc87_second_31 -105;
+    pos @kc87_first_66 @kc87_second_33 -140;
+    pos @kc87_first_66 @kc87_second_34 -105;
+    pos @kc87_first_66 @kc87_second_38 -35;
+    pos @kc87_first_66 @kc87_second_40 -105;
+    pos @kc87_first_66 @kc87_second_41 -35;
+    pos @kc87_first_66 @kc87_second_43 -175;
+    pos @kc87_first_66 @kc87_second_44 -142;
+    pos @kc87_first_66 @kc87_second_45 -245;
+    pos @kc87_first_66 @kc87_second_47 -210;
+    pos @kc87_first_66 @kc87_second_48 -175;
+    pos @kc87_first_66 @kc87_second_51 1;
     pos @kc87_first_66 @kc87_second_52 -35;
-    pos @kc87_first_66 @kc87_second_54 -140;
-    pos @kc87_first_66 @kc87_second_55 -70;
-    pos @kc87_first_66 @kc87_second_56 -210;
-    pos @kc87_first_66 @kc87_second_58 -210;
-    pos @kc87_first_66 @kc87_second_59 -210;
-    pos @kc87_first_66 @kc87_second_61 -35;
-    pos @kc87_first_66 @kc87_second_66 -175;
-    pos @kc87_first_66 @kc87_second_67 -245;
-    pos @kc87_first_67 @kc87_second_6 -35;
-    pos @kc87_first_67 @kc87_second_12 -240;
+    pos @kc87_first_66 @kc87_second_53 -210;
+    pos @kc87_first_66 @kc87_second_54 -210;
+    pos @kc87_first_66 @kc87_second_56 -35;
+    pos @kc87_first_66 @kc87_second_63 -280;
+    pos @kc87_first_66 @kc87_second_65 -175;
+    pos @kc87_first_66 @kc87_second_66 -140;
+    pos @kc87_first_66 @kc87_second_67 -140;
+    pos @kc87_first_66 @kc87_second_68 -70;
+    pos @kc87_first_66 @kc87_second_69 -70;
+    pos @kc87_first_67 @kc87_second_1 -175;
+    pos @kc87_first_67 @kc87_second_2 -175;
+    pos @kc87_first_67 @kc87_second_5 -70;
+    pos @kc87_first_67 @kc87_second_6 -105;
+    pos @kc87_first_67 @kc87_second_11 -105;
+    pos @kc87_first_67 @kc87_second_12 -175;
     pos @kc87_first_67 @kc87_second_13 -140;
     pos @kc87_first_67 @kc87_second_14 -70;
     pos @kc87_first_67 @kc87_second_15 -35;
-    pos @kc87_first_67 @kc87_second_18 -35;
-    pos @kc87_first_67 @kc87_second_22 -35;
-    pos @kc87_first_67 @kc87_second_24 -35;
-    pos @kc87_first_67 @kc87_second_37 -70;
-    pos @kc87_first_67 @kc87_second_41 -70;
-    pos @kc87_first_67 @kc87_second_42 -50;
-    pos @kc87_first_67 @kc87_second_48 1;
-    pos @kc87_first_67 @kc87_second_51 -35;
-    pos @kc87_first_67 @kc87_second_66 -35;
-    pos @kc87_first_67 @kc87_second_67 -35;
+    pos @kc87_first_67 @kc87_second_16 -140;
+    pos @kc87_first_67 @kc87_second_17 -70;
+    pos @kc87_first_67 @kc87_second_18 -70;
+    pos @kc87_first_67 @kc87_second_19 -140;
+    pos @kc87_first_67 @kc87_second_21 -175;
+    pos @kc87_first_67 @kc87_second_24 -70;
+    pos @kc87_first_67 @kc87_second_31 -35;
+    pos @kc87_first_67 @kc87_second_34 -70;
+    pos @kc87_first_67 @kc87_second_36 -70;
+    pos @kc87_first_67 @kc87_second_38 -105;
+    pos @kc87_first_67 @kc87_second_39 -175;
+    pos @kc87_first_67 @kc87_second_41 -35;
+    pos @kc87_first_67 @kc87_second_43 -70;
+    pos @kc87_first_67 @kc87_second_51 1;
+    pos @kc87_first_67 @kc87_second_56 -35;
+    pos @kc87_first_67 @kc87_second_58 -140;
+    pos @kc87_first_67 @kc87_second_60 -140;
+    pos @kc87_first_67 @kc87_second_61 -140;
+    pos @kc87_first_67 @kc87_second_68 -70;
+    pos @kc87_first_67 @kc87_second_69 -105;
     pos @kc87_first_68 @kc87_second_3 -100;
     pos @kc87_first_68 @kc87_second_4 -50;
     pos @kc87_first_68 @kc87_second_6 -50;
@@ -10164,23 +10232,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_68 @kc87_second_25 -70;
     pos @kc87_first_68 @kc87_second_31 -35;
     pos @kc87_first_68 @kc87_second_33 -70;
-    pos @kc87_first_68 @kc87_second_36 105;
-    pos @kc87_first_68 @kc87_second_37 -35;
-    pos @kc87_first_68 @kc87_second_41 -70;
-    pos @kc87_first_68 @kc87_second_42 -140;
-    pos @kc87_first_68 @kc87_second_43 -140;
-    pos @kc87_first_68 @kc87_second_46 -140;
-    pos @kc87_first_68 @kc87_second_47 -35;
-    pos @kc87_first_68 @kc87_second_48 1;
-    pos @kc87_first_68 @kc87_second_50 -70;
-    pos @kc87_first_68 @kc87_second_51 -100;
-    pos @kc87_first_68 @kc87_second_53 105;
-    pos @kc87_first_68 @kc87_second_61 -140;
-    pos @kc87_first_68 @kc87_second_63 -70;
-    pos @kc87_first_68 @kc87_second_64 -70;
-    pos @kc87_first_68 @kc87_second_65 -50;
-    pos @kc87_first_68 @kc87_second_66 -35;
-    pos @kc87_first_68 @kc87_second_67 -35;
+    pos @kc87_first_68 @kc87_second_34 -50;
+    pos @kc87_first_68 @kc87_second_37 105;
+    pos @kc87_first_68 @kc87_second_38 -35;
+    pos @kc87_first_68 @kc87_second_40 -35;
+    pos @kc87_first_68 @kc87_second_43 -70;
+    pos @kc87_first_68 @kc87_second_44 -140;
+    pos @kc87_first_68 @kc87_second_45 -140;
+    pos @kc87_first_68 @kc87_second_47 -140;
+    pos @kc87_first_68 @kc87_second_48 -50;
+    pos @kc87_first_68 @kc87_second_51 1;
+    pos @kc87_first_68 @kc87_second_53 -70;
+    pos @kc87_first_68 @kc87_second_54 -100;
+    pos @kc87_first_68 @kc87_second_55 105;
+    pos @kc87_first_68 @kc87_second_63 -140;
+    pos @kc87_first_68 @kc87_second_65 -70;
+    pos @kc87_first_68 @kc87_second_66 -70;
+    pos @kc87_first_68 @kc87_second_67 -50;
+    pos @kc87_first_68 @kc87_second_68 -35;
+    pos @kc87_first_68 @kc87_second_69 -35;
     pos @kc87_first_69 @kc87_second_3 -70;
     pos @kc87_first_69 @kc87_second_4 -50;
     pos @kc87_first_69 @kc87_second_6 -50;
@@ -10198,23 +10268,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_69 @kc87_second_25 -70;
     pos @kc87_first_69 @kc87_second_31 -35;
     pos @kc87_first_69 @kc87_second_33 -70;
-    pos @kc87_first_69 @kc87_second_36 105;
-    pos @kc87_first_69 @kc87_second_37 -35;
-    pos @kc87_first_69 @kc87_second_41 -70;
-    pos @kc87_first_69 @kc87_second_42 -140;
-    pos @kc87_first_69 @kc87_second_43 -140;
-    pos @kc87_first_69 @kc87_second_46 -140;
-    pos @kc87_first_69 @kc87_second_47 -35;
-    pos @kc87_first_69 @kc87_second_48 1;
-    pos @kc87_first_69 @kc87_second_50 -70;
-    pos @kc87_first_69 @kc87_second_51 -140;
-    pos @kc87_first_69 @kc87_second_53 105;
-    pos @kc87_first_69 @kc87_second_61 -140;
-    pos @kc87_first_69 @kc87_second_63 -70;
-    pos @kc87_first_69 @kc87_second_64 -105;
+    pos @kc87_first_69 @kc87_second_34 -50;
+    pos @kc87_first_69 @kc87_second_37 105;
+    pos @kc87_first_69 @kc87_second_38 -35;
+    pos @kc87_first_69 @kc87_second_40 -35;
+    pos @kc87_first_69 @kc87_second_43 -70;
+    pos @kc87_first_69 @kc87_second_44 -140;
+    pos @kc87_first_69 @kc87_second_45 -140;
+    pos @kc87_first_69 @kc87_second_47 -140;
+    pos @kc87_first_69 @kc87_second_48 -50;
+    pos @kc87_first_69 @kc87_second_51 1;
+    pos @kc87_first_69 @kc87_second_53 -70;
+    pos @kc87_first_69 @kc87_second_54 -140;
+    pos @kc87_first_69 @kc87_second_55 105;
+    pos @kc87_first_69 @kc87_second_63 -140;
     pos @kc87_first_69 @kc87_second_65 -70;
-    pos @kc87_first_69 @kc87_second_66 -35;
-    pos @kc87_first_69 @kc87_second_67 -35;
+    pos @kc87_first_69 @kc87_second_66 -105;
+    pos @kc87_first_69 @kc87_second_67 -70;
+    pos @kc87_first_69 @kc87_second_68 -35;
+    pos @kc87_first_69 @kc87_second_69 -35;
     pos @kc87_first_70 @kc87_second_3 -70;
     pos @kc87_first_70 @kc87_second_4 -50;
     pos @kc87_first_70 @kc87_second_6 -50;
@@ -10232,23 +10304,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_70 @kc87_second_25 -100;
     pos @kc87_first_70 @kc87_second_31 -35;
     pos @kc87_first_70 @kc87_second_33 -70;
-    pos @kc87_first_70 @kc87_second_36 105;
-    pos @kc87_first_70 @kc87_second_37 -35;
-    pos @kc87_first_70 @kc87_second_41 -70;
-    pos @kc87_first_70 @kc87_second_42 -140;
-    pos @kc87_first_70 @kc87_second_43 -140;
-    pos @kc87_first_70 @kc87_second_46 -140;
-    pos @kc87_first_70 @kc87_second_47 -35;
-    pos @kc87_first_70 @kc87_second_48 1;
-    pos @kc87_first_70 @kc87_second_50 -70;
-    pos @kc87_first_70 @kc87_second_51 -140;
-    pos @kc87_first_70 @kc87_second_53 105;
-    pos @kc87_first_70 @kc87_second_61 -140;
-    pos @kc87_first_70 @kc87_second_63 -70;
-    pos @kc87_first_70 @kc87_second_64 -70;
-    pos @kc87_first_70 @kc87_second_65 -50;
-    pos @kc87_first_70 @kc87_second_66 -35;
-    pos @kc87_first_70 @kc87_second_67 -35;
+    pos @kc87_first_70 @kc87_second_34 -50;
+    pos @kc87_first_70 @kc87_second_37 105;
+    pos @kc87_first_70 @kc87_second_38 -35;
+    pos @kc87_first_70 @kc87_second_40 -35;
+    pos @kc87_first_70 @kc87_second_43 -70;
+    pos @kc87_first_70 @kc87_second_44 -140;
+    pos @kc87_first_70 @kc87_second_45 -140;
+    pos @kc87_first_70 @kc87_second_47 -140;
+    pos @kc87_first_70 @kc87_second_48 -50;
+    pos @kc87_first_70 @kc87_second_51 1;
+    pos @kc87_first_70 @kc87_second_53 -70;
+    pos @kc87_first_70 @kc87_second_54 -140;
+    pos @kc87_first_70 @kc87_second_55 105;
+    pos @kc87_first_70 @kc87_second_63 -140;
+    pos @kc87_first_70 @kc87_second_65 -70;
+    pos @kc87_first_70 @kc87_second_66 -70;
+    pos @kc87_first_70 @kc87_second_67 -50;
+    pos @kc87_first_70 @kc87_second_68 -35;
+    pos @kc87_first_70 @kc87_second_69 -35;
     pos @kc87_first_71 @kc87_second_1 -210;
     pos @kc87_first_71 @kc87_second_2 -210;
     pos @kc87_first_71 @kc87_second_3 -35;
@@ -10264,26 +10338,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_71 @kc87_second_25 -105;
     pos @kc87_first_71 @kc87_second_26 -175;
     pos @kc87_first_71 @kc87_second_31 -105;
-    pos @kc87_first_71 @kc87_second_34 -210;
-    pos @kc87_first_71 @kc87_second_35 -105;
-    pos @kc87_first_71 @kc87_second_37 -175;
-    pos @kc87_first_71 @kc87_second_38 -140;
-    pos @kc87_first_71 @kc87_second_39 -70;
-    pos @kc87_first_71 @kc87_second_40 -105;
-    pos @kc87_first_71 @kc87_second_41 -105;
-    pos @kc87_first_71 @kc87_second_42 -70;
-    pos @kc87_first_71 @kc87_second_47 -35;
-    pos @kc87_first_71 @kc87_second_48 1;
-    pos @kc87_first_71 @kc87_second_53 -35;
-    pos @kc87_first_71 @kc87_second_54 -70;
-    pos @kc87_first_71 @kc87_second_55 -70;
-    pos @kc87_first_71 @kc87_second_56 -175;
+    pos @kc87_first_71 @kc87_second_34 -140;
+    pos @kc87_first_71 @kc87_second_35 -210;
+    pos @kc87_first_71 @kc87_second_36 -105;
+    pos @kc87_first_71 @kc87_second_38 -175;
+    pos @kc87_first_71 @kc87_second_39 -140;
+    pos @kc87_first_71 @kc87_second_40 -35;
+    pos @kc87_first_71 @kc87_second_41 -70;
+    pos @kc87_first_71 @kc87_second_42 -105;
+    pos @kc87_first_71 @kc87_second_43 -105;
+    pos @kc87_first_71 @kc87_second_44 -70;
+    pos @kc87_first_71 @kc87_second_51 1;
+    pos @kc87_first_71 @kc87_second_55 -35;
+    pos @kc87_first_71 @kc87_second_56 -70;
+    pos @kc87_first_71 @kc87_second_57 -70;
     pos @kc87_first_71 @kc87_second_58 -175;
-    pos @kc87_first_71 @kc87_second_59 -175;
-    pos @kc87_first_71 @kc87_second_61 -35;
-    pos @kc87_first_71 @kc87_second_62 -35;
-    pos @kc87_first_71 @kc87_second_66 -140;
-    pos @kc87_first_71 @kc87_second_67 -175;
+    pos @kc87_first_71 @kc87_second_60 -175;
+    pos @kc87_first_71 @kc87_second_61 -175;
+    pos @kc87_first_71 @kc87_second_63 -35;
+    pos @kc87_first_71 @kc87_second_64 -35;
+    pos @kc87_first_71 @kc87_second_68 -140;
+    pos @kc87_first_71 @kc87_second_69 -175;
     pos @kc87_first_72 @kc87_second_5 -70;
     pos @kc87_first_72 @kc87_second_8 -70;
     pos @kc87_first_72 @kc87_second_9 -105;
@@ -10298,22 +10373,23 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_72 @kc87_second_28 -35;
     pos @kc87_first_72 @kc87_second_29 -70;
     pos @kc87_first_72 @kc87_second_33 -70;
-    pos @kc87_first_72 @kc87_second_41 -35;
-    pos @kc87_first_72 @kc87_second_42 -245;
-    pos @kc87_first_72 @kc87_second_43 -70;
-    pos @kc87_first_72 @kc87_second_45 -35;
-    pos @kc87_first_72 @kc87_second_46 -240;
-    pos @kc87_first_72 @kc87_second_48 1;
-    pos @kc87_first_72 @kc87_second_50 -105;
-    pos @kc87_first_72 @kc87_second_51 -280;
-    pos @kc87_first_72 @kc87_second_52 -35;
-    pos @kc87_first_72 @kc87_second_57 -35;
-    pos @kc87_first_72 @kc87_second_60 -70;
-    pos @kc87_first_72 @kc87_second_61 -105;
-    pos @kc87_first_72 @kc87_second_62 -35;
-    pos @kc87_first_72 @kc87_second_63 -70;
-    pos @kc87_first_72 @kc87_second_64 -175;
-    pos @kc87_first_72 @kc87_second_65 -140;
+    pos @kc87_first_72 @kc87_second_43 -35;
+    pos @kc87_first_72 @kc87_second_44 -245;
+    pos @kc87_first_72 @kc87_second_45 -70;
+    pos @kc87_first_72 @kc87_second_47 -240;
+    pos @kc87_first_72 @kc87_second_48 -210;
+    pos @kc87_first_72 @kc87_second_49 -35;
+    pos @kc87_first_72 @kc87_second_50 -35;
+    pos @kc87_first_72 @kc87_second_51 1;
+    pos @kc87_first_72 @kc87_second_53 -105;
+    pos @kc87_first_72 @kc87_second_54 -280;
+    pos @kc87_first_72 @kc87_second_59 -35;
+    pos @kc87_first_72 @kc87_second_62 -70;
+    pos @kc87_first_72 @kc87_second_63 -105;
+    pos @kc87_first_72 @kc87_second_64 -35;
+    pos @kc87_first_72 @kc87_second_65 -70;
+    pos @kc87_first_72 @kc87_second_66 -175;
+    pos @kc87_first_72 @kc87_second_67 -140;
     pos @kc87_first_73 @kc87_second_1 -140;
     pos @kc87_first_73 @kc87_second_2 -140;
     pos @kc87_first_73 @kc87_second_6 -140;
@@ -10328,21 +10404,22 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_73 @kc87_second_25 -70;
     pos @kc87_first_73 @kc87_second_26 -140;
     pos @kc87_first_73 @kc87_second_31 -70;
-    pos @kc87_first_73 @kc87_second_35 -70;
-    pos @kc87_first_73 @kc87_second_37 -175;
-    pos @kc87_first_73 @kc87_second_38 -105;
-    pos @kc87_first_73 @kc87_second_39 -70;
-    pos @kc87_first_73 @kc87_second_40 -70;
+    pos @kc87_first_73 @kc87_second_34 -35;
+    pos @kc87_first_73 @kc87_second_36 -70;
+    pos @kc87_first_73 @kc87_second_38 -175;
+    pos @kc87_first_73 @kc87_second_39 -105;
     pos @kc87_first_73 @kc87_second_41 -70;
-    pos @kc87_first_73 @kc87_second_42 -35;
-    pos @kc87_first_73 @kc87_second_48 1;
-    pos @kc87_first_73 @kc87_second_53 -35;
-    pos @kc87_first_73 @kc87_second_54 -35;
-    pos @kc87_first_73 @kc87_second_56 -140;
+    pos @kc87_first_73 @kc87_second_42 -70;
+    pos @kc87_first_73 @kc87_second_43 -70;
+    pos @kc87_first_73 @kc87_second_44 -35;
+    pos @kc87_first_73 @kc87_second_51 1;
+    pos @kc87_first_73 @kc87_second_55 -35;
+    pos @kc87_first_73 @kc87_second_56 -35;
     pos @kc87_first_73 @kc87_second_58 -140;
-    pos @kc87_first_73 @kc87_second_59 -140;
-    pos @kc87_first_73 @kc87_second_66 -105;
-    pos @kc87_first_73 @kc87_second_67 -105;
+    pos @kc87_first_73 @kc87_second_60 -140;
+    pos @kc87_first_73 @kc87_second_61 -140;
+    pos @kc87_first_73 @kc87_second_68 -105;
+    pos @kc87_first_73 @kc87_second_69 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -12900,6 +12977,7 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
+#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 

--- a/sources/Giphurs-Regular.ufo/fontinfo.plist
+++ b/sources/Giphurs-Regular.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/30 16:40:30</string>
+    <string>2026/07/30 21:50:17</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-Thin.ufo/features.fea
+++ b/sources/Giphurs-Thin.ufo/features.fea
@@ -7931,10 +7931,11 @@ lookup kern_Horizontal_kerning {
 	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
 	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
     @kc87_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
-	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
-	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
-	\uni1FA9 \uni1FAA \uni1FAB \uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA 
-	\uni1FFB \uni1FFC \uni20B2 \uni20B2.ss05 ];
+	\Q.cv29 \two.cv02.pnum \two.cv12.pnum \two.pnum \uni01E4 \uni03A9 
+	\uni051A \uni051A.cv29 \uni1E20 \uni1F68 \uni1F69 \uni1F6A \uni1F6B 
+	\uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 \uni1FA9 \uni1FAA \uni1FAB 
+	\uni1FAC \uni1FAD \uni1FAE \uni1FAF \uni1FFA \uni1FFB \uni1FFC \uni20B2 
+	\uni20B2.ss05 ];
     @kc87_first_6 = [\Gamma \T \Tau \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni023E \uni0413 
 	\uni0422 \uni0490 \uni0492 \uni04A4 \uni04AC \uni1E6A \uni1E6C \uni1E6E 
 	\uni1E70 ];
@@ -7946,24 +7947,27 @@ lookup kern_Horizontal_kerning {
     @kc87_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc87_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
-	\uniA7AD ];
+    @kc87_first_9 = [\L \Lacute \one.cv01.ss06.pnum \one.cv11.ss06.pnum \one.ss06.pnum \uni023D 
+	\uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 \uniA7AD ];
     @kc87_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
     @kc87_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
     @kc87_first_12 = [\Psi \uni0470 ];
     @kc87_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
-	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
-	\uni2107 ];
+    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv08.onum 
+	\eight.cv08.pnum \eight.cv18.onum \eight.cv18.pnum \three.cv03.pnum 
+	\three.pnum \uni0190 \uni01A7 \uni03E8 \uni0405 \uni0510 \uni1E60 
+	\uni1E62 \uni1E64 \uni1E66 \uni1E68 \uni2107 ];
     @kc87_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
     @kc87_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc87_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
-	\uni2163 \uni2164 \uni2C6F \universal ];
+    @kc87_first_17 = [\V \gradient \nine.cv19.pnum \seven.cv07.pnum \seven.cv07.ss07.pnum 
+	\seven.cv17.pnum \seven.cv17.ss07.pnum \seven.pnum \seven.ss07.pnum 
+	\slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE \uni2163 
+	\uni2164 \uni2C6F \universal ];
     @kc87_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
     @kc87_first_19 = [\a \aacute \abreve \acircumflex \adieresis \agrave \amacron \aogonek \aring 
 	\atilde \uni01DF \uni01E1 \uni0201 \uni0203 \uni0227 \uni0430 \uni04D1 
@@ -8060,16 +8064,17 @@ lookup kern_Horizontal_kerning {
     @kc87_first_23 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
-	\uni0207 \uni020D \uni020F \uni0229 \uni022B \uni022D \uni022F \uni0231 
-	\uni0247 \uni0254 \uni0258 \uni0259 \uni0275 \uni0278 \uni037B \uni037D 
-	\uni03D9 \uni03F6 \uni0435 \uni043E \uni044D \uni044E \uni0473 \uni04BD 
-	\uni04BF \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni04ED 
-	\uni050D \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni018D \uni01D2 \uni01DD 
+	\uni01E3 \uni01EB \uni01ED \uni0205 \uni0207 \uni020D \uni020F \uni0229 
+	\uni022B \uni022D \uni022F \uni0231 \uni0247 \uni0254 \uni0258 \uni0259 
+	\uni0275 \uni0278 \uni037B \uni037D \uni03D9 \uni03F6 \uni0435 \uni043E 
+	\uni044D \uni044E \uni0473 \uni04BD \uni04BF \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni04ED \uni050D \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni2184 ];
     @kc87_first_24 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
@@ -8154,18 +8159,21 @@ lookup kern_Horizontal_kerning {
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc87_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
-	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
-	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
-	\uni037B.sc \uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc 
-	\uni0473.sc \uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc 
-	\uni04E9.sc \uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc 
-	\uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc 
-	\uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc 
-	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
-	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
-	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
+    @kc87_first_33 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \nine.cv09.onum \nine.cv19.onum \nine.onum 
+	\o.sc \oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohungarumlaut.sc \omacron.sc \omicron.sc \oslash.sc \otilde.sc 
+	\uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc \uni022D.sc 
+	\uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc \uni037B.sc 
+	\uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc \uni0473.sc 
+	\uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc 
+	\uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc 
+	\uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_first_34 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
@@ -8224,73 +8232,81 @@ lookup kern_Horizontal_kerning {
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
     @kc87_first_38 = [\eth \uni1EFC \uni1EFD ];
-    @kc87_first_39 = [\fraction ];
-    @kc87_first_40 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc87_first_41 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
-	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_first_42 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc87_first_39 = [\four.cv04.onum \four.cv14.onum \four.onum \l.sc \lacute.sc \lcaron.sc 
+	\lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc \uni0234.sc 
+	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
+    @kc87_first_40 = [\four.cv04.pnum \four.cv14.pnum \four.pnum \phi.sc \thorn.sc \uni01A5.sc 
+	\uni0444.sc ];
+    @kc87_first_41 = [\fraction ];
+    @kc87_first_42 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \three.cv03.onum 
+	\three.onum \uni01E5 \uni1E21 ];
+    @kc87_first_43 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \two.cv02.onum \two.cv12.onum 
+	\two.onum \uni0260.sc \uni051B.sc \uni051B.sc.cv29 \uni1F60.sc 
+	\uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc 
+	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc 
+	\uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
+	\uni1FF6.sc \uni1FF7.sc ];
+    @kc87_first_44 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc87_first_43 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc87_first_45 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc87_first_44 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc87_first_46 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc87_first_45 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc87_first_47 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc87_first_46 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc87_first_48 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc87_first_47 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
-	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc87_first_48 = [\lambda \uni019B ];
-    @kc87_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc87_first_50 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc87_first_49 = [\lambda \uni019B ];
+    @kc87_first_50 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc87_first_51 = [\theta \uni047C \uniA7B6 \uniA64C \uni0424.loclBGR \zero.pnum \nine.cv09.pnum 
+	\zero.cv10.pnum \zero.cv20.pnum \zero.zero.pnum 
+	\zero.cv10.zero.pnum \zero.cv20.zero.pnum ];
+    @kc87_first_52 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc87_first_51 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc87_first_52 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc87_first_53 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc87_first_53 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc87_first_54 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc87_first_55 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc87_first_54 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc87_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc87_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc87_first_56 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc87_first_57 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc87_first_58 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc87_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_first_59 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc87_first_59 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
-	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
-	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_first_60 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
-	\uni1E71 ];
-    @kc87_first_61 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
-    @kc87_first_62 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc87_first_63 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc87_first_64 = [\uni0196 \uni01AA ];
-    @kc87_first_65 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
-	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
-	\ygrave ];
-    @kc87_first_66 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_first_60 = [\seven.cv07.onum \seven.cv07.ss07.onum \seven.cv17.ss07.onum 
+	\seven.cv17.tnum \seven.onum \seven.ss07.onum \uni01B4.sc 
+	\uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_first_67 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
-	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
-	\zdotaccent ];
+    @kc87_first_61 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
+    @kc87_first_62 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+	\uni1E71 ];
+    @kc87_first_63 = [\tau \uni0433 \uni0442 \uni0491 \uni0493 \uni04A5 \uni04AD \uni04F7 ];
+    @kc87_first_64 = [\three.cv13.onum \uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 
+	\uni02A3 \uni02AB \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z 
+	\zacute \zcaron \zdotaccent ];
+    @kc87_first_65 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc87_first_66 = [\uni0196 \uni01AA ];
+    @kc87_first_67 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
+	\ygrave ];
     @kc87_first_68 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
     @kc87_first_69 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
@@ -8331,15 +8347,19 @@ lookup kern_Horizontal_kerning {
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
     @kc87_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc87_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc87_second_7 = [\Omega \nine.cv19.pnum \two.cv02.pnum \two.cv12.pnum \two.pnum \uni03A9 
+	\uni1FFC ];
     @kc87_second_8 = [\Phi \uni0424 ];
     @kc87_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
-	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
-	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
-	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
+    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv18.onum 
+	\eight.cv18.pnum \eight.onum \three.cv03.pnum \three.pnum \uni01A7 
+	\uni03E8 \uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 
+	\uni1E68 ];
+    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \three.cv13.pnum \uni01A9 \uni01B5 
+	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 ];
+    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \seven.cv07.pnum \seven.cv17.pnum \seven.pnum \uni0162 
+	\uni01AC \uni01AE \uni021A \uni0422 \uni042A \uni04AC \uni04B4 \uni050E 
+	\uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
     @kc87_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
@@ -8371,18 +8391,19 @@ lookup kern_Horizontal_kerning {
 	\uni1F84 \uni1F85 \uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 
 	\uni1FB4 \uni1FB6 \uni1FB7 \uni217E \uniA64D \uniA7C8 ];
     @kc87_second_19 = [\a.sc \aacute.sc \abreve.sc \acircumflex.sc \adieresis.sc \agrave.sc \alpha.sc 
-	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc \lambda.sc 
-	\uni019B.sc \uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc 
-	\uni0203.sc \uni0227.sc \uni0430.sc \uni0434.loclBGR.sc 
-	\uni043B.loclBGR.sc \uni0467.sc \uni0469.sc \uni04D1.sc \uni04D3.sc 
-	\uni1E01.sc \uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc 
-	\uni1EA9.sc \uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc 
-	\uni1EB3.sc \uni1EB5.sc \uni1EB7.sc \uni1F00.sc \uni1F01.sc 
-	\uni1F02.sc \uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc 
-	\uni1F07.sc \uni1F70.sc \uni1F71.sc \uni1F80.sc \uni1F81.sc 
-	\uni1F82.sc \uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc 
-	\uni1F87.sc \uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc 
-	\uni1FB4.sc \uni1FB6.sc \uni1FB7.sc ];
+	\amacron.sc \aogonek.sc \aring.sc \atilde.sc \delta.sc 
+	\four.cv04.onum \four.cv14.onum \four.onum \lambda.sc \uni019B.sc 
+	\uni01CE.sc \uni01DF.sc \uni01E1.sc \uni0201.sc \uni0203.sc 
+	\uni0227.sc \uni0430.sc \uni0434.loclBGR.sc \uni043B.loclBGR.sc 
+	\uni0467.sc \uni0469.sc \uni04D1.sc \uni04D3.sc \uni1E01.sc 
+	\uni1EA1.sc \uni1EA3.sc \uni1EA5.sc \uni1EA7.sc \uni1EA9.sc 
+	\uni1EAB.sc \uni1EAD.sc \uni1EAF.sc \uni1EB1.sc \uni1EB3.sc 
+	\uni1EB5.sc \uni1EB7.sc \uni1F00.sc \uni1F01.sc \uni1F02.sc 
+	\uni1F03.sc \uni1F04.sc \uni1F05.sc \uni1F06.sc \uni1F07.sc 
+	\uni1F70.sc \uni1F71.sc \uni1F80.sc \uni1F81.sc \uni1F82.sc 
+	\uni1F83.sc \uni1F84.sc \uni1F85.sc \uni1F86.sc \uni1F87.sc 
+	\uni1FB0.sc \uni1FB1.sc \uni1FB2.sc \uni1FB3.sc \uni1FB4.sc 
+	\uni1FB6.sc \uni1FB7.sc ];
     @kc87_second_20 = [\acute \asciicircum \asterisk \breve \caron \circumflex \degree \dieresis 
 	\dieresistonos \dotaccent \eight.cv08.superior 
 	\eight.cv08.superior.pnum \eight.cv08.superior.tnum 
@@ -8450,35 +8471,38 @@ lookup kern_Horizontal_kerning {
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni0188 \uni018D \uni01A3 \uni01D2 \uni01DD \uni01EB \uni020D 
-	\uni020F \uni022B \uni022D \uni022F \uni0231 \uni023C \uni0247 \uni0255 
-	\uni0258 \uni0259 \uni025A \uni0275 \uni0276 \uni029B \uni03D9 \uni03F2 
-	\uni03F5 \uni0435 \uni043E \uni0450 \uni0451 \uni0473 \uni047B \uni04A9 
-	\uni04AB \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni050D 
-	\uni1E09 \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni0188 \uni018D \uni01A3 
+	\uni01D2 \uni01DD \uni01EB \uni020D \uni020F \uni022B \uni022D \uni022F 
+	\uni0231 \uni023C \uni0247 \uni0255 \uni0258 \uni0259 \uni025A \uni0275 
+	\uni0276 \uni029B \uni03D9 \uni03F2 \uni03F5 \uni0435 \uni043E \uni0450 
+	\uni0451 \uni0473 \uni047B \uni04A9 \uni04AB \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni050D \uni1E09 \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni20C0 \uni217D ];
     @kc87_second_25 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
-	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
-	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \q.sc.cv29 \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc 
-	\uni01E5.sc \uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc 
-	\uni020F.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc 
-	\uni023C.sc \uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc 
-	\uni037C.sc \uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc 
-	\uni0444.loclBGR.sc \uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc 
-	\uni04AB.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
-	\uni04EB.sc \uni050D.sc \uni051B.sc \uni051B.sc.cv29 \uni1E09.sc 
-	\uni1E21.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
-	\uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc 
-	\uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
-	\uni1EE1.sc \uni1EE3.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc 
-	\uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc 
-	\uni217D.sc ];
+	\gdotaccent.sc \nine.cv09.onum \nine.cv19.onum \nine.onum \o.sc 
+	\oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohorn.sc \ohungarumlaut.sc \omacron.sc \omicron.sc \omicrontonos.sc 
+	\oslash.sc \oslashacute.sc \otilde.sc \q.sc \q.sc.cv29 \theta.sc 
+	\uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc \uni022B.sc 
+	\uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc \uni0259.sc 
+	\uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc \uni03D9.sc 
+	\uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc \uni0454.sc 
+	\uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc \uni04D9.sc 
+	\uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni050D.sc 
+	\uni051B.sc \uni051B.sc.cv29 \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
+	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
+	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
+	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_second_26 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
@@ -8541,14 +8565,15 @@ lookup kern_Horizontal_kerning {
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
     @kc87_second_29 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
-	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
-	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
-	\uni0457.sc \uni1E2D.sc \uni1E2F.sc \uni1EC9.sc \uni1ECB.sc 
-	\uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc 
-	\uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F76.sc \uni1F77.sc 
-	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2178.sc ];
+	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \one.cv01.ss06.onum 
+	\one.cv01.ss06.pnum \one.cv11.ss06.onum \one.cv11.ss06.pnum 
+	\one.ss06.onum \one.ss06.pnum \uni01D0.sc \uni0209.sc \uni020B.sc 
+	\uni0269.sc \uni026A.sc \uni0456.sc \uni0457.sc \uni1E2D.sc 
+	\uni1E2F.sc \uni1EC9.sc \uni1ECB.sc \uni1F30.sc \uni1F31.sc 
+	\uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
+	\uni1F37.sc \uni1F76.sc \uni1F77.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2178.sc ];
     @kc87_second_30 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
@@ -8591,21 +8616,22 @@ lookup kern_Horizontal_kerning {
 	\uni1E69 \uni1F10 \uni1F11 \uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 
 	\uni1F73 ];
     @kc87_second_32 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
-	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
-	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
-	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
-	\uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 \uni01D4.cv25 
-	\uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA \uni01DA.cv25 
-	\uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 \uni0215 
-	\uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 \uni0269 
-	\uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B \uni0299 
-	\uni029C \uni029F \uni0432 \uni0433 \uni0438 \uni0439 \uni043A \uni043C 
-	\uni043D \uni043F \uni0446 \uni0448 \uni0449 \uni044B \uni044C \uni044E 
-	\uni0453 \uni045C \uni045D \uni045F \uni0465 \uni0469 \uni046D \uni0491 
-	\uni0493 \uni0495 \uni049B \uni049D \uni04A1 \uni04A3 \uni04A5 \uni04A7 
-	\uni04C8 \uni04CA \uni04CE \uni04F7 \uni04FB \uni0523 \uni0525 \uni0529 
-	\uni1E3F \uni1E41 \uni1E43 \uni1E45 \uni1E47 \uni1E49 \uni1E4B \uni1E59 
-	\uni1E5B \uni1E5D \uni1E5F \uni1E73 \uni1E73.cv25 \uni1E75 
+	\ntilde \r \racute \rcaron \rcommaaccent \seven.cv07.ss07.onum 
+	\seven.cv17.ss07.onum \seven.ss07.onum \u \u.cv25 \uacute 
+	\uacute.cv25 \ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 
+	\udieresis \udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 
+	\uhungarumlaut \uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 
+	\uni01D4.cv25 \uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA 
+	\uni01DA.cv25 \uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 
+	\uni0215 \uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 
+	\uni0269 \uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B 
+	\uni0299 \uni029C \uni029F \uni0432 \uni0433 \uni0438 \uni0439 \uni043A 
+	\uni043C \uni043D \uni043F \uni0446 \uni0448 \uni0449 \uni044B \uni044C 
+	\uni044E \uni0453 \uni045C \uni045D \uni045F \uni0465 \uni0469 \uni046D 
+	\uni0491 \uni0493 \uni0495 \uni049B \uni049D \uni04A1 \uni04A3 \uni04A5 
+	\uni04A7 \uni04C8 \uni04CA \uni04CE \uni04F7 \uni04FB \uni0523 \uni0525 
+	\uni0529 \uni1E3F \uni1E41 \uni1E43 \uni1E45 \uni1E47 \uni1E49 \uni1E4B 
+	\uni1E59 \uni1E5B \uni1E5D \uni1E5F \uni1E73 \uni1E73.cv25 \uni1E75 
 	\uni1E75.cv25 \uni1E77 \uni1E77.cv25 \uni1E79 \uni1E79.cv25 \uni1E7B 
 	\uni1E7B.cv25 \uni1EE5 \uni1EE5.cv25 \uni1EE7 \uni1EE7.cv25 \uni1EE9 
 	\uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 \uni1EED \uni1EED.cv25 \uni1EEF 
@@ -8614,77 +8640,83 @@ lookup kern_Horizontal_kerning {
 	\uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 \upsilon 
 	\upsilondieresistonos \upsilontonos \uring \uring.cv25 \utilde 
 	\utilde.cv25 ];
-    @kc87_second_33 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
-	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc87_second_34 = [\fraction ];
-    @kc87_second_35 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \uni01E5 \uni1E21 ];
-    @kc87_second_36 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc87_second_37 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+    @kc87_second_33 = [\f \florin \one.cv01.onum \one.cv01.pnum \one.cv11.onum \one.cv11.pnum 
+	\one.onum \one.pnum \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 
+	\uni1E1F \uni1E6B \uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
+    @kc87_second_34 = [\four.cv04.pnum \four.cv14.pnum \four.pnum ];
+    @kc87_second_35 = [\fraction ];
+    @kc87_second_36 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \three.cv03.onum \three.onum 
+	\uni01E5 \uni1E21 ];
+    @kc87_second_37 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc87_second_38 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc87_second_38 = [\lambda \uni019B ];
-    @kc87_second_39 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc87_second_39 = [\lambda \uni019B ];
+    @kc87_second_40 = [\nine.cv09.pnum \nine.pnum \six.cv06.onum \six.cv06.pnum \six.onum \six.pnum 
+	\theta \uni0478 \uniA64C \zero.cv10.pnum \zero.cv10.zero.pnum 
+	\zero.cv20.pnum \zero.cv20.zero.pnum \zero.pnum \zero.zero.pnum ];
+    @kc87_second_41 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc87_second_40 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_second_41 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_second_42 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
-    @kc87_second_43 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc87_second_42 = [\omega.sc \omegatonos.sc \two.cv02.onum \two.cv12.onum \two.onum \uni1F60.sc 
+	\uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc 
+	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc 
+	\uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
+	\uni1FF6.sc \uni1FF7.sc ];
+    @kc87_second_43 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc87_second_44 = [\pi \tau \uni0442 \uni044A \uni04AD \uni04B5 ];
+    @kc87_second_45 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc87_second_44 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_second_46 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc87_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc87_second_47 = [\seven.cv07.onum \seven.cv17.onum \seven.onum \t.sc \tau.sc \tbar.sc 
+	\tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc \uni021B.sc 
+	\uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc \uni0442.sc 
+	\uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc 
+	\uni1E71.sc \uni1E97.sc ];
+    @kc87_second_48 = [\seven.cv07.ss07.pnum \seven.cv17.ss07.pnum \seven.ss07.pnum ];
+    @kc87_second_49 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_second_46 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
-	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
-	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc87_second_47 = [\theta \uni0478 \uniA64C ];
-    @kc87_second_48 = [\tonos2 ];
-    @kc87_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc87_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc87_second_50 = [\three.cv13.onum \uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 
+	\uniA641 \uniA643 \z \zacute \zcaron \zdotaccent ];
+    @kc87_second_51 = [\tonos2 ];
+    @kc87_second_52 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc87_second_53 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc87_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_second_54 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_second_52 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
-	\z \zacute \zcaron \zdotaccent ];
-    @kc87_second_53 = [\uni0237 ];
-    @kc87_second_54 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc87_second_55 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc87_second_56 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc87_second_57 = [\uni042F \uni0518 ];
-    @kc87_second_58 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
+    @kc87_second_55 = [\uni0237 ];
+    @kc87_second_56 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc87_second_57 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc87_second_58 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc87_second_59 = [\uni042F \uni0518 ];
+    @kc87_second_60 = [\uni0434 \uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B 
 	\uni052F ];
-    @kc87_second_59 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc87_second_61 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc87_second_60 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc87_second_62 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc87_second_61 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc87_second_62 = [\uni044F.sc \uni0519.sc ];
-    @kc87_second_63 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc87_second_63 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc87_second_64 = [\uni044F.sc \uni0519.sc ];
+    @kc87_second_65 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc87_second_64 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc87_second_65 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc87_second_66 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc87_second_67 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc87_second_66 = [\uni0500 \uni0502 ];
-    @kc87_second_67 = [\uni0501.sc \uni0503.sc ];
-    @kc87_second_68 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
-	\zero.cv20.zero.dnom.pnum \zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc87_second_69 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
-	\zero.cv20.zero.numr.pnum \zero.numr.pnum \zero.zero.numr.pnum ];
+    @kc87_second_68 = [\uni0500 \uni0502 ];
+    @kc87_second_69 = [\uni0501.sc \uni0503.sc ];
+    @kc87_second_70 = [\zero.cv10.zero.dnom.pnum \zero.cv20.zero.dnom.pnum \zero.zero.dnom.pnum ];
+    @kc87_second_71 = [\zero.cv10.zero.numr.pnum \zero.cv20.zero.numr.pnum \zero.zero.numr.pnum ];
     pos @kc87_first_1 @kc87_second_3 -70;
     pos @kc87_first_1 @kc87_second_8 -70;
     pos @kc87_first_1 @kc87_second_9 -140;
     pos @kc87_first_1 @kc87_second_10 -35;
-    pos @kc87_first_1 @kc87_second_12 -280;
+    pos @kc87_first_1 @kc87_second_12 -201;
     pos @kc87_first_1 @kc87_second_13 -280;
     pos @kc87_first_1 @kc87_second_14 -280;
     pos @kc87_first_1 @kc87_second_15 -210;
@@ -8692,26 +8724,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_1 @kc87_second_25 -35;
     pos @kc87_first_1 @kc87_second_27 -50;
     pos @kc87_first_1 @kc87_second_33 -70;
-    pos @kc87_first_1 @kc87_second_41 -35;
-    pos @kc87_first_1 @kc87_second_42 -140;
-    pos @kc87_first_1 @kc87_second_43 -105;
-    pos @kc87_first_1 @kc87_second_46 -210;
-    pos @kc87_first_1 @kc87_second_47 -35;
-    pos @kc87_first_1 @kc87_second_48 1;
-    pos @kc87_first_1 @kc87_second_50 -175;
-    pos @kc87_first_1 @kc87_second_51 -210;
-    pos @kc87_first_1 @kc87_second_61 -140;
+    pos @kc87_first_1 @kc87_second_40 -35;
+    pos @kc87_first_1 @kc87_second_43 -35;
+    pos @kc87_first_1 @kc87_second_44 -140;
+    pos @kc87_first_1 @kc87_second_45 -105;
+    pos @kc87_first_1 @kc87_second_47 -210;
+    pos @kc87_first_1 @kc87_second_48 -175;
+    pos @kc87_first_1 @kc87_second_51 1;
+    pos @kc87_first_1 @kc87_second_53 -175;
+    pos @kc87_first_1 @kc87_second_54 -210;
     pos @kc87_first_1 @kc87_second_63 -140;
-    pos @kc87_first_1 @kc87_second_64 -210;
     pos @kc87_first_1 @kc87_second_65 -140;
+    pos @kc87_first_1 @kc87_second_66 -210;
+    pos @kc87_first_1 @kc87_second_67 -140;
     pos @kc87_first_2 @kc87_second_9 -35;
     pos @kc87_first_2 @kc87_second_12 -70;
     pos @kc87_first_2 @kc87_second_13 -70;
     pos @kc87_first_2 @kc87_second_14 -70;
     pos @kc87_first_2 @kc87_second_15 -35;
     pos @kc87_first_2 @kc87_second_16 -35;
-    pos @kc87_first_2 @kc87_second_42 -35;
-    pos @kc87_first_2 @kc87_second_48 1;
+    pos @kc87_first_2 @kc87_second_44 -35;
+    pos @kc87_first_2 @kc87_second_51 1;
     pos @kc87_first_3 @kc87_second_1 -35;
     pos @kc87_first_3 @kc87_second_2 -70;
     pos @kc87_first_3 @kc87_second_5 -35;
@@ -8722,8 +8755,8 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_3 @kc87_second_16 -70;
     pos @kc87_first_3 @kc87_second_19 -35;
     pos @kc87_first_3 @kc87_second_21 -70;
-    pos @kc87_first_3 @kc87_second_38 -35;
-    pos @kc87_first_3 @kc87_second_48 1;
+    pos @kc87_first_3 @kc87_second_39 -35;
+    pos @kc87_first_3 @kc87_second_51 1;
     pos @kc87_first_4 @kc87_second_1 -70;
     pos @kc87_first_4 @kc87_second_2 -140;
     pos @kc87_first_4 @kc87_second_4 70;
@@ -8739,24 +8772,24 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_4 @kc87_second_28 -70;
     pos @kc87_first_4 @kc87_second_29 -35;
     pos @kc87_first_4 @kc87_second_33 35;
-    pos @kc87_first_4 @kc87_second_35 -35;
-    pos @kc87_first_4 @kc87_second_37 -70;
+    pos @kc87_first_4 @kc87_second_36 -35;
     pos @kc87_first_4 @kc87_second_38 -70;
-    pos @kc87_first_4 @kc87_second_46 -35;
-    pos @kc87_first_4 @kc87_second_48 1;
-    pos @kc87_first_4 @kc87_second_51 -70;
-    pos @kc87_first_4 @kc87_second_56 -70;
+    pos @kc87_first_4 @kc87_second_39 -70;
+    pos @kc87_first_4 @kc87_second_47 -35;
+    pos @kc87_first_4 @kc87_second_51 1;
+    pos @kc87_first_4 @kc87_second_54 -70;
     pos @kc87_first_4 @kc87_second_58 -70;
-    pos @kc87_first_4 @kc87_second_59 -70;
-    pos @kc87_first_4 @kc87_second_64 -35;
+    pos @kc87_first_4 @kc87_second_60 -70;
+    pos @kc87_first_4 @kc87_second_61 -70;
+    pos @kc87_first_4 @kc87_second_66 -35;
     pos @kc87_first_5 @kc87_second_12 -70;
-    pos @kc87_first_5 @kc87_second_48 1;
+    pos @kc87_first_5 @kc87_second_51 1;
     pos @kc87_first_6 @kc87_second_1 -280;
     pos @kc87_first_6 @kc87_second_2 -350;
     pos @kc87_first_6 @kc87_second_3 -140;
     pos @kc87_first_6 @kc87_second_4 -70;
     pos @kc87_first_6 @kc87_second_6 -350;
-    pos @kc87_first_6 @kc87_second_7 -140;
+    pos @kc87_first_6 @kc87_second_7 -70;
     pos @kc87_first_6 @kc87_second_8 -210;
     pos @kc87_first_6 @kc87_second_10 -70;
     pos @kc87_first_6 @kc87_second_17 -240;
@@ -8773,32 +8806,33 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_6 @kc87_second_31 -240;
     pos @kc87_first_6 @kc87_second_32 -240;
     pos @kc87_first_6 @kc87_second_33 -175;
-    pos @kc87_first_6 @kc87_second_35 -240;
-    pos @kc87_first_6 @kc87_second_37 -350;
-    pos @kc87_first_6 @kc87_second_38 -105;
-    pos @kc87_first_6 @kc87_second_39 -240;
-    pos @kc87_first_6 @kc87_second_40 -210;
+    pos @kc87_first_6 @kc87_second_34 -175;
+    pos @kc87_first_6 @kc87_second_36 -240;
+    pos @kc87_first_6 @kc87_second_38 -350;
+    pos @kc87_first_6 @kc87_second_39 -105;
+    pos @kc87_first_6 @kc87_second_40 -70;
     pos @kc87_first_6 @kc87_second_41 -240;
-    pos @kc87_first_6 @kc87_second_42 -240;
+    pos @kc87_first_6 @kc87_second_42 -210;
+    pos @kc87_first_6 @kc87_second_43 -240;
     pos @kc87_first_6 @kc87_second_44 -240;
-    pos @kc87_first_6 @kc87_second_47 -140;
-    pos @kc87_first_6 @kc87_second_48 1;
-    pos @kc87_first_6 @kc87_second_49 -35;
+    pos @kc87_first_6 @kc87_second_46 -240;
     pos @kc87_first_6 @kc87_second_50 -240;
-    pos @kc87_first_6 @kc87_second_52 -240;
+    pos @kc87_first_6 @kc87_second_51 1;
+    pos @kc87_first_6 @kc87_second_52 -35;
     pos @kc87_first_6 @kc87_second_53 -240;
-    pos @kc87_first_6 @kc87_second_54 -240;
     pos @kc87_first_6 @kc87_second_55 -240;
-    pos @kc87_first_6 @kc87_second_56 -280;
-    pos @kc87_first_6 @kc87_second_57 -70;
+    pos @kc87_first_6 @kc87_second_56 -240;
+    pos @kc87_first_6 @kc87_second_57 -240;
     pos @kc87_first_6 @kc87_second_58 -280;
-    pos @kc87_first_6 @kc87_second_59 -240;
-    pos @kc87_first_6 @kc87_second_60 -175;
+    pos @kc87_first_6 @kc87_second_59 -70;
+    pos @kc87_first_6 @kc87_second_60 -280;
     pos @kc87_first_6 @kc87_second_61 -240;
-    pos @kc87_first_6 @kc87_second_62 -210;
-    pos @kc87_first_6 @kc87_second_63 -175;
-    pos @kc87_first_6 @kc87_second_66 -175;
-    pos @kc87_first_6 @kc87_second_67 -175;
+    pos @kc87_first_6 @kc87_second_62 -175;
+    pos @kc87_first_6 @kc87_second_63 -240;
+    pos @kc87_first_6 @kc87_second_64 -210;
+    pos @kc87_first_6 @kc87_second_65 -175;
+    pos @kc87_first_6 @kc87_second_68 -175;
+    pos @kc87_first_6 @kc87_second_69 -175;
     pos @kc87_first_7 @kc87_second_3 -70;
     pos @kc87_first_7 @kc87_second_8 -105;
     pos @kc87_first_7 @kc87_second_17 -35;
@@ -8806,13 +8840,14 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_7 @kc87_second_22 -105;
     pos @kc87_first_7 @kc87_second_24 -105;
     pos @kc87_first_7 @kc87_second_25 -70;
-    pos @kc87_first_7 @kc87_second_48 1;
-    pos @kc87_first_7 @kc87_second_49 -35;
-    pos @kc87_first_7 @kc87_second_50 -70;
-    pos @kc87_first_7 @kc87_second_54 -50;
-    pos @kc87_first_7 @kc87_second_63 -35;
-    pos @kc87_first_7 @kc87_second_66 -70;
-    pos @kc87_first_7 @kc87_second_67 -70;
+    pos @kc87_first_7 @kc87_second_34 -70;
+    pos @kc87_first_7 @kc87_second_51 1;
+    pos @kc87_first_7 @kc87_second_52 -35;
+    pos @kc87_first_7 @kc87_second_53 -70;
+    pos @kc87_first_7 @kc87_second_56 -50;
+    pos @kc87_first_7 @kc87_second_65 -35;
+    pos @kc87_first_7 @kc87_second_68 -70;
+    pos @kc87_first_7 @kc87_second_69 -70;
     pos @kc87_first_8 @kc87_second_3 -140;
     pos @kc87_first_8 @kc87_second_4 -70;
     pos @kc87_first_8 @kc87_second_6 -70;
@@ -8826,26 +8861,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_8 @kc87_second_27 -140;
     pos @kc87_first_8 @kc87_second_31 -35;
     pos @kc87_first_8 @kc87_second_33 -105;
-    pos @kc87_first_8 @kc87_second_37 -70;
-    pos @kc87_first_8 @kc87_second_39 -70;
-    pos @kc87_first_8 @kc87_second_41 -105;
-    pos @kc87_first_8 @kc87_second_42 -175;
-    pos @kc87_first_8 @kc87_second_43 -140;
-    pos @kc87_first_8 @kc87_second_44 -35;
-    pos @kc87_first_8 @kc87_second_46 -140;
-    pos @kc87_first_8 @kc87_second_47 -105;
-    pos @kc87_first_8 @kc87_second_48 1;
-    pos @kc87_first_8 @kc87_second_49 -70;
-    pos @kc87_first_8 @kc87_second_50 -140;
-    pos @kc87_first_8 @kc87_second_51 -70;
-    pos @kc87_first_8 @kc87_second_54 -35;
-    pos @kc87_first_8 @kc87_second_55 -35;
-    pos @kc87_first_8 @kc87_second_61 -210;
-    pos @kc87_first_8 @kc87_second_63 -105;
-    pos @kc87_first_8 @kc87_second_64 -70;
-    pos @kc87_first_8 @kc87_second_65 -35;
+    pos @kc87_first_8 @kc87_second_34 -70;
+    pos @kc87_first_8 @kc87_second_38 -70;
+    pos @kc87_first_8 @kc87_second_40 -105;
+    pos @kc87_first_8 @kc87_second_41 -70;
+    pos @kc87_first_8 @kc87_second_43 -105;
+    pos @kc87_first_8 @kc87_second_44 -175;
+    pos @kc87_first_8 @kc87_second_45 -140;
+    pos @kc87_first_8 @kc87_second_46 -35;
+    pos @kc87_first_8 @kc87_second_47 -140;
+    pos @kc87_first_8 @kc87_second_51 1;
+    pos @kc87_first_8 @kc87_second_52 -70;
+    pos @kc87_first_8 @kc87_second_53 -140;
+    pos @kc87_first_8 @kc87_second_54 -70;
+    pos @kc87_first_8 @kc87_second_56 -35;
+    pos @kc87_first_8 @kc87_second_57 -35;
+    pos @kc87_first_8 @kc87_second_63 -210;
+    pos @kc87_first_8 @kc87_second_65 -105;
     pos @kc87_first_8 @kc87_second_66 -70;
     pos @kc87_first_8 @kc87_second_67 -35;
+    pos @kc87_first_8 @kc87_second_68 -70;
+    pos @kc87_first_8 @kc87_second_69 -35;
     pos @kc87_first_9 @kc87_second_3 -140;
     pos @kc87_first_9 @kc87_second_4 -70;
     pos @kc87_first_9 @kc87_second_6 -70;
@@ -8864,24 +8900,26 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_9 @kc87_second_25 -140;
     pos @kc87_first_9 @kc87_second_31 -50;
     pos @kc87_first_9 @kc87_second_33 -140;
-    pos @kc87_first_9 @kc87_second_37 -70;
-    pos @kc87_first_9 @kc87_second_41 -105;
-    pos @kc87_first_9 @kc87_second_42 -280;
-    pos @kc87_first_9 @kc87_second_43 -350;
-    pos @kc87_first_9 @kc87_second_44 -50;
-    pos @kc87_first_9 @kc87_second_46 -350;
-    pos @kc87_first_9 @kc87_second_48 1;
-    pos @kc87_first_9 @kc87_second_49 -35;
-    pos @kc87_first_9 @kc87_second_50 -210;
-    pos @kc87_first_9 @kc87_second_51 -350;
-    pos @kc87_first_9 @kc87_second_54 -35;
-    pos @kc87_first_9 @kc87_second_55 -35;
-    pos @kc87_first_9 @kc87_second_61 -280;
-    pos @kc87_first_9 @kc87_second_63 -175;
-    pos @kc87_first_9 @kc87_second_64 -280;
-    pos @kc87_first_9 @kc87_second_65 -210;
-    pos @kc87_first_9 @kc87_second_66 -70;
-    pos @kc87_first_9 @kc87_second_67 -70;
+    pos @kc87_first_9 @kc87_second_34 -70;
+    pos @kc87_first_9 @kc87_second_38 -70;
+    pos @kc87_first_9 @kc87_second_43 -105;
+    pos @kc87_first_9 @kc87_second_44 -280;
+    pos @kc87_first_9 @kc87_second_45 -350;
+    pos @kc87_first_9 @kc87_second_46 -50;
+    pos @kc87_first_9 @kc87_second_47 -350;
+    pos @kc87_first_9 @kc87_second_48 -280;
+    pos @kc87_first_9 @kc87_second_51 1;
+    pos @kc87_first_9 @kc87_second_52 -35;
+    pos @kc87_first_9 @kc87_second_53 -210;
+    pos @kc87_first_9 @kc87_second_54 -350;
+    pos @kc87_first_9 @kc87_second_56 -35;
+    pos @kc87_first_9 @kc87_second_57 -35;
+    pos @kc87_first_9 @kc87_second_63 -280;
+    pos @kc87_first_9 @kc87_second_65 -175;
+    pos @kc87_first_9 @kc87_second_66 -280;
+    pos @kc87_first_9 @kc87_second_67 -210;
+    pos @kc87_first_9 @kc87_second_68 -70;
+    pos @kc87_first_9 @kc87_second_69 -70;
     pos @kc87_first_10 @kc87_second_1 -210;
     pos @kc87_first_10 @kc87_second_2 -350;
     pos @kc87_first_10 @kc87_second_5 -70;
@@ -8898,18 +8936,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_10 @kc87_second_24 -70;
     pos @kc87_first_10 @kc87_second_26 -350;
     pos @kc87_first_10 @kc87_second_31 -70;
-    pos @kc87_first_10 @kc87_second_34 -140;
-    pos @kc87_first_10 @kc87_second_35 -70;
-    pos @kc87_first_10 @kc87_second_37 -210;
-    pos @kc87_first_10 @kc87_second_38 -105;
-    pos @kc87_first_10 @kc87_second_41 -70;
-    pos @kc87_first_10 @kc87_second_48 1;
-    pos @kc87_first_10 @kc87_second_56 -210;
+    pos @kc87_first_10 @kc87_second_34 -35;
+    pos @kc87_first_10 @kc87_second_35 -140;
+    pos @kc87_first_10 @kc87_second_36 -70;
+    pos @kc87_first_10 @kc87_second_38 -210;
+    pos @kc87_first_10 @kc87_second_39 -105;
+    pos @kc87_first_10 @kc87_second_43 -70;
+    pos @kc87_first_10 @kc87_second_51 1;
     pos @kc87_first_10 @kc87_second_58 -210;
-    pos @kc87_first_10 @kc87_second_59 -210;
-    pos @kc87_first_10 @kc87_second_64 -70;
+    pos @kc87_first_10 @kc87_second_60 -210;
+    pos @kc87_first_10 @kc87_second_61 -210;
     pos @kc87_first_10 @kc87_second_66 -70;
-    pos @kc87_first_10 @kc87_second_67 -105;
+    pos @kc87_first_10 @kc87_second_68 -70;
+    pos @kc87_first_10 @kc87_second_69 -105;
     pos @kc87_first_11 @kc87_second_1 -70;
     pos @kc87_first_11 @kc87_second_2 -140;
     pos @kc87_first_11 @kc87_second_5 -105;
@@ -8925,22 +8964,22 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_11 @kc87_second_26 -70;
     pos @kc87_first_11 @kc87_second_28 -70;
     pos @kc87_first_11 @kc87_second_29 -70;
-    pos @kc87_first_11 @kc87_second_35 -35;
-    pos @kc87_first_11 @kc87_second_37 -35;
-    pos @kc87_first_11 @kc87_second_38 -140;
-    pos @kc87_first_11 @kc87_second_42 -70;
-    pos @kc87_first_11 @kc87_second_45 -35;
-    pos @kc87_first_11 @kc87_second_46 -35;
-    pos @kc87_first_11 @kc87_second_48 1;
-    pos @kc87_first_11 @kc87_second_51 -70;
-    pos @kc87_first_11 @kc87_second_56 -210;
-    pos @kc87_first_11 @kc87_second_58 -175;
-    pos @kc87_first_11 @kc87_second_59 -175;
-    pos @kc87_first_11 @kc87_second_60 -35;
-    pos @kc87_first_11 @kc87_second_64 -70;
-    pos @kc87_first_11 @kc87_second_65 -35;
-    pos @kc87_first_11 @kc87_second_66 -35;
-    pos @kc87_first_11 @kc87_second_67 -70;
+    pos @kc87_first_11 @kc87_second_36 -35;
+    pos @kc87_first_11 @kc87_second_38 -35;
+    pos @kc87_first_11 @kc87_second_39 -140;
+    pos @kc87_first_11 @kc87_second_44 -70;
+    pos @kc87_first_11 @kc87_second_47 -35;
+    pos @kc87_first_11 @kc87_second_49 -35;
+    pos @kc87_first_11 @kc87_second_51 1;
+    pos @kc87_first_11 @kc87_second_54 -70;
+    pos @kc87_first_11 @kc87_second_58 -210;
+    pos @kc87_first_11 @kc87_second_60 -175;
+    pos @kc87_first_11 @kc87_second_61 -175;
+    pos @kc87_first_11 @kc87_second_62 -35;
+    pos @kc87_first_11 @kc87_second_66 -70;
+    pos @kc87_first_11 @kc87_second_67 -35;
+    pos @kc87_first_11 @kc87_second_68 -35;
+    pos @kc87_first_11 @kc87_second_69 -70;
     pos @kc87_first_12 @kc87_second_1 -140;
     pos @kc87_first_12 @kc87_second_2 -210;
     pos @kc87_first_12 @kc87_second_6 -140;
@@ -8951,18 +8990,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_12 @kc87_second_24 -70;
     pos @kc87_first_12 @kc87_second_26 -350;
     pos @kc87_first_12 @kc87_second_31 -35;
-    pos @kc87_first_12 @kc87_second_34 -140;
-    pos @kc87_first_12 @kc87_second_35 -70;
-    pos @kc87_first_12 @kc87_second_37 -140;
-    pos @kc87_first_12 @kc87_second_38 -70;
-    pos @kc87_first_12 @kc87_second_41 -70;
-    pos @kc87_first_12 @kc87_second_48 1;
-    pos @kc87_first_12 @kc87_second_54 -35;
-    pos @kc87_first_12 @kc87_second_56 -210;
+    pos @kc87_first_12 @kc87_second_34 -70;
+    pos @kc87_first_12 @kc87_second_35 -140;
+    pos @kc87_first_12 @kc87_second_36 -70;
+    pos @kc87_first_12 @kc87_second_38 -140;
+    pos @kc87_first_12 @kc87_second_39 -70;
+    pos @kc87_first_12 @kc87_second_43 -70;
+    pos @kc87_first_12 @kc87_second_51 1;
+    pos @kc87_first_12 @kc87_second_56 -35;
     pos @kc87_first_12 @kc87_second_58 -210;
-    pos @kc87_first_12 @kc87_second_59 -210;
-    pos @kc87_first_12 @kc87_second_66 -70;
-    pos @kc87_first_12 @kc87_second_67 -105;
+    pos @kc87_first_12 @kc87_second_60 -210;
+    pos @kc87_first_12 @kc87_second_61 -210;
+    pos @kc87_first_12 @kc87_second_68 -70;
+    pos @kc87_first_12 @kc87_second_69 -105;
     pos @kc87_first_13 @kc87_second_6 -70;
     pos @kc87_first_13 @kc87_second_12 -70;
     pos @kc87_first_13 @kc87_second_13 -105;
@@ -8970,11 +9010,12 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_13 @kc87_second_18 -35;
     pos @kc87_first_13 @kc87_second_24 -35;
     pos @kc87_first_13 @kc87_second_31 -35;
-    pos @kc87_first_13 @kc87_second_37 -70;
-    pos @kc87_first_13 @kc87_second_41 -70;
-    pos @kc87_first_13 @kc87_second_48 1;
-    pos @kc87_first_13 @kc87_second_66 -70;
-    pos @kc87_first_13 @kc87_second_67 -35;
+    pos @kc87_first_13 @kc87_second_34 -35;
+    pos @kc87_first_13 @kc87_second_38 -70;
+    pos @kc87_first_13 @kc87_second_43 -70;
+    pos @kc87_first_13 @kc87_second_51 1;
+    pos @kc87_first_13 @kc87_second_68 -70;
+    pos @kc87_first_13 @kc87_second_69 -35;
     pos @kc87_first_14 @kc87_second_2 -35;
     pos @kc87_first_14 @kc87_second_11 -35;
     pos @kc87_first_14 @kc87_second_12 -70;
@@ -8983,15 +9024,15 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_14 @kc87_second_16 -35;
     pos @kc87_first_14 @kc87_second_21 -35;
     pos @kc87_first_14 @kc87_second_27 -35;
-    pos @kc87_first_14 @kc87_second_35 -35;
-    pos @kc87_first_14 @kc87_second_42 -70;
-    pos @kc87_first_14 @kc87_second_48 1;
-    pos @kc87_first_14 @kc87_second_50 -70;
-    pos @kc87_first_14 @kc87_second_51 -35;
-    pos @kc87_first_14 @kc87_second_60 -35;
-    pos @kc87_first_14 @kc87_second_61 -35;
+    pos @kc87_first_14 @kc87_second_36 -35;
+    pos @kc87_first_14 @kc87_second_44 -70;
+    pos @kc87_first_14 @kc87_second_51 1;
+    pos @kc87_first_14 @kc87_second_53 -70;
+    pos @kc87_first_14 @kc87_second_54 -35;
+    pos @kc87_first_14 @kc87_second_62 -35;
     pos @kc87_first_14 @kc87_second_63 -35;
     pos @kc87_first_14 @kc87_second_65 -35;
+    pos @kc87_first_14 @kc87_second_67 -35;
     pos @kc87_first_15 @kc87_second_3 -70;
     pos @kc87_first_15 @kc87_second_4 -70;
     pos @kc87_first_15 @kc87_second_6 -35;
@@ -9004,20 +9045,20 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_15 @kc87_second_27 -70;
     pos @kc87_first_15 @kc87_second_31 -35;
     pos @kc87_first_15 @kc87_second_33 -35;
-    pos @kc87_first_15 @kc87_second_39 -35;
-    pos @kc87_first_15 @kc87_second_41 -70;
-    pos @kc87_first_15 @kc87_second_42 -142;
-    pos @kc87_first_15 @kc87_second_43 -35;
-    pos @kc87_first_15 @kc87_second_47 -35;
-    pos @kc87_first_15 @kc87_second_48 1;
-    pos @kc87_first_15 @kc87_second_49 -35;
-    pos @kc87_first_15 @kc87_second_50 -70;
-    pos @kc87_first_15 @kc87_second_54 -35;
-    pos @kc87_first_15 @kc87_second_55 -35;
-    pos @kc87_first_15 @kc87_second_61 -105;
-    pos @kc87_first_15 @kc87_second_63 -35;
-    pos @kc87_first_15 @kc87_second_66 -35;
-    pos @kc87_first_15 @kc87_second_67 -35;
+    pos @kc87_first_15 @kc87_second_40 -35;
+    pos @kc87_first_15 @kc87_second_41 -35;
+    pos @kc87_first_15 @kc87_second_43 -70;
+    pos @kc87_first_15 @kc87_second_44 -142;
+    pos @kc87_first_15 @kc87_second_45 -35;
+    pos @kc87_first_15 @kc87_second_51 1;
+    pos @kc87_first_15 @kc87_second_52 -35;
+    pos @kc87_first_15 @kc87_second_53 -70;
+    pos @kc87_first_15 @kc87_second_56 -35;
+    pos @kc87_first_15 @kc87_second_57 -35;
+    pos @kc87_first_15 @kc87_second_63 -105;
+    pos @kc87_first_15 @kc87_second_65 -35;
+    pos @kc87_first_15 @kc87_second_68 -35;
+    pos @kc87_first_15 @kc87_second_69 -35;
     pos @kc87_first_16 @kc87_second_1 -280;
     pos @kc87_first_16 @kc87_second_2 -280;
     pos @kc87_first_16 @kc87_second_3 -140;
@@ -9040,35 +9081,35 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_16 @kc87_second_31 -240;
     pos @kc87_first_16 @kc87_second_32 -140;
     pos @kc87_first_16 @kc87_second_33 -140;
-    pos @kc87_first_16 @kc87_second_34 -245;
-    pos @kc87_first_16 @kc87_second_35 -315;
-    pos @kc87_first_16 @kc87_second_37 -315;
-    pos @kc87_first_16 @kc87_second_38 -70;
-    pos @kc87_first_16 @kc87_second_39 -210;
-    pos @kc87_first_16 @kc87_second_40 -210;
-    pos @kc87_first_16 @kc87_second_41 -245;
-    pos @kc87_first_16 @kc87_second_42 -245;
-    pos @kc87_first_16 @kc87_second_43 -70;
-    pos @kc87_first_16 @kc87_second_45 -35;
-    pos @kc87_first_16 @kc87_second_46 -140;
+    pos @kc87_first_16 @kc87_second_35 -245;
+    pos @kc87_first_16 @kc87_second_36 -315;
+    pos @kc87_first_16 @kc87_second_38 -315;
+    pos @kc87_first_16 @kc87_second_39 -70;
+    pos @kc87_first_16 @kc87_second_40 -140;
+    pos @kc87_first_16 @kc87_second_41 -210;
+    pos @kc87_first_16 @kc87_second_42 -210;
+    pos @kc87_first_16 @kc87_second_43 -245;
+    pos @kc87_first_16 @kc87_second_44 -245;
+    pos @kc87_first_16 @kc87_second_45 -70;
     pos @kc87_first_16 @kc87_second_47 -140;
-    pos @kc87_first_16 @kc87_second_48 1;
-    pos @kc87_first_16 @kc87_second_49 -70;
+    pos @kc87_first_16 @kc87_second_49 -35;
     pos @kc87_first_16 @kc87_second_50 -140;
-    pos @kc87_first_16 @kc87_second_52 -140;
+    pos @kc87_first_16 @kc87_second_51 1;
+    pos @kc87_first_16 @kc87_second_52 -70;
     pos @kc87_first_16 @kc87_second_53 -140;
-    pos @kc87_first_16 @kc87_second_54 -240;
     pos @kc87_first_16 @kc87_second_55 -140;
-    pos @kc87_first_16 @kc87_second_56 -280;
-    pos @kc87_first_16 @kc87_second_57 -105;
-    pos @kc87_first_16 @kc87_second_58 -315;
-    pos @kc87_first_16 @kc87_second_59 -280;
-    pos @kc87_first_16 @kc87_second_60 -140;
-    pos @kc87_first_16 @kc87_second_61 -210;
-    pos @kc87_first_16 @kc87_second_62 -210;
-    pos @kc87_first_16 @kc87_second_63 -105;
-    pos @kc87_first_16 @kc87_second_66 -315;
-    pos @kc87_first_16 @kc87_second_67 -350;
+    pos @kc87_first_16 @kc87_second_56 -240;
+    pos @kc87_first_16 @kc87_second_57 -140;
+    pos @kc87_first_16 @kc87_second_58 -280;
+    pos @kc87_first_16 @kc87_second_59 -105;
+    pos @kc87_first_16 @kc87_second_60 -315;
+    pos @kc87_first_16 @kc87_second_61 -280;
+    pos @kc87_first_16 @kc87_second_62 -140;
+    pos @kc87_first_16 @kc87_second_63 -210;
+    pos @kc87_first_16 @kc87_second_64 -210;
+    pos @kc87_first_16 @kc87_second_65 -105;
+    pos @kc87_first_16 @kc87_second_68 -315;
+    pos @kc87_first_16 @kc87_second_69 -350;
     pos @kc87_first_17 @kc87_second_1 -280;
     pos @kc87_first_17 @kc87_second_2 -280;
     pos @kc87_first_17 @kc87_second_3 -105;
@@ -9088,34 +9129,35 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_17 @kc87_second_29 -70;
     pos @kc87_first_17 @kc87_second_31 -140;
     pos @kc87_first_17 @kc87_second_32 -105;
-    pos @kc87_first_17 @kc87_second_34 -210;
-    pos @kc87_first_17 @kc87_second_35 -175;
-    pos @kc87_first_17 @kc87_second_37 -245;
-    pos @kc87_first_17 @kc87_second_38 -70;
-    pos @kc87_first_17 @kc87_second_39 -140;
-    pos @kc87_first_17 @kc87_second_40 -140;
+    pos @kc87_first_17 @kc87_second_34 -175;
+    pos @kc87_first_17 @kc87_second_35 -210;
+    pos @kc87_first_17 @kc87_second_36 -175;
+    pos @kc87_first_17 @kc87_second_38 -245;
+    pos @kc87_first_17 @kc87_second_39 -70;
+    pos @kc87_first_17 @kc87_second_40 -70;
     pos @kc87_first_17 @kc87_second_41 -140;
-    pos @kc87_first_17 @kc87_second_42 -105;
-    pos @kc87_first_17 @kc87_second_43 -35;
-    pos @kc87_first_17 @kc87_second_46 -35;
-    pos @kc87_first_17 @kc87_second_47 -70;
-    pos @kc87_first_17 @kc87_second_48 1;
-    pos @kc87_first_17 @kc87_second_49 -35;
-    pos @kc87_first_17 @kc87_second_50 -70;
-    pos @kc87_first_17 @kc87_second_52 -105;
+    pos @kc87_first_17 @kc87_second_42 -140;
+    pos @kc87_first_17 @kc87_second_43 -140;
+    pos @kc87_first_17 @kc87_second_44 -105;
+    pos @kc87_first_17 @kc87_second_45 -35;
+    pos @kc87_first_17 @kc87_second_47 -35;
+    pos @kc87_first_17 @kc87_second_50 -105;
+    pos @kc87_first_17 @kc87_second_51 1;
+    pos @kc87_first_17 @kc87_second_52 -35;
     pos @kc87_first_17 @kc87_second_53 -70;
-    pos @kc87_first_17 @kc87_second_54 -105;
     pos @kc87_first_17 @kc87_second_55 -70;
-    pos @kc87_first_17 @kc87_second_56 -210;
-    pos @kc87_first_17 @kc87_second_57 -35;
-    pos @kc87_first_17 @kc87_second_58 -245;
-    pos @kc87_first_17 @kc87_second_59 -210;
-    pos @kc87_first_17 @kc87_second_60 -70;
-    pos @kc87_first_17 @kc87_second_61 -105;
-    pos @kc87_first_17 @kc87_second_62 -105;
-    pos @kc87_first_17 @kc87_second_63 -70;
-    pos @kc87_first_17 @kc87_second_66 -175;
-    pos @kc87_first_17 @kc87_second_67 -245;
+    pos @kc87_first_17 @kc87_second_56 -105;
+    pos @kc87_first_17 @kc87_second_57 -70;
+    pos @kc87_first_17 @kc87_second_58 -210;
+    pos @kc87_first_17 @kc87_second_59 -35;
+    pos @kc87_first_17 @kc87_second_60 -245;
+    pos @kc87_first_17 @kc87_second_61 -210;
+    pos @kc87_first_17 @kc87_second_62 -70;
+    pos @kc87_first_17 @kc87_second_63 -105;
+    pos @kc87_first_17 @kc87_second_64 -105;
+    pos @kc87_first_17 @kc87_second_65 -70;
+    pos @kc87_first_17 @kc87_second_68 -175;
+    pos @kc87_first_17 @kc87_second_69 -245;
     pos @kc87_first_18 @kc87_second_1 -210;
     pos @kc87_first_18 @kc87_second_2 -245;
     pos @kc87_first_18 @kc87_second_3 -35;
@@ -9131,41 +9173,42 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_18 @kc87_second_25 -70;
     pos @kc87_first_18 @kc87_second_26 -140;
     pos @kc87_first_18 @kc87_second_29 -35;
-    pos @kc87_first_18 @kc87_second_34 -140;
-    pos @kc87_first_18 @kc87_second_35 -105;
-    pos @kc87_first_18 @kc87_second_37 -140;
-    pos @kc87_first_18 @kc87_second_39 -105;
-    pos @kc87_first_18 @kc87_second_40 -70;
+    pos @kc87_first_18 @kc87_second_34 -105;
+    pos @kc87_first_18 @kc87_second_35 -140;
+    pos @kc87_first_18 @kc87_second_36 -105;
+    pos @kc87_first_18 @kc87_second_38 -140;
     pos @kc87_first_18 @kc87_second_41 -105;
     pos @kc87_first_18 @kc87_second_42 -70;
-    pos @kc87_first_18 @kc87_second_44 -35;
-    pos @kc87_first_18 @kc87_second_48 1;
-    pos @kc87_first_18 @kc87_second_53 -35;
-    pos @kc87_first_18 @kc87_second_54 -70;
-    pos @kc87_first_18 @kc87_second_56 -140;
-    pos @kc87_first_18 @kc87_second_58 -175;
-    pos @kc87_first_18 @kc87_second_59 -140;
-    pos @kc87_first_18 @kc87_second_61 -70;
-    pos @kc87_first_18 @kc87_second_66 -105;
-    pos @kc87_first_18 @kc87_second_67 -140;
+    pos @kc87_first_18 @kc87_second_43 -105;
+    pos @kc87_first_18 @kc87_second_44 -70;
+    pos @kc87_first_18 @kc87_second_46 -35;
+    pos @kc87_first_18 @kc87_second_51 1;
+    pos @kc87_first_18 @kc87_second_55 -35;
+    pos @kc87_first_18 @kc87_second_56 -70;
+    pos @kc87_first_18 @kc87_second_58 -140;
+    pos @kc87_first_18 @kc87_second_60 -175;
+    pos @kc87_first_18 @kc87_second_61 -140;
+    pos @kc87_first_18 @kc87_second_63 -70;
+    pos @kc87_first_18 @kc87_second_68 -105;
+    pos @kc87_first_18 @kc87_second_69 -140;
     pos @kc87_first_19 @kc87_second_12 -280;
     pos @kc87_first_19 @kc87_second_14 -175;
     pos @kc87_first_19 @kc87_second_15 -140;
     pos @kc87_first_19 @kc87_second_18 -35;
     pos @kc87_first_19 @kc87_second_31 -35;
     pos @kc87_first_19 @kc87_second_33 -50;
-    pos @kc87_first_19 @kc87_second_48 1;
-    pos @kc87_first_19 @kc87_second_50 -70;
-    pos @kc87_first_19 @kc87_second_51 -140;
-    pos @kc87_first_19 @kc87_second_61 -70;
-    pos @kc87_first_19 @kc87_second_63 -35;
-    pos @kc87_first_19 @kc87_second_64 -105;
-    pos @kc87_first_19 @kc87_second_65 -70;
+    pos @kc87_first_19 @kc87_second_51 1;
+    pos @kc87_first_19 @kc87_second_53 -70;
+    pos @kc87_first_19 @kc87_second_54 -140;
+    pos @kc87_first_19 @kc87_second_63 -70;
+    pos @kc87_first_19 @kc87_second_65 -35;
+    pos @kc87_first_19 @kc87_second_66 -105;
+    pos @kc87_first_19 @kc87_second_67 -70;
     pos @kc87_first_20 @kc87_second_12 -240;
     pos @kc87_first_20 @kc87_second_13 -140;
     pos @kc87_first_20 @kc87_second_14 -105;
     pos @kc87_first_20 @kc87_second_15 -35;
-    pos @kc87_first_20 @kc87_second_48 1;
+    pos @kc87_first_20 @kc87_second_51 1;
     pos @kc87_first_21 @kc87_second_8 -35;
     pos @kc87_first_21 @kc87_second_9 -140;
     pos @kc87_first_21 @kc87_second_12 -280;
@@ -9176,25 +9219,26 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_21 @kc87_second_22 -70;
     pos @kc87_first_21 @kc87_second_27 -70;
     pos @kc87_first_21 @kc87_second_33 -50;
-    pos @kc87_first_21 @kc87_second_42 -140;
-    pos @kc87_first_21 @kc87_second_43 -105;
-    pos @kc87_first_21 @kc87_second_46 -210;
-    pos @kc87_first_21 @kc87_second_48 1;
-    pos @kc87_first_21 @kc87_second_49 -35;
-    pos @kc87_first_21 @kc87_second_50 -140;
-    pos @kc87_first_21 @kc87_second_51 -210;
-    pos @kc87_first_21 @kc87_second_55 -35;
-    pos @kc87_first_21 @kc87_second_61 -105;
+    pos @kc87_first_21 @kc87_second_44 -140;
+    pos @kc87_first_21 @kc87_second_45 -105;
+    pos @kc87_first_21 @kc87_second_47 -210;
+    pos @kc87_first_21 @kc87_second_48 -175;
+    pos @kc87_first_21 @kc87_second_51 1;
+    pos @kc87_first_21 @kc87_second_52 -35;
+    pos @kc87_first_21 @kc87_second_53 -140;
+    pos @kc87_first_21 @kc87_second_54 -210;
+    pos @kc87_first_21 @kc87_second_57 -35;
     pos @kc87_first_21 @kc87_second_63 -105;
-    pos @kc87_first_21 @kc87_second_64 -210;
-    pos @kc87_first_21 @kc87_second_65 -140;
+    pos @kc87_first_21 @kc87_second_65 -105;
+    pos @kc87_first_21 @kc87_second_66 -210;
+    pos @kc87_first_21 @kc87_second_67 -140;
     pos @kc87_first_22 @kc87_second_1 -140;
     pos @kc87_first_22 @kc87_second_2 -350;
     pos @kc87_first_22 @kc87_second_19 -140;
     pos @kc87_first_22 @kc87_second_21 -280;
-    pos @kc87_first_22 @kc87_second_41 -70;
-    pos @kc87_first_22 @kc87_second_48 1;
-    pos @kc87_first_22 @kc87_second_67 -210;
+    pos @kc87_first_22 @kc87_second_43 -70;
+    pos @kc87_first_22 @kc87_second_51 1;
+    pos @kc87_first_22 @kc87_second_69 -210;
     pos @kc87_first_23 @kc87_second_1 -35;
     pos @kc87_first_23 @kc87_second_5 -105;
     pos @kc87_first_23 @kc87_second_9 -70;
@@ -9207,21 +9251,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_23 @kc87_second_27 -35;
     pos @kc87_first_23 @kc87_second_28 -70;
     pos @kc87_first_23 @kc87_second_29 -105;
-    pos @kc87_first_23 @kc87_second_35 -35;
-    pos @kc87_first_23 @kc87_second_38 -70;
-    pos @kc87_first_23 @kc87_second_42 -70;
-    pos @kc87_first_23 @kc87_second_43 -35;
+    pos @kc87_first_23 @kc87_second_36 -35;
+    pos @kc87_first_23 @kc87_second_39 -70;
+    pos @kc87_first_23 @kc87_second_44 -70;
     pos @kc87_first_23 @kc87_second_45 -35;
-    pos @kc87_first_23 @kc87_second_46 -140;
-    pos @kc87_first_23 @kc87_second_48 1;
-    pos @kc87_first_23 @kc87_second_50 -70;
-    pos @kc87_first_23 @kc87_second_51 -175;
-    pos @kc87_first_23 @kc87_second_52 -35;
-    pos @kc87_first_23 @kc87_second_60 -105;
-    pos @kc87_first_23 @kc87_second_61 -35;
-    pos @kc87_first_23 @kc87_second_63 -50;
-    pos @kc87_first_23 @kc87_second_64 -105;
-    pos @kc87_first_23 @kc87_second_65 -70;
+    pos @kc87_first_23 @kc87_second_47 -140;
+    pos @kc87_first_23 @kc87_second_49 -35;
+    pos @kc87_first_23 @kc87_second_50 -35;
+    pos @kc87_first_23 @kc87_second_51 1;
+    pos @kc87_first_23 @kc87_second_53 -70;
+    pos @kc87_first_23 @kc87_second_54 -175;
+    pos @kc87_first_23 @kc87_second_62 -105;
+    pos @kc87_first_23 @kc87_second_63 -35;
+    pos @kc87_first_23 @kc87_second_65 -50;
+    pos @kc87_first_23 @kc87_second_66 -105;
+    pos @kc87_first_23 @kc87_second_67 -70;
     pos @kc87_first_24 @kc87_second_6 -35;
     pos @kc87_first_24 @kc87_second_12 -240;
     pos @kc87_first_24 @kc87_second_13 -175;
@@ -9230,17 +9274,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_24 @kc87_second_18 -70;
     pos @kc87_first_24 @kc87_second_24 -70;
     pos @kc87_first_24 @kc87_second_25 -35;
-    pos @kc87_first_24 @kc87_second_37 -35;
-    pos @kc87_first_24 @kc87_second_42 -35;
-    pos @kc87_first_24 @kc87_second_43 -35;
-    pos @kc87_first_24 @kc87_second_46 -70;
-    pos @kc87_first_24 @kc87_second_47 -35;
-    pos @kc87_first_24 @kc87_second_48 1;
-    pos @kc87_first_24 @kc87_second_51 -35;
-    pos @kc87_first_24 @kc87_second_61 -35;
-    pos @kc87_first_24 @kc87_second_65 -35;
-    pos @kc87_first_24 @kc87_second_66 -35;
+    pos @kc87_first_24 @kc87_second_38 -35;
+    pos @kc87_first_24 @kc87_second_40 -35;
+    pos @kc87_first_24 @kc87_second_44 -35;
+    pos @kc87_first_24 @kc87_second_45 -35;
+    pos @kc87_first_24 @kc87_second_47 -70;
+    pos @kc87_first_24 @kc87_second_51 1;
+    pos @kc87_first_24 @kc87_second_54 -35;
+    pos @kc87_first_24 @kc87_second_63 -35;
     pos @kc87_first_24 @kc87_second_67 -35;
+    pos @kc87_first_24 @kc87_second_68 -35;
+    pos @kc87_first_24 @kc87_second_69 -35;
     pos @kc87_first_25 @kc87_second_1 -70;
     pos @kc87_first_25 @kc87_second_2 -140;
     pos @kc87_first_25 @kc87_second_5 -105;
@@ -9253,19 +9297,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_25 @kc87_second_21 -70;
     pos @kc87_first_25 @kc87_second_28 -70;
     pos @kc87_first_25 @kc87_second_29 -70;
-    pos @kc87_first_25 @kc87_second_34 -70;
-    pos @kc87_first_25 @kc87_second_38 -70;
-    pos @kc87_first_25 @kc87_second_45 -35;
-    pos @kc87_first_25 @kc87_second_46 -140;
-    pos @kc87_first_25 @kc87_second_48 1;
-    pos @kc87_first_25 @kc87_second_51 -140;
-    pos @kc87_first_25 @kc87_second_52 -35;
-    pos @kc87_first_25 @kc87_second_56 -140;
-    pos @kc87_first_25 @kc87_second_58 -70;
-    pos @kc87_first_25 @kc87_second_59 -105;
+    pos @kc87_first_25 @kc87_second_35 -70;
+    pos @kc87_first_25 @kc87_second_39 -70;
+    pos @kc87_first_25 @kc87_second_47 -140;
+    pos @kc87_first_25 @kc87_second_49 -35;
+    pos @kc87_first_25 @kc87_second_50 -35;
+    pos @kc87_first_25 @kc87_second_51 1;
+    pos @kc87_first_25 @kc87_second_54 -140;
+    pos @kc87_first_25 @kc87_second_58 -140;
     pos @kc87_first_25 @kc87_second_60 -70;
-    pos @kc87_first_25 @kc87_second_64 -70;
-    pos @kc87_first_25 @kc87_second_65 -35;
+    pos @kc87_first_25 @kc87_second_61 -105;
+    pos @kc87_first_25 @kc87_second_62 -70;
+    pos @kc87_first_25 @kc87_second_66 -70;
+    pos @kc87_first_25 @kc87_second_67 -35;
     pos @kc87_first_26 @kc87_second_5 -70;
     pos @kc87_first_26 @kc87_second_9 -70;
     pos @kc87_first_26 @kc87_second_12 -240;
@@ -9276,32 +9320,33 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_26 @kc87_second_27 -35;
     pos @kc87_first_26 @kc87_second_28 -70;
     pos @kc87_first_26 @kc87_second_29 -70;
-    pos @kc87_first_26 @kc87_second_38 -70;
-    pos @kc87_first_26 @kc87_second_42 -70;
-    pos @kc87_first_26 @kc87_second_43 -35;
-    pos @kc87_first_26 @kc87_second_46 -140;
-    pos @kc87_first_26 @kc87_second_48 1;
-    pos @kc87_first_26 @kc87_second_50 -70;
-    pos @kc87_first_26 @kc87_second_51 -140;
-    pos @kc87_first_26 @kc87_second_52 -35;
-    pos @kc87_first_26 @kc87_second_56 -50;
-    pos @kc87_first_26 @kc87_second_57 -35;
+    pos @kc87_first_26 @kc87_second_39 -70;
+    pos @kc87_first_26 @kc87_second_44 -70;
+    pos @kc87_first_26 @kc87_second_45 -35;
+    pos @kc87_first_26 @kc87_second_47 -140;
+    pos @kc87_first_26 @kc87_second_48 -105;
+    pos @kc87_first_26 @kc87_second_50 -35;
+    pos @kc87_first_26 @kc87_second_51 1;
+    pos @kc87_first_26 @kc87_second_53 -70;
+    pos @kc87_first_26 @kc87_second_54 -140;
     pos @kc87_first_26 @kc87_second_58 -50;
-    pos @kc87_first_26 @kc87_second_59 -50;
-    pos @kc87_first_26 @kc87_second_60 -105;
+    pos @kc87_first_26 @kc87_second_59 -35;
+    pos @kc87_first_26 @kc87_second_60 -50;
     pos @kc87_first_26 @kc87_second_61 -50;
-    pos @kc87_first_26 @kc87_second_63 -35;
-    pos @kc87_first_26 @kc87_second_64 -105;
-    pos @kc87_first_26 @kc87_second_65 -70;
+    pos @kc87_first_26 @kc87_second_62 -105;
+    pos @kc87_first_26 @kc87_second_63 -50;
+    pos @kc87_first_26 @kc87_second_65 -35;
+    pos @kc87_first_26 @kc87_second_66 -105;
+    pos @kc87_first_26 @kc87_second_67 -70;
     pos @kc87_first_27 @kc87_second_9 -35;
     pos @kc87_first_27 @kc87_second_12 -140;
     pos @kc87_first_27 @kc87_second_28 -70;
-    pos @kc87_first_27 @kc87_second_42 -35;
-    pos @kc87_first_27 @kc87_second_46 -70;
-    pos @kc87_first_27 @kc87_second_48 1;
-    pos @kc87_first_27 @kc87_second_51 -70;
-    pos @kc87_first_27 @kc87_second_64 -70;
-    pos @kc87_first_27 @kc87_second_65 -35;
+    pos @kc87_first_27 @kc87_second_44 -35;
+    pos @kc87_first_27 @kc87_second_47 -70;
+    pos @kc87_first_27 @kc87_second_51 1;
+    pos @kc87_first_27 @kc87_second_54 -70;
+    pos @kc87_first_27 @kc87_second_66 -70;
+    pos @kc87_first_27 @kc87_second_67 -35;
     pos @kc87_first_28 @kc87_second_5 -50;
     pos @kc87_first_28 @kc87_second_9 -35;
     pos @kc87_first_28 @kc87_second_11 -35;
@@ -9312,18 +9357,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_28 @kc87_second_16 -35;
     pos @kc87_first_28 @kc87_second_28 -35;
     pos @kc87_first_28 @kc87_second_29 -35;
-    pos @kc87_first_28 @kc87_second_35 -35;
-    pos @kc87_first_28 @kc87_second_38 -35;
-    pos @kc87_first_28 @kc87_second_42 -50;
-    pos @kc87_first_28 @kc87_second_43 -35;
-    pos @kc87_first_28 @kc87_second_46 -100;
-    pos @kc87_first_28 @kc87_second_48 1;
-    pos @kc87_first_28 @kc87_second_50 -35;
-    pos @kc87_first_28 @kc87_second_51 -140;
-    pos @kc87_first_28 @kc87_second_60 -35;
-    pos @kc87_first_28 @kc87_second_64 -70;
-    pos @kc87_first_28 @kc87_second_65 -35;
-    pos @kc87_first_29 @kc87_second_48 1;
+    pos @kc87_first_28 @kc87_second_36 -35;
+    pos @kc87_first_28 @kc87_second_39 -35;
+    pos @kc87_first_28 @kc87_second_44 -50;
+    pos @kc87_first_28 @kc87_second_45 -35;
+    pos @kc87_first_28 @kc87_second_47 -100;
+    pos @kc87_first_28 @kc87_second_48 -35;
+    pos @kc87_first_28 @kc87_second_51 1;
+    pos @kc87_first_28 @kc87_second_53 -35;
+    pos @kc87_first_28 @kc87_second_54 -140;
+    pos @kc87_first_28 @kc87_second_62 -35;
+    pos @kc87_first_28 @kc87_second_66 -70;
+    pos @kc87_first_28 @kc87_second_67 -35;
+    pos @kc87_first_29 @kc87_second_51 1;
     pos @kc87_first_30 @kc87_second_8 -70;
     pos @kc87_first_30 @kc87_second_9 -210;
     pos @kc87_first_30 @kc87_second_12 -350;
@@ -9331,17 +9377,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_30 @kc87_second_14 -210;
     pos @kc87_first_30 @kc87_second_15 -175;
     pos @kc87_first_30 @kc87_second_27 -70;
-    pos @kc87_first_30 @kc87_second_41 -35;
-    pos @kc87_first_30 @kc87_second_42 -210;
-    pos @kc87_first_30 @kc87_second_43 -210;
-    pos @kc87_first_30 @kc87_second_46 -210;
-    pos @kc87_first_30 @kc87_second_48 1;
-    pos @kc87_first_30 @kc87_second_50 -140;
-    pos @kc87_first_30 @kc87_second_51 -280;
-    pos @kc87_first_30 @kc87_second_61 -210;
-    pos @kc87_first_30 @kc87_second_63 -105;
-    pos @kc87_first_30 @kc87_second_64 -175;
-    pos @kc87_first_30 @kc87_second_65 -140;
+    pos @kc87_first_30 @kc87_second_43 -35;
+    pos @kc87_first_30 @kc87_second_44 -210;
+    pos @kc87_first_30 @kc87_second_45 -210;
+    pos @kc87_first_30 @kc87_second_47 -210;
+    pos @kc87_first_30 @kc87_second_51 1;
+    pos @kc87_first_30 @kc87_second_53 -140;
+    pos @kc87_first_30 @kc87_second_54 -280;
+    pos @kc87_first_30 @kc87_second_63 -210;
+    pos @kc87_first_30 @kc87_second_65 -105;
+    pos @kc87_first_30 @kc87_second_66 -175;
+    pos @kc87_first_30 @kc87_second_67 -140;
     pos @kc87_first_31 @kc87_second_1 -175;
     pos @kc87_first_31 @kc87_second_2 -175;
     pos @kc87_first_31 @kc87_second_5 -70;
@@ -9359,16 +9405,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_31 @kc87_second_21 -175;
     pos @kc87_first_31 @kc87_second_24 -70;
     pos @kc87_first_31 @kc87_second_31 -105;
-    pos @kc87_first_31 @kc87_second_36 180;
-    pos @kc87_first_31 @kc87_second_37 -105;
-    pos @kc87_first_31 @kc87_second_38 -175;
-    pos @kc87_first_31 @kc87_second_39 -35;
-    pos @kc87_first_31 @kc87_second_41 -70;
-    pos @kc87_first_31 @kc87_second_48 1;
-    pos @kc87_first_31 @kc87_second_53 180;
-    pos @kc87_first_31 @kc87_second_54 -35;
-    pos @kc87_first_31 @kc87_second_66 -70;
-    pos @kc87_first_31 @kc87_second_67 -105;
+    pos @kc87_first_31 @kc87_second_37 180;
+    pos @kc87_first_31 @kc87_second_38 -105;
+    pos @kc87_first_31 @kc87_second_39 -175;
+    pos @kc87_first_31 @kc87_second_41 -35;
+    pos @kc87_first_31 @kc87_second_43 -70;
+    pos @kc87_first_31 @kc87_second_51 1;
+    pos @kc87_first_31 @kc87_second_55 180;
+    pos @kc87_first_31 @kc87_second_56 -35;
+    pos @kc87_first_31 @kc87_second_68 -70;
+    pos @kc87_first_31 @kc87_second_69 -105;
     pos @kc87_first_32 @kc87_second_3 -70;
     pos @kc87_first_32 @kc87_second_4 -35;
     pos @kc87_first_32 @kc87_second_6 -70;
@@ -9379,16 +9425,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_32 @kc87_second_24 -70;
     pos @kc87_first_32 @kc87_second_25 -140;
     pos @kc87_first_32 @kc87_second_31 -35;
-    pos @kc87_first_32 @kc87_second_37 -70;
-    pos @kc87_first_32 @kc87_second_39 -35;
-    pos @kc87_first_32 @kc87_second_41 -140;
-    pos @kc87_first_32 @kc87_second_42 -70;
-    pos @kc87_first_32 @kc87_second_48 1;
-    pos @kc87_first_32 @kc87_second_54 -35;
-    pos @kc87_first_32 @kc87_second_55 -35;
-    pos @kc87_first_32 @kc87_second_61 -140;
-    pos @kc87_first_32 @kc87_second_66 -70;
-    pos @kc87_first_32 @kc87_second_67 -70;
+    pos @kc87_first_32 @kc87_second_38 -70;
+    pos @kc87_first_32 @kc87_second_41 -35;
+    pos @kc87_first_32 @kc87_second_43 -140;
+    pos @kc87_first_32 @kc87_second_44 -70;
+    pos @kc87_first_32 @kc87_second_51 1;
+    pos @kc87_first_32 @kc87_second_56 -35;
+    pos @kc87_first_32 @kc87_second_57 -35;
+    pos @kc87_first_32 @kc87_second_63 -140;
+    pos @kc87_first_32 @kc87_second_68 -70;
+    pos @kc87_first_32 @kc87_second_69 -70;
     pos @kc87_first_33 @kc87_second_1 -35;
     pos @kc87_first_33 @kc87_second_2 -105;
     pos @kc87_first_33 @kc87_second_3 -70;
@@ -9403,21 +9449,22 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_33 @kc87_second_19 -70;
     pos @kc87_first_33 @kc87_second_26 -35;
     pos @kc87_first_33 @kc87_second_29 -70;
-    pos @kc87_first_33 @kc87_second_35 -35;
-    pos @kc87_first_33 @kc87_second_38 -35;
-    pos @kc87_first_33 @kc87_second_42 -35;
-    pos @kc87_first_33 @kc87_second_43 -35;
+    pos @kc87_first_33 @kc87_second_36 -35;
+    pos @kc87_first_33 @kc87_second_39 -35;
+    pos @kc87_first_33 @kc87_second_44 -35;
     pos @kc87_first_33 @kc87_second_45 -35;
-    pos @kc87_first_33 @kc87_second_46 -140;
-    pos @kc87_first_33 @kc87_second_48 1;
-    pos @kc87_first_33 @kc87_second_50 -50;
-    pos @kc87_first_33 @kc87_second_51 -140;
-    pos @kc87_first_33 @kc87_second_52 -35;
-    pos @kc87_first_33 @kc87_second_56 -70;
+    pos @kc87_first_33 @kc87_second_47 -140;
+    pos @kc87_first_33 @kc87_second_48 -70;
+    pos @kc87_first_33 @kc87_second_49 -35;
+    pos @kc87_first_33 @kc87_second_50 -35;
+    pos @kc87_first_33 @kc87_second_51 1;
+    pos @kc87_first_33 @kc87_second_53 -50;
+    pos @kc87_first_33 @kc87_second_54 -140;
     pos @kc87_first_33 @kc87_second_58 -70;
-    pos @kc87_first_33 @kc87_second_59 -70;
-    pos @kc87_first_33 @kc87_second_64 -70;
-    pos @kc87_first_33 @kc87_second_65 -35;
+    pos @kc87_first_33 @kc87_second_60 -70;
+    pos @kc87_first_33 @kc87_second_61 -70;
+    pos @kc87_first_33 @kc87_second_66 -70;
+    pos @kc87_first_33 @kc87_second_67 -35;
     pos @kc87_first_34 @kc87_second_3 -35;
     pos @kc87_first_34 @kc87_second_4 -70;
     pos @kc87_first_34 @kc87_second_6 -70;
@@ -9431,35 +9478,36 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_34 @kc87_second_24 -105;
     pos @kc87_first_34 @kc87_second_25 -70;
     pos @kc87_first_34 @kc87_second_31 -35;
-    pos @kc87_first_34 @kc87_second_37 -70;
-    pos @kc87_first_34 @kc87_second_39 -70;
-    pos @kc87_first_34 @kc87_second_41 -105;
-    pos @kc87_first_34 @kc87_second_42 -70;
-    pos @kc87_first_34 @kc87_second_47 -70;
-    pos @kc87_first_34 @kc87_second_48 1;
-    pos @kc87_first_34 @kc87_second_54 -35;
-    pos @kc87_first_34 @kc87_second_55 -35;
-    pos @kc87_first_34 @kc87_second_66 -70;
-    pos @kc87_first_34 @kc87_second_67 -70;
-    pos @kc87_first_35 @kc87_second_34 -315;
-    pos @kc87_first_35 @kc87_second_48 1;
+    pos @kc87_first_34 @kc87_second_34 -70;
+    pos @kc87_first_34 @kc87_second_38 -70;
+    pos @kc87_first_34 @kc87_second_40 -70;
+    pos @kc87_first_34 @kc87_second_41 -70;
+    pos @kc87_first_34 @kc87_second_43 -105;
+    pos @kc87_first_34 @kc87_second_44 -70;
+    pos @kc87_first_34 @kc87_second_51 1;
+    pos @kc87_first_34 @kc87_second_56 -35;
+    pos @kc87_first_34 @kc87_second_57 -35;
+    pos @kc87_first_34 @kc87_second_68 -70;
+    pos @kc87_first_34 @kc87_second_69 -70;
+    pos @kc87_first_35 @kc87_second_35 -315;
+    pos @kc87_first_35 @kc87_second_51 1;
     pos @kc87_first_36 @kc87_second_9 -70;
     pos @kc87_first_36 @kc87_second_12 -240;
     pos @kc87_first_36 @kc87_second_13 -210;
     pos @kc87_first_36 @kc87_second_14 -140;
     pos @kc87_first_36 @kc87_second_15 -105;
-    pos @kc87_first_36 @kc87_second_36 100;
-    pos @kc87_first_36 @kc87_second_42 -70;
-    pos @kc87_first_36 @kc87_second_43 -35;
-    pos @kc87_first_36 @kc87_second_46 -140;
-    pos @kc87_first_36 @kc87_second_48 1;
-    pos @kc87_first_36 @kc87_second_50 -50;
-    pos @kc87_first_36 @kc87_second_51 -140;
-    pos @kc87_first_36 @kc87_second_53 100;
-    pos @kc87_first_36 @kc87_second_61 -35;
+    pos @kc87_first_36 @kc87_second_37 100;
+    pos @kc87_first_36 @kc87_second_44 -70;
+    pos @kc87_first_36 @kc87_second_45 -35;
+    pos @kc87_first_36 @kc87_second_47 -140;
+    pos @kc87_first_36 @kc87_second_51 1;
+    pos @kc87_first_36 @kc87_second_53 -50;
+    pos @kc87_first_36 @kc87_second_54 -140;
+    pos @kc87_first_36 @kc87_second_55 100;
     pos @kc87_first_36 @kc87_second_63 -35;
-    pos @kc87_first_36 @kc87_second_64 -70;
-    pos @kc87_first_36 @kc87_second_65 -70;
+    pos @kc87_first_36 @kc87_second_65 -35;
+    pos @kc87_first_36 @kc87_second_66 -70;
+    pos @kc87_first_36 @kc87_second_67 -70;
     pos @kc87_first_37 @kc87_second_9 -35;
     pos @kc87_first_37 @kc87_second_12 -240;
     pos @kc87_first_37 @kc87_second_13 -240;
@@ -9468,15 +9516,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_37 @kc87_second_16 -35;
     pos @kc87_first_37 @kc87_second_28 -35;
     pos @kc87_first_37 @kc87_second_29 -35;
-    pos @kc87_first_37 @kc87_second_42 -70;
-    pos @kc87_first_37 @kc87_second_43 -35;
-    pos @kc87_first_37 @kc87_second_46 -70;
-    pos @kc87_first_37 @kc87_second_48 1;
-    pos @kc87_first_37 @kc87_second_50 -35;
-    pos @kc87_first_37 @kc87_second_51 -70;
-    pos @kc87_first_37 @kc87_second_63 -35;
-    pos @kc87_first_37 @kc87_second_64 -70;
-    pos @kc87_first_37 @kc87_second_65 -70;
+    pos @kc87_first_37 @kc87_second_44 -70;
+    pos @kc87_first_37 @kc87_second_45 -35;
+    pos @kc87_first_37 @kc87_second_47 -70;
+    pos @kc87_first_37 @kc87_second_48 -35;
+    pos @kc87_first_37 @kc87_second_51 1;
+    pos @kc87_first_37 @kc87_second_53 -35;
+    pos @kc87_first_37 @kc87_second_54 -70;
+    pos @kc87_first_37 @kc87_second_65 -35;
+    pos @kc87_first_37 @kc87_second_66 -70;
+    pos @kc87_first_37 @kc87_second_67 -70;
     pos @kc87_first_38 @kc87_second_5 -70;
     pos @kc87_first_38 @kc87_second_9 -70;
     pos @kc87_first_38 @kc87_second_12 -140;
@@ -9486,665 +9535,681 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_38 @kc87_second_16 -70;
     pos @kc87_first_38 @kc87_second_28 -70;
     pos @kc87_first_38 @kc87_second_29 -70;
-    pos @kc87_first_38 @kc87_second_38 -50;
-    pos @kc87_first_38 @kc87_second_42 -50;
-    pos @kc87_first_38 @kc87_second_43 -35;
-    pos @kc87_first_38 @kc87_second_48 1;
-    pos @kc87_first_38 @kc87_second_50 -35;
-    pos @kc87_first_38 @kc87_second_51 -140;
-    pos @kc87_first_38 @kc87_second_60 -35;
-    pos @kc87_first_38 @kc87_second_64 -70;
-    pos @kc87_first_38 @kc87_second_65 -35;
-    pos @kc87_first_39 @kc87_second_1 -210;
-    pos @kc87_first_39 @kc87_second_2 -280;
-    pos @kc87_first_39 @kc87_second_6 -280;
-    pos @kc87_first_39 @kc87_second_8 -70;
-    pos @kc87_first_39 @kc87_second_17 -140;
-    pos @kc87_first_39 @kc87_second_18 -140;
-    pos @kc87_first_39 @kc87_second_19 -245;
-    pos @kc87_first_39 @kc87_second_21 -350;
-    pos @kc87_first_39 @kc87_second_22 -140;
-    pos @kc87_first_39 @kc87_second_24 -140;
-    pos @kc87_first_39 @kc87_second_25 -70;
-    pos @kc87_first_39 @kc87_second_26 -280;
-    pos @kc87_first_39 @kc87_second_30 -315;
-    pos @kc87_first_39 @kc87_second_31 -140;
-    pos @kc87_first_39 @kc87_second_34 -385;
-    pos @kc87_first_39 @kc87_second_35 -140;
-    pos @kc87_first_39 @kc87_second_37 -210;
+    pos @kc87_first_38 @kc87_second_39 -50;
+    pos @kc87_first_38 @kc87_second_44 -50;
+    pos @kc87_first_38 @kc87_second_45 -35;
+    pos @kc87_first_38 @kc87_second_51 1;
+    pos @kc87_first_38 @kc87_second_53 -35;
+    pos @kc87_first_38 @kc87_second_54 -140;
+    pos @kc87_first_38 @kc87_second_62 -35;
+    pos @kc87_first_38 @kc87_second_66 -70;
+    pos @kc87_first_38 @kc87_second_67 -35;
+    pos @kc87_first_39 @kc87_second_3 -140;
+    pos @kc87_first_39 @kc87_second_4 -70;
+    pos @kc87_first_39 @kc87_second_6 -70;
+    pos @kc87_first_39 @kc87_second_8 -210;
+    pos @kc87_first_39 @kc87_second_9 -420;
+    pos @kc87_first_39 @kc87_second_12 -350;
+    pos @kc87_first_39 @kc87_second_13 -420;
+    pos @kc87_first_39 @kc87_second_14 -350;
+    pos @kc87_first_39 @kc87_second_15 -280;
+    pos @kc87_first_39 @kc87_second_17 -70;
+    pos @kc87_first_39 @kc87_second_18 -70;
+    pos @kc87_first_39 @kc87_second_20 -210;
+    pos @kc87_first_39 @kc87_second_22 -210;
+    pos @kc87_first_39 @kc87_second_24 -70;
+    pos @kc87_first_39 @kc87_second_25 -140;
+    pos @kc87_first_39 @kc87_second_31 -35;
+    pos @kc87_first_39 @kc87_second_33 -140;
     pos @kc87_first_39 @kc87_second_38 -70;
-    pos @kc87_first_39 @kc87_second_39 -140;
-    pos @kc87_first_39 @kc87_second_40 -140;
-    pos @kc87_first_39 @kc87_second_41 -140;
-    pos @kc87_first_39 @kc87_second_42 -70;
-    pos @kc87_first_39 @kc87_second_44 -70;
-    pos @kc87_first_39 @kc87_second_48 1;
-    pos @kc87_first_39 @kc87_second_54 -140;
-    pos @kc87_first_39 @kc87_second_55 -70;
-    pos @kc87_first_39 @kc87_second_56 -140;
-    pos @kc87_first_39 @kc87_second_58 -245;
-    pos @kc87_first_39 @kc87_second_59 -210;
-    pos @kc87_first_39 @kc87_second_60 -70;
-    pos @kc87_first_39 @kc87_second_61 -70;
-    pos @kc87_first_39 @kc87_second_62 -70;
-    pos @kc87_first_39 @kc87_second_63 -70;
-    pos @kc87_first_39 @kc87_second_66 -245;
-    pos @kc87_first_39 @kc87_second_67 -280;
-    pos @kc87_first_39 @kc87_second_68 -315;
+    pos @kc87_first_39 @kc87_second_41 -70;
+    pos @kc87_first_39 @kc87_second_43 -210;
+    pos @kc87_first_39 @kc87_second_44 -280;
+    pos @kc87_first_39 @kc87_second_45 -420;
+    pos @kc87_first_39 @kc87_second_47 -350;
+    pos @kc87_first_39 @kc87_second_48 -280;
+    pos @kc87_first_39 @kc87_second_51 1;
+    pos @kc87_first_39 @kc87_second_52 -35;
+    pos @kc87_first_39 @kc87_second_53 -210;
+    pos @kc87_first_39 @kc87_second_54 -350;
+    pos @kc87_first_39 @kc87_second_56 -35;
+    pos @kc87_first_39 @kc87_second_57 -35;
+    pos @kc87_first_39 @kc87_second_63 -280;
+    pos @kc87_first_39 @kc87_second_65 -175;
+    pos @kc87_first_39 @kc87_second_66 -280;
+    pos @kc87_first_39 @kc87_second_67 -210;
+    pos @kc87_first_39 @kc87_second_68 -70;
+    pos @kc87_first_40 @kc87_second_1 -35;
+    pos @kc87_first_40 @kc87_second_2 -70;
+    pos @kc87_first_40 @kc87_second_5 -105;
     pos @kc87_first_40 @kc87_second_6 -35;
+    pos @kc87_first_40 @kc87_second_9 -70;
+    pos @kc87_first_40 @kc87_second_11 -70;
     pos @kc87_first_40 @kc87_second_12 -240;
-    pos @kc87_first_40 @kc87_second_13 -140;
-    pos @kc87_first_40 @kc87_second_14 -35;
-    pos @kc87_first_40 @kc87_second_15 -35;
-    pos @kc87_first_40 @kc87_second_36 100;
-    pos @kc87_first_40 @kc87_second_37 -35;
-    pos @kc87_first_40 @kc87_second_48 1;
-    pos @kc87_first_40 @kc87_second_53 100;
-    pos @kc87_first_40 @kc87_second_66 -35;
-    pos @kc87_first_40 @kc87_second_67 -35;
-    pos @kc87_first_41 @kc87_second_12 -210;
-    pos @kc87_first_41 @kc87_second_13 -175;
-    pos @kc87_first_41 @kc87_second_14 -105;
-    pos @kc87_first_41 @kc87_second_15 -70;
+    pos @kc87_first_40 @kc87_second_13 -245;
+    pos @kc87_first_40 @kc87_second_14 -140;
+    pos @kc87_first_40 @kc87_second_15 -105;
+    pos @kc87_first_40 @kc87_second_16 -105;
+    pos @kc87_first_40 @kc87_second_19 -35;
+    pos @kc87_first_40 @kc87_second_20 -70;
+    pos @kc87_first_40 @kc87_second_21 -70;
+    pos @kc87_first_40 @kc87_second_26 -35;
+    pos @kc87_first_40 @kc87_second_27 -70;
+    pos @kc87_first_40 @kc87_second_28 -140;
+    pos @kc87_first_40 @kc87_second_29 -105;
+    pos @kc87_first_40 @kc87_second_36 -35;
+    pos @kc87_first_40 @kc87_second_38 -35;
+    pos @kc87_first_40 @kc87_second_39 -140;
+    pos @kc87_first_40 @kc87_second_44 -105;
+    pos @kc87_first_40 @kc87_second_45 -70;
+    pos @kc87_first_40 @kc87_second_47 -175;
+    pos @kc87_first_40 @kc87_second_49 -105;
+    pos @kc87_first_40 @kc87_second_50 -70;
+    pos @kc87_first_40 @kc87_second_51 1;
+    pos @kc87_first_40 @kc87_second_53 -70;
+    pos @kc87_first_40 @kc87_second_54 -140;
+    pos @kc87_first_40 @kc87_second_58 -210;
+    pos @kc87_first_40 @kc87_second_59 -70;
+    pos @kc87_first_40 @kc87_second_60 -175;
+    pos @kc87_first_40 @kc87_second_61 -175;
+    pos @kc87_first_40 @kc87_second_62 -105;
+    pos @kc87_first_40 @kc87_second_65 -50;
+    pos @kc87_first_40 @kc87_second_66 -105;
+    pos @kc87_first_40 @kc87_second_67 -70;
+    pos @kc87_first_40 @kc87_second_69 -35;
+    pos @kc87_first_41 @kc87_second_1 -210;
+    pos @kc87_first_41 @kc87_second_2 -280;
+    pos @kc87_first_41 @kc87_second_6 -280;
+    pos @kc87_first_41 @kc87_second_8 -70;
+    pos @kc87_first_41 @kc87_second_17 -140;
+    pos @kc87_first_41 @kc87_second_18 -140;
+    pos @kc87_first_41 @kc87_second_19 -245;
+    pos @kc87_first_41 @kc87_second_21 -350;
+    pos @kc87_first_41 @kc87_second_22 -140;
+    pos @kc87_first_41 @kc87_second_24 -140;
+    pos @kc87_first_41 @kc87_second_25 -70;
+    pos @kc87_first_41 @kc87_second_26 -280;
+    pos @kc87_first_41 @kc87_second_30 -315;
+    pos @kc87_first_41 @kc87_second_31 -140;
+    pos @kc87_first_41 @kc87_second_35 -385;
+    pos @kc87_first_41 @kc87_second_36 -140;
+    pos @kc87_first_41 @kc87_second_38 -210;
+    pos @kc87_first_41 @kc87_second_39 -70;
+    pos @kc87_first_41 @kc87_second_41 -140;
+    pos @kc87_first_41 @kc87_second_42 -140;
+    pos @kc87_first_41 @kc87_second_43 -140;
+    pos @kc87_first_41 @kc87_second_44 -70;
     pos @kc87_first_41 @kc87_second_46 -70;
-    pos @kc87_first_41 @kc87_second_48 1;
-    pos @kc87_first_41 @kc87_second_51 -105;
+    pos @kc87_first_41 @kc87_second_51 1;
+    pos @kc87_first_41 @kc87_second_56 -140;
+    pos @kc87_first_41 @kc87_second_57 -70;
+    pos @kc87_first_41 @kc87_second_58 -140;
+    pos @kc87_first_41 @kc87_second_60 -245;
+    pos @kc87_first_41 @kc87_second_61 -210;
+    pos @kc87_first_41 @kc87_second_62 -70;
+    pos @kc87_first_41 @kc87_second_63 -70;
     pos @kc87_first_41 @kc87_second_64 -70;
-    pos @kc87_first_42 @kc87_second_1 -140;
-    pos @kc87_first_42 @kc87_second_2 -175;
-    pos @kc87_first_42 @kc87_second_5 -105;
-    pos @kc87_first_42 @kc87_second_6 -70;
-    pos @kc87_first_42 @kc87_second_11 -70;
-    pos @kc87_first_42 @kc87_second_12 -175;
-    pos @kc87_first_42 @kc87_second_13 -105;
-    pos @kc87_first_42 @kc87_second_14 -70;
+    pos @kc87_first_41 @kc87_second_65 -70;
+    pos @kc87_first_41 @kc87_second_68 -245;
+    pos @kc87_first_41 @kc87_second_69 -280;
+    pos @kc87_first_41 @kc87_second_70 -315;
+    pos @kc87_first_42 @kc87_second_6 -35;
+    pos @kc87_first_42 @kc87_second_12 -240;
+    pos @kc87_first_42 @kc87_second_13 -140;
+    pos @kc87_first_42 @kc87_second_14 -35;
     pos @kc87_first_42 @kc87_second_15 -35;
-    pos @kc87_first_42 @kc87_second_16 -105;
-    pos @kc87_first_42 @kc87_second_17 -35;
-    pos @kc87_first_42 @kc87_second_18 -50;
-    pos @kc87_first_42 @kc87_second_19 -140;
-    pos @kc87_first_42 @kc87_second_21 -175;
-    pos @kc87_first_42 @kc87_second_24 -50;
-    pos @kc87_first_42 @kc87_second_26 -105;
-    pos @kc87_first_42 @kc87_second_31 -35;
-    pos @kc87_first_42 @kc87_second_34 -70;
-    pos @kc87_first_42 @kc87_second_35 -50;
-    pos @kc87_first_42 @kc87_second_37 -70;
-    pos @kc87_first_42 @kc87_second_38 -140;
-    pos @kc87_first_42 @kc87_second_39 -35;
-    pos @kc87_first_42 @kc87_second_41 -50;
-    pos @kc87_first_42 @kc87_second_48 1;
-    pos @kc87_first_42 @kc87_second_54 -35;
-    pos @kc87_first_42 @kc87_second_56 -105;
-    pos @kc87_first_42 @kc87_second_58 -105;
-    pos @kc87_first_42 @kc87_second_59 -105;
-    pos @kc87_first_42 @kc87_second_66 -50;
-    pos @kc87_first_42 @kc87_second_67 -70;
-    pos @kc87_first_43 @kc87_second_1 -210;
-    pos @kc87_first_43 @kc87_second_2 -280;
-    pos @kc87_first_43 @kc87_second_3 -70;
-    pos @kc87_first_43 @kc87_second_6 -280;
-    pos @kc87_first_43 @kc87_second_8 -35;
-    pos @kc87_first_43 @kc87_second_11 -70;
-    pos @kc87_first_43 @kc87_second_13 -140;
-    pos @kc87_first_43 @kc87_second_14 -35;
-    pos @kc87_first_43 @kc87_second_15 -35;
-    pos @kc87_first_43 @kc87_second_16 -140;
-    pos @kc87_first_43 @kc87_second_17 -105;
-    pos @kc87_first_43 @kc87_second_18 -140;
-    pos @kc87_first_43 @kc87_second_19 -210;
-    pos @kc87_first_43 @kc87_second_21 -280;
-    pos @kc87_first_43 @kc87_second_22 -140;
-    pos @kc87_first_43 @kc87_second_24 -140;
-    pos @kc87_first_43 @kc87_second_25 -140;
-    pos @kc87_first_43 @kc87_second_26 -210;
-    pos @kc87_first_43 @kc87_second_34 -140;
-    pos @kc87_first_43 @kc87_second_35 -140;
-    pos @kc87_first_43 @kc87_second_37 -280;
-    pos @kc87_first_43 @kc87_second_38 -140;
-    pos @kc87_first_43 @kc87_second_39 -70;
-    pos @kc87_first_43 @kc87_second_40 -140;
-    pos @kc87_first_43 @kc87_second_41 -175;
+    pos @kc87_first_42 @kc87_second_37 100;
+    pos @kc87_first_42 @kc87_second_38 -35;
+    pos @kc87_first_42 @kc87_second_51 1;
+    pos @kc87_first_42 @kc87_second_55 100;
+    pos @kc87_first_42 @kc87_second_68 -35;
+    pos @kc87_first_42 @kc87_second_69 -35;
+    pos @kc87_first_43 @kc87_second_12 -210;
+    pos @kc87_first_43 @kc87_second_13 -175;
+    pos @kc87_first_43 @kc87_second_14 -105;
+    pos @kc87_first_43 @kc87_second_15 -70;
     pos @kc87_first_43 @kc87_second_47 -70;
-    pos @kc87_first_43 @kc87_second_48 1;
-    pos @kc87_first_43 @kc87_second_56 -210;
-    pos @kc87_first_43 @kc87_second_58 -210;
-    pos @kc87_first_43 @kc87_second_59 -175;
-    pos @kc87_first_43 @kc87_second_62 -70;
-    pos @kc87_first_43 @kc87_second_66 -175;
-    pos @kc87_first_43 @kc87_second_67 -175;
-    pos @kc87_first_44 @kc87_second_9 -70;
-    pos @kc87_first_44 @kc87_second_12 -240;
-    pos @kc87_first_44 @kc87_second_13 -210;
-    pos @kc87_first_44 @kc87_second_14 -140;
-    pos @kc87_first_44 @kc87_second_15 -105;
-    pos @kc87_first_44 @kc87_second_42 -70;
-    pos @kc87_first_44 @kc87_second_43 -35;
-    pos @kc87_first_44 @kc87_second_46 -140;
-    pos @kc87_first_44 @kc87_second_48 1;
-    pos @kc87_first_44 @kc87_second_50 -50;
-    pos @kc87_first_44 @kc87_second_51 -140;
-    pos @kc87_first_44 @kc87_second_61 -35;
-    pos @kc87_first_44 @kc87_second_63 -35;
-    pos @kc87_first_44 @kc87_second_64 -70;
-    pos @kc87_first_44 @kc87_second_65 -70;
+    pos @kc87_first_43 @kc87_second_48 -35;
+    pos @kc87_first_43 @kc87_second_51 1;
+    pos @kc87_first_43 @kc87_second_54 -105;
+    pos @kc87_first_43 @kc87_second_66 -70;
+    pos @kc87_first_44 @kc87_second_1 -140;
+    pos @kc87_first_44 @kc87_second_2 -175;
+    pos @kc87_first_44 @kc87_second_5 -105;
+    pos @kc87_first_44 @kc87_second_6 -70;
+    pos @kc87_first_44 @kc87_second_11 -70;
+    pos @kc87_first_44 @kc87_second_12 -175;
+    pos @kc87_first_44 @kc87_second_13 -105;
+    pos @kc87_first_44 @kc87_second_14 -70;
+    pos @kc87_first_44 @kc87_second_15 -35;
+    pos @kc87_first_44 @kc87_second_16 -105;
+    pos @kc87_first_44 @kc87_second_17 -35;
+    pos @kc87_first_44 @kc87_second_18 -50;
+    pos @kc87_first_44 @kc87_second_19 -140;
+    pos @kc87_first_44 @kc87_second_21 -175;
+    pos @kc87_first_44 @kc87_second_24 -50;
+    pos @kc87_first_44 @kc87_second_26 -105;
+    pos @kc87_first_44 @kc87_second_31 -35;
+    pos @kc87_first_44 @kc87_second_34 -70;
+    pos @kc87_first_44 @kc87_second_35 -70;
+    pos @kc87_first_44 @kc87_second_36 -50;
+    pos @kc87_first_44 @kc87_second_38 -70;
+    pos @kc87_first_44 @kc87_second_39 -140;
+    pos @kc87_first_44 @kc87_second_41 -35;
+    pos @kc87_first_44 @kc87_second_43 -50;
+    pos @kc87_first_44 @kc87_second_51 1;
+    pos @kc87_first_44 @kc87_second_56 -35;
+    pos @kc87_first_44 @kc87_second_58 -105;
+    pos @kc87_first_44 @kc87_second_60 -105;
+    pos @kc87_first_44 @kc87_second_61 -105;
+    pos @kc87_first_44 @kc87_second_68 -50;
+    pos @kc87_first_44 @kc87_second_69 -70;
+    pos @kc87_first_45 @kc87_second_1 -210;
+    pos @kc87_first_45 @kc87_second_2 -280;
+    pos @kc87_first_45 @kc87_second_3 -70;
+    pos @kc87_first_45 @kc87_second_6 -280;
     pos @kc87_first_45 @kc87_second_8 -35;
-    pos @kc87_first_45 @kc87_second_9 -70;
-    pos @kc87_first_45 @kc87_second_12 -240;
-    pos @kc87_first_45 @kc87_second_13 -210;
-    pos @kc87_first_45 @kc87_second_14 -70;
-    pos @kc87_first_45 @kc87_second_15 -105;
-    pos @kc87_first_45 @kc87_second_18 -35;
-    pos @kc87_first_45 @kc87_second_24 -35;
+    pos @kc87_first_45 @kc87_second_11 -70;
+    pos @kc87_first_45 @kc87_second_13 -140;
+    pos @kc87_first_45 @kc87_second_14 -35;
+    pos @kc87_first_45 @kc87_second_15 -35;
+    pos @kc87_first_45 @kc87_second_16 -140;
+    pos @kc87_first_45 @kc87_second_17 -105;
+    pos @kc87_first_45 @kc87_second_18 -140;
+    pos @kc87_first_45 @kc87_second_19 -210;
+    pos @kc87_first_45 @kc87_second_21 -280;
+    pos @kc87_first_45 @kc87_second_22 -140;
+    pos @kc87_first_45 @kc87_second_24 -140;
+    pos @kc87_first_45 @kc87_second_25 -140;
+    pos @kc87_first_45 @kc87_second_26 -210;
+    pos @kc87_first_45 @kc87_second_34 -70;
+    pos @kc87_first_45 @kc87_second_35 -140;
+    pos @kc87_first_45 @kc87_second_36 -140;
+    pos @kc87_first_45 @kc87_second_38 -280;
+    pos @kc87_first_45 @kc87_second_39 -140;
+    pos @kc87_first_45 @kc87_second_40 -70;
     pos @kc87_first_45 @kc87_second_41 -70;
-    pos @kc87_first_45 @kc87_second_42 -105;
-    pos @kc87_first_45 @kc87_second_43 -70;
-    pos @kc87_first_45 @kc87_second_46 -70;
-    pos @kc87_first_45 @kc87_second_47 -35;
-    pos @kc87_first_45 @kc87_second_48 1;
-    pos @kc87_first_45 @kc87_second_50 -70;
-    pos @kc87_first_45 @kc87_second_51 -70;
-    pos @kc87_first_45 @kc87_second_61 -70;
-    pos @kc87_first_45 @kc87_second_63 -50;
-    pos @kc87_first_45 @kc87_second_65 -70;
-    pos @kc87_first_45 @kc87_second_66 -35;
-    pos @kc87_first_45 @kc87_second_67 -35;
-    pos @kc87_first_46 @kc87_second_6 -70;
-    pos @kc87_first_46 @kc87_second_8 -35;
-    pos @kc87_first_46 @kc87_second_12 -175;
-    pos @kc87_first_46 @kc87_second_13 -140;
-    pos @kc87_first_46 @kc87_second_14 -70;
-    pos @kc87_first_46 @kc87_second_15 -35;
-    pos @kc87_first_46 @kc87_second_17 -70;
-    pos @kc87_first_46 @kc87_second_18 -105;
-    pos @kc87_first_46 @kc87_second_22 -70;
-    pos @kc87_first_46 @kc87_second_24 -105;
-    pos @kc87_first_46 @kc87_second_31 -35;
-    pos @kc87_first_46 @kc87_second_37 -70;
-    pos @kc87_first_46 @kc87_second_39 -35;
-    pos @kc87_first_46 @kc87_second_41 -105;
-    pos @kc87_first_46 @kc87_second_48 1;
-    pos @kc87_first_46 @kc87_second_54 -35;
+    pos @kc87_first_45 @kc87_second_42 -140;
+    pos @kc87_first_45 @kc87_second_43 -175;
+    pos @kc87_first_45 @kc87_second_51 1;
+    pos @kc87_first_45 @kc87_second_58 -210;
+    pos @kc87_first_45 @kc87_second_60 -210;
+    pos @kc87_first_45 @kc87_second_61 -175;
+    pos @kc87_first_45 @kc87_second_64 -70;
+    pos @kc87_first_45 @kc87_second_68 -175;
+    pos @kc87_first_45 @kc87_second_69 -175;
+    pos @kc87_first_46 @kc87_second_9 -70;
+    pos @kc87_first_46 @kc87_second_12 -240;
+    pos @kc87_first_46 @kc87_second_13 -210;
+    pos @kc87_first_46 @kc87_second_14 -140;
+    pos @kc87_first_46 @kc87_second_15 -105;
+    pos @kc87_first_46 @kc87_second_44 -70;
+    pos @kc87_first_46 @kc87_second_45 -35;
+    pos @kc87_first_46 @kc87_second_47 -140;
+    pos @kc87_first_46 @kc87_second_48 -70;
+    pos @kc87_first_46 @kc87_second_51 1;
+    pos @kc87_first_46 @kc87_second_53 -50;
+    pos @kc87_first_46 @kc87_second_54 -140;
+    pos @kc87_first_46 @kc87_second_63 -35;
+    pos @kc87_first_46 @kc87_second_65 -35;
     pos @kc87_first_46 @kc87_second_66 -70;
     pos @kc87_first_46 @kc87_second_67 -70;
-    pos @kc87_first_47 @kc87_second_3 -140;
-    pos @kc87_first_47 @kc87_second_4 -70;
-    pos @kc87_first_47 @kc87_second_6 -70;
-    pos @kc87_first_47 @kc87_second_8 -210;
-    pos @kc87_first_47 @kc87_second_9 -420;
-    pos @kc87_first_47 @kc87_second_12 -350;
-    pos @kc87_first_47 @kc87_second_13 -420;
-    pos @kc87_first_47 @kc87_second_14 -350;
-    pos @kc87_first_47 @kc87_second_15 -280;
-    pos @kc87_first_47 @kc87_second_17 -70;
-    pos @kc87_first_47 @kc87_second_18 -70;
-    pos @kc87_first_47 @kc87_second_20 -210;
-    pos @kc87_first_47 @kc87_second_22 -210;
-    pos @kc87_first_47 @kc87_second_24 -70;
-    pos @kc87_first_47 @kc87_second_25 -140;
-    pos @kc87_first_47 @kc87_second_31 -35;
-    pos @kc87_first_47 @kc87_second_33 -140;
-    pos @kc87_first_47 @kc87_second_37 -70;
-    pos @kc87_first_47 @kc87_second_39 -70;
-    pos @kc87_first_47 @kc87_second_41 -210;
-    pos @kc87_first_47 @kc87_second_42 -280;
-    pos @kc87_first_47 @kc87_second_43 -420;
-    pos @kc87_first_47 @kc87_second_46 -350;
-    pos @kc87_first_47 @kc87_second_48 1;
-    pos @kc87_first_47 @kc87_second_49 -35;
-    pos @kc87_first_47 @kc87_second_50 -210;
-    pos @kc87_first_47 @kc87_second_51 -350;
-    pos @kc87_first_47 @kc87_second_54 -35;
-    pos @kc87_first_47 @kc87_second_55 -35;
-    pos @kc87_first_47 @kc87_second_61 -280;
-    pos @kc87_first_47 @kc87_second_63 -175;
-    pos @kc87_first_47 @kc87_second_64 -280;
-    pos @kc87_first_47 @kc87_second_65 -210;
-    pos @kc87_first_47 @kc87_second_66 -70;
-    pos @kc87_first_48 @kc87_second_3 -140;
-    pos @kc87_first_48 @kc87_second_4 -105;
+    pos @kc87_first_47 @kc87_second_8 -35;
+    pos @kc87_first_47 @kc87_second_9 -70;
+    pos @kc87_first_47 @kc87_second_12 -240;
+    pos @kc87_first_47 @kc87_second_13 -210;
+    pos @kc87_first_47 @kc87_second_14 -70;
+    pos @kc87_first_47 @kc87_second_15 -105;
+    pos @kc87_first_47 @kc87_second_18 -35;
+    pos @kc87_first_47 @kc87_second_24 -35;
+    pos @kc87_first_47 @kc87_second_40 -35;
+    pos @kc87_first_47 @kc87_second_43 -70;
+    pos @kc87_first_47 @kc87_second_44 -105;
+    pos @kc87_first_47 @kc87_second_45 -70;
+    pos @kc87_first_47 @kc87_second_47 -70;
+    pos @kc87_first_47 @kc87_second_51 1;
+    pos @kc87_first_47 @kc87_second_53 -70;
+    pos @kc87_first_47 @kc87_second_54 -70;
+    pos @kc87_first_47 @kc87_second_63 -70;
+    pos @kc87_first_47 @kc87_second_65 -50;
+    pos @kc87_first_47 @kc87_second_67 -70;
+    pos @kc87_first_47 @kc87_second_68 -35;
+    pos @kc87_first_47 @kc87_second_69 -35;
     pos @kc87_first_48 @kc87_second_6 -70;
-    pos @kc87_first_48 @kc87_second_8 -210;
-    pos @kc87_first_48 @kc87_second_9 -280;
-    pos @kc87_first_48 @kc87_second_12 -350;
-    pos @kc87_first_48 @kc87_second_13 -385;
-    pos @kc87_first_48 @kc87_second_14 -350;
-    pos @kc87_first_48 @kc87_second_15 -280;
+    pos @kc87_first_48 @kc87_second_8 -35;
+    pos @kc87_first_48 @kc87_second_12 -175;
+    pos @kc87_first_48 @kc87_second_13 -140;
+    pos @kc87_first_48 @kc87_second_14 -70;
+    pos @kc87_first_48 @kc87_second_15 -35;
+    pos @kc87_first_48 @kc87_second_17 -70;
     pos @kc87_first_48 @kc87_second_18 -105;
-    pos @kc87_first_48 @kc87_second_20 -210;
-    pos @kc87_first_48 @kc87_second_22 -140;
+    pos @kc87_first_48 @kc87_second_22 -70;
     pos @kc87_first_48 @kc87_second_24 -105;
-    pos @kc87_first_48 @kc87_second_25 -140;
-    pos @kc87_first_48 @kc87_second_31 -70;
-    pos @kc87_first_48 @kc87_second_33 -175;
-    pos @kc87_first_48 @kc87_second_37 -70;
-    pos @kc87_first_48 @kc87_second_39 -35;
-    pos @kc87_first_48 @kc87_second_41 -175;
-    pos @kc87_first_48 @kc87_second_42 -280;
-    pos @kc87_first_48 @kc87_second_43 -280;
-    pos @kc87_first_48 @kc87_second_46 -280;
-    pos @kc87_first_48 @kc87_second_47 -140;
-    pos @kc87_first_48 @kc87_second_48 1;
-    pos @kc87_first_48 @kc87_second_49 -70;
-    pos @kc87_first_48 @kc87_second_50 -280;
-    pos @kc87_first_48 @kc87_second_51 -350;
-    pos @kc87_first_48 @kc87_second_54 -35;
-    pos @kc87_first_48 @kc87_second_55 -70;
-    pos @kc87_first_48 @kc87_second_61 -245;
-    pos @kc87_first_48 @kc87_second_63 -245;
-    pos @kc87_first_48 @kc87_second_64 -280;
-    pos @kc87_first_48 @kc87_second_65 -210;
-    pos @kc87_first_48 @kc87_second_66 -70;
-    pos @kc87_first_48 @kc87_second_67 -70;
-    pos @kc87_first_49 @kc87_second_3 -70;
+    pos @kc87_first_48 @kc87_second_31 -35;
+    pos @kc87_first_48 @kc87_second_34 -70;
+    pos @kc87_first_48 @kc87_second_38 -70;
+    pos @kc87_first_48 @kc87_second_41 -35;
+    pos @kc87_first_48 @kc87_second_43 -105;
+    pos @kc87_first_48 @kc87_second_51 1;
+    pos @kc87_first_48 @kc87_second_56 -35;
+    pos @kc87_first_48 @kc87_second_68 -70;
+    pos @kc87_first_48 @kc87_second_69 -70;
+    pos @kc87_first_49 @kc87_second_3 -140;
     pos @kc87_first_49 @kc87_second_4 -105;
-    pos @kc87_first_49 @kc87_second_6 -210;
-    pos @kc87_first_49 @kc87_second_7 -70;
-    pos @kc87_first_49 @kc87_second_8 -175;
-    pos @kc87_first_49 @kc87_second_17 -210;
-    pos @kc87_first_49 @kc87_second_18 -210;
+    pos @kc87_first_49 @kc87_second_6 -70;
+    pos @kc87_first_49 @kc87_second_8 -210;
+    pos @kc87_first_49 @kc87_second_9 -280;
+    pos @kc87_first_49 @kc87_second_12 -350;
+    pos @kc87_first_49 @kc87_second_13 -385;
+    pos @kc87_first_49 @kc87_second_14 -350;
+    pos @kc87_first_49 @kc87_second_15 -280;
+    pos @kc87_first_49 @kc87_second_18 -105;
+    pos @kc87_first_49 @kc87_second_20 -210;
     pos @kc87_first_49 @kc87_second_22 -140;
-    pos @kc87_first_49 @kc87_second_23 -210;
-    pos @kc87_first_49 @kc87_second_24 -210;
-    pos @kc87_first_49 @kc87_second_25 -210;
-    pos @kc87_first_49 @kc87_second_26 -140;
-    pos @kc87_first_49 @kc87_second_27 -140;
-    pos @kc87_first_49 @kc87_second_29 -140;
-    pos @kc87_first_49 @kc87_second_31 -210;
-    pos @kc87_first_49 @kc87_second_32 -210;
-    pos @kc87_first_49 @kc87_second_33 -140;
-    pos @kc87_first_49 @kc87_second_35 -210;
-    pos @kc87_first_49 @kc87_second_37 -210;
+    pos @kc87_first_49 @kc87_second_24 -105;
+    pos @kc87_first_49 @kc87_second_25 -140;
+    pos @kc87_first_49 @kc87_second_31 -70;
+    pos @kc87_first_49 @kc87_second_33 -175;
     pos @kc87_first_49 @kc87_second_38 -70;
-    pos @kc87_first_49 @kc87_second_39 -175;
-    pos @kc87_first_49 @kc87_second_40 -210;
-    pos @kc87_first_49 @kc87_second_41 -175;
-    pos @kc87_first_49 @kc87_second_42 -210;
-    pos @kc87_first_49 @kc87_second_43 -105;
-    pos @kc87_first_49 @kc87_second_46 -70;
-    pos @kc87_first_49 @kc87_second_47 -105;
-    pos @kc87_first_49 @kc87_second_48 1;
-    pos @kc87_first_49 @kc87_second_49 -35;
-    pos @kc87_first_49 @kc87_second_50 -210;
-    pos @kc87_first_49 @kc87_second_53 -210;
-    pos @kc87_first_49 @kc87_second_54 -210;
-    pos @kc87_first_49 @kc87_second_55 -175;
-    pos @kc87_first_49 @kc87_second_56 -175;
-    pos @kc87_first_49 @kc87_second_58 -210;
-    pos @kc87_first_49 @kc87_second_59 -210;
-    pos @kc87_first_49 @kc87_second_60 -140;
-    pos @kc87_first_49 @kc87_second_61 -210;
-    pos @kc87_first_49 @kc87_second_62 -175;
-    pos @kc87_first_49 @kc87_second_63 -175;
-    pos @kc87_first_49 @kc87_second_66 -210;
+    pos @kc87_first_49 @kc87_second_40 -140;
+    pos @kc87_first_49 @kc87_second_41 -35;
+    pos @kc87_first_49 @kc87_second_43 -175;
+    pos @kc87_first_49 @kc87_second_44 -280;
+    pos @kc87_first_49 @kc87_second_45 -280;
+    pos @kc87_first_49 @kc87_second_47 -280;
+    pos @kc87_first_49 @kc87_second_48 -210;
+    pos @kc87_first_49 @kc87_second_51 1;
+    pos @kc87_first_49 @kc87_second_52 -70;
+    pos @kc87_first_49 @kc87_second_53 -280;
+    pos @kc87_first_49 @kc87_second_54 -350;
+    pos @kc87_first_49 @kc87_second_56 -35;
+    pos @kc87_first_49 @kc87_second_57 -70;
+    pos @kc87_first_49 @kc87_second_63 -245;
+    pos @kc87_first_49 @kc87_second_65 -245;
+    pos @kc87_first_49 @kc87_second_66 -280;
     pos @kc87_first_49 @kc87_second_67 -210;
-    pos @kc87_first_50 @kc87_second_5 -70;
-    pos @kc87_first_50 @kc87_second_11 -35;
-    pos @kc87_first_50 @kc87_second_12 -240;
-    pos @kc87_first_50 @kc87_second_13 -70;
-    pos @kc87_first_50 @kc87_second_14 -140;
-    pos @kc87_first_50 @kc87_second_15 -105;
-    pos @kc87_first_50 @kc87_second_16 -70;
-    pos @kc87_first_50 @kc87_second_28 -70;
-    pos @kc87_first_50 @kc87_second_29 -70;
-    pos @kc87_first_50 @kc87_second_38 -35;
-    pos @kc87_first_50 @kc87_second_42 -70;
-    pos @kc87_first_50 @kc87_second_45 -35;
-    pos @kc87_first_50 @kc87_second_46 -70;
-    pos @kc87_first_50 @kc87_second_48 1;
-    pos @kc87_first_50 @kc87_second_50 -35;
-    pos @kc87_first_50 @kc87_second_51 -140;
-    pos @kc87_first_50 @kc87_second_54 1;
-    pos @kc87_first_50 @kc87_second_60 -35;
-    pos @kc87_first_50 @kc87_second_63 -35;
-    pos @kc87_first_50 @kc87_second_64 -105;
-    pos @kc87_first_50 @kc87_second_65 -70;
-    pos @kc87_first_51 @kc87_second_68 -210;
-    pos @kc87_first_52 @kc87_second_34 -315;
-    pos @kc87_first_52 @kc87_second_69 -210;
-    pos @kc87_first_53 @kc87_second_1 -105;
-    pos @kc87_first_53 @kc87_second_2 -210;
-    pos @kc87_first_53 @kc87_second_6 -140;
-    pos @kc87_first_53 @kc87_second_11 -70;
-    pos @kc87_first_53 @kc87_second_12 -210;
-    pos @kc87_first_53 @kc87_second_13 -210;
-    pos @kc87_first_53 @kc87_second_14 -105;
-    pos @kc87_first_53 @kc87_second_15 -70;
-    pos @kc87_first_53 @kc87_second_16 -140;
-    pos @kc87_first_53 @kc87_second_17 -35;
-    pos @kc87_first_53 @kc87_second_18 -35;
-    pos @kc87_first_53 @kc87_second_19 -105;
-    pos @kc87_first_53 @kc87_second_24 -35;
-    pos @kc87_first_53 @kc87_second_26 -210;
-    pos @kc87_first_53 @kc87_second_28 -70;
-    pos @kc87_first_53 @kc87_second_29 -70;
-    pos @kc87_first_53 @kc87_second_31 -35;
-    pos @kc87_first_53 @kc87_second_35 -70;
-    pos @kc87_first_53 @kc87_second_37 -210;
-    pos @kc87_first_53 @kc87_second_38 -140;
-    pos @kc87_first_53 @kc87_second_45 -35;
-    pos @kc87_first_53 @kc87_second_46 -70;
-    pos @kc87_first_53 @kc87_second_48 1;
-    pos @kc87_first_53 @kc87_second_50 -35;
-    pos @kc87_first_53 @kc87_second_51 -105;
-    pos @kc87_first_53 @kc87_second_56 -210;
-    pos @kc87_first_53 @kc87_second_58 -175;
-    pos @kc87_first_53 @kc87_second_59 -140;
-    pos @kc87_first_53 @kc87_second_64 -35;
-    pos @kc87_first_53 @kc87_second_65 -35;
-    pos @kc87_first_53 @kc87_second_66 -35;
-    pos @kc87_first_53 @kc87_second_67 -70;
-    pos @kc87_first_54 @kc87_second_1 -35;
-    pos @kc87_first_54 @kc87_second_2 -70;
-    pos @kc87_first_54 @kc87_second_5 -105;
-    pos @kc87_first_54 @kc87_second_6 -35;
-    pos @kc87_first_54 @kc87_second_9 -70;
-    pos @kc87_first_54 @kc87_second_11 -70;
-    pos @kc87_first_54 @kc87_second_12 -240;
-    pos @kc87_first_54 @kc87_second_13 -245;
-    pos @kc87_first_54 @kc87_second_14 -140;
-    pos @kc87_first_54 @kc87_second_15 -105;
-    pos @kc87_first_54 @kc87_second_16 -105;
-    pos @kc87_first_54 @kc87_second_19 -35;
-    pos @kc87_first_54 @kc87_second_20 -70;
-    pos @kc87_first_54 @kc87_second_21 -70;
-    pos @kc87_first_54 @kc87_second_26 -35;
-    pos @kc87_first_54 @kc87_second_27 -70;
-    pos @kc87_first_54 @kc87_second_28 -140;
-    pos @kc87_first_54 @kc87_second_29 -105;
-    pos @kc87_first_54 @kc87_second_35 -35;
-    pos @kc87_first_54 @kc87_second_37 -35;
-    pos @kc87_first_54 @kc87_second_38 -140;
-    pos @kc87_first_54 @kc87_second_42 -105;
-    pos @kc87_first_54 @kc87_second_43 -70;
-    pos @kc87_first_54 @kc87_second_45 -105;
-    pos @kc87_first_54 @kc87_second_46 -175;
-    pos @kc87_first_54 @kc87_second_48 1;
-    pos @kc87_first_54 @kc87_second_50 -70;
-    pos @kc87_first_54 @kc87_second_51 -140;
-    pos @kc87_first_54 @kc87_second_52 -70;
-    pos @kc87_first_54 @kc87_second_56 -210;
-    pos @kc87_first_54 @kc87_second_57 -70;
-    pos @kc87_first_54 @kc87_second_58 -175;
-    pos @kc87_first_54 @kc87_second_59 -175;
-    pos @kc87_first_54 @kc87_second_60 -105;
-    pos @kc87_first_54 @kc87_second_63 -50;
-    pos @kc87_first_54 @kc87_second_64 -105;
-    pos @kc87_first_54 @kc87_second_65 -70;
-    pos @kc87_first_54 @kc87_second_67 -35;
+    pos @kc87_first_49 @kc87_second_68 -70;
+    pos @kc87_first_49 @kc87_second_69 -70;
+    pos @kc87_first_50 @kc87_second_3 -70;
+    pos @kc87_first_50 @kc87_second_4 -105;
+    pos @kc87_first_50 @kc87_second_6 -210;
+    pos @kc87_first_50 @kc87_second_7 -70;
+    pos @kc87_first_50 @kc87_second_8 -175;
+    pos @kc87_first_50 @kc87_second_17 -210;
+    pos @kc87_first_50 @kc87_second_18 -210;
+    pos @kc87_first_50 @kc87_second_22 -140;
+    pos @kc87_first_50 @kc87_second_23 -210;
+    pos @kc87_first_50 @kc87_second_24 -210;
+    pos @kc87_first_50 @kc87_second_25 -210;
+    pos @kc87_first_50 @kc87_second_26 -140;
+    pos @kc87_first_50 @kc87_second_27 -140;
+    pos @kc87_first_50 @kc87_second_29 -140;
+    pos @kc87_first_50 @kc87_second_31 -210;
+    pos @kc87_first_50 @kc87_second_32 -210;
+    pos @kc87_first_50 @kc87_second_33 -140;
+    pos @kc87_first_50 @kc87_second_34 -140;
+    pos @kc87_first_50 @kc87_second_36 -210;
+    pos @kc87_first_50 @kc87_second_38 -210;
+    pos @kc87_first_50 @kc87_second_39 -70;
+    pos @kc87_first_50 @kc87_second_40 -105;
+    pos @kc87_first_50 @kc87_second_41 -175;
+    pos @kc87_first_50 @kc87_second_42 -210;
+    pos @kc87_first_50 @kc87_second_43 -175;
+    pos @kc87_first_50 @kc87_second_44 -210;
+    pos @kc87_first_50 @kc87_second_45 -105;
+    pos @kc87_first_50 @kc87_second_47 -70;
+    pos @kc87_first_50 @kc87_second_51 1;
+    pos @kc87_first_50 @kc87_second_52 -35;
+    pos @kc87_first_50 @kc87_second_53 -210;
+    pos @kc87_first_50 @kc87_second_55 -210;
+    pos @kc87_first_50 @kc87_second_56 -210;
+    pos @kc87_first_50 @kc87_second_57 -175;
+    pos @kc87_first_50 @kc87_second_58 -175;
+    pos @kc87_first_50 @kc87_second_60 -210;
+    pos @kc87_first_50 @kc87_second_61 -210;
+    pos @kc87_first_50 @kc87_second_62 -140;
+    pos @kc87_first_50 @kc87_second_63 -210;
+    pos @kc87_first_50 @kc87_second_64 -175;
+    pos @kc87_first_50 @kc87_second_65 -175;
+    pos @kc87_first_50 @kc87_second_68 -210;
+    pos @kc87_first_50 @kc87_second_69 -210;
+    pos @kc87_first_51 @kc87_second_1 -35;
+    pos @kc87_first_51 @kc87_second_2 -70;
+    pos @kc87_first_51 @kc87_second_5 -70;
+    pos @kc87_first_51 @kc87_second_11 -35;
+    pos @kc87_first_51 @kc87_second_12 -70;
+    pos @kc87_first_51 @kc87_second_13 -140;
+    pos @kc87_first_51 @kc87_second_14 -70;
+    pos @kc87_first_51 @kc87_second_15 -35;
+    pos @kc87_first_51 @kc87_second_16 -105;
+    pos @kc87_first_51 @kc87_second_28 -35;
+    pos @kc87_first_51 @kc87_second_29 -70;
+    pos @kc87_first_51 @kc87_second_36 -35;
+    pos @kc87_first_51 @kc87_second_39 -70;
+    pos @kc87_first_51 @kc87_second_47 -70;
+    pos @kc87_first_51 @kc87_second_51 1;
+    pos @kc87_first_51 @kc87_second_58 -175;
+    pos @kc87_first_51 @kc87_second_60 -140;
+    pos @kc87_first_51 @kc87_second_61 -140;
+    pos @kc87_first_51 @kc87_second_66 -35;
+    pos @kc87_first_52 @kc87_second_5 -70;
+    pos @kc87_first_52 @kc87_second_11 -35;
+    pos @kc87_first_52 @kc87_second_12 -240;
+    pos @kc87_first_52 @kc87_second_13 -70;
+    pos @kc87_first_52 @kc87_second_14 -140;
+    pos @kc87_first_52 @kc87_second_15 -105;
+    pos @kc87_first_52 @kc87_second_16 -70;
+    pos @kc87_first_52 @kc87_second_28 -70;
+    pos @kc87_first_52 @kc87_second_29 -70;
+    pos @kc87_first_52 @kc87_second_39 -35;
+    pos @kc87_first_52 @kc87_second_44 -70;
+    pos @kc87_first_52 @kc87_second_47 -70;
+    pos @kc87_first_52 @kc87_second_49 -35;
+    pos @kc87_first_52 @kc87_second_51 1;
+    pos @kc87_first_52 @kc87_second_53 -35;
+    pos @kc87_first_52 @kc87_second_54 -140;
+    pos @kc87_first_52 @kc87_second_56 1;
+    pos @kc87_first_52 @kc87_second_62 -35;
+    pos @kc87_first_52 @kc87_second_65 -35;
+    pos @kc87_first_52 @kc87_second_66 -105;
+    pos @kc87_first_52 @kc87_second_67 -70;
+    pos @kc87_first_53 @kc87_second_70 -210;
+    pos @kc87_first_54 @kc87_second_35 -315;
+    pos @kc87_first_54 @kc87_second_71 -210;
     pos @kc87_first_55 @kc87_second_1 -105;
     pos @kc87_first_55 @kc87_second_2 -210;
-    pos @kc87_first_55 @kc87_second_5 -70;
-    pos @kc87_first_55 @kc87_second_6 -105;
-    pos @kc87_first_55 @kc87_second_13 -70;
-    pos @kc87_first_55 @kc87_second_14 -35;
+    pos @kc87_first_55 @kc87_second_6 -140;
+    pos @kc87_first_55 @kc87_second_11 -70;
+    pos @kc87_first_55 @kc87_second_12 -210;
+    pos @kc87_first_55 @kc87_second_13 -210;
+    pos @kc87_first_55 @kc87_second_14 -105;
+    pos @kc87_first_55 @kc87_second_15 -70;
     pos @kc87_first_55 @kc87_second_16 -140;
-    pos @kc87_first_55 @kc87_second_17 -70;
+    pos @kc87_first_55 @kc87_second_17 -35;
     pos @kc87_first_55 @kc87_second_18 -35;
     pos @kc87_first_55 @kc87_second_19 -105;
-    pos @kc87_first_55 @kc87_second_21 -210;
     pos @kc87_first_55 @kc87_second_24 -35;
     pos @kc87_first_55 @kc87_second_26 -210;
+    pos @kc87_first_55 @kc87_second_28 -70;
+    pos @kc87_first_55 @kc87_second_29 -70;
     pos @kc87_first_55 @kc87_second_31 -35;
-    pos @kc87_first_55 @kc87_second_34 -105;
-    pos @kc87_first_55 @kc87_second_35 -35;
-    pos @kc87_first_55 @kc87_second_37 -105;
-    pos @kc87_first_55 @kc87_second_38 -140;
-    pos @kc87_first_55 @kc87_second_41 -70;
-    pos @kc87_first_55 @kc87_second_48 1;
-    pos @kc87_first_55 @kc87_second_54 -35;
-    pos @kc87_first_55 @kc87_second_56 -245;
+    pos @kc87_first_55 @kc87_second_36 -70;
+    pos @kc87_first_55 @kc87_second_38 -210;
+    pos @kc87_first_55 @kc87_second_39 -140;
+    pos @kc87_first_55 @kc87_second_47 -70;
+    pos @kc87_first_55 @kc87_second_49 -35;
+    pos @kc87_first_55 @kc87_second_51 1;
+    pos @kc87_first_55 @kc87_second_53 -35;
+    pos @kc87_first_55 @kc87_second_54 -105;
     pos @kc87_first_55 @kc87_second_58 -210;
-    pos @kc87_first_55 @kc87_second_59 -210;
-    pos @kc87_first_55 @kc87_second_66 -70;
-    pos @kc87_first_55 @kc87_second_67 -105;
-    pos @kc87_first_56 @kc87_second_12 -240;
-    pos @kc87_first_56 @kc87_second_13 -140;
-    pos @kc87_first_56 @kc87_second_14 -105;
-    pos @kc87_first_56 @kc87_second_15 -35;
-    pos @kc87_first_56 @kc87_second_36 100;
-    pos @kc87_first_56 @kc87_second_48 1;
-    pos @kc87_first_56 @kc87_second_53 100;
-    pos @kc87_first_57 @kc87_second_1 -140;
-    pos @kc87_first_57 @kc87_second_2 -210;
-    pos @kc87_first_57 @kc87_second_6 -140;
-    pos @kc87_first_57 @kc87_second_12 -175;
+    pos @kc87_first_55 @kc87_second_60 -175;
+    pos @kc87_first_55 @kc87_second_61 -140;
+    pos @kc87_first_55 @kc87_second_66 -35;
+    pos @kc87_first_55 @kc87_second_67 -35;
+    pos @kc87_first_55 @kc87_second_68 -35;
+    pos @kc87_first_55 @kc87_second_69 -70;
+    pos @kc87_first_56 @kc87_second_1 -105;
+    pos @kc87_first_56 @kc87_second_2 -210;
+    pos @kc87_first_56 @kc87_second_5 -70;
+    pos @kc87_first_56 @kc87_second_6 -105;
+    pos @kc87_first_56 @kc87_second_13 -70;
+    pos @kc87_first_56 @kc87_second_14 -35;
+    pos @kc87_first_56 @kc87_second_16 -140;
+    pos @kc87_first_56 @kc87_second_17 -70;
+    pos @kc87_first_56 @kc87_second_18 -35;
+    pos @kc87_first_56 @kc87_second_19 -105;
+    pos @kc87_first_56 @kc87_second_21 -210;
+    pos @kc87_first_56 @kc87_second_24 -35;
+    pos @kc87_first_56 @kc87_second_26 -210;
+    pos @kc87_first_56 @kc87_second_31 -35;
+    pos @kc87_first_56 @kc87_second_34 -70;
+    pos @kc87_first_56 @kc87_second_35 -105;
+    pos @kc87_first_56 @kc87_second_36 -35;
+    pos @kc87_first_56 @kc87_second_38 -105;
+    pos @kc87_first_56 @kc87_second_39 -140;
+    pos @kc87_first_56 @kc87_second_43 -70;
+    pos @kc87_first_56 @kc87_second_51 1;
+    pos @kc87_first_56 @kc87_second_56 -35;
+    pos @kc87_first_56 @kc87_second_58 -245;
+    pos @kc87_first_56 @kc87_second_60 -210;
+    pos @kc87_first_56 @kc87_second_61 -210;
+    pos @kc87_first_56 @kc87_second_68 -70;
+    pos @kc87_first_56 @kc87_second_69 -105;
+    pos @kc87_first_57 @kc87_second_12 -240;
     pos @kc87_first_57 @kc87_second_13 -140;
-    pos @kc87_first_57 @kc87_second_16 -140;
-    pos @kc87_first_57 @kc87_second_19 -140;
-    pos @kc87_first_57 @kc87_second_21 -210;
-    pos @kc87_first_57 @kc87_second_26 -210;
-    pos @kc87_first_57 @kc87_second_34 -140;
-    pos @kc87_first_57 @kc87_second_35 -50;
-    pos @kc87_first_57 @kc87_second_37 -140;
-    pos @kc87_first_57 @kc87_second_38 -210;
-    pos @kc87_first_57 @kc87_second_39 -35;
-    pos @kc87_first_57 @kc87_second_48 1;
-    pos @kc87_first_57 @kc87_second_56 -210;
-    pos @kc87_first_57 @kc87_second_58 -175;
-    pos @kc87_first_57 @kc87_second_59 -175;
-    pos @kc87_first_57 @kc87_second_66 -105;
-    pos @kc87_first_57 @kc87_second_67 -210;
-    pos @kc87_first_58 @kc87_second_12 -240;
-    pos @kc87_first_58 @kc87_second_13 -175;
-    pos @kc87_first_58 @kc87_second_14 -70;
-    pos @kc87_first_58 @kc87_second_15 -35;
-    pos @kc87_first_58 @kc87_second_21 -35;
-    pos @kc87_first_58 @kc87_second_28 -35;
-    pos @kc87_first_58 @kc87_second_42 -35;
-    pos @kc87_first_58 @kc87_second_43 -35;
-    pos @kc87_first_58 @kc87_second_46 -70;
-    pos @kc87_first_58 @kc87_second_48 1;
-    pos @kc87_first_58 @kc87_second_50 -35;
-    pos @kc87_first_58 @kc87_second_51 -70;
-    pos @kc87_first_58 @kc87_second_61 -35;
-    pos @kc87_first_58 @kc87_second_63 -35;
-    pos @kc87_first_58 @kc87_second_64 -70;
-    pos @kc87_first_58 @kc87_second_65 -35;
-    pos @kc87_first_59 @kc87_second_13 -35;
-    pos @kc87_first_59 @kc87_second_18 -70;
-    pos @kc87_first_59 @kc87_second_61 -35;
+    pos @kc87_first_57 @kc87_second_14 -105;
+    pos @kc87_first_57 @kc87_second_15 -35;
+    pos @kc87_first_57 @kc87_second_37 100;
+    pos @kc87_first_57 @kc87_second_51 1;
+    pos @kc87_first_57 @kc87_second_55 100;
+    pos @kc87_first_58 @kc87_second_1 -140;
+    pos @kc87_first_58 @kc87_second_2 -210;
+    pos @kc87_first_58 @kc87_second_6 -140;
+    pos @kc87_first_58 @kc87_second_12 -175;
+    pos @kc87_first_58 @kc87_second_13 -140;
+    pos @kc87_first_58 @kc87_second_16 -140;
+    pos @kc87_first_58 @kc87_second_19 -140;
+    pos @kc87_first_58 @kc87_second_21 -210;
+    pos @kc87_first_58 @kc87_second_26 -210;
+    pos @kc87_first_58 @kc87_second_34 -35;
+    pos @kc87_first_58 @kc87_second_35 -140;
+    pos @kc87_first_58 @kc87_second_36 -50;
+    pos @kc87_first_58 @kc87_second_38 -140;
+    pos @kc87_first_58 @kc87_second_39 -210;
+    pos @kc87_first_58 @kc87_second_41 -35;
+    pos @kc87_first_58 @kc87_second_51 1;
+    pos @kc87_first_58 @kc87_second_58 -210;
+    pos @kc87_first_58 @kc87_second_60 -175;
+    pos @kc87_first_58 @kc87_second_61 -175;
+    pos @kc87_first_58 @kc87_second_68 -105;
+    pos @kc87_first_58 @kc87_second_69 -210;
+    pos @kc87_first_59 @kc87_second_12 -240;
+    pos @kc87_first_59 @kc87_second_13 -175;
+    pos @kc87_first_59 @kc87_second_14 -70;
+    pos @kc87_first_59 @kc87_second_15 -35;
+    pos @kc87_first_59 @kc87_second_21 -35;
+    pos @kc87_first_59 @kc87_second_28 -35;
+    pos @kc87_first_59 @kc87_second_44 -35;
+    pos @kc87_first_59 @kc87_second_45 -35;
+    pos @kc87_first_59 @kc87_second_47 -70;
+    pos @kc87_first_59 @kc87_second_51 1;
+    pos @kc87_first_59 @kc87_second_53 -35;
+    pos @kc87_first_59 @kc87_second_54 -70;
+    pos @kc87_first_59 @kc87_second_63 -35;
+    pos @kc87_first_59 @kc87_second_65 -35;
+    pos @kc87_first_59 @kc87_second_66 -70;
     pos @kc87_first_59 @kc87_second_67 -35;
-    pos @kc87_first_60 @kc87_second_12 -175;
-    pos @kc87_first_60 @kc87_second_13 -140;
-    pos @kc87_first_60 @kc87_second_14 -35;
-    pos @kc87_first_60 @kc87_second_48 1;
-    pos @kc87_first_61 @kc87_second_1 -140;
-    pos @kc87_first_61 @kc87_second_2 -280;
-    pos @kc87_first_61 @kc87_second_5 -140;
-    pos @kc87_first_61 @kc87_second_6 -280;
-    pos @kc87_first_61 @kc87_second_8 -70;
-    pos @kc87_first_61 @kc87_second_10 -70;
-    pos @kc87_first_61 @kc87_second_11 -175;
-    pos @kc87_first_61 @kc87_second_12 -240;
-    pos @kc87_first_61 @kc87_second_13 -140;
-    pos @kc87_first_61 @kc87_second_14 -105;
-    pos @kc87_first_61 @kc87_second_15 -70;
-    pos @kc87_first_61 @kc87_second_16 -175;
-    pos @kc87_first_61 @kc87_second_17 -70;
+    pos @kc87_first_60 @kc87_second_1 -210;
+    pos @kc87_first_60 @kc87_second_2 -210;
+    pos @kc87_first_60 @kc87_second_3 -70;
+    pos @kc87_first_60 @kc87_second_4 -35;
+    pos @kc87_first_60 @kc87_second_6 -210;
+    pos @kc87_first_60 @kc87_second_7 -70;
+    pos @kc87_first_60 @kc87_second_8 -70;
+    pos @kc87_first_60 @kc87_second_16 -70;
+    pos @kc87_first_60 @kc87_second_17 -70;
+    pos @kc87_first_60 @kc87_second_18 -175;
+    pos @kc87_first_60 @kc87_second_19 -210;
+    pos @kc87_first_60 @kc87_second_21 -210;
+    pos @kc87_first_60 @kc87_second_22 -140;
+    pos @kc87_first_60 @kc87_second_23 -35;
+    pos @kc87_first_60 @kc87_second_24 -175;
+    pos @kc87_first_60 @kc87_second_25 -140;
+    pos @kc87_first_60 @kc87_second_26 -280;
+    pos @kc87_first_60 @kc87_second_31 -35;
+    pos @kc87_first_60 @kc87_second_32 -35;
+    pos @kc87_first_60 @kc87_second_34 -140;
+    pos @kc87_first_60 @kc87_second_35 -210;
+    pos @kc87_first_60 @kc87_second_36 -175;
+    pos @kc87_first_60 @kc87_second_38 -245;
+    pos @kc87_first_60 @kc87_second_39 -140;
+    pos @kc87_first_60 @kc87_second_40 -35;
+    pos @kc87_first_60 @kc87_second_41 -140;
+    pos @kc87_first_60 @kc87_second_42 -140;
+    pos @kc87_first_60 @kc87_second_43 -140;
+    pos @kc87_first_60 @kc87_second_44 -35;
+    pos @kc87_first_60 @kc87_second_50 -35;
+    pos @kc87_first_60 @kc87_second_51 1;
+    pos @kc87_first_60 @kc87_second_56 -140;
+    pos @kc87_first_60 @kc87_second_57 -70;
+    pos @kc87_first_60 @kc87_second_58 -210;
+    pos @kc87_first_60 @kc87_second_60 -210;
+    pos @kc87_first_60 @kc87_second_61 -210;
+    pos @kc87_first_60 @kc87_second_63 -35;
+    pos @kc87_first_60 @kc87_second_68 -175;
+    pos @kc87_first_60 @kc87_second_69 -245;
+    pos @kc87_first_61 @kc87_second_13 -35;
     pos @kc87_first_61 @kc87_second_18 -70;
-    pos @kc87_first_61 @kc87_second_19 -140;
-    pos @kc87_first_61 @kc87_second_21 -280;
-    pos @kc87_first_61 @kc87_second_24 -70;
-    pos @kc87_first_61 @kc87_second_25 -70;
-    pos @kc87_first_61 @kc87_second_26 -210;
-    pos @kc87_first_61 @kc87_second_28 -70;
-    pos @kc87_first_61 @kc87_second_29 -70;
-    pos @kc87_first_61 @kc87_second_31 -70;
     pos @kc87_first_61 @kc87_second_34 -70;
-    pos @kc87_first_61 @kc87_second_35 -70;
-    pos @kc87_first_61 @kc87_second_37 -315;
-    pos @kc87_first_61 @kc87_second_38 -140;
-    pos @kc87_first_61 @kc87_second_39 -70;
-    pos @kc87_first_61 @kc87_second_41 -105;
-    pos @kc87_first_61 @kc87_second_48 1;
-    pos @kc87_first_61 @kc87_second_51 -35;
-    pos @kc87_first_61 @kc87_second_54 -50;
-    pos @kc87_first_61 @kc87_second_56 -210;
-    pos @kc87_first_61 @kc87_second_58 -210;
-    pos @kc87_first_61 @kc87_second_59 -175;
-    pos @kc87_first_61 @kc87_second_62 -35;
-    pos @kc87_first_61 @kc87_second_64 -70;
-    pos @kc87_first_61 @kc87_second_65 -35;
-    pos @kc87_first_61 @kc87_second_66 -140;
-    pos @kc87_first_61 @kc87_second_67 -210;
-    pos @kc87_first_62 @kc87_second_1 -35;
-    pos @kc87_first_62 @kc87_second_2 -70;
-    pos @kc87_first_62 @kc87_second_5 -70;
-    pos @kc87_first_62 @kc87_second_11 -35;
-    pos @kc87_first_62 @kc87_second_12 -140;
+    pos @kc87_first_61 @kc87_second_63 -35;
+    pos @kc87_first_61 @kc87_second_69 -35;
+    pos @kc87_first_62 @kc87_second_12 -175;
     pos @kc87_first_62 @kc87_second_13 -140;
-    pos @kc87_first_62 @kc87_second_14 -70;
-    pos @kc87_first_62 @kc87_second_15 -35;
-    pos @kc87_first_62 @kc87_second_16 -105;
-    pos @kc87_first_62 @kc87_second_28 -35;
-    pos @kc87_first_62 @kc87_second_29 -70;
-    pos @kc87_first_62 @kc87_second_35 -35;
-    pos @kc87_first_62 @kc87_second_38 -70;
-    pos @kc87_first_62 @kc87_second_46 -70;
-    pos @kc87_first_62 @kc87_second_48 1;
-    pos @kc87_first_62 @kc87_second_56 -175;
-    pos @kc87_first_62 @kc87_second_58 -140;
-    pos @kc87_first_62 @kc87_second_59 -140;
-    pos @kc87_first_62 @kc87_second_64 -35;
-    pos @kc87_first_63 @kc87_second_5 -70;
-    pos @kc87_first_63 @kc87_second_9 -70;
-    pos @kc87_first_63 @kc87_second_11 -35;
-    pos @kc87_first_63 @kc87_second_12 -350;
-    pos @kc87_first_63 @kc87_second_13 -315;
-    pos @kc87_first_63 @kc87_second_14 -175;
-    pos @kc87_first_63 @kc87_second_15 -140;
-    pos @kc87_first_63 @kc87_second_16 -70;
-    pos @kc87_first_63 @kc87_second_20 -70;
+    pos @kc87_first_62 @kc87_second_14 -35;
+    pos @kc87_first_62 @kc87_second_51 1;
+    pos @kc87_first_63 @kc87_second_1 -140;
+    pos @kc87_first_63 @kc87_second_2 -280;
+    pos @kc87_first_63 @kc87_second_5 -140;
+    pos @kc87_first_63 @kc87_second_6 -280;
+    pos @kc87_first_63 @kc87_second_8 -70;
+    pos @kc87_first_63 @kc87_second_10 -70;
+    pos @kc87_first_63 @kc87_second_11 -175;
+    pos @kc87_first_63 @kc87_second_12 -240;
+    pos @kc87_first_63 @kc87_second_13 -140;
+    pos @kc87_first_63 @kc87_second_14 -105;
+    pos @kc87_first_63 @kc87_second_15 -70;
+    pos @kc87_first_63 @kc87_second_16 -175;
+    pos @kc87_first_63 @kc87_second_17 -70;
+    pos @kc87_first_63 @kc87_second_18 -70;
+    pos @kc87_first_63 @kc87_second_19 -140;
+    pos @kc87_first_63 @kc87_second_21 -280;
+    pos @kc87_first_63 @kc87_second_24 -70;
+    pos @kc87_first_63 @kc87_second_25 -70;
+    pos @kc87_first_63 @kc87_second_26 -210;
+    pos @kc87_first_63 @kc87_second_28 -70;
     pos @kc87_first_63 @kc87_second_29 -70;
-    pos @kc87_first_63 @kc87_second_33 -50;
-    pos @kc87_first_63 @kc87_second_42 -140;
-    pos @kc87_first_63 @kc87_second_43 -50;
-    pos @kc87_first_63 @kc87_second_45 -35;
-    pos @kc87_first_63 @kc87_second_46 -175;
-    pos @kc87_first_63 @kc87_second_48 1;
-    pos @kc87_first_63 @kc87_second_50 -70;
-    pos @kc87_first_63 @kc87_second_51 -175;
-    pos @kc87_first_63 @kc87_second_57 -70;
-    pos @kc87_first_63 @kc87_second_61 -70;
-    pos @kc87_first_63 @kc87_second_63 -50;
-    pos @kc87_first_63 @kc87_second_64 -140;
-    pos @kc87_first_63 @kc87_second_65 -105;
-    pos @kc87_first_64 @kc87_second_4 -105;
+    pos @kc87_first_63 @kc87_second_31 -70;
+    pos @kc87_first_63 @kc87_second_34 -70;
+    pos @kc87_first_63 @kc87_second_35 -70;
+    pos @kc87_first_63 @kc87_second_36 -70;
+    pos @kc87_first_63 @kc87_second_38 -315;
+    pos @kc87_first_63 @kc87_second_39 -140;
+    pos @kc87_first_63 @kc87_second_41 -70;
+    pos @kc87_first_63 @kc87_second_43 -105;
+    pos @kc87_first_63 @kc87_second_51 1;
+    pos @kc87_first_63 @kc87_second_54 -35;
+    pos @kc87_first_63 @kc87_second_56 -50;
+    pos @kc87_first_63 @kc87_second_58 -210;
+    pos @kc87_first_63 @kc87_second_60 -210;
+    pos @kc87_first_63 @kc87_second_61 -175;
+    pos @kc87_first_63 @kc87_second_64 -35;
+    pos @kc87_first_63 @kc87_second_66 -70;
+    pos @kc87_first_63 @kc87_second_67 -35;
+    pos @kc87_first_63 @kc87_second_68 -140;
+    pos @kc87_first_63 @kc87_second_69 -210;
     pos @kc87_first_64 @kc87_second_6 -35;
-    pos @kc87_first_64 @kc87_second_8 1;
-    pos @kc87_first_64 @kc87_second_9 -245;
-    pos @kc87_first_64 @kc87_second_12 -210;
-    pos @kc87_first_64 @kc87_second_13 -210;
-    pos @kc87_first_64 @kc87_second_14 -210;
-    pos @kc87_first_64 @kc87_second_15 -175;
-    pos @kc87_first_64 @kc87_second_17 -70;
-    pos @kc87_first_64 @kc87_second_18 -105;
-    pos @kc87_first_64 @kc87_second_20 -180;
-    pos @kc87_first_64 @kc87_second_22 -140;
-    pos @kc87_first_64 @kc87_second_24 -105;
-    pos @kc87_first_64 @kc87_second_27 -140;
-    pos @kc87_first_64 @kc87_second_31 -105;
-    pos @kc87_first_64 @kc87_second_33 -140;
-    pos @kc87_first_64 @kc87_second_37 -35;
-    pos @kc87_first_64 @kc87_second_39 -35;
-    pos @kc87_first_64 @kc87_second_41 -175;
-    pos @kc87_first_64 @kc87_second_42 -142;
-    pos @kc87_first_64 @kc87_second_43 -245;
-    pos @kc87_first_64 @kc87_second_46 -210;
-    pos @kc87_first_64 @kc87_second_47 -105;
-    pos @kc87_first_64 @kc87_second_48 1;
-    pos @kc87_first_64 @kc87_second_49 -35;
-    pos @kc87_first_64 @kc87_second_50 -210;
-    pos @kc87_first_64 @kc87_second_51 -210;
+    pos @kc87_first_64 @kc87_second_12 -240;
+    pos @kc87_first_64 @kc87_second_13 -140;
+    pos @kc87_first_64 @kc87_second_14 -70;
+    pos @kc87_first_64 @kc87_second_15 -35;
+    pos @kc87_first_64 @kc87_second_18 -35;
+    pos @kc87_first_64 @kc87_second_22 -35;
+    pos @kc87_first_64 @kc87_second_24 -35;
+    pos @kc87_first_64 @kc87_second_38 -70;
+    pos @kc87_first_64 @kc87_second_43 -70;
+    pos @kc87_first_64 @kc87_second_44 -50;
+    pos @kc87_first_64 @kc87_second_51 1;
     pos @kc87_first_64 @kc87_second_54 -35;
-    pos @kc87_first_64 @kc87_second_61 -280;
-    pos @kc87_first_64 @kc87_second_63 -175;
-    pos @kc87_first_64 @kc87_second_64 -140;
-    pos @kc87_first_64 @kc87_second_65 -140;
-    pos @kc87_first_64 @kc87_second_66 -70;
-    pos @kc87_first_64 @kc87_second_67 -70;
-    pos @kc87_first_65 @kc87_second_1 -175;
-    pos @kc87_first_65 @kc87_second_2 -175;
+    pos @kc87_first_64 @kc87_second_68 -35;
+    pos @kc87_first_64 @kc87_second_69 -35;
     pos @kc87_first_65 @kc87_second_5 -70;
-    pos @kc87_first_65 @kc87_second_6 -105;
-    pos @kc87_first_65 @kc87_second_11 -105;
-    pos @kc87_first_65 @kc87_second_12 -175;
-    pos @kc87_first_65 @kc87_second_13 -140;
-    pos @kc87_first_65 @kc87_second_14 -70;
-    pos @kc87_first_65 @kc87_second_15 -35;
-    pos @kc87_first_65 @kc87_second_16 -140;
-    pos @kc87_first_65 @kc87_second_17 -70;
-    pos @kc87_first_65 @kc87_second_18 -70;
-    pos @kc87_first_65 @kc87_second_19 -140;
-    pos @kc87_first_65 @kc87_second_21 -175;
-    pos @kc87_first_65 @kc87_second_24 -70;
-    pos @kc87_first_65 @kc87_second_31 -35;
-    pos @kc87_first_65 @kc87_second_35 -70;
-    pos @kc87_first_65 @kc87_second_37 -105;
-    pos @kc87_first_65 @kc87_second_38 -175;
-    pos @kc87_first_65 @kc87_second_39 -35;
-    pos @kc87_first_65 @kc87_second_41 -70;
-    pos @kc87_first_65 @kc87_second_48 1;
-    pos @kc87_first_65 @kc87_second_54 -35;
-    pos @kc87_first_65 @kc87_second_56 -140;
-    pos @kc87_first_65 @kc87_second_58 -140;
-    pos @kc87_first_65 @kc87_second_59 -140;
-    pos @kc87_first_65 @kc87_second_66 -70;
+    pos @kc87_first_65 @kc87_second_9 -70;
+    pos @kc87_first_65 @kc87_second_11 -35;
+    pos @kc87_first_65 @kc87_second_12 -350;
+    pos @kc87_first_65 @kc87_second_13 -315;
+    pos @kc87_first_65 @kc87_second_14 -175;
+    pos @kc87_first_65 @kc87_second_15 -140;
+    pos @kc87_first_65 @kc87_second_16 -70;
+    pos @kc87_first_65 @kc87_second_20 -70;
+    pos @kc87_first_65 @kc87_second_29 -70;
+    pos @kc87_first_65 @kc87_second_33 -50;
+    pos @kc87_first_65 @kc87_second_44 -140;
+    pos @kc87_first_65 @kc87_second_45 -50;
+    pos @kc87_first_65 @kc87_second_47 -175;
+    pos @kc87_first_65 @kc87_second_49 -35;
+    pos @kc87_first_65 @kc87_second_51 1;
+    pos @kc87_first_65 @kc87_second_53 -70;
+    pos @kc87_first_65 @kc87_second_54 -175;
+    pos @kc87_first_65 @kc87_second_59 -70;
+    pos @kc87_first_65 @kc87_second_63 -70;
+    pos @kc87_first_65 @kc87_second_65 -50;
+    pos @kc87_first_65 @kc87_second_66 -140;
     pos @kc87_first_65 @kc87_second_67 -105;
-    pos @kc87_first_66 @kc87_second_1 -210;
-    pos @kc87_first_66 @kc87_second_2 -210;
-    pos @kc87_first_66 @kc87_second_3 -70;
-    pos @kc87_first_66 @kc87_second_4 -35;
-    pos @kc87_first_66 @kc87_second_6 -210;
-    pos @kc87_first_66 @kc87_second_7 -70;
-    pos @kc87_first_66 @kc87_second_8 -70;
-    pos @kc87_first_66 @kc87_second_16 -70;
-    pos @kc87_first_66 @kc87_second_17 -140;
-    pos @kc87_first_66 @kc87_second_18 -175;
-    pos @kc87_first_66 @kc87_second_19 -210;
-    pos @kc87_first_66 @kc87_second_21 -210;
+    pos @kc87_first_66 @kc87_second_4 -105;
+    pos @kc87_first_66 @kc87_second_6 -35;
+    pos @kc87_first_66 @kc87_second_8 1;
+    pos @kc87_first_66 @kc87_second_9 -245;
+    pos @kc87_first_66 @kc87_second_12 -210;
+    pos @kc87_first_66 @kc87_second_13 -210;
+    pos @kc87_first_66 @kc87_second_14 -210;
+    pos @kc87_first_66 @kc87_second_15 -175;
+    pos @kc87_first_66 @kc87_second_17 -70;
+    pos @kc87_first_66 @kc87_second_18 -105;
+    pos @kc87_first_66 @kc87_second_20 -180;
     pos @kc87_first_66 @kc87_second_22 -140;
-    pos @kc87_first_66 @kc87_second_23 -35;
-    pos @kc87_first_66 @kc87_second_24 -175;
-    pos @kc87_first_66 @kc87_second_25 -140;
-    pos @kc87_first_66 @kc87_second_26 -280;
-    pos @kc87_first_66 @kc87_second_31 -35;
-    pos @kc87_first_66 @kc87_second_32 -35;
-    pos @kc87_first_66 @kc87_second_34 -210;
-    pos @kc87_first_66 @kc87_second_35 -175;
-    pos @kc87_first_66 @kc87_second_37 -245;
-    pos @kc87_first_66 @kc87_second_38 -140;
-    pos @kc87_first_66 @kc87_second_39 -140;
-    pos @kc87_first_66 @kc87_second_40 -140;
-    pos @kc87_first_66 @kc87_second_41 -140;
-    pos @kc87_first_66 @kc87_second_42 -35;
-    pos @kc87_first_66 @kc87_second_47 -35;
-    pos @kc87_first_66 @kc87_second_48 1;
+    pos @kc87_first_66 @kc87_second_24 -105;
+    pos @kc87_first_66 @kc87_second_27 -140;
+    pos @kc87_first_66 @kc87_second_31 -105;
+    pos @kc87_first_66 @kc87_second_33 -140;
+    pos @kc87_first_66 @kc87_second_34 -105;
+    pos @kc87_first_66 @kc87_second_38 -35;
+    pos @kc87_first_66 @kc87_second_40 -105;
+    pos @kc87_first_66 @kc87_second_41 -35;
+    pos @kc87_first_66 @kc87_second_43 -175;
+    pos @kc87_first_66 @kc87_second_44 -142;
+    pos @kc87_first_66 @kc87_second_45 -245;
+    pos @kc87_first_66 @kc87_second_47 -210;
+    pos @kc87_first_66 @kc87_second_48 -175;
+    pos @kc87_first_66 @kc87_second_51 1;
     pos @kc87_first_66 @kc87_second_52 -35;
-    pos @kc87_first_66 @kc87_second_54 -140;
-    pos @kc87_first_66 @kc87_second_55 -70;
-    pos @kc87_first_66 @kc87_second_56 -210;
-    pos @kc87_first_66 @kc87_second_58 -210;
-    pos @kc87_first_66 @kc87_second_59 -210;
-    pos @kc87_first_66 @kc87_second_61 -35;
-    pos @kc87_first_66 @kc87_second_66 -175;
-    pos @kc87_first_66 @kc87_second_67 -245;
-    pos @kc87_first_67 @kc87_second_6 -35;
-    pos @kc87_first_67 @kc87_second_12 -240;
+    pos @kc87_first_66 @kc87_second_53 -210;
+    pos @kc87_first_66 @kc87_second_54 -210;
+    pos @kc87_first_66 @kc87_second_56 -35;
+    pos @kc87_first_66 @kc87_second_63 -280;
+    pos @kc87_first_66 @kc87_second_65 -175;
+    pos @kc87_first_66 @kc87_second_66 -140;
+    pos @kc87_first_66 @kc87_second_67 -140;
+    pos @kc87_first_66 @kc87_second_68 -70;
+    pos @kc87_first_66 @kc87_second_69 -70;
+    pos @kc87_first_67 @kc87_second_1 -175;
+    pos @kc87_first_67 @kc87_second_2 -175;
+    pos @kc87_first_67 @kc87_second_5 -70;
+    pos @kc87_first_67 @kc87_second_6 -105;
+    pos @kc87_first_67 @kc87_second_11 -105;
+    pos @kc87_first_67 @kc87_second_12 -175;
     pos @kc87_first_67 @kc87_second_13 -140;
     pos @kc87_first_67 @kc87_second_14 -70;
     pos @kc87_first_67 @kc87_second_15 -35;
-    pos @kc87_first_67 @kc87_second_18 -35;
-    pos @kc87_first_67 @kc87_second_22 -35;
-    pos @kc87_first_67 @kc87_second_24 -35;
-    pos @kc87_first_67 @kc87_second_37 -70;
-    pos @kc87_first_67 @kc87_second_41 -70;
-    pos @kc87_first_67 @kc87_second_42 -50;
-    pos @kc87_first_67 @kc87_second_48 1;
-    pos @kc87_first_67 @kc87_second_51 -35;
-    pos @kc87_first_67 @kc87_second_66 -35;
-    pos @kc87_first_67 @kc87_second_67 -35;
+    pos @kc87_first_67 @kc87_second_16 -140;
+    pos @kc87_first_67 @kc87_second_17 -70;
+    pos @kc87_first_67 @kc87_second_18 -70;
+    pos @kc87_first_67 @kc87_second_19 -140;
+    pos @kc87_first_67 @kc87_second_21 -175;
+    pos @kc87_first_67 @kc87_second_24 -70;
+    pos @kc87_first_67 @kc87_second_31 -35;
+    pos @kc87_first_67 @kc87_second_34 -70;
+    pos @kc87_first_67 @kc87_second_36 -70;
+    pos @kc87_first_67 @kc87_second_38 -105;
+    pos @kc87_first_67 @kc87_second_39 -175;
+    pos @kc87_first_67 @kc87_second_41 -35;
+    pos @kc87_first_67 @kc87_second_43 -70;
+    pos @kc87_first_67 @kc87_second_51 1;
+    pos @kc87_first_67 @kc87_second_56 -35;
+    pos @kc87_first_67 @kc87_second_58 -140;
+    pos @kc87_first_67 @kc87_second_60 -140;
+    pos @kc87_first_67 @kc87_second_61 -140;
+    pos @kc87_first_67 @kc87_second_68 -70;
+    pos @kc87_first_67 @kc87_second_69 -105;
     pos @kc87_first_68 @kc87_second_3 -100;
     pos @kc87_first_68 @kc87_second_4 -50;
     pos @kc87_first_68 @kc87_second_6 -50;
@@ -10162,23 +10227,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_68 @kc87_second_25 -70;
     pos @kc87_first_68 @kc87_second_31 -35;
     pos @kc87_first_68 @kc87_second_33 -70;
-    pos @kc87_first_68 @kc87_second_36 105;
-    pos @kc87_first_68 @kc87_second_37 -35;
-    pos @kc87_first_68 @kc87_second_41 -70;
-    pos @kc87_first_68 @kc87_second_42 -140;
-    pos @kc87_first_68 @kc87_second_43 -140;
-    pos @kc87_first_68 @kc87_second_46 -140;
-    pos @kc87_first_68 @kc87_second_47 -35;
-    pos @kc87_first_68 @kc87_second_48 1;
-    pos @kc87_first_68 @kc87_second_50 -70;
-    pos @kc87_first_68 @kc87_second_51 -100;
-    pos @kc87_first_68 @kc87_second_53 105;
-    pos @kc87_first_68 @kc87_second_61 -140;
-    pos @kc87_first_68 @kc87_second_63 -70;
-    pos @kc87_first_68 @kc87_second_64 -70;
-    pos @kc87_first_68 @kc87_second_65 -50;
-    pos @kc87_first_68 @kc87_second_66 -35;
-    pos @kc87_first_68 @kc87_second_67 -35;
+    pos @kc87_first_68 @kc87_second_34 -50;
+    pos @kc87_first_68 @kc87_second_37 105;
+    pos @kc87_first_68 @kc87_second_38 -35;
+    pos @kc87_first_68 @kc87_second_40 -35;
+    pos @kc87_first_68 @kc87_second_43 -70;
+    pos @kc87_first_68 @kc87_second_44 -140;
+    pos @kc87_first_68 @kc87_second_45 -140;
+    pos @kc87_first_68 @kc87_second_47 -140;
+    pos @kc87_first_68 @kc87_second_48 -50;
+    pos @kc87_first_68 @kc87_second_51 1;
+    pos @kc87_first_68 @kc87_second_53 -70;
+    pos @kc87_first_68 @kc87_second_54 -100;
+    pos @kc87_first_68 @kc87_second_55 105;
+    pos @kc87_first_68 @kc87_second_63 -140;
+    pos @kc87_first_68 @kc87_second_65 -70;
+    pos @kc87_first_68 @kc87_second_66 -70;
+    pos @kc87_first_68 @kc87_second_67 -50;
+    pos @kc87_first_68 @kc87_second_68 -35;
+    pos @kc87_first_68 @kc87_second_69 -35;
     pos @kc87_first_69 @kc87_second_3 -70;
     pos @kc87_first_69 @kc87_second_4 -50;
     pos @kc87_first_69 @kc87_second_6 -50;
@@ -10196,23 +10263,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_69 @kc87_second_25 -70;
     pos @kc87_first_69 @kc87_second_31 -35;
     pos @kc87_first_69 @kc87_second_33 -70;
-    pos @kc87_first_69 @kc87_second_36 105;
-    pos @kc87_first_69 @kc87_second_37 -35;
-    pos @kc87_first_69 @kc87_second_41 -70;
-    pos @kc87_first_69 @kc87_second_42 -140;
-    pos @kc87_first_69 @kc87_second_43 -140;
-    pos @kc87_first_69 @kc87_second_46 -140;
-    pos @kc87_first_69 @kc87_second_47 -35;
-    pos @kc87_first_69 @kc87_second_48 1;
-    pos @kc87_first_69 @kc87_second_50 -70;
-    pos @kc87_first_69 @kc87_second_51 -140;
-    pos @kc87_first_69 @kc87_second_53 105;
-    pos @kc87_first_69 @kc87_second_61 -140;
-    pos @kc87_first_69 @kc87_second_63 -70;
-    pos @kc87_first_69 @kc87_second_64 -105;
+    pos @kc87_first_69 @kc87_second_34 -50;
+    pos @kc87_first_69 @kc87_second_37 105;
+    pos @kc87_first_69 @kc87_second_38 -35;
+    pos @kc87_first_69 @kc87_second_40 -35;
+    pos @kc87_first_69 @kc87_second_43 -70;
+    pos @kc87_first_69 @kc87_second_44 -140;
+    pos @kc87_first_69 @kc87_second_45 -140;
+    pos @kc87_first_69 @kc87_second_47 -140;
+    pos @kc87_first_69 @kc87_second_48 -50;
+    pos @kc87_first_69 @kc87_second_51 1;
+    pos @kc87_first_69 @kc87_second_53 -70;
+    pos @kc87_first_69 @kc87_second_54 -140;
+    pos @kc87_first_69 @kc87_second_55 105;
+    pos @kc87_first_69 @kc87_second_63 -140;
     pos @kc87_first_69 @kc87_second_65 -70;
-    pos @kc87_first_69 @kc87_second_66 -35;
-    pos @kc87_first_69 @kc87_second_67 -35;
+    pos @kc87_first_69 @kc87_second_66 -105;
+    pos @kc87_first_69 @kc87_second_67 -70;
+    pos @kc87_first_69 @kc87_second_68 -35;
+    pos @kc87_first_69 @kc87_second_69 -35;
     pos @kc87_first_70 @kc87_second_3 -70;
     pos @kc87_first_70 @kc87_second_4 -50;
     pos @kc87_first_70 @kc87_second_6 -50;
@@ -10230,23 +10299,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_70 @kc87_second_25 -100;
     pos @kc87_first_70 @kc87_second_31 -35;
     pos @kc87_first_70 @kc87_second_33 -70;
-    pos @kc87_first_70 @kc87_second_36 105;
-    pos @kc87_first_70 @kc87_second_37 -35;
-    pos @kc87_first_70 @kc87_second_41 -70;
-    pos @kc87_first_70 @kc87_second_42 -140;
-    pos @kc87_first_70 @kc87_second_43 -140;
-    pos @kc87_first_70 @kc87_second_46 -140;
-    pos @kc87_first_70 @kc87_second_47 -35;
-    pos @kc87_first_70 @kc87_second_48 1;
-    pos @kc87_first_70 @kc87_second_50 -70;
-    pos @kc87_first_70 @kc87_second_51 -140;
-    pos @kc87_first_70 @kc87_second_53 105;
-    pos @kc87_first_70 @kc87_second_61 -140;
-    pos @kc87_first_70 @kc87_second_63 -70;
-    pos @kc87_first_70 @kc87_second_64 -70;
-    pos @kc87_first_70 @kc87_second_65 -50;
-    pos @kc87_first_70 @kc87_second_66 -35;
-    pos @kc87_first_70 @kc87_second_67 -35;
+    pos @kc87_first_70 @kc87_second_34 -50;
+    pos @kc87_first_70 @kc87_second_37 105;
+    pos @kc87_first_70 @kc87_second_38 -35;
+    pos @kc87_first_70 @kc87_second_40 -35;
+    pos @kc87_first_70 @kc87_second_43 -70;
+    pos @kc87_first_70 @kc87_second_44 -140;
+    pos @kc87_first_70 @kc87_second_45 -140;
+    pos @kc87_first_70 @kc87_second_47 -140;
+    pos @kc87_first_70 @kc87_second_48 -50;
+    pos @kc87_first_70 @kc87_second_51 1;
+    pos @kc87_first_70 @kc87_second_53 -70;
+    pos @kc87_first_70 @kc87_second_54 -140;
+    pos @kc87_first_70 @kc87_second_55 105;
+    pos @kc87_first_70 @kc87_second_63 -140;
+    pos @kc87_first_70 @kc87_second_65 -70;
+    pos @kc87_first_70 @kc87_second_66 -70;
+    pos @kc87_first_70 @kc87_second_67 -50;
+    pos @kc87_first_70 @kc87_second_68 -35;
+    pos @kc87_first_70 @kc87_second_69 -35;
     pos @kc87_first_71 @kc87_second_1 -210;
     pos @kc87_first_71 @kc87_second_2 -210;
     pos @kc87_first_71 @kc87_second_3 -35;
@@ -10262,26 +10333,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_71 @kc87_second_25 -105;
     pos @kc87_first_71 @kc87_second_26 -175;
     pos @kc87_first_71 @kc87_second_31 -105;
-    pos @kc87_first_71 @kc87_second_34 -210;
-    pos @kc87_first_71 @kc87_second_35 -105;
-    pos @kc87_first_71 @kc87_second_37 -175;
-    pos @kc87_first_71 @kc87_second_38 -140;
-    pos @kc87_first_71 @kc87_second_39 -70;
-    pos @kc87_first_71 @kc87_second_40 -105;
-    pos @kc87_first_71 @kc87_second_41 -105;
-    pos @kc87_first_71 @kc87_second_42 -70;
-    pos @kc87_first_71 @kc87_second_47 -35;
-    pos @kc87_first_71 @kc87_second_48 1;
-    pos @kc87_first_71 @kc87_second_53 -35;
-    pos @kc87_first_71 @kc87_second_54 -70;
-    pos @kc87_first_71 @kc87_second_55 -70;
-    pos @kc87_first_71 @kc87_second_56 -175;
+    pos @kc87_first_71 @kc87_second_34 -140;
+    pos @kc87_first_71 @kc87_second_35 -210;
+    pos @kc87_first_71 @kc87_second_36 -105;
+    pos @kc87_first_71 @kc87_second_38 -175;
+    pos @kc87_first_71 @kc87_second_39 -140;
+    pos @kc87_first_71 @kc87_second_40 -35;
+    pos @kc87_first_71 @kc87_second_41 -70;
+    pos @kc87_first_71 @kc87_second_42 -105;
+    pos @kc87_first_71 @kc87_second_43 -105;
+    pos @kc87_first_71 @kc87_second_44 -70;
+    pos @kc87_first_71 @kc87_second_51 1;
+    pos @kc87_first_71 @kc87_second_55 -35;
+    pos @kc87_first_71 @kc87_second_56 -70;
+    pos @kc87_first_71 @kc87_second_57 -70;
     pos @kc87_first_71 @kc87_second_58 -175;
-    pos @kc87_first_71 @kc87_second_59 -175;
-    pos @kc87_first_71 @kc87_second_61 -35;
-    pos @kc87_first_71 @kc87_second_62 -35;
-    pos @kc87_first_71 @kc87_second_66 -140;
-    pos @kc87_first_71 @kc87_second_67 -175;
+    pos @kc87_first_71 @kc87_second_60 -175;
+    pos @kc87_first_71 @kc87_second_61 -175;
+    pos @kc87_first_71 @kc87_second_63 -35;
+    pos @kc87_first_71 @kc87_second_64 -35;
+    pos @kc87_first_71 @kc87_second_68 -140;
+    pos @kc87_first_71 @kc87_second_69 -175;
     pos @kc87_first_72 @kc87_second_5 -70;
     pos @kc87_first_72 @kc87_second_8 -70;
     pos @kc87_first_72 @kc87_second_9 -105;
@@ -10296,22 +10368,23 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_72 @kc87_second_28 -35;
     pos @kc87_first_72 @kc87_second_29 -70;
     pos @kc87_first_72 @kc87_second_33 -70;
-    pos @kc87_first_72 @kc87_second_41 -35;
-    pos @kc87_first_72 @kc87_second_42 -245;
-    pos @kc87_first_72 @kc87_second_43 -70;
-    pos @kc87_first_72 @kc87_second_45 -35;
-    pos @kc87_first_72 @kc87_second_46 -240;
-    pos @kc87_first_72 @kc87_second_48 1;
-    pos @kc87_first_72 @kc87_second_50 -105;
-    pos @kc87_first_72 @kc87_second_51 -280;
-    pos @kc87_first_72 @kc87_second_52 -35;
-    pos @kc87_first_72 @kc87_second_57 -35;
-    pos @kc87_first_72 @kc87_second_60 -70;
-    pos @kc87_first_72 @kc87_second_61 -105;
-    pos @kc87_first_72 @kc87_second_62 -35;
-    pos @kc87_first_72 @kc87_second_63 -70;
-    pos @kc87_first_72 @kc87_second_64 -175;
-    pos @kc87_first_72 @kc87_second_65 -140;
+    pos @kc87_first_72 @kc87_second_43 -35;
+    pos @kc87_first_72 @kc87_second_44 -245;
+    pos @kc87_first_72 @kc87_second_45 -70;
+    pos @kc87_first_72 @kc87_second_47 -240;
+    pos @kc87_first_72 @kc87_second_48 -210;
+    pos @kc87_first_72 @kc87_second_49 -35;
+    pos @kc87_first_72 @kc87_second_50 -35;
+    pos @kc87_first_72 @kc87_second_51 1;
+    pos @kc87_first_72 @kc87_second_53 -105;
+    pos @kc87_first_72 @kc87_second_54 -280;
+    pos @kc87_first_72 @kc87_second_59 -35;
+    pos @kc87_first_72 @kc87_second_62 -70;
+    pos @kc87_first_72 @kc87_second_63 -105;
+    pos @kc87_first_72 @kc87_second_64 -35;
+    pos @kc87_first_72 @kc87_second_65 -70;
+    pos @kc87_first_72 @kc87_second_66 -175;
+    pos @kc87_first_72 @kc87_second_67 -140;
     pos @kc87_first_73 @kc87_second_1 -140;
     pos @kc87_first_73 @kc87_second_2 -140;
     pos @kc87_first_73 @kc87_second_6 -140;
@@ -10326,21 +10399,22 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_73 @kc87_second_25 -70;
     pos @kc87_first_73 @kc87_second_26 -140;
     pos @kc87_first_73 @kc87_second_31 -70;
-    pos @kc87_first_73 @kc87_second_35 -70;
-    pos @kc87_first_73 @kc87_second_37 -175;
-    pos @kc87_first_73 @kc87_second_38 -105;
-    pos @kc87_first_73 @kc87_second_39 -70;
-    pos @kc87_first_73 @kc87_second_40 -70;
+    pos @kc87_first_73 @kc87_second_34 -35;
+    pos @kc87_first_73 @kc87_second_36 -70;
+    pos @kc87_first_73 @kc87_second_38 -175;
+    pos @kc87_first_73 @kc87_second_39 -105;
     pos @kc87_first_73 @kc87_second_41 -70;
-    pos @kc87_first_73 @kc87_second_42 -35;
-    pos @kc87_first_73 @kc87_second_48 1;
-    pos @kc87_first_73 @kc87_second_53 -35;
-    pos @kc87_first_73 @kc87_second_54 -35;
-    pos @kc87_first_73 @kc87_second_56 -140;
+    pos @kc87_first_73 @kc87_second_42 -70;
+    pos @kc87_first_73 @kc87_second_43 -70;
+    pos @kc87_first_73 @kc87_second_44 -35;
+    pos @kc87_first_73 @kc87_second_51 1;
+    pos @kc87_first_73 @kc87_second_55 -35;
+    pos @kc87_first_73 @kc87_second_56 -35;
     pos @kc87_first_73 @kc87_second_58 -140;
-    pos @kc87_first_73 @kc87_second_59 -140;
-    pos @kc87_first_73 @kc87_second_66 -105;
-    pos @kc87_first_73 @kc87_second_67 -105;
+    pos @kc87_first_73 @kc87_second_60 -140;
+    pos @kc87_first_73 @kc87_second_61 -140;
+    pos @kc87_first_73 @kc87_second_68 -105;
+    pos @kc87_first_73 @kc87_second_69 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -12749,6 +12823,7 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
+#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 

--- a/sources/Giphurs-Thin.ufo/fontinfo.plist
+++ b/sources/Giphurs-Thin.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/30 16:40:06</string>
+    <string>2026/07/30 22:06:29</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>

--- a/sources/Giphurs-ThinItalic.ufo/features.fea
+++ b/sources/Giphurs-ThinItalic.ufo/features.fea
@@ -7920,16 +7920,17 @@ lookup kern_Horizontal_kerning {
     @kc87_first_4 = [\D \Dcaron \Dcroat \Eth \G.cv21 \Gbreve.cv21 \Gcaron.cv21 \Gcircumflex.cv21 
 	\Gcommaaccent.cv21 \Gdotaccent.cv21 \O \Oacute \Obreve \Ocircumflex 
 	\Odieresis \Ograve \Ohungarumlaut \Omacron \Omicron \Omicrontonos 
-	\Oslash \Oslashacute \Otilde \Theta \uni0189 \uni018A \uni018F 
-	\uni0193.cv21 \uni019F \uni01D1 \uni01E4.cv21 \uni01EA \uni01EC 
-	\uni01F4.cv21 \uni020C \uni020E \uni022A \uni022C \uni022E \uni0230 
-	\uni0298 \uni03D8 \uni03F4 \uni03FD \uni03FF \uni041E \uni042E \uni0472 
-	\uni047A \uni04BC \uni04BE \uni04D8 \uni04DA \uni04E6 \uni04E8 \uni04EA 
-	\uni04EC \uni050C \uni1E0A \uni1E0C \uni1E0E \uni1E10 \uni1E12 
-	\uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 \uni1E52 \uni1ECC \uni1ECE 
-	\uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 \uni1EDA \uni1EDC \uni1EDE 
-	\uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A \uni1F4B \uni1F4C \uni1F4D 
-	\uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 \uni2181 \uni2182 \uniA7C7 ];
+	\Oslash \Oslashacute \Otilde \Theta \two.cv02.pnum \two.cv12.pnum 
+	\two.pnum \uni0189 \uni018A \uni018F \uni0193.cv21 \uni019F \uni01D1 
+	\uni01E4.cv21 \uni01EA \uni01EC \uni01F4.cv21 \uni020C \uni020E 
+	\uni022A \uni022C \uni022E \uni0230 \uni0298 \uni03D8 \uni03F4 \uni03FD 
+	\uni03FF \uni041E \uni042E \uni0472 \uni047A \uni04BC \uni04BE \uni04D8 
+	\uni04DA \uni04E6 \uni04E8 \uni04EA \uni04EC \uni050C \uni1E0A \uni1E0C 
+	\uni1E0E \uni1E10 \uni1E12 \uni1E20.cv21 \uni1E4C \uni1E4E \uni1E50 
+	\uni1E52 \uni1ECC \uni1ECE \uni1ED0 \uni1ED2 \uni1ED4 \uni1ED6 \uni1ED8 
+	\uni1EDA \uni1EDC \uni1EDE \uni1EE0 \uni1EE2 \uni1F48 \uni1F49 \uni1F4A 
+	\uni1F4B \uni1F4C \uni1F4D \uni1FF8 \uni1FF9 \uni2108 \uni216E \uni2180 
+	\uni2181 \uni2182 \uniA7C7 ];
     @kc87_first_5 = [\G \Gbreve \Gcaron \Gcircumflex \Gcommaaccent \Gdotaccent \Omega \Omegatonos \Q 
 	\Q.cv29 \uni01E4 \uni03A9 \uni051A \uni051A.cv29 \uni1E20 \uni1F68 
 	\uni1F69 \uni1F6A \uni1F6B \uni1F6C \uni1F6D \uni1F6E \uni1F6F \uni1FA8 
@@ -7946,24 +7947,27 @@ lookup kern_Horizontal_kerning {
     @kc87_first_8 = [\K \Kappa \Kcommaaccent \X \uni0198 \uni0416 \uni041A \uni0496 \uni049A \uni04B2 
 	\uni04C1 \uni04DC \uni04FC \uni04FE \uni0514 \uni0516 \uni052A \uni1E30 
 	\uni1E32 \uni1E34 \uni1E8A \uni1E8C \uni20AD \uni212A \uni2168 \uni2169 ];
-    @kc87_first_9 = [\L \Lacute \uni023D \uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 
-	\uniA7AD ];
+    @kc87_first_9 = [\L \Lacute \one.cv01.ss06.pnum \one.cv11.ss06.pnum \one.ss06.pnum \uni023D 
+	\uni1E36 \uni1E38 \uni1E3A \uni1E3C \uni1EFA \uni2104 \uniA7AD ];
     @kc87_first_10 = [\P \Rho \peseta \uni01A4 \uni0420 \uni048E \uni1E54 \uni1E56 \uni1FEC \uni2C63 ];
     @kc87_first_11 = [\Phi \Thorn \uni03F7 \uni0424 ];
     @kc87_first_12 = [\Psi \uni0470 ];
     @kc87_first_13 = [\R \Racute \Rcommaaccent \uni01A6 \uni0210 \uni0212 \uni024C \uni1E58 \uni1E5A 
 	\uni1E5C \uni1E5E \uni211F \uni2C64 ];
-    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni0190 \uni01A7 
-	\uni03E8 \uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 
-	\uni2107 ];
+    @kc87_first_14 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv08.onum 
+	\eight.cv08.pnum \eight.cv18.onum \eight.cv18.pnum \eight.onum 
+	\eight.pnum \three.cv03.pnum \three.pnum \uni0190 \uni01A7 \uni03E8 
+	\uni0405 \uni0510 \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 \uni2107 ];
     @kc87_first_15 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni01C4 \uni01F1 
 	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 \zeta ];
     @kc87_first_16 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
 	\uni1FE8 \uni1FE9 \uni1FEA \uni1FEB ];
-    @kc87_first_17 = [\V \gradient \slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE 
-	\uni2163 \uni2164 \universal ];
+    @kc87_first_17 = [\V \gradient \nine.cv19.pnum \seven.cv07.pnum \seven.cv07.ss07.pnum 
+	\seven.cv17.pnum \seven.cv17.ss07.pnum \seven.pnum \seven.ss07.pnum 
+	\slash \uni0423 \uni0474 \uni0476 \uni1E7C \uni1E7E \uni1EFE \uni2163 
+	\uni2164 \universal ];
     @kc87_first_18 = [\W \Wacute \Wcircumflex \Wdieresis \Wgrave \uni0460 \uni1E86 \uni1E88 \uni2C72 ];
     @kc87_first_19 = [\a \a.cv23 \aacute \aacute.cv23 \abreve \abreve.cv23 \acircumflex 
 	\acircumflex.cv23 \adieresis \adieresis.cv23 \agrave \agrave.cv23 
@@ -8059,16 +8063,17 @@ lookup kern_Horizontal_kerning {
     @kc87_first_22 = [\aeacute \e \eacute \ebreve \ecircumflex \edieresis \edotaccent \egrave \emacron 
 	\eogonek \o \oacute \obreve \ocircumflex \odieresis \oe \ograve 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni018D \uni01D2 \uni01DD \uni01E3 \uni01EB \uni01ED \uni0205 
-	\uni0207 \uni020D \uni020F \uni0229 \uni022B \uni022D \uni022F \uni0231 
-	\uni0247 \uni0254 \uni0258 \uni0259 \uni0275 \uni0278 \uni037B \uni037D 
-	\uni03D9 \uni03F6 \uni0435 \uni043E \uni044D \uni044E \uni0473 \uni04BD 
-	\uni04BF \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni04ED 
-	\uni050D \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni2184 ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni018D \uni01D2 \uni01DD 
+	\uni01E3 \uni01EB \uni01ED \uni0205 \uni0207 \uni020D \uni020F \uni0229 
+	\uni022B \uni022D \uni022F \uni0231 \uni0247 \uni0254 \uni0258 \uni0259 
+	\uni0275 \uni0278 \uni037B \uni037D \uni03D9 \uni03F6 \uni0435 \uni043E 
+	\uni044D \uni044E \uni0473 \uni04BD \uni04BF \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni04ED \uni050D \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni2184 ];
     @kc87_first_23 = [\alpha \alphatonos \pi \uni1F00 \uni1F01 \uni1F02 \uni1F03 \uni1F04 \uni1F05 
 	\uni1F06 \uni1F07 \uni1F80 \uni1F81 \uni1F82 \uni1F83 \uni1F84 \uni1F85 
 	\uni1F86 \uni1F87 \uni1FB0 \uni1FB1 \uni1FB2 \uni1FB3 \uni1FB4 \uni1FB6 
@@ -8153,18 +8158,21 @@ lookup kern_Horizontal_kerning {
 	\uni04FD.sc \uni04FF.sc \uni0515.sc \uni0517.sc \uni051F.sc 
 	\uni052B.sc \uni1E31.sc \uni1E33.sc \uni1E35.sc \uni1E8B.sc 
 	\uni1E8D.sc \x.sc ];
-    @kc87_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohungarumlaut.sc \omacron.sc \omicron.sc 
-	\oslash.sc \otilde.sc \uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc 
-	\uni022D.sc \uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc 
-	\uni037B.sc \uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc 
-	\uni0473.sc \uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc 
-	\uni04E9.sc \uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc 
-	\uni1E0F.sc \uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc 
-	\uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc 
-	\uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc 
-	\uni1EDD.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc 
-	\uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc ];
+    @kc87_first_32 = [\d.sc \dcaron.sc \dcroat.sc \eth.sc \nine.cv09.onum \nine.cv19.onum \nine.onum 
+	\o.sc \oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohungarumlaut.sc \omacron.sc \omicron.sc \oslash.sc \otilde.sc 
+	\uni01D2.sc \uni020D.sc \uni020F.sc \uni022B.sc \uni022D.sc 
+	\uni022F.sc \uni0231.sc \uni0256.sc \uni0257.sc \uni037B.sc 
+	\uni037D.sc \uni03D9.sc \uni043E.sc \uni044E.sc \uni0473.sc 
+	\uni047B.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
+	\uni04EB.sc \uni04ED.sc \uni1E0B.sc \uni1E0D.sc \uni1E0F.sc 
+	\uni1E11.sc \uni1E13.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc 
+	\uni1E53.sc \uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc 
+	\uni1ED5.sc \uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uniA7C8.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_first_33 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
 	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
@@ -8223,73 +8231,82 @@ lookup kern_Horizontal_kerning {
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
     @kc87_first_37 = [\eth \uni1EFC \uni1EFD ];
-    @kc87_first_38 = [\fraction ];
-    @kc87_first_39 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \uni01E5 \uni1E21 ];
-    @kc87_first_40 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
-	\omegatonos.sc \q.sc \q.sc.cv29 \uni0260.sc \uni051B.sc 
-	\uni051B.sc.cv29 \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_first_41 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
+    @kc87_first_38 = [\four.cv04.onum \four.cv14.onum \four.onum \l.sc \lacute.sc \lcaron.sc 
+	\lcommaaccent.sc \ldot.sc \lslash.sc \one.cv01.ss06.onum 
+	\one.cv11.ss06.onum \one.ss06.onum \uni019A.sc \uni0234.sc 
+	\uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
+    @kc87_first_39 = [\four.cv04.pnum \four.cv14.pnum \four.pnum \phi.sc \thorn.sc \uni01A5.sc 
+	\uni0444.sc ];
+    @kc87_first_40 = [\fraction ];
+    @kc87_first_41 = [\g \gbreve \gcircumflex \gcommaaccent \gdotaccent \sigma \three.cv03.onum 
+	\three.onum \uni01E5 \uni1E21 ];
+    @kc87_first_42 = [\g.sc \gbreve.sc \gcircumflex.sc \gcommaaccent.sc \gdotaccent.sc \omega.sc 
+	\omegatonos.sc \q.sc \q.sc.cv29 \two.cv02.onum \two.cv12.onum 
+	\two.onum \uni0260.sc \uni051B.sc \uni051B.sc.cv29 \uni1F60.sc 
+	\uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc \uni1F65.sc 
+	\uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc \uni1FA0.sc 
+	\uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc \uni1FA5.sc 
+	\uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc \uni1FF4.sc 
+	\uni1FF6.sc \uni1FF7.sc ];
+    @kc87_first_43 = [\gamma \uni0461 \uni047F \uni04B1 \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w 
 	\wacute \wcircumflex \wdieresis \wgrave ];
-    @kc87_first_42 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
+    @kc87_first_44 = [\gamma.sc \t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
 	\uni021B.sc \uni0288.sc \uni0433.sc \uni0442.sc \uni0453.sc 
 	\uni0491.sc \uni0493.sc \uni04A5.sc \uni04F7.sc \uni04FB.sc 
 	\uni1E6B.sc \uni1E6D.sc \uni1E6F.sc \uni1E71.sc ];
-    @kc87_first_43 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
+    @kc87_first_45 = [\h \hbar \hcircumflex \m \n \nacute \napostrophe \ncaron \ncommaaccent \uni0266 
 	\uni0439 \uni045B \uni1E23 \uni1E25 \uni1E27 \uni1E29 \uni1E2B \uni217F ];
-    @kc87_first_44 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
+    @kc87_first_46 = [\iota \iotadieresis \iotadieresistonos \uni0269 \uni1F30 \uni1F31 \uni1F32 
 	\uni1F33 \uni1F34 \uni1F35 \uni1F36 \uni1F37 \uni1F76 \uni1F77 \uni1FD0 
 	\uni1FD1 \uni1FD2 \uni1FD3 \uni1FD6 \uni1FD7 ];
-    @kc87_first_45 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
+    @kc87_first_47 = [\k \kappa \kcommaaccent \kgreenlandic \uni0199 \uni01E9 \uni0436 
 	\uni0436.loclBGR \uni043A.loclBGR \uni0445 \uni045C \uni049B \uni049D 
 	\uni049F \uni04A1 \uni04C2 \uni04DD \uni04FD \uni04FF \uni051F \uni1E33 
 	\uni1E35 \uni1E8B \uni1E8D \uni2178 \uni2179 \x ];
-    @kc87_first_46 = [\l.sc \lacute.sc \lcaron.sc \lcommaaccent.sc \ldot.sc \lslash.sc \uni019A.sc 
-	\uni0234.sc \uni1E37.sc \uni1E39.sc \uni1E3B.sc \uni1E3D.sc ];
-    @kc87_first_47 = [\lambda \uni019B ];
-    @kc87_first_48 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
-    @kc87_first_49 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
+    @kc87_first_48 = [\lambda \uni019B ];
+    @kc87_first_49 = [\longs \uni0283 \uni0284 \uni0286 \uni02A7 \uni1E9B ];
+    @kc87_first_50 = [\theta \uni047C \uniA7B6 \uniA64C \uni0424.loclBGR \zero.pnum \nine.pnum 
+	\nine.cv09.pnum \zero.cv10.pnum \zero.cv20.pnum \zero.zero.pnum 
+	\zero.cv10.zero.pnum \zero.cv20.zero.pnum ];
+    @kc87_first_51 = [\omega \omega1 \phi \psi \uni0195 \uni0277 \uni0471 \uni1F50 \uni1F51 \uni1F52 
 	\uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F60 \uni1F61 \uni1F62 
 	\uni1F63 \uni1F64 \uni1F65 \uni1F66 \uni1F67 \uni1F7A \uni1F7B \uni1F7C 
 	\uni1F7D \uni1FA0 \uni1FA1 \uni1FA2 \uni1FA3 \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FE0 \uni1FE1 \uni1FE2 \uni1FE3 \uni1FE6 \uni1FE7 \uni1FF2 
 	\uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 \upsilon \upsilondieresistonos ];
-    @kc87_first_50 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
-    @kc87_first_51 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
-    @kc87_first_52 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
+    @kc87_first_52 = [\one.cv01.ss06.dnom.pnum \one.cv11.ss06.dnom.pnum \one.ss06.dnom.pnum ];
+    @kc87_first_53 = [\one.cv01.ss06.numr.pnum \one.cv11.ss06.numr.pnum \one.ss06.numr.pnum ];
+    @kc87_first_54 = [\p.sc \rho.sc \uni0440.sc \uni048F.sc \uni1E55.sc \uni1E57.sc \uni1FE4.sc 
 	\uni1FE5.sc ];
-    @kc87_first_53 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_first_54 = [\psi.sc \uni0447.sc \uni0471.sc ];
-    @kc87_first_55 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
-    @kc87_first_56 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
+    @kc87_first_55 = [\psi.sc \uni0447.sc \uni0471.sc ];
+    @kc87_first_56 = [\q \uni0237 \uni0270 \uni04C8 \uni0513 \uni051B ];
+    @kc87_first_57 = [\r \racute \rcaron \rcommaaccent \uni0211 \uni0213 \uni024D \uni027C \uni027D 
 	\uni027E \uni1E59 \uni1E5B \uni1E5D \uni1E5F ];
-    @kc87_first_57 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_first_58 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni02A6.sc \uni02AA.sc \uni0437.sc \uni0455.sc \uni0499.sc 
 	\uni04DF.sc \uni0511.sc ];
-    @kc87_first_58 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
-	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
-	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_first_59 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
-	\uni1E71 ];
-    @kc87_first_60 = [\tau \uni0491 \uni04A5 ];
-    @kc87_first_61 = [\theta \uni0424.loclBGR \uni047C \uniA64C \uniA7B6 ];
-    @kc87_first_62 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
-    @kc87_first_63 = [\uni0196 \uni01AA ];
-    @kc87_first_64 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
-	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
-	\ygrave ];
-    @kc87_first_65 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_first_59 = [\seven.cv07.onum \seven.cv07.ss07.onum \seven.cv17.onum 
+	\seven.cv17.ss07.onum \seven.onum \seven.ss07.onum \uni01B4.sc 
+	\uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_first_66 = [\uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 \uni02A3 \uni02AB 
-	\uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z \zacute \zcaron 
-	\zdotaccent ];
+    @kc87_first_60 = [\sigma.sc \uni01B6.sc \uni01C5.sc \uni01C6.sc \uni01F2.sc \uni01F3.sc 
+	\uni0225.sc \uni02A3.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
+    @kc87_first_61 = [\t \tbar \uni0163 \uni01AB \uni01AD \uni021B \uni0236 \uni1E6B \uni1E6D \uni1E6F 
+	\uni1E71 ];
+    @kc87_first_62 = [\tau \uni0491 \uni04A5 ];
+    @kc87_first_63 = [\three.cv13.onum \uni01C5 \uni01C6 \uni01F2 \uni01F3 \uni0225 \uni0240 \uni0290 
+	\uni02A3 \uni02AB \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 \z 
+	\zacute \zcaron \zdotaccent ];
+    @kc87_first_64 = [\uni0184 \uni0402 \uni0409 \uni040A \uni042A \uni042C \uni048C ];
+    @kc87_first_65 = [\uni0196 \uni01AA ];
+    @kc87_first_66 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2173 \uni2174 \v \y \ycircumflex 
+	\ygrave ];
     @kc87_first_67 = [\uni0414 \uni0426 \uni0429 \uni048A \uni04A2 \uni04B4 \uni04B6 \uni04C5 \uni04C9 
 	\uni0524 \uni052E ];
     @kc87_first_68 = [\uni0434 \uni0446 \uni0449 \uni04A3 \uni04B7 \uni04C6 \uni04CA \uni04CE \uni0525 
@@ -8330,15 +8347,19 @@ lookup kern_Horizontal_kerning {
 	\uni0407 \uni04C0 \uni1E2C \uni1E2E \uni1EC8 \uni1ECA \uni1FD8 \uni1FD9 
 	\uni2160 \uni2161 \uni2162 \uni2163 \uni2168 \uniA7AE ];
     @kc87_second_6 = [\J \Jcircumflex \uni0248 \uni037F \uni0408 ];
-    @kc87_second_7 = [\Omega \uni03A9 \uni1FFC ];
+    @kc87_second_7 = [\Omega \nine.cv19.pnum \two.cv02.pnum \two.cv12.pnum \two.pnum \uni03A9 
+	\uni1FFC ];
     @kc87_second_8 = [\Phi \uni0424 ];
     @kc87_second_9 = [\Psi \uni0427 \uni0470 \uni04B6 \uni04B8 \uni04CB \uni04F4 ];
-    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \uni01A7 \uni03E8 
-	\uni0405 \uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
-    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \uni01A9 \uni01B5 \uni0224 \uni1E90 
-	\uni1E92 \uni1E94 \uniA640 \uniA642 ];
-    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \uni0162 \uni01AC \uni01AE \uni021A \uni0422 \uni042A 
-	\uni04AC \uni04B4 \uni050E \uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
+    @kc87_second_10 = [\S \Sacute \Scaron \Scedilla \Scircumflex \Scommaaccent \eight.cv08.onum 
+	\eight.cv08.pnum \eight.cv18.onum \eight.cv18.pnum \eight.onum 
+	\eight.tnum \three.cv03.pnum \three.tnum \uni01A7 \uni03E8 \uni0405 
+	\uni0417 \uni04DE \uni1E60 \uni1E62 \uni1E64 \uni1E66 \uni1E68 ];
+    @kc87_second_11 = [\Sigma \Z \Zacute \Zcaron \Zdotaccent \Zeta \three.cv13.pnum \uni01A9 \uni01B5 
+	\uni0224 \uni1E90 \uni1E92 \uni1E94 \uniA640 \uniA642 ];
+    @kc87_second_12 = [\T \Tau \Tbar \Tcaron \seven.cv07.pnum \seven.cv17.pnum \seven.pnum \uni0162 
+	\uni01AC \uni01AE \uni021A \uni0422 \uni042A \uni04AC \uni04B4 \uni050E 
+	\uni1E6A \uni1E6C \uni1E6E \uni1E70 \uni2142 ];
     @kc87_second_13 = [\Upsilon \Upsilon1 \Upsilondieresis \Upsilontonos \Y \Ycircumflex \Ydieresis 
 	\Ygrave \uni01B3 \uni0232 \uni024E \uni03D3 \uni03D4 \uni04AE \uni04B0 
 	\uni1E8E \uni1EF4 \uni1EF6 \uni1EF8 \uni1F59 \uni1F5B \uni1F5D \uni1F5F 
@@ -8354,15 +8375,16 @@ lookup kern_Horizontal_kerning {
 	\agrave.cv23 \agrave.sc \alpha \alpha.sc \alphatonos \amacron 
 	\amacron.cv23 \amacron.sc \aogonek \aogonek.cv23 \aogonek.sc \aring 
 	\aring.cv23 \aring.sc \aringacute.cv23 \atilde \atilde.cv23 
-	\atilde.sc \d \dcaron \dcroat \delta.sc \dong \eth \g \g.cv24 \gbreve 
-	\gbreve.cv24 \gcaron.cv24 \gcircumflex \gcircumflex.cv24 
-	\gcommaaccent \gcommaaccent.cv24 \gdotaccent \gdotaccent.cv24 
-	\lambda.sc \phi \q \sigma \uni019B.sc \uni01CE.cv23 \uni01CE.sc 
-	\uni01DF \uni01DF.cv23 \uni01DF.sc \uni01E1 \uni01E1.cv23 \uni01E1.sc 
-	\uni01E3.cv23 \uni01E5 \uni01E5.cv24 \uni01F5.cv24 \uni0201 
-	\uni0201.cv23 \uni0201.sc \uni0203 \uni0203.cv23 \uni0203.sc \uni0227 
-	\uni0227.cv23 \uni0227.sc \uni0238 \uni0239 \uni024B \uni0260 \uni0261 
-	\uni0278 \uni0430 \uni0430.cv23 \uni0430.sc \uni0432 \uni0434 
+	\atilde.sc \d \dcaron \dcroat \delta.sc \dong \eth \four.cv04.onum 
+	\four.cv14.onum \four.onum \g \g.cv24 \gbreve \gbreve.cv24 
+	\gcaron.cv24 \gcircumflex \gcircumflex.cv24 \gcommaaccent 
+	\gcommaaccent.cv24 \gdotaccent \gdotaccent.cv24 \lambda.sc \phi \q 
+	\sigma \three.cv03.onum \three.onum \uni019B.sc \uni01CE.cv23 
+	\uni01CE.sc \uni01DF \uni01DF.cv23 \uni01DF.sc \uni01E1 \uni01E1.cv23 
+	\uni01E1.sc \uni01E3.cv23 \uni01E5 \uni01E5.cv24 \uni01F5.cv24 
+	\uni0201 \uni0201.cv23 \uni0201.sc \uni0203 \uni0203.cv23 \uni0203.sc 
+	\uni0227 \uni0227.cv23 \uni0227.sc \uni0238 \uni0239 \uni024B \uni0260 
+	\uni0261 \uni0278 \uni0430 \uni0430.cv23 \uni0430.sc \uni0432 \uni0434 
 	\uni0434.loclBGR \uni0434.loclBGR.sc \uni043B.loclBGR.sc \uni0444 
 	\uni0467.sc \uni0469.sc \uni04D1 \uni04D1.cv23 \uni04D1.sc \uni04D3 
 	\uni04D3.cv23 \uni04D3.sc \uni04D5.cv23 \uni0501 \uni0503 \uni051B 
@@ -8449,35 +8471,38 @@ lookup kern_Horizontal_kerning {
 	\ecircumflex \edieresis \edotaccent \egrave \emacron \eogonek \o 
 	\oacute \obreve \ocircumflex \odieresis \oe \ograve \ohorn 
 	\ohungarumlaut \omacron \omicron \omicrontonos \oslash \oslashacute 
-	\otilde \uni0188 \uni018D \uni01A3 \uni01D2 \uni01DD \uni01EB \uni020D 
-	\uni020F \uni022B \uni022D \uni022F \uni0231 \uni023C \uni0247 \uni0255 
-	\uni0258 \uni0259 \uni025A \uni0275 \uni0276 \uni029B \uni03D9 \uni03F2 
-	\uni03F5 \uni0435 \uni043E \uni0450 \uni0451 \uni0473 \uni047B \uni04A9 
-	\uni04AB \uni04D7 \uni04D9 \uni04DB \uni04E7 \uni04E9 \uni04EB \uni050D 
-	\uni1E09 \uni1E15 \uni1E17 \uni1E19 \uni1E1B \uni1E1D \uni1E4D \uni1E4F 
-	\uni1E51 \uni1E53 \uni1EB9 \uni1EBB \uni1EBD \uni1EBF \uni1EC1 \uni1EC3 
-	\uni1EC5 \uni1EC7 \uni1ECD \uni1ECF \uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 
-	\uni1ED9 \uni1EDB \uni1EDD \uni1EDF \uni1EE1 \uni1EE3 \uni1F40 \uni1F41 
-	\uni1F42 \uni1F43 \uni1F44 \uni1F45 \uni1F78 \uni1F79 \uni20C0 \uni217D ];
+	\otilde \six.cv16.onum \six.cv16.pnum \uni0188 \uni018D \uni01A3 
+	\uni01D2 \uni01DD \uni01EB \uni020D \uni020F \uni022B \uni022D \uni022F 
+	\uni0231 \uni023C \uni0247 \uni0255 \uni0258 \uni0259 \uni025A \uni0275 
+	\uni0276 \uni029B \uni03D9 \uni03F2 \uni03F5 \uni0435 \uni043E \uni0450 
+	\uni0451 \uni0473 \uni047B \uni04A9 \uni04AB \uni04D7 \uni04D9 \uni04DB 
+	\uni04E7 \uni04E9 \uni04EB \uni050D \uni1E09 \uni1E15 \uni1E17 \uni1E19 
+	\uni1E1B \uni1E1D \uni1E4D \uni1E4F \uni1E51 \uni1E53 \uni1EB9 \uni1EBB 
+	\uni1EBD \uni1EBF \uni1EC1 \uni1EC3 \uni1EC5 \uni1EC7 \uni1ECD \uni1ECF 
+	\uni1ED1 \uni1ED3 \uni1ED5 \uni1ED7 \uni1ED9 \uni1EDB \uni1EDD \uni1EDF 
+	\uni1EE1 \uni1EE3 \uni1F40 \uni1F41 \uni1F42 \uni1F43 \uni1F44 \uni1F45 
+	\uni1F78 \uni1F79 \uni20C0 \uni217D ];
     @kc87_second_23 = [\c.sc \cacute.sc \ccaron.sc \ccedilla.sc \ccircumflex.sc \cdotaccent.sc \g.sc 
 	\gbreve.sc \gcaron.sc \gcircumflex.sc \gcommaaccent.sc 
-	\gdotaccent.sc \o.sc \oacute.sc \obreve.sc \ocircumflex.sc 
-	\odieresis.sc \ograve.sc \ohorn.sc \ohungarumlaut.sc \omacron.sc 
-	\omicron.sc \omicrontonos.sc \oslash.sc \oslashacute.sc \otilde.sc 
-	\q.sc \q.sc.cv29 \theta.sc \uni0188.sc \uni01A3.sc \uni01D2.sc 
-	\uni01E5.sc \uni01EB.sc \uni01ED.sc \uni01F5.sc \uni020D.sc 
-	\uni020F.sc \uni022B.sc \uni022D.sc \uni022F.sc \uni0231.sc 
-	\uni023C.sc \uni0259.sc \uni0260.sc \uni0275.sc \uni0298.sc 
-	\uni037C.sc \uni03D9.sc \uni03F2.sc \uni043E.sc \uni0441.sc 
-	\uni0444.loclBGR.sc \uni0454.sc \uni0473.sc \uni047B.sc \uni0481.sc 
-	\uni04AB.sc \uni04D9.sc \uni04DB.sc \uni04E7.sc \uni04E9.sc 
-	\uni04EB.sc \uni050D.sc \uni051B.sc \uni051B.sc.cv29 \uni1E09.sc 
-	\uni1E21.sc \uni1E4D.sc \uni1E4F.sc \uni1E51.sc \uni1E53.sc 
-	\uni1ECD.sc \uni1ECF.sc \uni1ED1.sc \uni1ED3.sc \uni1ED5.sc 
-	\uni1ED7.sc \uni1ED9.sc \uni1EDB.sc \uni1EDD.sc \uni1EDF.sc 
-	\uni1EE1.sc \uni1EE3.sc \uni1F40.sc \uni1F41.sc \uni1F42.sc 
-	\uni1F43.sc \uni1F44.sc \uni1F45.sc \uni1F78.sc \uni1F79.sc 
-	\uni217D.sc ];
+	\gdotaccent.sc \nine.cv09.onum \nine.cv19.onum \nine.onum \o.sc 
+	\oacute.sc \obreve.sc \ocircumflex.sc \odieresis.sc \ograve.sc 
+	\ohorn.sc \ohungarumlaut.sc \omacron.sc \omicron.sc \omicrontonos.sc 
+	\oslash.sc \oslashacute.sc \otilde.sc \q.sc \q.sc.cv29 \theta.sc 
+	\uni0188.sc \uni01A3.sc \uni01D2.sc \uni01E5.sc \uni01EB.sc 
+	\uni01ED.sc \uni01F5.sc \uni020D.sc \uni020F.sc \uni022B.sc 
+	\uni022D.sc \uni022F.sc \uni0231.sc \uni023C.sc \uni0259.sc 
+	\uni0260.sc \uni0275.sc \uni0298.sc \uni037C.sc \uni03D9.sc 
+	\uni03F2.sc \uni043E.sc \uni0441.sc \uni0444.loclBGR.sc \uni0454.sc 
+	\uni0473.sc \uni047B.sc \uni0481.sc \uni04AB.sc \uni04D9.sc 
+	\uni04DB.sc \uni04E7.sc \uni04E9.sc \uni04EB.sc \uni050D.sc 
+	\uni051B.sc \uni051B.sc.cv29 \uni1E09.sc \uni1E21.sc \uni1E4D.sc 
+	\uni1E4F.sc \uni1E51.sc \uni1E53.sc \uni1ECD.sc \uni1ECF.sc 
+	\uni1ED1.sc \uni1ED3.sc \uni1ED5.sc \uni1ED7.sc \uni1ED9.sc 
+	\uni1EDB.sc \uni1EDD.sc \uni1EDF.sc \uni1EE1.sc \uni1EE3.sc 
+	\uni1F40.sc \uni1F41.sc \uni1F42.sc \uni1F43.sc \uni1F44.sc 
+	\uni1F45.sc \uni1F78.sc \uni1F79.sc \uni217D.sc \zero.cv10.onum 
+	\zero.cv10.zero.onum \zero.cv20.onum \zero.cv20.zero.onum 
+	\zero.onum \zero.zero.onum ];
     @kc87_second_24 = [\cedilla \comma \eight.cv08.subscript \eight.cv08.subscript.pnum 
 	\eight.cv08.subscript.tnum \eight.cv18.subscript 
 	\eight.cv18.subscript.pnum \eight.cv18.subscript.tnum 
@@ -8540,14 +8565,15 @@ lookup kern_Horizontal_kerning {
 	\uni2179.sc \uni217A.sc \uni217B.sc \x.sc ];
     @kc87_second_27 = [\dotlessi.sc \i.sc \iacute.sc \ibreve.sc \icircumflex.sc \idieresis.sc 
 	\igrave.sc \imacron.sc \iogonek.sc \iota.sc \iotadieresis.sc 
-	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \uni01D0.sc 
-	\uni0209.sc \uni020B.sc \uni0269.sc \uni026A.sc \uni0456.sc 
-	\uni0457.sc \uni1E2D.sc \uni1E2F.sc \uni1EC9.sc \uni1ECB.sc 
-	\uni1F30.sc \uni1F31.sc \uni1F32.sc \uni1F33.sc \uni1F34.sc 
-	\uni1F35.sc \uni1F36.sc \uni1F37.sc \uni1F76.sc \uni1F77.sc 
-	\uni1FD0.sc \uni1FD1.sc \uni1FD2.sc \uni1FD3.sc \uni1FD6.sc 
-	\uni1FD7.sc \uni2170.sc \uni2171.sc \uni2172.sc \uni2173.sc 
-	\uni2178.sc ];
+	\iotadieresistonos.sc \iotatonos.sc \itilde.sc \one.cv01.ss06.onum 
+	\one.cv01.ss06.pnum \one.cv11.ss06.onum \one.cv11.ss06.pnum 
+	\one.ss06.onum \one.ss06.pnum \uni01D0.sc \uni0209.sc \uni020B.sc 
+	\uni0269.sc \uni026A.sc \uni0456.sc \uni0457.sc \uni1E2D.sc 
+	\uni1E2F.sc \uni1EC9.sc \uni1ECB.sc \uni1F30.sc \uni1F31.sc 
+	\uni1F32.sc \uni1F33.sc \uni1F34.sc \uni1F35.sc \uni1F36.sc 
+	\uni1F37.sc \uni1F76.sc \uni1F77.sc \uni1FD0.sc \uni1FD1.sc 
+	\uni1FD2.sc \uni1FD3.sc \uni1FD6.sc \uni1FD7.sc \uni2170.sc 
+	\uni2171.sc \uni2172.sc \uni2173.sc \uni2178.sc ];
     @kc87_second_28 = [\eight.cv08.dnom \eight.cv08.dnom.pnum \eight.cv08.dnom.tnum 
 	\eight.cv18.dnom \eight.cv18.dnom.pnum \eight.cv18.dnom.tnum 
 	\eight.dnom \eight.dnom.pnum \eight.dnom.tnum \five.cv05.dnom 
@@ -8579,108 +8605,116 @@ lookup kern_Horizontal_kerning {
 	\three.cv13.dnom.tnum \three.dnom \three.dnom.pnum \three.dnom.tnum 
 	\two.cv02.dnom \two.cv02.dnom.pnum \two.cv02.dnom.tnum 
 	\two.cv12.dnom \two.cv12.dnom.pnum \two.cv12.dnom.tnum \two.dnom 
-	\two.dnom.pnum \two.dnom.tnum \zero.cv10.dnom.pnum 
-	\zero.cv10.dnom.tnum \zero.cv10.zero.dnom 
-	\zero.cv10.zero.dnom.tnum \zero.cv20.dnom \zero.cv20.dnom.tnum 
-	\zero.cv20.zero.dnom \zero.cv20.zero.dnom.tnum \zero.dnom 
-	\zero.dnom.tnum \zero.zero.dnom \zero.zero.dnom.tnum ];
+	\two.dnom.pnum \two.dnom.tnum \zero.cv10.dnom \zero.cv10.dnom.tnum 
+	\zero.cv10.zero.dnom \zero.cv10.zero.dnom.tnum \zero.cv20.dnom 
+	\zero.cv20.dnom.tnum \zero.cv20.zero.dnom 
+	\zero.cv20.zero.dnom.tnum \zero.dnom \zero.dnom.tnum 
+	\zero.zero.dnom \zero.zero.dnom.tnum ];
     @kc87_second_29 = [\epsilon \epsilontonos \s \sacute \scaron \scedilla \scircumflex \scommaaccent 
 	\uni01A8 \uni023F \uni025B \uni025C \uni025D \uni0282 \uni0433 \uni0437 
 	\uni0453 \uni0455 \uni0479 \uni0493 \uni0499 \uni04DF \uni04F7 \uni04FB 
 	\uni0511 \uni1E61 \uni1E63 \uni1E65 \uni1E67 \uni1E69 \uni1F10 \uni1F11 
 	\uni1F12 \uni1F13 \uni1F14 \uni1F15 \uni1F72 \uni1F73 ];
     @kc87_second_30 = [\eta \etatonos \iota \kappa \m \n \nacute \napostrophe \ncaron \ncommaaccent 
-	\ntilde \r \racute \rcaron \rcommaaccent \u \u.cv25 \uacute \uacute.cv25 
-	\ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 \udieresis 
-	\udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 \uhungarumlaut 
-	\uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 \uni01D4.cv25 
-	\uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA \uni01DA.cv25 
-	\uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 \uni0215 
-	\uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 \uni0269 
-	\uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B \uni0299 
-	\uni029C \uni029F \uni0438 \uni0439 \uni043A \uni043C \uni043D \uni043F 
-	\uni0442 \uni0446 \uni0448 \uni0449 \uni044B \uni044C \uni044E \uni045C 
-	\uni045D \uni045F \uni0465 \uni0469 \uni046D \uni0491 \uni0495 \uni049B 
-	\uni049D \uni04A1 \uni04A3 \uni04A5 \uni04A7 \uni04AD \uni04C8 \uni04CA 
-	\uni04CE \uni0523 \uni0525 \uni0529 \uni1E3F \uni1E41 \uni1E43 \uni1E45 
-	\uni1E47 \uni1E49 \uni1E4B \uni1E59 \uni1E5B \uni1E5D \uni1E5F \uni1E73 
-	\uni1E73.cv25 \uni1E75 \uni1E75.cv25 \uni1E77 \uni1E77.cv25 \uni1E79 
-	\uni1E79.cv25 \uni1E7B \uni1E7B.cv25 \uni1EE5 \uni1EE5.cv25 \uni1EE7 
-	\uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 \uni1EED 
-	\uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 \uni1F50 
-	\uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 \uni1F7A 
-	\uni1F7B \uni1FE6 \uni1FE7 \uni20AA \uniA657 \uogonek \uogonek.cv25 
-	\upsilon \upsilondieresistonos \upsilontonos \uring \uring.cv25 
-	\utilde \utilde.cv25 ];
-    @kc87_second_31 = [\f \florin \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 \uni1E1F \uni1E6B 
-	\uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
-    @kc87_second_32 = [\fraction ];
-    @kc87_second_33 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
-    @kc87_second_34 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
+	\ntilde \r \racute \rcaron \rcommaaccent \seven.cv07.ss07.onum 
+	\seven.cv17.ss07.onum \seven.ss07.onum \u \u.cv25 \uacute 
+	\uacute.cv25 \ubreve \ubreve.cv25 \ucircumflex \ucircumflex.cv25 
+	\udieresis \udieresis.cv25 \ugrave \ugrave.cv25 \uhorn.cv25 
+	\uhungarumlaut \uhungarumlaut.cv25 \umacron \umacron.cv25 \uni01D4 
+	\uni01D4.cv25 \uni01D6 \uni01D6.cv25 \uni01D8 \uni01D8.cv25 \uni01DA 
+	\uni01DA.cv25 \uni01DC \uni01DC.cv25 \uni01F9 \uni0211 \uni0213 
+	\uni0215 \uni0215.cv25 \uni0217 \uni0217.cv25 \uni024D \uni0265 
+	\uni0269 \uni026F \uni0270 \uni0271 \uni0273 \uni0289 \uni028A \uni028B 
+	\uni0299 \uni029C \uni029F \uni0438 \uni0439 \uni043A \uni043C \uni043D 
+	\uni043F \uni0442 \uni0446 \uni0448 \uni0449 \uni044B \uni044C \uni044E 
+	\uni045C \uni045D \uni045F \uni0465 \uni0469 \uni046D \uni0491 \uni0495 
+	\uni049B \uni049D \uni04A1 \uni04A3 \uni04A5 \uni04A7 \uni04AD \uni04C8 
+	\uni04CA \uni04CE \uni0523 \uni0525 \uni0529 \uni1E3F \uni1E41 \uni1E43 
+	\uni1E45 \uni1E47 \uni1E49 \uni1E4B \uni1E59 \uni1E5B \uni1E5D \uni1E5F 
+	\uni1E73 \uni1E73.cv25 \uni1E75 \uni1E75.cv25 \uni1E77 \uni1E77.cv25 
+	\uni1E79 \uni1E79.cv25 \uni1E7B \uni1E7B.cv25 \uni1EE5 \uni1EE5.cv25 
+	\uni1EE7 \uni1EE7.cv25 \uni1EE9 \uni1EE9.cv25 \uni1EEB \uni1EEB.cv25 
+	\uni1EED \uni1EED.cv25 \uni1EEF \uni1EEF.cv25 \uni1EF1 \uni1EF1.cv25 
+	\uni1F50 \uni1F51 \uni1F52 \uni1F53 \uni1F54 \uni1F55 \uni1F56 \uni1F57 
+	\uni1F7A \uni1F7B \uni1FE6 \uni1FE7 \uni20AA \uniA657 \uogonek 
+	\uogonek.cv25 \upsilon \upsilondieresistonos \upsilontonos \uring 
+	\uring.cv25 \utilde \utilde.cv25 ];
+    @kc87_second_31 = [\f \florin \one.cv01.onum \one.cv01.pnum \one.cv11.onum \one.cv11.pnum 
+	\one.onum \one.pnum \t \tcaron \uni0163 \uni01AB \uni01AD \uni0236 
+	\uni1E1F \uni1E6B \uni1E6D \uni1E6F \uni1E71 \uni1E9D ];
+    @kc87_second_32 = [\four.cv04.pnum \four.cv14.pnum \four.pnum ];
+    @kc87_second_33 = [\fraction ];
+    @kc87_second_34 = [\j \jcircumflex \uni01F0 \uni03F3 \uni0458 ];
+    @kc87_second_35 = [\j.sc \jcircumflex.sc \uni01F0.sc \uni0237.sc \uni029D.sc \uni03F3.sc 
 	\uni0458.sc ];
-    @kc87_second_35 = [\lambda \uni019B ];
-    @kc87_second_36 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
+    @kc87_second_36 = [\lambda \uni019B ];
+    @kc87_second_37 = [\omega \omega1 \psi \uni0277 \uni1F60 \uni1F61 \uni1F62 \uni1F63 \uni1F64 
 	\uni1F65 \uni1F66 \uni1F67 \uni1F7C \uni1F7D \uni1FA4 \uni1FA5 \uni1FA6 
 	\uni1FA7 \uni1FF2 \uni1FF3 \uni1FF4 \uni1FF6 \uni1FF7 ];
-    @kc87_second_37 = [\omega.sc \omegatonos.sc \uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc 
-	\uni1F64.sc \uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc 
-	\uni1F7D.sc \uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc 
-	\uni1FA4.sc \uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc 
-	\uni1FF3.sc \uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
-    @kc87_second_38 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
-    @kc87_second_39 = [\pi \tau \uni044A \uni04B5 ];
-    @kc87_second_40 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
+    @kc87_second_38 = [\omega.sc \omegatonos.sc \two.cv02.onum \two.cv12.onum \two.onum.tnum 
+	\uni1F60.sc \uni1F61.sc \uni1F62.sc \uni1F63.sc \uni1F64.sc 
+	\uni1F65.sc \uni1F66.sc \uni1F67.sc \uni1F7C.sc \uni1F7D.sc 
+	\uni1FA0.sc \uni1FA1.sc \uni1FA2.sc \uni1FA3.sc \uni1FA4.sc 
+	\uni1FA5.sc \uni1FA6.sc \uni1FA7.sc \uni1FF2.sc \uni1FF3.sc 
+	\uni1FF4.sc \uni1FF6.sc \uni1FF7.sc ];
+    @kc87_second_39 = [\phi.sc \thorn.sc \uni01A5.sc \uni0444.sc ];
+    @kc87_second_40 = [\pi \tau \uni044A \uni04B5 ];
+    @kc87_second_41 = [\psi.sc \uni0447.sc \uni0471.sc \uni04B7.sc \uni04B9.sc \uni04CC.sc 
 	\uni04F5.sc ];
-    @kc87_second_41 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
+    @kc87_second_42 = [\s.sc \sacute.sc \scaron.sc \scedilla.sc \scircumflex.sc \uni01A8.sc 
 	\uni0437.sc \uni0455.sc \uni0499.sc \uni04DF.sc \uni0511.sc ];
-    @kc87_second_42 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
+    @kc87_second_43 = [\seven.cv07.onum \seven.cv17.onum \seven.onum \t.sc \tau.sc \tbar.sc 
+	\tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc \uni021B.sc 
+	\uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc \uni0442.sc 
+	\uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc \uni1E6F.sc 
+	\uni1E71.sc \uni1E97.sc ];
+    @kc87_second_44 = [\seven.cv07.ss07.pnum \seven.cv17.ss07.pnum \seven.ss07.pnum ];
+    @kc87_second_45 = [\sigma.sc \uni01B6.sc \uni0225.sc \uni1E91.sc \uni1E93.sc \uni1E95.sc \z.sc 
 	\zacute.sc \zcaron.sc \zdotaccent.sc \zeta.sc ];
-    @kc87_second_43 = [\t.sc \tau.sc \tbar.sc \tcaron.sc \uni0163.sc \uni01AB.sc \uni01AD.sc 
-	\uni021B.sc \uni0288.sc \uni02A6.sc \uni02A7.sc \uni02A8.sc 
-	\uni0442.sc \uni04AD.sc \uni04B5.sc \uni1E6B.sc \uni1E6D.sc 
-	\uni1E6F.sc \uni1E71.sc \uni1E97.sc ];
-    @kc87_second_44 = [\theta \uni0478 \uniA64C ];
-    @kc87_second_45 = [\tonos2 ];
-    @kc87_second_46 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
-    @kc87_second_47 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
+    @kc87_second_46 = [\six.cv06.onum \six.cv06.pnum \six.onum \six.pnum \theta \uni0478 \uniA64C 
+	\zero.cv10.pnum \zero.cv10.zero.pnum \zero.cv20.pnum 
+	\zero.cv20.zero.pnum \zero.pnum \zero.zero.pnum ];
+    @kc87_second_47 = [\three.cv13.onum \uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 
+	\uniA641 \uniA643 \z \zacute \zcaron \zdotaccent ];
+    @kc87_second_48 = [\tonos2 ];
+    @kc87_second_49 = [\uni0186 \uni03FD \uni042D \uni04EC \uni2108 ];
+    @kc87_second_50 = [\uni01B4 \uni0233 \uni024F \uni0443 \uni0475 \uni0477 \uni04EF \uni04F1 \uni04F3 
 	\uni1EF5 \uni1EF7 \uni1EF9 \uni1EFF \uni2174 \uni2175 \uni2176 \uni2177 
 	\v \y \ycircumflex \ygrave ];
-    @kc87_second_48 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
+    @kc87_second_51 = [\uni01B4.sc \uni0233.sc \uni04AF.sc \uni04B1.sc \uni1EF5.sc \uni1EF7.sc 
 	\uni1EF9.sc \uni1F50.sc \uni1F51.sc \uni1F52.sc \uni1F53.sc 
 	\uni1F54.sc \uni1F55.sc \uni1F56.sc \uni1F57.sc \uni1F7A.sc 
 	\uni1F7B.sc \uni1FE6.sc \uni1FE7.sc \upsilon.sc \upsilondieresis.sc 
 	\upsilondieresistonos.sc \upsilontonos.sc \y.sc \yacute.sc 
 	\ycircumflex.sc \ydieresis.sc \ygrave.sc ];
-    @kc87_second_49 = [\uni0225 \uni0240 \uni0290 \uni0291 \uni1E91 \uni1E93 \uni1E95 \uniA641 \uniA643 
-	\z \zacute \zcaron \zdotaccent ];
-    @kc87_second_50 = [\uni0237 ];
-    @kc87_second_51 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
-    @kc87_second_52 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
-    @kc87_second_53 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
-    @kc87_second_54 = [\uni042F \uni0518 ];
-    @kc87_second_55 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
+    @kc87_second_52 = [\uni0237 ];
+    @kc87_second_53 = [\uni0254 \uni037D \uni03F6 \uni044D \uni04ED ];
+    @kc87_second_54 = [\uni0254.sc \uni037B.sc \uni037D.sc \uni044D.sc \uni04ED.sc ];
+    @kc87_second_55 = [\uni0414 \uni041B \uni04C5 \uni0508 \uni0512 \uni0514 \uni0520 \uni052A \uni052E ];
+    @kc87_second_56 = [\uni042F \uni0518 ];
+    @kc87_second_57 = [\uni0434.sc \uni043B.sc \uni0459.sc \uni04C6.sc \uni0509.sc \uni0513.sc 
 	\uni0515.sc \uni0521.sc \uni052B.sc \uni052F.sc ];
-    @kc87_second_56 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
+    @kc87_second_58 = [\uni0436 \uni0445 \uni0497 \uni04B3 \uni04C2 \uni04DD \uni04FD \uni04FF \uni1E8B 
 	\uni1E8D \uni2179 \uni217A \uni217B \x ];
-    @kc87_second_57 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
-    @kc87_second_58 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
-    @kc87_second_59 = [\uni044F.sc \uni0519.sc ];
-    @kc87_second_60 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
+    @kc87_second_59 = [\uni043B \uni0459 \uni04C6 \uni0509 \uni0513 \uni0515 \uni0521 \uni052B \uni052F ];
+    @kc87_second_60 = [\uni0447 \uni04B7 \uni04B9 \uni04CC \uni04F5 ];
+    @kc87_second_61 = [\uni044F.sc \uni0519.sc ];
+    @kc87_second_62 = [\uni0461 \uni047F \uni051D \uni1E87 \uni1E89 \uni1E98 \uni2C73 \w \wacute 
 	\wcircumflex \wdieresis \wgrave ];
-    @kc87_second_61 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
-    @kc87_second_62 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
+    @kc87_second_63 = [\uni0475.sc \uni2174.sc \uni2175.sc \uni2176.sc \uni2177.sc \v.sc ];
+    @kc87_second_64 = [\uni047F.sc \uni051D.sc \uni1E87.sc \uni1E89.sc \uni1E98.sc \uni2C73.sc \w.sc 
 	\wacute.sc \wdieresis.sc \wgrave.sc ];
-    @kc87_second_63 = [\uni0500 \uni0502 ];
-    @kc87_second_64 = [\uni0501.sc \uni0503.sc ];
-    @kc87_second_65 = [\zero.cv10.dnom \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
+    @kc87_second_65 = [\uni0500 \uni0502 ];
+    @kc87_second_66 = [\uni0501.sc \uni0503.sc ];
+    @kc87_second_67 = [\zero.cv10.dnom.pnum \zero.cv10.zero.dnom.pnum \zero.cv20.dnom.pnum 
 	\zero.cv20.zero.dnom.pnum \zero.dnom.pnum \zero.zero.dnom.pnum ];
-    @kc87_second_66 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
+    @kc87_second_68 = [\zero.cv10.numr.pnum \zero.cv10.zero.numr.pnum \zero.cv20.numr.pnum 
 	\zero.cv20.zero.numr.pnum \zero.numr.pnum \zero.zero.numr.pnum ];
     pos @kc87_first_1 @kc87_second_3 -70;
     pos @kc87_first_1 @kc87_second_8 -70;
     pos @kc87_first_1 @kc87_second_9 -140;
     pos @kc87_first_1 @kc87_second_10 -35;
-    pos @kc87_first_1 @kc87_second_12 -280;
+    pos @kc87_first_1 @kc87_second_12 -210;
     pos @kc87_first_1 @kc87_second_13 -280;
     pos @kc87_first_1 @kc87_second_14 -280;
     pos @kc87_first_1 @kc87_second_15 -210;
@@ -8688,26 +8722,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_1 @kc87_second_23 -35;
     pos @kc87_first_1 @kc87_second_25 -50;
     pos @kc87_first_1 @kc87_second_31 -70;
-    pos @kc87_first_1 @kc87_second_38 -35;
-    pos @kc87_first_1 @kc87_second_39 -140;
-    pos @kc87_first_1 @kc87_second_40 -105;
+    pos @kc87_first_1 @kc87_second_39 -35;
+    pos @kc87_first_1 @kc87_second_40 -140;
+    pos @kc87_first_1 @kc87_second_41 -105;
     pos @kc87_first_1 @kc87_second_43 -210;
-    pos @kc87_first_1 @kc87_second_44 -35;
-    pos @kc87_first_1 @kc87_second_45 1;
-    pos @kc87_first_1 @kc87_second_47 -175;
-    pos @kc87_first_1 @kc87_second_48 -210;
-    pos @kc87_first_1 @kc87_second_58 -140;
+    pos @kc87_first_1 @kc87_second_44 -175;
+    pos @kc87_first_1 @kc87_second_46 -35;
+    pos @kc87_first_1 @kc87_second_48 1;
+    pos @kc87_first_1 @kc87_second_50 -175;
+    pos @kc87_first_1 @kc87_second_51 -210;
     pos @kc87_first_1 @kc87_second_60 -140;
-    pos @kc87_first_1 @kc87_second_61 -210;
     pos @kc87_first_1 @kc87_second_62 -140;
+    pos @kc87_first_1 @kc87_second_63 -210;
+    pos @kc87_first_1 @kc87_second_64 -140;
     pos @kc87_first_2 @kc87_second_9 -35;
     pos @kc87_first_2 @kc87_second_12 -70;
     pos @kc87_first_2 @kc87_second_13 -70;
     pos @kc87_first_2 @kc87_second_14 -70;
     pos @kc87_first_2 @kc87_second_15 -35;
     pos @kc87_first_2 @kc87_second_16 -35;
-    pos @kc87_first_2 @kc87_second_39 -35;
-    pos @kc87_first_2 @kc87_second_45 1;
+    pos @kc87_first_2 @kc87_second_40 -35;
+    pos @kc87_first_2 @kc87_second_48 1;
     pos @kc87_first_3 @kc87_second_1 -35;
     pos @kc87_first_3 @kc87_second_2 -70;
     pos @kc87_first_3 @kc87_second_5 -35;
@@ -8717,14 +8752,14 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_3 @kc87_second_14 -35;
     pos @kc87_first_3 @kc87_second_16 -70;
     pos @kc87_first_3 @kc87_second_19 -70;
-    pos @kc87_first_3 @kc87_second_35 -35;
-    pos @kc87_first_3 @kc87_second_45 1;
+    pos @kc87_first_3 @kc87_second_36 -35;
+    pos @kc87_first_3 @kc87_second_48 1;
     pos @kc87_first_4 @kc87_second_1 -70;
     pos @kc87_first_4 @kc87_second_2 -140;
     pos @kc87_first_4 @kc87_second_4 70;
     pos @kc87_first_4 @kc87_second_5 -70;
     pos @kc87_first_4 @kc87_second_11 -105;
-    pos @kc87_first_4 @kc87_second_12 -140;
+    pos @kc87_first_4 @kc87_second_12 -70;
     pos @kc87_first_4 @kc87_second_13 -140;
     pos @kc87_first_4 @kc87_second_14 -105;
     pos @kc87_first_4 @kc87_second_15 -35;
@@ -8733,23 +8768,23 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_4 @kc87_second_26 -70;
     pos @kc87_first_4 @kc87_second_27 -35;
     pos @kc87_first_4 @kc87_second_31 35;
-    pos @kc87_first_4 @kc87_second_34 -70;
     pos @kc87_first_4 @kc87_second_35 -70;
+    pos @kc87_first_4 @kc87_second_36 -70;
     pos @kc87_first_4 @kc87_second_43 -35;
-    pos @kc87_first_4 @kc87_second_45 1;
-    pos @kc87_first_4 @kc87_second_48 -70;
-    pos @kc87_first_4 @kc87_second_53 -70;
+    pos @kc87_first_4 @kc87_second_48 1;
+    pos @kc87_first_4 @kc87_second_51 -70;
     pos @kc87_first_4 @kc87_second_55 -70;
     pos @kc87_first_4 @kc87_second_57 -70;
-    pos @kc87_first_4 @kc87_second_61 -35;
+    pos @kc87_first_4 @kc87_second_59 -70;
+    pos @kc87_first_4 @kc87_second_63 -35;
     pos @kc87_first_5 @kc87_second_12 -70;
-    pos @kc87_first_5 @kc87_second_45 1;
+    pos @kc87_first_5 @kc87_second_48 1;
     pos @kc87_first_6 @kc87_second_1 -280;
     pos @kc87_first_6 @kc87_second_2 -350;
     pos @kc87_first_6 @kc87_second_3 -140;
     pos @kc87_first_6 @kc87_second_4 -70;
     pos @kc87_first_6 @kc87_second_6 -350;
-    pos @kc87_first_6 @kc87_second_7 -140;
+    pos @kc87_first_6 @kc87_second_7 -70;
     pos @kc87_first_6 @kc87_second_8 -210;
     pos @kc87_first_6 @kc87_second_10 -70;
     pos @kc87_first_6 @kc87_second_17 -240;
@@ -8764,44 +8799,46 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_6 @kc87_second_29 -240;
     pos @kc87_first_6 @kc87_second_30 -240;
     pos @kc87_first_6 @kc87_second_31 -175;
-    pos @kc87_first_6 @kc87_second_34 -350;
-    pos @kc87_first_6 @kc87_second_35 -105;
-    pos @kc87_first_6 @kc87_second_36 -240;
-    pos @kc87_first_6 @kc87_second_37 -210;
-    pos @kc87_first_6 @kc87_second_38 -240;
+    pos @kc87_first_6 @kc87_second_32 -175;
+    pos @kc87_first_6 @kc87_second_35 -350;
+    pos @kc87_first_6 @kc87_second_36 -105;
+    pos @kc87_first_6 @kc87_second_37 -240;
+    pos @kc87_first_6 @kc87_second_38 -210;
     pos @kc87_first_6 @kc87_second_39 -240;
-    pos @kc87_first_6 @kc87_second_41 -240;
-    pos @kc87_first_6 @kc87_second_44 -140;
-    pos @kc87_first_6 @kc87_second_45 1;
-    pos @kc87_first_6 @kc87_second_46 -35;
+    pos @kc87_first_6 @kc87_second_40 -240;
+    pos @kc87_first_6 @kc87_second_42 -240;
+    pos @kc87_first_6 @kc87_second_46 -140;
     pos @kc87_first_6 @kc87_second_47 -240;
-    pos @kc87_first_6 @kc87_second_49 -240;
+    pos @kc87_first_6 @kc87_second_48 1;
+    pos @kc87_first_6 @kc87_second_49 -35;
     pos @kc87_first_6 @kc87_second_50 -240;
-    pos @kc87_first_6 @kc87_second_51 -240;
     pos @kc87_first_6 @kc87_second_52 -240;
-    pos @kc87_first_6 @kc87_second_53 -280;
-    pos @kc87_first_6 @kc87_second_54 -70;
-    pos @kc87_first_6 @kc87_second_55 -240;
-    pos @kc87_first_6 @kc87_second_56 -175;
-    pos @kc87_first_6 @kc87_second_57 -280;
-    pos @kc87_first_6 @kc87_second_58 -240;
-    pos @kc87_first_6 @kc87_second_59 -210;
-    pos @kc87_first_6 @kc87_second_60 -175;
-    pos @kc87_first_6 @kc87_second_63 -175;
-    pos @kc87_first_6 @kc87_second_64 -175;
+    pos @kc87_first_6 @kc87_second_53 -240;
+    pos @kc87_first_6 @kc87_second_54 -240;
+    pos @kc87_first_6 @kc87_second_55 -280;
+    pos @kc87_first_6 @kc87_second_56 -70;
+    pos @kc87_first_6 @kc87_second_57 -240;
+    pos @kc87_first_6 @kc87_second_58 -175;
+    pos @kc87_first_6 @kc87_second_59 -280;
+    pos @kc87_first_6 @kc87_second_60 -240;
+    pos @kc87_first_6 @kc87_second_61 -210;
+    pos @kc87_first_6 @kc87_second_62 -175;
+    pos @kc87_first_6 @kc87_second_65 -175;
+    pos @kc87_first_6 @kc87_second_66 -175;
     pos @kc87_first_7 @kc87_second_3 -70;
     pos @kc87_first_7 @kc87_second_8 -105;
     pos @kc87_first_7 @kc87_second_17 -35;
     pos @kc87_first_7 @kc87_second_20 -105;
     pos @kc87_first_7 @kc87_second_22 -105;
     pos @kc87_first_7 @kc87_second_23 -70;
-    pos @kc87_first_7 @kc87_second_45 1;
-    pos @kc87_first_7 @kc87_second_46 -35;
-    pos @kc87_first_7 @kc87_second_47 -70;
-    pos @kc87_first_7 @kc87_second_51 -50;
-    pos @kc87_first_7 @kc87_second_60 -35;
-    pos @kc87_first_7 @kc87_second_63 -70;
-    pos @kc87_first_7 @kc87_second_64 -70;
+    pos @kc87_first_7 @kc87_second_32 -70;
+    pos @kc87_first_7 @kc87_second_48 1;
+    pos @kc87_first_7 @kc87_second_49 -35;
+    pos @kc87_first_7 @kc87_second_50 -70;
+    pos @kc87_first_7 @kc87_second_53 -50;
+    pos @kc87_first_7 @kc87_second_62 -35;
+    pos @kc87_first_7 @kc87_second_65 -70;
+    pos @kc87_first_7 @kc87_second_66 -70;
     pos @kc87_first_8 @kc87_second_3 -140;
     pos @kc87_first_8 @kc87_second_4 -70;
     pos @kc87_first_8 @kc87_second_6 -70;
@@ -8814,26 +8851,27 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_8 @kc87_second_25 -140;
     pos @kc87_first_8 @kc87_second_29 -35;
     pos @kc87_first_8 @kc87_second_31 -105;
-    pos @kc87_first_8 @kc87_second_34 -70;
-    pos @kc87_first_8 @kc87_second_36 -70;
-    pos @kc87_first_8 @kc87_second_38 -105;
-    pos @kc87_first_8 @kc87_second_39 -175;
-    pos @kc87_first_8 @kc87_second_40 -140;
-    pos @kc87_first_8 @kc87_second_41 -35;
+    pos @kc87_first_8 @kc87_second_32 -70;
+    pos @kc87_first_8 @kc87_second_35 -70;
+    pos @kc87_first_8 @kc87_second_37 -70;
+    pos @kc87_first_8 @kc87_second_39 -105;
+    pos @kc87_first_8 @kc87_second_40 -175;
+    pos @kc87_first_8 @kc87_second_41 -140;
+    pos @kc87_first_8 @kc87_second_42 -35;
     pos @kc87_first_8 @kc87_second_43 -140;
-    pos @kc87_first_8 @kc87_second_44 -105;
-    pos @kc87_first_8 @kc87_second_45 1;
-    pos @kc87_first_8 @kc87_second_46 -70;
-    pos @kc87_first_8 @kc87_second_47 -140;
-    pos @kc87_first_8 @kc87_second_48 -70;
-    pos @kc87_first_8 @kc87_second_51 -35;
-    pos @kc87_first_8 @kc87_second_52 -35;
-    pos @kc87_first_8 @kc87_second_58 -210;
-    pos @kc87_first_8 @kc87_second_60 -105;
-    pos @kc87_first_8 @kc87_second_61 -70;
-    pos @kc87_first_8 @kc87_second_62 -35;
+    pos @kc87_first_8 @kc87_second_46 -105;
+    pos @kc87_first_8 @kc87_second_48 1;
+    pos @kc87_first_8 @kc87_second_49 -70;
+    pos @kc87_first_8 @kc87_second_50 -140;
+    pos @kc87_first_8 @kc87_second_51 -70;
+    pos @kc87_first_8 @kc87_second_53 -35;
+    pos @kc87_first_8 @kc87_second_54 -35;
+    pos @kc87_first_8 @kc87_second_60 -210;
+    pos @kc87_first_8 @kc87_second_62 -105;
     pos @kc87_first_8 @kc87_second_63 -70;
     pos @kc87_first_8 @kc87_second_64 -35;
+    pos @kc87_first_8 @kc87_second_65 -70;
+    pos @kc87_first_8 @kc87_second_66 -35;
     pos @kc87_first_9 @kc87_second_3 -140;
     pos @kc87_first_9 @kc87_second_4 -70;
     pos @kc87_first_9 @kc87_second_6 -70;
@@ -8851,24 +8889,26 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_9 @kc87_second_23 -140;
     pos @kc87_first_9 @kc87_second_29 -50;
     pos @kc87_first_9 @kc87_second_31 -140;
-    pos @kc87_first_9 @kc87_second_34 -70;
-    pos @kc87_first_9 @kc87_second_38 -105;
-    pos @kc87_first_9 @kc87_second_39 -280;
-    pos @kc87_first_9 @kc87_second_40 -350;
-    pos @kc87_first_9 @kc87_second_41 -50;
+    pos @kc87_first_9 @kc87_second_32 -70;
+    pos @kc87_first_9 @kc87_second_35 -70;
+    pos @kc87_first_9 @kc87_second_39 -105;
+    pos @kc87_first_9 @kc87_second_40 -280;
+    pos @kc87_first_9 @kc87_second_41 -350;
+    pos @kc87_first_9 @kc87_second_42 -50;
     pos @kc87_first_9 @kc87_second_43 -350;
-    pos @kc87_first_9 @kc87_second_45 1;
-    pos @kc87_first_9 @kc87_second_46 -35;
-    pos @kc87_first_9 @kc87_second_47 -210;
-    pos @kc87_first_9 @kc87_second_48 -350;
-    pos @kc87_first_9 @kc87_second_51 -35;
-    pos @kc87_first_9 @kc87_second_52 -35;
-    pos @kc87_first_9 @kc87_second_58 -280;
-    pos @kc87_first_9 @kc87_second_60 -175;
-    pos @kc87_first_9 @kc87_second_61 -280;
-    pos @kc87_first_9 @kc87_second_62 -210;
-    pos @kc87_first_9 @kc87_second_63 -70;
-    pos @kc87_first_9 @kc87_second_64 -70;
+    pos @kc87_first_9 @kc87_second_44 -280;
+    pos @kc87_first_9 @kc87_second_48 1;
+    pos @kc87_first_9 @kc87_second_49 -35;
+    pos @kc87_first_9 @kc87_second_50 -210;
+    pos @kc87_first_9 @kc87_second_51 -350;
+    pos @kc87_first_9 @kc87_second_53 -35;
+    pos @kc87_first_9 @kc87_second_54 -35;
+    pos @kc87_first_9 @kc87_second_60 -280;
+    pos @kc87_first_9 @kc87_second_62 -175;
+    pos @kc87_first_9 @kc87_second_63 -280;
+    pos @kc87_first_9 @kc87_second_64 -210;
+    pos @kc87_first_9 @kc87_second_65 -70;
+    pos @kc87_first_9 @kc87_second_66 -70;
     pos @kc87_first_10 @kc87_second_1 -210;
     pos @kc87_first_10 @kc87_second_2 -350;
     pos @kc87_first_10 @kc87_second_5 -70;
@@ -8883,17 +8923,18 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_10 @kc87_second_22 -70;
     pos @kc87_first_10 @kc87_second_24 -350;
     pos @kc87_first_10 @kc87_second_29 -70;
-    pos @kc87_first_10 @kc87_second_32 -140;
-    pos @kc87_first_10 @kc87_second_34 -210;
-    pos @kc87_first_10 @kc87_second_35 -105;
-    pos @kc87_first_10 @kc87_second_38 -70;
-    pos @kc87_first_10 @kc87_second_45 1;
-    pos @kc87_first_10 @kc87_second_53 -210;
+    pos @kc87_first_10 @kc87_second_32 -35;
+    pos @kc87_first_10 @kc87_second_33 -140;
+    pos @kc87_first_10 @kc87_second_35 -210;
+    pos @kc87_first_10 @kc87_second_36 -105;
+    pos @kc87_first_10 @kc87_second_39 -70;
+    pos @kc87_first_10 @kc87_second_48 1;
     pos @kc87_first_10 @kc87_second_55 -210;
     pos @kc87_first_10 @kc87_second_57 -210;
-    pos @kc87_first_10 @kc87_second_61 -70;
+    pos @kc87_first_10 @kc87_second_59 -210;
     pos @kc87_first_10 @kc87_second_63 -70;
-    pos @kc87_first_10 @kc87_second_64 -105;
+    pos @kc87_first_10 @kc87_second_65 -70;
+    pos @kc87_first_10 @kc87_second_66 -105;
     pos @kc87_first_11 @kc87_second_1 -70;
     pos @kc87_first_11 @kc87_second_2 -140;
     pos @kc87_first_11 @kc87_second_5 -105;
@@ -8908,21 +8949,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_11 @kc87_second_24 -70;
     pos @kc87_first_11 @kc87_second_26 -70;
     pos @kc87_first_11 @kc87_second_27 -70;
-    pos @kc87_first_11 @kc87_second_34 -35;
-    pos @kc87_first_11 @kc87_second_35 -140;
-    pos @kc87_first_11 @kc87_second_39 -70;
-    pos @kc87_first_11 @kc87_second_42 -35;
+    pos @kc87_first_11 @kc87_second_35 -35;
+    pos @kc87_first_11 @kc87_second_36 -140;
+    pos @kc87_first_11 @kc87_second_40 -70;
     pos @kc87_first_11 @kc87_second_43 -35;
-    pos @kc87_first_11 @kc87_second_45 1;
-    pos @kc87_first_11 @kc87_second_48 -70;
-    pos @kc87_first_11 @kc87_second_53 -210;
-    pos @kc87_first_11 @kc87_second_55 -175;
-    pos @kc87_first_11 @kc87_second_56 -35;
+    pos @kc87_first_11 @kc87_second_45 -35;
+    pos @kc87_first_11 @kc87_second_48 1;
+    pos @kc87_first_11 @kc87_second_51 -70;
+    pos @kc87_first_11 @kc87_second_55 -210;
     pos @kc87_first_11 @kc87_second_57 -175;
-    pos @kc87_first_11 @kc87_second_61 -70;
-    pos @kc87_first_11 @kc87_second_62 -35;
-    pos @kc87_first_11 @kc87_second_63 -35;
-    pos @kc87_first_11 @kc87_second_64 -70;
+    pos @kc87_first_11 @kc87_second_58 -35;
+    pos @kc87_first_11 @kc87_second_59 -175;
+    pos @kc87_first_11 @kc87_second_63 -70;
+    pos @kc87_first_11 @kc87_second_64 -35;
+    pos @kc87_first_11 @kc87_second_65 -35;
+    pos @kc87_first_11 @kc87_second_66 -70;
     pos @kc87_first_12 @kc87_second_1 -140;
     pos @kc87_first_12 @kc87_second_2 -210;
     pos @kc87_first_12 @kc87_second_6 -140;
@@ -8931,28 +8972,30 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_12 @kc87_second_22 -70;
     pos @kc87_first_12 @kc87_second_24 -350;
     pos @kc87_first_12 @kc87_second_29 -35;
-    pos @kc87_first_12 @kc87_second_32 -140;
-    pos @kc87_first_12 @kc87_second_34 -140;
-    pos @kc87_first_12 @kc87_second_35 -70;
-    pos @kc87_first_12 @kc87_second_38 -70;
-    pos @kc87_first_12 @kc87_second_45 1;
-    pos @kc87_first_12 @kc87_second_51 -35;
-    pos @kc87_first_12 @kc87_second_53 -210;
+    pos @kc87_first_12 @kc87_second_32 -70;
+    pos @kc87_first_12 @kc87_second_33 -140;
+    pos @kc87_first_12 @kc87_second_35 -140;
+    pos @kc87_first_12 @kc87_second_36 -70;
+    pos @kc87_first_12 @kc87_second_39 -70;
+    pos @kc87_first_12 @kc87_second_48 1;
+    pos @kc87_first_12 @kc87_second_53 -35;
     pos @kc87_first_12 @kc87_second_55 -210;
     pos @kc87_first_12 @kc87_second_57 -210;
-    pos @kc87_first_12 @kc87_second_63 -70;
-    pos @kc87_first_12 @kc87_second_64 -105;
+    pos @kc87_first_12 @kc87_second_59 -210;
+    pos @kc87_first_12 @kc87_second_65 -70;
+    pos @kc87_first_12 @kc87_second_66 -105;
     pos @kc87_first_13 @kc87_second_6 -70;
     pos @kc87_first_13 @kc87_second_12 -70;
     pos @kc87_first_13 @kc87_second_13 -105;
     pos @kc87_first_13 @kc87_second_14 -35;
     pos @kc87_first_13 @kc87_second_22 -35;
     pos @kc87_first_13 @kc87_second_29 -35;
-    pos @kc87_first_13 @kc87_second_34 -70;
-    pos @kc87_first_13 @kc87_second_38 -70;
-    pos @kc87_first_13 @kc87_second_45 1;
-    pos @kc87_first_13 @kc87_second_63 -70;
-    pos @kc87_first_13 @kc87_second_64 -35;
+    pos @kc87_first_13 @kc87_second_32 -35;
+    pos @kc87_first_13 @kc87_second_35 -70;
+    pos @kc87_first_13 @kc87_second_39 -70;
+    pos @kc87_first_13 @kc87_second_48 1;
+    pos @kc87_first_13 @kc87_second_65 -70;
+    pos @kc87_first_13 @kc87_second_66 -35;
     pos @kc87_first_14 @kc87_second_2 -35;
     pos @kc87_first_14 @kc87_second_11 -35;
     pos @kc87_first_14 @kc87_second_12 -70;
@@ -8961,14 +9004,14 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_14 @kc87_second_16 -35;
     pos @kc87_first_14 @kc87_second_19 -35;
     pos @kc87_first_14 @kc87_second_25 -35;
-    pos @kc87_first_14 @kc87_second_39 -70;
-    pos @kc87_first_14 @kc87_second_45 1;
-    pos @kc87_first_14 @kc87_second_47 -70;
-    pos @kc87_first_14 @kc87_second_48 -35;
-    pos @kc87_first_14 @kc87_second_56 -35;
+    pos @kc87_first_14 @kc87_second_40 -70;
+    pos @kc87_first_14 @kc87_second_48 1;
+    pos @kc87_first_14 @kc87_second_50 -70;
+    pos @kc87_first_14 @kc87_second_51 -35;
     pos @kc87_first_14 @kc87_second_58 -35;
     pos @kc87_first_14 @kc87_second_60 -35;
     pos @kc87_first_14 @kc87_second_62 -35;
+    pos @kc87_first_14 @kc87_second_64 -35;
     pos @kc87_first_15 @kc87_second_3 -70;
     pos @kc87_first_15 @kc87_second_4 -70;
     pos @kc87_first_15 @kc87_second_6 -35;
@@ -8980,20 +9023,20 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_15 @kc87_second_25 -70;
     pos @kc87_first_15 @kc87_second_29 -35;
     pos @kc87_first_15 @kc87_second_31 -35;
-    pos @kc87_first_15 @kc87_second_36 -35;
-    pos @kc87_first_15 @kc87_second_38 -70;
-    pos @kc87_first_15 @kc87_second_39 -142;
-    pos @kc87_first_15 @kc87_second_40 -35;
-    pos @kc87_first_15 @kc87_second_44 -35;
-    pos @kc87_first_15 @kc87_second_45 1;
+    pos @kc87_first_15 @kc87_second_37 -35;
+    pos @kc87_first_15 @kc87_second_39 -70;
+    pos @kc87_first_15 @kc87_second_40 -142;
+    pos @kc87_first_15 @kc87_second_41 -35;
     pos @kc87_first_15 @kc87_second_46 -35;
-    pos @kc87_first_15 @kc87_second_47 -70;
-    pos @kc87_first_15 @kc87_second_51 -35;
-    pos @kc87_first_15 @kc87_second_52 -35;
-    pos @kc87_first_15 @kc87_second_58 -105;
-    pos @kc87_first_15 @kc87_second_60 -35;
-    pos @kc87_first_15 @kc87_second_63 -35;
-    pos @kc87_first_15 @kc87_second_64 -35;
+    pos @kc87_first_15 @kc87_second_48 1;
+    pos @kc87_first_15 @kc87_second_49 -35;
+    pos @kc87_first_15 @kc87_second_50 -70;
+    pos @kc87_first_15 @kc87_second_53 -35;
+    pos @kc87_first_15 @kc87_second_54 -35;
+    pos @kc87_first_15 @kc87_second_60 -105;
+    pos @kc87_first_15 @kc87_second_62 -35;
+    pos @kc87_first_15 @kc87_second_65 -35;
+    pos @kc87_first_15 @kc87_second_66 -35;
     pos @kc87_first_16 @kc87_second_1 -280;
     pos @kc87_first_16 @kc87_second_2 -280;
     pos @kc87_first_16 @kc87_second_3 -140;
@@ -9014,34 +9057,35 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_16 @kc87_second_29 -240;
     pos @kc87_first_16 @kc87_second_30 -140;
     pos @kc87_first_16 @kc87_second_31 -140;
-    pos @kc87_first_16 @kc87_second_32 -245;
-    pos @kc87_first_16 @kc87_second_34 -315;
-    pos @kc87_first_16 @kc87_second_35 -70;
-    pos @kc87_first_16 @kc87_second_36 -210;
+    pos @kc87_first_16 @kc87_second_32 -280;
+    pos @kc87_first_16 @kc87_second_33 -245;
+    pos @kc87_first_16 @kc87_second_35 -315;
+    pos @kc87_first_16 @kc87_second_36 -70;
     pos @kc87_first_16 @kc87_second_37 -210;
-    pos @kc87_first_16 @kc87_second_38 -245;
+    pos @kc87_first_16 @kc87_second_38 -210;
     pos @kc87_first_16 @kc87_second_39 -245;
-    pos @kc87_first_16 @kc87_second_40 -70;
-    pos @kc87_first_16 @kc87_second_42 -35;
+    pos @kc87_first_16 @kc87_second_40 -245;
+    pos @kc87_first_16 @kc87_second_41 -70;
     pos @kc87_first_16 @kc87_second_43 -140;
-    pos @kc87_first_16 @kc87_second_44 -140;
-    pos @kc87_first_16 @kc87_second_45 1;
-    pos @kc87_first_16 @kc87_second_46 -70;
+    pos @kc87_first_16 @kc87_second_45 -35;
+    pos @kc87_first_16 @kc87_second_46 -140;
     pos @kc87_first_16 @kc87_second_47 -140;
-    pos @kc87_first_16 @kc87_second_49 -140;
+    pos @kc87_first_16 @kc87_second_48 1;
+    pos @kc87_first_16 @kc87_second_49 -70;
     pos @kc87_first_16 @kc87_second_50 -140;
-    pos @kc87_first_16 @kc87_second_51 -240;
     pos @kc87_first_16 @kc87_second_52 -140;
-    pos @kc87_first_16 @kc87_second_53 -280;
-    pos @kc87_first_16 @kc87_second_54 -105;
+    pos @kc87_first_16 @kc87_second_53 -240;
+    pos @kc87_first_16 @kc87_second_54 -140;
     pos @kc87_first_16 @kc87_second_55 -280;
-    pos @kc87_first_16 @kc87_second_56 -140;
-    pos @kc87_first_16 @kc87_second_57 -315;
-    pos @kc87_first_16 @kc87_second_58 -210;
-    pos @kc87_first_16 @kc87_second_59 -210;
-    pos @kc87_first_16 @kc87_second_60 -105;
-    pos @kc87_first_16 @kc87_second_63 -315;
-    pos @kc87_first_16 @kc87_second_64 -350;
+    pos @kc87_first_16 @kc87_second_56 -105;
+    pos @kc87_first_16 @kc87_second_57 -280;
+    pos @kc87_first_16 @kc87_second_58 -140;
+    pos @kc87_first_16 @kc87_second_59 -315;
+    pos @kc87_first_16 @kc87_second_60 -210;
+    pos @kc87_first_16 @kc87_second_61 -210;
+    pos @kc87_first_16 @kc87_second_62 -105;
+    pos @kc87_first_16 @kc87_second_65 -315;
+    pos @kc87_first_16 @kc87_second_66 -350;
     pos @kc87_first_17 @kc87_second_1 -280;
     pos @kc87_first_17 @kc87_second_2 -280;
     pos @kc87_first_17 @kc87_second_3 -105;
@@ -9059,33 +9103,34 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_17 @kc87_second_27 -70;
     pos @kc87_first_17 @kc87_second_29 -140;
     pos @kc87_first_17 @kc87_second_30 -105;
-    pos @kc87_first_17 @kc87_second_32 -210;
-    pos @kc87_first_17 @kc87_second_34 -245;
-    pos @kc87_first_17 @kc87_second_35 -70;
-    pos @kc87_first_17 @kc87_second_36 -140;
+    pos @kc87_first_17 @kc87_second_32 -175;
+    pos @kc87_first_17 @kc87_second_33 -210;
+    pos @kc87_first_17 @kc87_second_35 -245;
+    pos @kc87_first_17 @kc87_second_36 -70;
     pos @kc87_first_17 @kc87_second_37 -140;
     pos @kc87_first_17 @kc87_second_38 -140;
-    pos @kc87_first_17 @kc87_second_39 -105;
-    pos @kc87_first_17 @kc87_second_40 -35;
+    pos @kc87_first_17 @kc87_second_39 -140;
+    pos @kc87_first_17 @kc87_second_40 -105;
+    pos @kc87_first_17 @kc87_second_41 -35;
     pos @kc87_first_17 @kc87_second_43 -35;
-    pos @kc87_first_17 @kc87_second_44 -70;
-    pos @kc87_first_17 @kc87_second_45 1;
-    pos @kc87_first_17 @kc87_second_46 -35;
-    pos @kc87_first_17 @kc87_second_47 -70;
-    pos @kc87_first_17 @kc87_second_49 -105;
+    pos @kc87_first_17 @kc87_second_46 -70;
+    pos @kc87_first_17 @kc87_second_47 -105;
+    pos @kc87_first_17 @kc87_second_48 1;
+    pos @kc87_first_17 @kc87_second_49 -35;
     pos @kc87_first_17 @kc87_second_50 -70;
-    pos @kc87_first_17 @kc87_second_51 -105;
     pos @kc87_first_17 @kc87_second_52 -70;
-    pos @kc87_first_17 @kc87_second_53 -210;
-    pos @kc87_first_17 @kc87_second_54 -35;
+    pos @kc87_first_17 @kc87_second_53 -105;
+    pos @kc87_first_17 @kc87_second_54 -70;
     pos @kc87_first_17 @kc87_second_55 -210;
-    pos @kc87_first_17 @kc87_second_56 -70;
-    pos @kc87_first_17 @kc87_second_57 -245;
-    pos @kc87_first_17 @kc87_second_58 -105;
-    pos @kc87_first_17 @kc87_second_59 -105;
-    pos @kc87_first_17 @kc87_second_60 -70;
-    pos @kc87_first_17 @kc87_second_63 -175;
-    pos @kc87_first_17 @kc87_second_64 -245;
+    pos @kc87_first_17 @kc87_second_56 -35;
+    pos @kc87_first_17 @kc87_second_57 -210;
+    pos @kc87_first_17 @kc87_second_58 -70;
+    pos @kc87_first_17 @kc87_second_59 -245;
+    pos @kc87_first_17 @kc87_second_60 -105;
+    pos @kc87_first_17 @kc87_second_61 -105;
+    pos @kc87_first_17 @kc87_second_62 -70;
+    pos @kc87_first_17 @kc87_second_65 -175;
+    pos @kc87_first_17 @kc87_second_66 -245;
     pos @kc87_first_18 @kc87_second_1 -210;
     pos @kc87_first_18 @kc87_second_2 -245;
     pos @kc87_first_18 @kc87_second_3 -35;
@@ -9099,33 +9144,34 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_18 @kc87_second_23 -70;
     pos @kc87_first_18 @kc87_second_24 -140;
     pos @kc87_first_18 @kc87_second_27 -35;
-    pos @kc87_first_18 @kc87_second_32 -140;
-    pos @kc87_first_18 @kc87_second_34 -140;
-    pos @kc87_first_18 @kc87_second_36 -105;
-    pos @kc87_first_18 @kc87_second_37 -70;
-    pos @kc87_first_18 @kc87_second_38 -105;
-    pos @kc87_first_18 @kc87_second_39 -70;
-    pos @kc87_first_18 @kc87_second_41 -35;
-    pos @kc87_first_18 @kc87_second_45 1;
-    pos @kc87_first_18 @kc87_second_50 -35;
-    pos @kc87_first_18 @kc87_second_51 -70;
-    pos @kc87_first_18 @kc87_second_53 -140;
+    pos @kc87_first_18 @kc87_second_32 -105;
+    pos @kc87_first_18 @kc87_second_33 -140;
+    pos @kc87_first_18 @kc87_second_35 -140;
+    pos @kc87_first_18 @kc87_second_37 -105;
+    pos @kc87_first_18 @kc87_second_38 -70;
+    pos @kc87_first_18 @kc87_second_39 -105;
+    pos @kc87_first_18 @kc87_second_40 -70;
+    pos @kc87_first_18 @kc87_second_42 -35;
+    pos @kc87_first_18 @kc87_second_48 1;
+    pos @kc87_first_18 @kc87_second_52 -35;
+    pos @kc87_first_18 @kc87_second_53 -70;
     pos @kc87_first_18 @kc87_second_55 -140;
-    pos @kc87_first_18 @kc87_second_57 -175;
-    pos @kc87_first_18 @kc87_second_58 -70;
-    pos @kc87_first_18 @kc87_second_63 -105;
-    pos @kc87_first_18 @kc87_second_64 -140;
+    pos @kc87_first_18 @kc87_second_57 -140;
+    pos @kc87_first_18 @kc87_second_59 -175;
+    pos @kc87_first_18 @kc87_second_60 -70;
+    pos @kc87_first_18 @kc87_second_65 -105;
+    pos @kc87_first_18 @kc87_second_66 -140;
     pos @kc87_first_19 @kc87_second_12 -280;
     pos @kc87_first_19 @kc87_second_14 -175;
     pos @kc87_first_19 @kc87_second_15 -140;
     pos @kc87_first_19 @kc87_second_29 -35;
-    pos @kc87_first_19 @kc87_second_45 1;
-    pos @kc87_first_19 @kc87_second_47 -70;
-    pos @kc87_first_19 @kc87_second_48 -140;
-    pos @kc87_first_19 @kc87_second_58 -70;
-    pos @kc87_first_19 @kc87_second_60 -35;
-    pos @kc87_first_19 @kc87_second_61 -105;
-    pos @kc87_first_19 @kc87_second_62 -70;
+    pos @kc87_first_19 @kc87_second_48 1;
+    pos @kc87_first_19 @kc87_second_50 -70;
+    pos @kc87_first_19 @kc87_second_51 -140;
+    pos @kc87_first_19 @kc87_second_60 -70;
+    pos @kc87_first_19 @kc87_second_62 -35;
+    pos @kc87_first_19 @kc87_second_63 -105;
+    pos @kc87_first_19 @kc87_second_64 -70;
     pos @kc87_first_20 @kc87_second_8 -35;
     pos @kc87_first_20 @kc87_second_9 -140;
     pos @kc87_first_20 @kc87_second_12 -280;
@@ -9136,24 +9182,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_20 @kc87_second_20 -70;
     pos @kc87_first_20 @kc87_second_25 -70;
     pos @kc87_first_20 @kc87_second_31 -50;
-    pos @kc87_first_20 @kc87_second_39 -140;
-    pos @kc87_first_20 @kc87_second_40 -105;
+    pos @kc87_first_20 @kc87_second_40 -140;
+    pos @kc87_first_20 @kc87_second_41 -105;
     pos @kc87_first_20 @kc87_second_43 -210;
-    pos @kc87_first_20 @kc87_second_45 1;
-    pos @kc87_first_20 @kc87_second_46 -35;
-    pos @kc87_first_20 @kc87_second_47 -140;
-    pos @kc87_first_20 @kc87_second_48 -210;
-    pos @kc87_first_20 @kc87_second_52 -35;
-    pos @kc87_first_20 @kc87_second_58 -105;
+    pos @kc87_first_20 @kc87_second_44 -175;
+    pos @kc87_first_20 @kc87_second_48 1;
+    pos @kc87_first_20 @kc87_second_49 -35;
+    pos @kc87_first_20 @kc87_second_50 -140;
+    pos @kc87_first_20 @kc87_second_51 -210;
+    pos @kc87_first_20 @kc87_second_54 -35;
     pos @kc87_first_20 @kc87_second_60 -105;
-    pos @kc87_first_20 @kc87_second_61 -210;
-    pos @kc87_first_20 @kc87_second_62 -140;
+    pos @kc87_first_20 @kc87_second_62 -105;
+    pos @kc87_first_20 @kc87_second_63 -210;
+    pos @kc87_first_20 @kc87_second_64 -140;
     pos @kc87_first_21 @kc87_second_1 -140;
     pos @kc87_first_21 @kc87_second_2 -350;
     pos @kc87_first_21 @kc87_second_19 -280;
-    pos @kc87_first_21 @kc87_second_38 -70;
-    pos @kc87_first_21 @kc87_second_45 1;
-    pos @kc87_first_21 @kc87_second_64 -210;
+    pos @kc87_first_21 @kc87_second_39 -70;
+    pos @kc87_first_21 @kc87_second_48 1;
+    pos @kc87_first_21 @kc87_second_66 -210;
     pos @kc87_first_22 @kc87_second_1 -35;
     pos @kc87_first_22 @kc87_second_5 -105;
     pos @kc87_first_22 @kc87_second_9 -70;
@@ -9166,20 +9213,20 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_22 @kc87_second_25 -35;
     pos @kc87_first_22 @kc87_second_26 -70;
     pos @kc87_first_22 @kc87_second_27 -105;
-    pos @kc87_first_22 @kc87_second_35 -70;
-    pos @kc87_first_22 @kc87_second_39 -70;
-    pos @kc87_first_22 @kc87_second_40 -35;
-    pos @kc87_first_22 @kc87_second_42 -35;
+    pos @kc87_first_22 @kc87_second_36 -70;
+    pos @kc87_first_22 @kc87_second_40 -70;
+    pos @kc87_first_22 @kc87_second_41 -35;
     pos @kc87_first_22 @kc87_second_43 -140;
-    pos @kc87_first_22 @kc87_second_45 1;
-    pos @kc87_first_22 @kc87_second_47 -70;
-    pos @kc87_first_22 @kc87_second_48 -175;
-    pos @kc87_first_22 @kc87_second_49 -35;
-    pos @kc87_first_22 @kc87_second_56 -105;
-    pos @kc87_first_22 @kc87_second_58 -35;
-    pos @kc87_first_22 @kc87_second_60 -50;
-    pos @kc87_first_22 @kc87_second_61 -105;
-    pos @kc87_first_22 @kc87_second_62 -70;
+    pos @kc87_first_22 @kc87_second_45 -35;
+    pos @kc87_first_22 @kc87_second_47 -35;
+    pos @kc87_first_22 @kc87_second_48 1;
+    pos @kc87_first_22 @kc87_second_50 -70;
+    pos @kc87_first_22 @kc87_second_51 -175;
+    pos @kc87_first_22 @kc87_second_58 -105;
+    pos @kc87_first_22 @kc87_second_60 -35;
+    pos @kc87_first_22 @kc87_second_62 -50;
+    pos @kc87_first_22 @kc87_second_63 -105;
+    pos @kc87_first_22 @kc87_second_64 -70;
     pos @kc87_first_23 @kc87_second_6 -35;
     pos @kc87_first_23 @kc87_second_12 -240;
     pos @kc87_first_23 @kc87_second_13 -175;
@@ -9187,17 +9234,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_23 @kc87_second_15 -70;
     pos @kc87_first_23 @kc87_second_22 -70;
     pos @kc87_first_23 @kc87_second_23 -35;
-    pos @kc87_first_23 @kc87_second_34 -35;
-    pos @kc87_first_23 @kc87_second_39 -35;
+    pos @kc87_first_23 @kc87_second_35 -35;
     pos @kc87_first_23 @kc87_second_40 -35;
+    pos @kc87_first_23 @kc87_second_41 -35;
     pos @kc87_first_23 @kc87_second_43 -70;
-    pos @kc87_first_23 @kc87_second_44 -35;
-    pos @kc87_first_23 @kc87_second_45 1;
-    pos @kc87_first_23 @kc87_second_48 -35;
-    pos @kc87_first_23 @kc87_second_58 -35;
-    pos @kc87_first_23 @kc87_second_62 -35;
-    pos @kc87_first_23 @kc87_second_63 -35;
+    pos @kc87_first_23 @kc87_second_46 -35;
+    pos @kc87_first_23 @kc87_second_48 1;
+    pos @kc87_first_23 @kc87_second_51 -35;
+    pos @kc87_first_23 @kc87_second_60 -35;
     pos @kc87_first_23 @kc87_second_64 -35;
+    pos @kc87_first_23 @kc87_second_65 -35;
+    pos @kc87_first_23 @kc87_second_66 -35;
     pos @kc87_first_24 @kc87_second_1 -70;
     pos @kc87_first_24 @kc87_second_2 -140;
     pos @kc87_first_24 @kc87_second_5 -105;
@@ -9210,19 +9257,19 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_24 @kc87_second_19 -70;
     pos @kc87_first_24 @kc87_second_26 -70;
     pos @kc87_first_24 @kc87_second_27 -70;
-    pos @kc87_first_24 @kc87_second_32 -70;
-    pos @kc87_first_24 @kc87_second_35 -70;
-    pos @kc87_first_24 @kc87_second_42 -35;
+    pos @kc87_first_24 @kc87_second_33 -70;
+    pos @kc87_first_24 @kc87_second_36 -70;
     pos @kc87_first_24 @kc87_second_43 -140;
-    pos @kc87_first_24 @kc87_second_45 1;
-    pos @kc87_first_24 @kc87_second_48 -140;
-    pos @kc87_first_24 @kc87_second_49 -35;
-    pos @kc87_first_24 @kc87_second_53 -140;
-    pos @kc87_first_24 @kc87_second_55 -105;
-    pos @kc87_first_24 @kc87_second_56 -70;
-    pos @kc87_first_24 @kc87_second_57 -70;
-    pos @kc87_first_24 @kc87_second_61 -70;
-    pos @kc87_first_24 @kc87_second_62 -35;
+    pos @kc87_first_24 @kc87_second_45 -35;
+    pos @kc87_first_24 @kc87_second_47 -35;
+    pos @kc87_first_24 @kc87_second_48 1;
+    pos @kc87_first_24 @kc87_second_51 -140;
+    pos @kc87_first_24 @kc87_second_55 -140;
+    pos @kc87_first_24 @kc87_second_57 -105;
+    pos @kc87_first_24 @kc87_second_58 -70;
+    pos @kc87_first_24 @kc87_second_59 -70;
+    pos @kc87_first_24 @kc87_second_63 -70;
+    pos @kc87_first_24 @kc87_second_64 -35;
     pos @kc87_first_25 @kc87_second_5 -70;
     pos @kc87_first_25 @kc87_second_9 -70;
     pos @kc87_first_25 @kc87_second_12 -240;
@@ -9233,32 +9280,33 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_25 @kc87_second_25 -35;
     pos @kc87_first_25 @kc87_second_26 -70;
     pos @kc87_first_25 @kc87_second_27 -70;
-    pos @kc87_first_25 @kc87_second_35 -70;
-    pos @kc87_first_25 @kc87_second_39 -70;
-    pos @kc87_first_25 @kc87_second_40 -35;
+    pos @kc87_first_25 @kc87_second_36 -70;
+    pos @kc87_first_25 @kc87_second_40 -70;
+    pos @kc87_first_25 @kc87_second_41 -35;
     pos @kc87_first_25 @kc87_second_43 -140;
-    pos @kc87_first_25 @kc87_second_45 1;
-    pos @kc87_first_25 @kc87_second_47 -70;
-    pos @kc87_first_25 @kc87_second_48 -140;
-    pos @kc87_first_25 @kc87_second_49 -35;
-    pos @kc87_first_25 @kc87_second_53 -50;
-    pos @kc87_first_25 @kc87_second_54 -35;
+    pos @kc87_first_25 @kc87_second_44 -105;
+    pos @kc87_first_25 @kc87_second_47 -35;
+    pos @kc87_first_25 @kc87_second_48 1;
+    pos @kc87_first_25 @kc87_second_50 -70;
+    pos @kc87_first_25 @kc87_second_51 -140;
     pos @kc87_first_25 @kc87_second_55 -50;
-    pos @kc87_first_25 @kc87_second_56 -105;
+    pos @kc87_first_25 @kc87_second_56 -35;
     pos @kc87_first_25 @kc87_second_57 -50;
-    pos @kc87_first_25 @kc87_second_58 -50;
-    pos @kc87_first_25 @kc87_second_60 -35;
-    pos @kc87_first_25 @kc87_second_61 -105;
-    pos @kc87_first_25 @kc87_second_62 -70;
+    pos @kc87_first_25 @kc87_second_58 -105;
+    pos @kc87_first_25 @kc87_second_59 -50;
+    pos @kc87_first_25 @kc87_second_60 -50;
+    pos @kc87_first_25 @kc87_second_62 -35;
+    pos @kc87_first_25 @kc87_second_63 -105;
+    pos @kc87_first_25 @kc87_second_64 -70;
     pos @kc87_first_26 @kc87_second_9 -35;
     pos @kc87_first_26 @kc87_second_12 -140;
     pos @kc87_first_26 @kc87_second_26 -70;
-    pos @kc87_first_26 @kc87_second_39 -35;
+    pos @kc87_first_26 @kc87_second_40 -35;
     pos @kc87_first_26 @kc87_second_43 -70;
-    pos @kc87_first_26 @kc87_second_45 1;
-    pos @kc87_first_26 @kc87_second_48 -70;
-    pos @kc87_first_26 @kc87_second_61 -70;
-    pos @kc87_first_26 @kc87_second_62 -35;
+    pos @kc87_first_26 @kc87_second_48 1;
+    pos @kc87_first_26 @kc87_second_51 -70;
+    pos @kc87_first_26 @kc87_second_63 -70;
+    pos @kc87_first_26 @kc87_second_64 -35;
     pos @kc87_first_27 @kc87_second_5 -50;
     pos @kc87_first_27 @kc87_second_9 -35;
     pos @kc87_first_27 @kc87_second_11 -35;
@@ -9269,17 +9317,18 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_27 @kc87_second_16 -35;
     pos @kc87_first_27 @kc87_second_26 -35;
     pos @kc87_first_27 @kc87_second_27 -35;
-    pos @kc87_first_27 @kc87_second_35 -35;
-    pos @kc87_first_27 @kc87_second_39 -50;
-    pos @kc87_first_27 @kc87_second_40 -35;
+    pos @kc87_first_27 @kc87_second_36 -35;
+    pos @kc87_first_27 @kc87_second_40 -50;
+    pos @kc87_first_27 @kc87_second_41 -35;
     pos @kc87_first_27 @kc87_second_43 -100;
-    pos @kc87_first_27 @kc87_second_45 1;
-    pos @kc87_first_27 @kc87_second_47 -35;
-    pos @kc87_first_27 @kc87_second_48 -140;
-    pos @kc87_first_27 @kc87_second_56 -35;
-    pos @kc87_first_27 @kc87_second_61 -70;
-    pos @kc87_first_27 @kc87_second_62 -35;
-    pos @kc87_first_28 @kc87_second_45 1;
+    pos @kc87_first_27 @kc87_second_44 -35;
+    pos @kc87_first_27 @kc87_second_48 1;
+    pos @kc87_first_27 @kc87_second_50 -35;
+    pos @kc87_first_27 @kc87_second_51 -140;
+    pos @kc87_first_27 @kc87_second_58 -35;
+    pos @kc87_first_27 @kc87_second_63 -70;
+    pos @kc87_first_27 @kc87_second_64 -35;
+    pos @kc87_first_28 @kc87_second_48 1;
     pos @kc87_first_29 @kc87_second_8 -70;
     pos @kc87_first_29 @kc87_second_9 -210;
     pos @kc87_first_29 @kc87_second_12 -350;
@@ -9287,17 +9336,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_29 @kc87_second_14 -210;
     pos @kc87_first_29 @kc87_second_15 -175;
     pos @kc87_first_29 @kc87_second_25 -70;
-    pos @kc87_first_29 @kc87_second_38 -35;
-    pos @kc87_first_29 @kc87_second_39 -210;
+    pos @kc87_first_29 @kc87_second_39 -35;
     pos @kc87_first_29 @kc87_second_40 -210;
+    pos @kc87_first_29 @kc87_second_41 -210;
     pos @kc87_first_29 @kc87_second_43 -210;
-    pos @kc87_first_29 @kc87_second_45 1;
-    pos @kc87_first_29 @kc87_second_47 -140;
-    pos @kc87_first_29 @kc87_second_48 -280;
-    pos @kc87_first_29 @kc87_second_58 -210;
-    pos @kc87_first_29 @kc87_second_60 -105;
-    pos @kc87_first_29 @kc87_second_61 -175;
-    pos @kc87_first_29 @kc87_second_62 -140;
+    pos @kc87_first_29 @kc87_second_48 1;
+    pos @kc87_first_29 @kc87_second_50 -140;
+    pos @kc87_first_29 @kc87_second_51 -280;
+    pos @kc87_first_29 @kc87_second_60 -210;
+    pos @kc87_first_29 @kc87_second_62 -105;
+    pos @kc87_first_29 @kc87_second_63 -175;
+    pos @kc87_first_29 @kc87_second_64 -140;
     pos @kc87_first_30 @kc87_second_1 -175;
     pos @kc87_first_30 @kc87_second_2 -175;
     pos @kc87_first_30 @kc87_second_5 -70;
@@ -9313,16 +9362,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_30 @kc87_second_19 -175;
     pos @kc87_first_30 @kc87_second_22 -70;
     pos @kc87_first_30 @kc87_second_29 -105;
-    pos @kc87_first_30 @kc87_second_33 180;
-    pos @kc87_first_30 @kc87_second_34 -105;
-    pos @kc87_first_30 @kc87_second_35 -175;
-    pos @kc87_first_30 @kc87_second_36 -35;
-    pos @kc87_first_30 @kc87_second_38 -70;
-    pos @kc87_first_30 @kc87_second_45 1;
-    pos @kc87_first_30 @kc87_second_50 180;
-    pos @kc87_first_30 @kc87_second_51 -35;
-    pos @kc87_first_30 @kc87_second_63 -70;
-    pos @kc87_first_30 @kc87_second_64 -105;
+    pos @kc87_first_30 @kc87_second_34 180;
+    pos @kc87_first_30 @kc87_second_35 -105;
+    pos @kc87_first_30 @kc87_second_36 -175;
+    pos @kc87_first_30 @kc87_second_37 -35;
+    pos @kc87_first_30 @kc87_second_39 -70;
+    pos @kc87_first_30 @kc87_second_48 1;
+    pos @kc87_first_30 @kc87_second_52 180;
+    pos @kc87_first_30 @kc87_second_53 -35;
+    pos @kc87_first_30 @kc87_second_65 -70;
+    pos @kc87_first_30 @kc87_second_66 -105;
     pos @kc87_first_31 @kc87_second_3 -70;
     pos @kc87_first_31 @kc87_second_4 -35;
     pos @kc87_first_31 @kc87_second_6 -70;
@@ -9332,16 +9381,17 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_31 @kc87_second_22 -70;
     pos @kc87_first_31 @kc87_second_23 -140;
     pos @kc87_first_31 @kc87_second_29 -35;
-    pos @kc87_first_31 @kc87_second_34 -70;
-    pos @kc87_first_31 @kc87_second_36 -35;
-    pos @kc87_first_31 @kc87_second_38 -140;
-    pos @kc87_first_31 @kc87_second_39 -70;
-    pos @kc87_first_31 @kc87_second_45 1;
-    pos @kc87_first_31 @kc87_second_51 -35;
-    pos @kc87_first_31 @kc87_second_52 -35;
-    pos @kc87_first_31 @kc87_second_58 -140;
-    pos @kc87_first_31 @kc87_second_63 -70;
-    pos @kc87_first_31 @kc87_second_64 -70;
+    pos @kc87_first_31 @kc87_second_32 -70;
+    pos @kc87_first_31 @kc87_second_35 -70;
+    pos @kc87_first_31 @kc87_second_37 -35;
+    pos @kc87_first_31 @kc87_second_39 -140;
+    pos @kc87_first_31 @kc87_second_40 -70;
+    pos @kc87_first_31 @kc87_second_48 1;
+    pos @kc87_first_31 @kc87_second_53 -35;
+    pos @kc87_first_31 @kc87_second_54 -35;
+    pos @kc87_first_31 @kc87_second_60 -140;
+    pos @kc87_first_31 @kc87_second_65 -70;
+    pos @kc87_first_31 @kc87_second_66 -70;
     pos @kc87_first_32 @kc87_second_1 -35;
     pos @kc87_first_32 @kc87_second_2 -105;
     pos @kc87_first_32 @kc87_second_3 -70;
@@ -9355,20 +9405,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_32 @kc87_second_16 -70;
     pos @kc87_first_32 @kc87_second_24 -35;
     pos @kc87_first_32 @kc87_second_27 -70;
-    pos @kc87_first_32 @kc87_second_35 -35;
-    pos @kc87_first_32 @kc87_second_39 -35;
+    pos @kc87_first_32 @kc87_second_36 -35;
     pos @kc87_first_32 @kc87_second_40 -35;
-    pos @kc87_first_32 @kc87_second_42 -35;
+    pos @kc87_first_32 @kc87_second_41 -35;
     pos @kc87_first_32 @kc87_second_43 -140;
-    pos @kc87_first_32 @kc87_second_45 1;
-    pos @kc87_first_32 @kc87_second_47 -50;
-    pos @kc87_first_32 @kc87_second_48 -140;
-    pos @kc87_first_32 @kc87_second_49 -35;
-    pos @kc87_first_32 @kc87_second_53 -70;
+    pos @kc87_first_32 @kc87_second_44 -70;
+    pos @kc87_first_32 @kc87_second_45 -35;
+    pos @kc87_first_32 @kc87_second_47 -35;
+    pos @kc87_first_32 @kc87_second_48 1;
+    pos @kc87_first_32 @kc87_second_50 -50;
+    pos @kc87_first_32 @kc87_second_51 -140;
     pos @kc87_first_32 @kc87_second_55 -70;
     pos @kc87_first_32 @kc87_second_57 -70;
-    pos @kc87_first_32 @kc87_second_61 -70;
-    pos @kc87_first_32 @kc87_second_62 -35;
+    pos @kc87_first_32 @kc87_second_59 -70;
+    pos @kc87_first_32 @kc87_second_63 -70;
+    pos @kc87_first_32 @kc87_second_64 -35;
     pos @kc87_first_33 @kc87_second_3 -35;
     pos @kc87_first_33 @kc87_second_4 -70;
     pos @kc87_first_33 @kc87_second_6 -70;
@@ -9381,33 +9432,34 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_33 @kc87_second_22 -105;
     pos @kc87_first_33 @kc87_second_23 -70;
     pos @kc87_first_33 @kc87_second_29 -35;
-    pos @kc87_first_33 @kc87_second_34 -70;
-    pos @kc87_first_33 @kc87_second_36 -70;
-    pos @kc87_first_33 @kc87_second_38 -105;
-    pos @kc87_first_33 @kc87_second_39 -70;
-    pos @kc87_first_33 @kc87_second_44 -70;
-    pos @kc87_first_33 @kc87_second_45 1;
-    pos @kc87_first_33 @kc87_second_51 -35;
-    pos @kc87_first_33 @kc87_second_52 -35;
-    pos @kc87_first_33 @kc87_second_63 -70;
-    pos @kc87_first_33 @kc87_second_64 -70;
-    pos @kc87_first_34 @kc87_second_32 -315;
-    pos @kc87_first_34 @kc87_second_45 1;
+    pos @kc87_first_33 @kc87_second_32 -70;
+    pos @kc87_first_33 @kc87_second_35 -70;
+    pos @kc87_first_33 @kc87_second_37 -70;
+    pos @kc87_first_33 @kc87_second_39 -105;
+    pos @kc87_first_33 @kc87_second_40 -70;
+    pos @kc87_first_33 @kc87_second_46 -70;
+    pos @kc87_first_33 @kc87_second_48 1;
+    pos @kc87_first_33 @kc87_second_53 -35;
+    pos @kc87_first_33 @kc87_second_54 -35;
+    pos @kc87_first_33 @kc87_second_65 -70;
+    pos @kc87_first_33 @kc87_second_66 -70;
+    pos @kc87_first_34 @kc87_second_33 -315;
+    pos @kc87_first_34 @kc87_second_48 1;
     pos @kc87_first_35 @kc87_second_9 -70;
     pos @kc87_first_35 @kc87_second_12 -240;
     pos @kc87_first_35 @kc87_second_13 -210;
     pos @kc87_first_35 @kc87_second_14 -140;
     pos @kc87_first_35 @kc87_second_15 -105;
-    pos @kc87_first_35 @kc87_second_39 -70;
-    pos @kc87_first_35 @kc87_second_40 -35;
+    pos @kc87_first_35 @kc87_second_40 -70;
+    pos @kc87_first_35 @kc87_second_41 -35;
     pos @kc87_first_35 @kc87_second_43 -140;
-    pos @kc87_first_35 @kc87_second_45 1;
-    pos @kc87_first_35 @kc87_second_47 -50;
-    pos @kc87_first_35 @kc87_second_48 -140;
-    pos @kc87_first_35 @kc87_second_58 -35;
+    pos @kc87_first_35 @kc87_second_48 1;
+    pos @kc87_first_35 @kc87_second_50 -50;
+    pos @kc87_first_35 @kc87_second_51 -140;
     pos @kc87_first_35 @kc87_second_60 -35;
-    pos @kc87_first_35 @kc87_second_61 -70;
-    pos @kc87_first_35 @kc87_second_62 -70;
+    pos @kc87_first_35 @kc87_second_62 -35;
+    pos @kc87_first_35 @kc87_second_63 -70;
+    pos @kc87_first_35 @kc87_second_64 -70;
     pos @kc87_first_36 @kc87_second_9 -35;
     pos @kc87_first_36 @kc87_second_12 -240;
     pos @kc87_first_36 @kc87_second_13 -240;
@@ -9416,15 +9468,16 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_36 @kc87_second_16 -35;
     pos @kc87_first_36 @kc87_second_26 -35;
     pos @kc87_first_36 @kc87_second_27 -35;
-    pos @kc87_first_36 @kc87_second_39 -70;
-    pos @kc87_first_36 @kc87_second_40 -35;
+    pos @kc87_first_36 @kc87_second_40 -70;
+    pos @kc87_first_36 @kc87_second_41 -35;
     pos @kc87_first_36 @kc87_second_43 -70;
-    pos @kc87_first_36 @kc87_second_45 1;
-    pos @kc87_first_36 @kc87_second_47 -35;
-    pos @kc87_first_36 @kc87_second_48 -70;
-    pos @kc87_first_36 @kc87_second_60 -35;
-    pos @kc87_first_36 @kc87_second_61 -70;
-    pos @kc87_first_36 @kc87_second_62 -70;
+    pos @kc87_first_36 @kc87_second_44 -35;
+    pos @kc87_first_36 @kc87_second_48 1;
+    pos @kc87_first_36 @kc87_second_50 -35;
+    pos @kc87_first_36 @kc87_second_51 -70;
+    pos @kc87_first_36 @kc87_second_62 -35;
+    pos @kc87_first_36 @kc87_second_63 -70;
+    pos @kc87_first_36 @kc87_second_64 -70;
     pos @kc87_first_37 @kc87_second_5 -70;
     pos @kc87_first_37 @kc87_second_9 -70;
     pos @kc87_first_37 @kc87_second_12 -140;
@@ -9434,619 +9487,636 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_37 @kc87_second_16 -70;
     pos @kc87_first_37 @kc87_second_26 -70;
     pos @kc87_first_37 @kc87_second_27 -70;
-    pos @kc87_first_37 @kc87_second_35 -50;
-    pos @kc87_first_37 @kc87_second_39 -50;
-    pos @kc87_first_37 @kc87_second_40 -35;
-    pos @kc87_first_37 @kc87_second_45 1;
-    pos @kc87_first_37 @kc87_second_47 -35;
-    pos @kc87_first_37 @kc87_second_48 -140;
-    pos @kc87_first_37 @kc87_second_56 -35;
-    pos @kc87_first_37 @kc87_second_61 -70;
-    pos @kc87_first_37 @kc87_second_62 -35;
-    pos @kc87_first_38 @kc87_second_1 -210;
-    pos @kc87_first_38 @kc87_second_2 -280;
-    pos @kc87_first_38 @kc87_second_6 -280;
-    pos @kc87_first_38 @kc87_second_8 -70;
-    pos @kc87_first_38 @kc87_second_17 -140;
-    pos @kc87_first_38 @kc87_second_19 -350;
-    pos @kc87_first_38 @kc87_second_20 -140;
-    pos @kc87_first_38 @kc87_second_22 -140;
-    pos @kc87_first_38 @kc87_second_23 -70;
-    pos @kc87_first_38 @kc87_second_24 -280;
-    pos @kc87_first_38 @kc87_second_28 -315;
-    pos @kc87_first_38 @kc87_second_29 -140;
-    pos @kc87_first_38 @kc87_second_32 -385;
-    pos @kc87_first_38 @kc87_second_34 -210;
+    pos @kc87_first_37 @kc87_second_36 -50;
+    pos @kc87_first_37 @kc87_second_40 -50;
+    pos @kc87_first_37 @kc87_second_41 -35;
+    pos @kc87_first_37 @kc87_second_48 1;
+    pos @kc87_first_37 @kc87_second_50 -35;
+    pos @kc87_first_37 @kc87_second_51 -140;
+    pos @kc87_first_37 @kc87_second_58 -35;
+    pos @kc87_first_37 @kc87_second_63 -70;
+    pos @kc87_first_37 @kc87_second_64 -35;
+    pos @kc87_first_38 @kc87_second_3 -140;
+    pos @kc87_first_38 @kc87_second_4 -70;
+    pos @kc87_first_38 @kc87_second_6 -70;
+    pos @kc87_first_38 @kc87_second_8 -210;
+    pos @kc87_first_38 @kc87_second_9 -420;
+    pos @kc87_first_38 @kc87_second_12 -350;
+    pos @kc87_first_38 @kc87_second_13 -420;
+    pos @kc87_first_38 @kc87_second_14 -350;
+    pos @kc87_first_38 @kc87_second_15 -280;
+    pos @kc87_first_38 @kc87_second_17 -70;
+    pos @kc87_first_38 @kc87_second_18 -210;
+    pos @kc87_first_38 @kc87_second_20 -210;
+    pos @kc87_first_38 @kc87_second_22 -70;
+    pos @kc87_first_38 @kc87_second_23 -140;
+    pos @kc87_first_38 @kc87_second_29 -35;
+    pos @kc87_first_38 @kc87_second_31 -140;
+    pos @kc87_first_38 @kc87_second_32 -70;
     pos @kc87_first_38 @kc87_second_35 -70;
-    pos @kc87_first_38 @kc87_second_36 -140;
-    pos @kc87_first_38 @kc87_second_37 -140;
-    pos @kc87_first_38 @kc87_second_38 -140;
-    pos @kc87_first_38 @kc87_second_41 -70;
-    pos @kc87_first_38 @kc87_second_45 1;
-    pos @kc87_first_38 @kc87_second_51 -140;
-    pos @kc87_first_38 @kc87_second_52 -70;
-    pos @kc87_first_38 @kc87_second_53 -140;
-    pos @kc87_first_38 @kc87_second_55 -245;
-    pos @kc87_first_38 @kc87_second_58 -70;
-    pos @kc87_first_38 @kc87_second_59 -70;
-    pos @kc87_first_38 @kc87_second_63 -245;
-    pos @kc87_first_38 @kc87_second_64 -280;
-    pos @kc87_first_38 @kc87_second_65 -315;
+    pos @kc87_first_38 @kc87_second_37 -70;
+    pos @kc87_first_38 @kc87_second_39 -210;
+    pos @kc87_first_38 @kc87_second_40 -280;
+    pos @kc87_first_38 @kc87_second_41 -420;
+    pos @kc87_first_38 @kc87_second_43 -350;
+    pos @kc87_first_38 @kc87_second_44 -280;
+    pos @kc87_first_38 @kc87_second_48 1;
+    pos @kc87_first_38 @kc87_second_49 -35;
+    pos @kc87_first_38 @kc87_second_50 -210;
+    pos @kc87_first_38 @kc87_second_51 -350;
+    pos @kc87_first_38 @kc87_second_53 -35;
+    pos @kc87_first_38 @kc87_second_54 -35;
+    pos @kc87_first_38 @kc87_second_60 -280;
+    pos @kc87_first_38 @kc87_second_62 -175;
+    pos @kc87_first_38 @kc87_second_63 -280;
+    pos @kc87_first_38 @kc87_second_64 -210;
+    pos @kc87_first_38 @kc87_second_65 -70;
+    pos @kc87_first_39 @kc87_second_1 -35;
+    pos @kc87_first_39 @kc87_second_2 -70;
+    pos @kc87_first_39 @kc87_second_5 -105;
     pos @kc87_first_39 @kc87_second_6 -35;
+    pos @kc87_first_39 @kc87_second_9 -70;
+    pos @kc87_first_39 @kc87_second_11 -70;
     pos @kc87_first_39 @kc87_second_12 -240;
-    pos @kc87_first_39 @kc87_second_13 -140;
-    pos @kc87_first_39 @kc87_second_14 -35;
-    pos @kc87_first_39 @kc87_second_15 -35;
-    pos @kc87_first_39 @kc87_second_34 -35;
-    pos @kc87_first_39 @kc87_second_45 1;
-    pos @kc87_first_39 @kc87_second_63 -35;
-    pos @kc87_first_39 @kc87_second_64 -35;
-    pos @kc87_first_40 @kc87_second_12 -210;
-    pos @kc87_first_40 @kc87_second_13 -175;
-    pos @kc87_first_40 @kc87_second_14 -105;
-    pos @kc87_first_40 @kc87_second_15 -70;
-    pos @kc87_first_40 @kc87_second_43 -70;
-    pos @kc87_first_40 @kc87_second_45 1;
-    pos @kc87_first_40 @kc87_second_48 -105;
+    pos @kc87_first_39 @kc87_second_13 -245;
+    pos @kc87_first_39 @kc87_second_14 -140;
+    pos @kc87_first_39 @kc87_second_15 -105;
+    pos @kc87_first_39 @kc87_second_16 -105;
+    pos @kc87_first_39 @kc87_second_18 -70;
+    pos @kc87_first_39 @kc87_second_19 -70;
+    pos @kc87_first_39 @kc87_second_24 -35;
+    pos @kc87_first_39 @kc87_second_25 -70;
+    pos @kc87_first_39 @kc87_second_26 -140;
+    pos @kc87_first_39 @kc87_second_27 -105;
+    pos @kc87_first_39 @kc87_second_35 -35;
+    pos @kc87_first_39 @kc87_second_36 -140;
+    pos @kc87_first_39 @kc87_second_40 -105;
+    pos @kc87_first_39 @kc87_second_41 -70;
+    pos @kc87_first_39 @kc87_second_43 -175;
+    pos @kc87_first_39 @kc87_second_45 -105;
+    pos @kc87_first_39 @kc87_second_47 -70;
+    pos @kc87_first_39 @kc87_second_48 1;
+    pos @kc87_first_39 @kc87_second_50 -70;
+    pos @kc87_first_39 @kc87_second_51 -140;
+    pos @kc87_first_39 @kc87_second_55 -210;
+    pos @kc87_first_39 @kc87_second_56 -70;
+    pos @kc87_first_39 @kc87_second_57 -175;
+    pos @kc87_first_39 @kc87_second_58 -105;
+    pos @kc87_first_39 @kc87_second_59 -175;
+    pos @kc87_first_39 @kc87_second_62 -50;
+    pos @kc87_first_39 @kc87_second_63 -105;
+    pos @kc87_first_39 @kc87_second_64 -70;
+    pos @kc87_first_39 @kc87_second_66 -35;
+    pos @kc87_first_40 @kc87_second_1 -210;
+    pos @kc87_first_40 @kc87_second_2 -280;
+    pos @kc87_first_40 @kc87_second_6 -280;
+    pos @kc87_first_40 @kc87_second_8 -70;
+    pos @kc87_first_40 @kc87_second_17 -140;
+    pos @kc87_first_40 @kc87_second_19 -350;
+    pos @kc87_first_40 @kc87_second_20 -140;
+    pos @kc87_first_40 @kc87_second_22 -140;
+    pos @kc87_first_40 @kc87_second_23 -70;
+    pos @kc87_first_40 @kc87_second_24 -280;
+    pos @kc87_first_40 @kc87_second_28 -315;
+    pos @kc87_first_40 @kc87_second_29 -140;
+    pos @kc87_first_40 @kc87_second_33 -385;
+    pos @kc87_first_40 @kc87_second_35 -210;
+    pos @kc87_first_40 @kc87_second_36 -70;
+    pos @kc87_first_40 @kc87_second_37 -140;
+    pos @kc87_first_40 @kc87_second_38 -140;
+    pos @kc87_first_40 @kc87_second_39 -140;
+    pos @kc87_first_40 @kc87_second_42 -70;
+    pos @kc87_first_40 @kc87_second_48 1;
+    pos @kc87_first_40 @kc87_second_53 -140;
+    pos @kc87_first_40 @kc87_second_54 -70;
+    pos @kc87_first_40 @kc87_second_55 -140;
+    pos @kc87_first_40 @kc87_second_57 -245;
+    pos @kc87_first_40 @kc87_second_60 -70;
     pos @kc87_first_40 @kc87_second_61 -70;
-    pos @kc87_first_41 @kc87_second_1 -140;
-    pos @kc87_first_41 @kc87_second_2 -175;
-    pos @kc87_first_41 @kc87_second_5 -105;
-    pos @kc87_first_41 @kc87_second_6 -70;
-    pos @kc87_first_41 @kc87_second_11 -70;
-    pos @kc87_first_41 @kc87_second_12 -175;
-    pos @kc87_first_41 @kc87_second_13 -105;
-    pos @kc87_first_41 @kc87_second_14 -70;
+    pos @kc87_first_40 @kc87_second_65 -245;
+    pos @kc87_first_40 @kc87_second_66 -280;
+    pos @kc87_first_40 @kc87_second_67 -315;
+    pos @kc87_first_41 @kc87_second_6 -35;
+    pos @kc87_first_41 @kc87_second_12 -240;
+    pos @kc87_first_41 @kc87_second_13 -140;
+    pos @kc87_first_41 @kc87_second_14 -35;
     pos @kc87_first_41 @kc87_second_15 -35;
-    pos @kc87_first_41 @kc87_second_16 -105;
-    pos @kc87_first_41 @kc87_second_17 -35;
-    pos @kc87_first_41 @kc87_second_19 -175;
-    pos @kc87_first_41 @kc87_second_22 -50;
-    pos @kc87_first_41 @kc87_second_24 -105;
-    pos @kc87_first_41 @kc87_second_29 -35;
-    pos @kc87_first_41 @kc87_second_34 -70;
-    pos @kc87_first_41 @kc87_second_35 -140;
-    pos @kc87_first_41 @kc87_second_36 -35;
-    pos @kc87_first_41 @kc87_second_38 -50;
-    pos @kc87_first_41 @kc87_second_45 1;
-    pos @kc87_first_41 @kc87_second_51 -35;
-    pos @kc87_first_41 @kc87_second_53 -105;
-    pos @kc87_first_41 @kc87_second_55 -105;
-    pos @kc87_first_41 @kc87_second_57 -105;
-    pos @kc87_first_41 @kc87_second_63 -50;
-    pos @kc87_first_41 @kc87_second_64 -70;
-    pos @kc87_first_42 @kc87_second_1 -210;
-    pos @kc87_first_42 @kc87_second_2 -280;
-    pos @kc87_first_42 @kc87_second_3 -70;
-    pos @kc87_first_42 @kc87_second_6 -280;
-    pos @kc87_first_42 @kc87_second_8 -35;
-    pos @kc87_first_42 @kc87_second_11 -70;
-    pos @kc87_first_42 @kc87_second_13 -140;
-    pos @kc87_first_42 @kc87_second_14 -35;
-    pos @kc87_first_42 @kc87_second_15 -35;
-    pos @kc87_first_42 @kc87_second_16 -140;
-    pos @kc87_first_42 @kc87_second_17 -105;
-    pos @kc87_first_42 @kc87_second_19 -280;
-    pos @kc87_first_42 @kc87_second_20 -140;
-    pos @kc87_first_42 @kc87_second_22 -140;
-    pos @kc87_first_42 @kc87_second_23 -140;
-    pos @kc87_first_42 @kc87_second_24 -210;
-    pos @kc87_first_42 @kc87_second_34 -280;
-    pos @kc87_first_42 @kc87_second_35 -140;
-    pos @kc87_first_42 @kc87_second_36 -70;
-    pos @kc87_first_42 @kc87_second_37 -140;
-    pos @kc87_first_42 @kc87_second_38 -175;
-    pos @kc87_first_42 @kc87_second_44 -70;
-    pos @kc87_first_42 @kc87_second_45 1;
-    pos @kc87_first_42 @kc87_second_53 -210;
-    pos @kc87_first_42 @kc87_second_55 -175;
-    pos @kc87_first_42 @kc87_second_57 -210;
-    pos @kc87_first_42 @kc87_second_59 -70;
-    pos @kc87_first_42 @kc87_second_63 -175;
-    pos @kc87_first_42 @kc87_second_64 -175;
-    pos @kc87_first_43 @kc87_second_9 -70;
-    pos @kc87_first_43 @kc87_second_12 -240;
-    pos @kc87_first_43 @kc87_second_13 -210;
-    pos @kc87_first_43 @kc87_second_14 -140;
-    pos @kc87_first_43 @kc87_second_15 -105;
-    pos @kc87_first_43 @kc87_second_39 -70;
-    pos @kc87_first_43 @kc87_second_40 -35;
-    pos @kc87_first_43 @kc87_second_43 -140;
-    pos @kc87_first_43 @kc87_second_45 1;
-    pos @kc87_first_43 @kc87_second_47 -50;
-    pos @kc87_first_43 @kc87_second_48 -140;
-    pos @kc87_first_43 @kc87_second_58 -35;
-    pos @kc87_first_43 @kc87_second_60 -35;
-    pos @kc87_first_43 @kc87_second_61 -70;
-    pos @kc87_first_43 @kc87_second_62 -70;
+    pos @kc87_first_41 @kc87_second_35 -35;
+    pos @kc87_first_41 @kc87_second_48 1;
+    pos @kc87_first_41 @kc87_second_65 -35;
+    pos @kc87_first_41 @kc87_second_66 -35;
+    pos @kc87_first_42 @kc87_second_12 -210;
+    pos @kc87_first_42 @kc87_second_13 -175;
+    pos @kc87_first_42 @kc87_second_14 -105;
+    pos @kc87_first_42 @kc87_second_15 -70;
+    pos @kc87_first_42 @kc87_second_43 -70;
+    pos @kc87_first_42 @kc87_second_44 -35;
+    pos @kc87_first_42 @kc87_second_48 1;
+    pos @kc87_first_42 @kc87_second_51 -105;
+    pos @kc87_first_42 @kc87_second_63 -70;
+    pos @kc87_first_43 @kc87_second_1 -140;
+    pos @kc87_first_43 @kc87_second_2 -175;
+    pos @kc87_first_43 @kc87_second_5 -105;
+    pos @kc87_first_43 @kc87_second_6 -70;
+    pos @kc87_first_43 @kc87_second_11 -70;
+    pos @kc87_first_43 @kc87_second_12 -175;
+    pos @kc87_first_43 @kc87_second_13 -105;
+    pos @kc87_first_43 @kc87_second_14 -70;
+    pos @kc87_first_43 @kc87_second_15 -35;
+    pos @kc87_first_43 @kc87_second_16 -105;
+    pos @kc87_first_43 @kc87_second_17 -35;
+    pos @kc87_first_43 @kc87_second_19 -175;
+    pos @kc87_first_43 @kc87_second_22 -50;
+    pos @kc87_first_43 @kc87_second_24 -105;
+    pos @kc87_first_43 @kc87_second_29 -35;
+    pos @kc87_first_43 @kc87_second_32 -70;
+    pos @kc87_first_43 @kc87_second_35 -70;
+    pos @kc87_first_43 @kc87_second_36 -140;
+    pos @kc87_first_43 @kc87_second_37 -35;
+    pos @kc87_first_43 @kc87_second_39 -50;
+    pos @kc87_first_43 @kc87_second_48 1;
+    pos @kc87_first_43 @kc87_second_53 -35;
+    pos @kc87_first_43 @kc87_second_55 -105;
+    pos @kc87_first_43 @kc87_second_57 -105;
+    pos @kc87_first_43 @kc87_second_59 -105;
+    pos @kc87_first_43 @kc87_second_65 -50;
+    pos @kc87_first_43 @kc87_second_66 -70;
+    pos @kc87_first_44 @kc87_second_1 -210;
+    pos @kc87_first_44 @kc87_second_2 -280;
+    pos @kc87_first_44 @kc87_second_3 -70;
+    pos @kc87_first_44 @kc87_second_6 -280;
     pos @kc87_first_44 @kc87_second_8 -35;
-    pos @kc87_first_44 @kc87_second_9 -70;
-    pos @kc87_first_44 @kc87_second_12 -240;
-    pos @kc87_first_44 @kc87_second_13 -210;
-    pos @kc87_first_44 @kc87_second_14 -70;
-    pos @kc87_first_44 @kc87_second_15 -105;
-    pos @kc87_first_44 @kc87_second_22 -35;
-    pos @kc87_first_44 @kc87_second_38 -70;
-    pos @kc87_first_44 @kc87_second_39 -105;
-    pos @kc87_first_44 @kc87_second_40 -70;
-    pos @kc87_first_44 @kc87_second_43 -70;
-    pos @kc87_first_44 @kc87_second_44 -35;
-    pos @kc87_first_44 @kc87_second_45 1;
-    pos @kc87_first_44 @kc87_second_47 -70;
-    pos @kc87_first_44 @kc87_second_48 -70;
-    pos @kc87_first_44 @kc87_second_58 -70;
-    pos @kc87_first_44 @kc87_second_60 -50;
-    pos @kc87_first_44 @kc87_second_62 -70;
-    pos @kc87_first_44 @kc87_second_63 -35;
-    pos @kc87_first_44 @kc87_second_64 -35;
-    pos @kc87_first_45 @kc87_second_6 -70;
-    pos @kc87_first_45 @kc87_second_8 -35;
-    pos @kc87_first_45 @kc87_second_12 -175;
-    pos @kc87_first_45 @kc87_second_13 -140;
-    pos @kc87_first_45 @kc87_second_14 -70;
-    pos @kc87_first_45 @kc87_second_15 -35;
-    pos @kc87_first_45 @kc87_second_17 -70;
-    pos @kc87_first_45 @kc87_second_20 -70;
-    pos @kc87_first_45 @kc87_second_22 -105;
-    pos @kc87_first_45 @kc87_second_29 -35;
-    pos @kc87_first_45 @kc87_second_34 -70;
-    pos @kc87_first_45 @kc87_second_36 -35;
-    pos @kc87_first_45 @kc87_second_38 -105;
-    pos @kc87_first_45 @kc87_second_45 1;
-    pos @kc87_first_45 @kc87_second_51 -35;
+    pos @kc87_first_44 @kc87_second_11 -70;
+    pos @kc87_first_44 @kc87_second_13 -140;
+    pos @kc87_first_44 @kc87_second_14 -35;
+    pos @kc87_first_44 @kc87_second_15 -35;
+    pos @kc87_first_44 @kc87_second_16 -140;
+    pos @kc87_first_44 @kc87_second_17 -105;
+    pos @kc87_first_44 @kc87_second_19 -280;
+    pos @kc87_first_44 @kc87_second_20 -140;
+    pos @kc87_first_44 @kc87_second_22 -140;
+    pos @kc87_first_44 @kc87_second_23 -140;
+    pos @kc87_first_44 @kc87_second_24 -210;
+    pos @kc87_first_44 @kc87_second_32 -70;
+    pos @kc87_first_44 @kc87_second_35 -280;
+    pos @kc87_first_44 @kc87_second_36 -140;
+    pos @kc87_first_44 @kc87_second_37 -70;
+    pos @kc87_first_44 @kc87_second_38 -140;
+    pos @kc87_first_44 @kc87_second_39 -175;
+    pos @kc87_first_44 @kc87_second_46 -70;
+    pos @kc87_first_44 @kc87_second_48 1;
+    pos @kc87_first_44 @kc87_second_55 -210;
+    pos @kc87_first_44 @kc87_second_57 -175;
+    pos @kc87_first_44 @kc87_second_59 -210;
+    pos @kc87_first_44 @kc87_second_61 -70;
+    pos @kc87_first_44 @kc87_second_65 -175;
+    pos @kc87_first_44 @kc87_second_66 -175;
+    pos @kc87_first_45 @kc87_second_9 -70;
+    pos @kc87_first_45 @kc87_second_12 -240;
+    pos @kc87_first_45 @kc87_second_13 -210;
+    pos @kc87_first_45 @kc87_second_14 -140;
+    pos @kc87_first_45 @kc87_second_15 -105;
+    pos @kc87_first_45 @kc87_second_40 -70;
+    pos @kc87_first_45 @kc87_second_41 -35;
+    pos @kc87_first_45 @kc87_second_43 -140;
+    pos @kc87_first_45 @kc87_second_44 -70;
+    pos @kc87_first_45 @kc87_second_48 1;
+    pos @kc87_first_45 @kc87_second_50 -50;
+    pos @kc87_first_45 @kc87_second_51 -140;
+    pos @kc87_first_45 @kc87_second_60 -35;
+    pos @kc87_first_45 @kc87_second_62 -35;
     pos @kc87_first_45 @kc87_second_63 -70;
     pos @kc87_first_45 @kc87_second_64 -70;
-    pos @kc87_first_46 @kc87_second_3 -140;
-    pos @kc87_first_46 @kc87_second_4 -70;
-    pos @kc87_first_46 @kc87_second_6 -70;
-    pos @kc87_first_46 @kc87_second_8 -210;
-    pos @kc87_first_46 @kc87_second_9 -420;
-    pos @kc87_first_46 @kc87_second_12 -350;
-    pos @kc87_first_46 @kc87_second_13 -420;
-    pos @kc87_first_46 @kc87_second_14 -350;
-    pos @kc87_first_46 @kc87_second_15 -280;
-    pos @kc87_first_46 @kc87_second_17 -70;
-    pos @kc87_first_46 @kc87_second_18 -210;
-    pos @kc87_first_46 @kc87_second_20 -210;
-    pos @kc87_first_46 @kc87_second_22 -70;
-    pos @kc87_first_46 @kc87_second_23 -140;
-    pos @kc87_first_46 @kc87_second_29 -35;
-    pos @kc87_first_46 @kc87_second_31 -140;
-    pos @kc87_first_46 @kc87_second_34 -70;
-    pos @kc87_first_46 @kc87_second_36 -70;
-    pos @kc87_first_46 @kc87_second_38 -210;
-    pos @kc87_first_46 @kc87_second_39 -280;
-    pos @kc87_first_46 @kc87_second_40 -420;
-    pos @kc87_first_46 @kc87_second_43 -350;
-    pos @kc87_first_46 @kc87_second_45 1;
+    pos @kc87_first_46 @kc87_second_8 -35;
+    pos @kc87_first_46 @kc87_second_9 -70;
+    pos @kc87_first_46 @kc87_second_12 -240;
+    pos @kc87_first_46 @kc87_second_13 -210;
+    pos @kc87_first_46 @kc87_second_14 -70;
+    pos @kc87_first_46 @kc87_second_15 -105;
+    pos @kc87_first_46 @kc87_second_22 -35;
+    pos @kc87_first_46 @kc87_second_39 -70;
+    pos @kc87_first_46 @kc87_second_40 -105;
+    pos @kc87_first_46 @kc87_second_41 -70;
+    pos @kc87_first_46 @kc87_second_43 -70;
     pos @kc87_first_46 @kc87_second_46 -35;
-    pos @kc87_first_46 @kc87_second_47 -210;
-    pos @kc87_first_46 @kc87_second_48 -350;
-    pos @kc87_first_46 @kc87_second_51 -35;
-    pos @kc87_first_46 @kc87_second_52 -35;
-    pos @kc87_first_46 @kc87_second_58 -280;
-    pos @kc87_first_46 @kc87_second_60 -175;
-    pos @kc87_first_46 @kc87_second_61 -280;
-    pos @kc87_first_46 @kc87_second_62 -210;
-    pos @kc87_first_46 @kc87_second_63 -70;
-    pos @kc87_first_47 @kc87_second_3 -140;
-    pos @kc87_first_47 @kc87_second_4 -105;
+    pos @kc87_first_46 @kc87_second_48 1;
+    pos @kc87_first_46 @kc87_second_50 -70;
+    pos @kc87_first_46 @kc87_second_51 -70;
+    pos @kc87_first_46 @kc87_second_60 -70;
+    pos @kc87_first_46 @kc87_second_62 -50;
+    pos @kc87_first_46 @kc87_second_64 -70;
+    pos @kc87_first_46 @kc87_second_65 -35;
+    pos @kc87_first_46 @kc87_second_66 -35;
     pos @kc87_first_47 @kc87_second_6 -70;
-    pos @kc87_first_47 @kc87_second_8 -210;
-    pos @kc87_first_47 @kc87_second_9 -280;
-    pos @kc87_first_47 @kc87_second_12 -350;
-    pos @kc87_first_47 @kc87_second_13 -385;
-    pos @kc87_first_47 @kc87_second_14 -350;
-    pos @kc87_first_47 @kc87_second_15 -280;
-    pos @kc87_first_47 @kc87_second_18 -210;
-    pos @kc87_first_47 @kc87_second_20 -140;
+    pos @kc87_first_47 @kc87_second_8 -35;
+    pos @kc87_first_47 @kc87_second_12 -175;
+    pos @kc87_first_47 @kc87_second_13 -140;
+    pos @kc87_first_47 @kc87_second_14 -70;
+    pos @kc87_first_47 @kc87_second_15 -35;
+    pos @kc87_first_47 @kc87_second_17 -70;
+    pos @kc87_first_47 @kc87_second_20 -70;
     pos @kc87_first_47 @kc87_second_22 -105;
-    pos @kc87_first_47 @kc87_second_23 -140;
-    pos @kc87_first_47 @kc87_second_29 -70;
-    pos @kc87_first_47 @kc87_second_31 -175;
-    pos @kc87_first_47 @kc87_second_34 -70;
-    pos @kc87_first_47 @kc87_second_36 -35;
-    pos @kc87_first_47 @kc87_second_38 -175;
-    pos @kc87_first_47 @kc87_second_39 -280;
-    pos @kc87_first_47 @kc87_second_40 -280;
-    pos @kc87_first_47 @kc87_second_43 -280;
-    pos @kc87_first_47 @kc87_second_44 -140;
-    pos @kc87_first_47 @kc87_second_45 1;
-    pos @kc87_first_47 @kc87_second_46 -70;
-    pos @kc87_first_47 @kc87_second_47 -280;
-    pos @kc87_first_47 @kc87_second_48 -350;
-    pos @kc87_first_47 @kc87_second_51 -35;
-    pos @kc87_first_47 @kc87_second_52 -70;
-    pos @kc87_first_47 @kc87_second_58 -245;
-    pos @kc87_first_47 @kc87_second_60 -245;
-    pos @kc87_first_47 @kc87_second_61 -280;
-    pos @kc87_first_47 @kc87_second_62 -210;
-    pos @kc87_first_47 @kc87_second_63 -70;
-    pos @kc87_first_47 @kc87_second_64 -70;
-    pos @kc87_first_48 @kc87_second_3 -70;
+    pos @kc87_first_47 @kc87_second_29 -35;
+    pos @kc87_first_47 @kc87_second_32 -70;
+    pos @kc87_first_47 @kc87_second_35 -70;
+    pos @kc87_first_47 @kc87_second_37 -35;
+    pos @kc87_first_47 @kc87_second_39 -105;
+    pos @kc87_first_47 @kc87_second_48 1;
+    pos @kc87_first_47 @kc87_second_53 -35;
+    pos @kc87_first_47 @kc87_second_65 -70;
+    pos @kc87_first_47 @kc87_second_66 -70;
+    pos @kc87_first_48 @kc87_second_3 -140;
     pos @kc87_first_48 @kc87_second_4 -105;
-    pos @kc87_first_48 @kc87_second_6 -210;
-    pos @kc87_first_48 @kc87_second_7 -70;
-    pos @kc87_first_48 @kc87_second_8 -175;
-    pos @kc87_first_48 @kc87_second_17 -210;
+    pos @kc87_first_48 @kc87_second_6 -70;
+    pos @kc87_first_48 @kc87_second_8 -210;
+    pos @kc87_first_48 @kc87_second_9 -280;
+    pos @kc87_first_48 @kc87_second_12 -350;
+    pos @kc87_first_48 @kc87_second_13 -385;
+    pos @kc87_first_48 @kc87_second_14 -350;
+    pos @kc87_first_48 @kc87_second_15 -280;
+    pos @kc87_first_48 @kc87_second_18 -210;
     pos @kc87_first_48 @kc87_second_20 -140;
-    pos @kc87_first_48 @kc87_second_21 -210;
-    pos @kc87_first_48 @kc87_second_22 -210;
-    pos @kc87_first_48 @kc87_second_23 -210;
-    pos @kc87_first_48 @kc87_second_24 -140;
-    pos @kc87_first_48 @kc87_second_25 -140;
-    pos @kc87_first_48 @kc87_second_27 -140;
-    pos @kc87_first_48 @kc87_second_29 -210;
-    pos @kc87_first_48 @kc87_second_30 -210;
-    pos @kc87_first_48 @kc87_second_31 -140;
-    pos @kc87_first_48 @kc87_second_34 -210;
+    pos @kc87_first_48 @kc87_second_22 -105;
+    pos @kc87_first_48 @kc87_second_23 -140;
+    pos @kc87_first_48 @kc87_second_29 -70;
+    pos @kc87_first_48 @kc87_second_31 -175;
     pos @kc87_first_48 @kc87_second_35 -70;
-    pos @kc87_first_48 @kc87_second_36 -175;
-    pos @kc87_first_48 @kc87_second_37 -210;
-    pos @kc87_first_48 @kc87_second_38 -175;
-    pos @kc87_first_48 @kc87_second_39 -210;
-    pos @kc87_first_48 @kc87_second_40 -105;
-    pos @kc87_first_48 @kc87_second_43 -70;
-    pos @kc87_first_48 @kc87_second_44 -105;
-    pos @kc87_first_48 @kc87_second_45 1;
-    pos @kc87_first_48 @kc87_second_46 -35;
-    pos @kc87_first_48 @kc87_second_47 -210;
-    pos @kc87_first_48 @kc87_second_50 -210;
-    pos @kc87_first_48 @kc87_second_51 -210;
-    pos @kc87_first_48 @kc87_second_52 -175;
-    pos @kc87_first_48 @kc87_second_53 -175;
-    pos @kc87_first_48 @kc87_second_55 -210;
-    pos @kc87_first_48 @kc87_second_56 -140;
-    pos @kc87_first_48 @kc87_second_57 -210;
-    pos @kc87_first_48 @kc87_second_58 -210;
-    pos @kc87_first_48 @kc87_second_59 -175;
-    pos @kc87_first_48 @kc87_second_60 -175;
-    pos @kc87_first_48 @kc87_second_63 -210;
+    pos @kc87_first_48 @kc87_second_37 -35;
+    pos @kc87_first_48 @kc87_second_39 -175;
+    pos @kc87_first_48 @kc87_second_40 -280;
+    pos @kc87_first_48 @kc87_second_41 -280;
+    pos @kc87_first_48 @kc87_second_43 -280;
+    pos @kc87_first_48 @kc87_second_44 -210;
+    pos @kc87_first_48 @kc87_second_46 -140;
+    pos @kc87_first_48 @kc87_second_48 1;
+    pos @kc87_first_48 @kc87_second_49 -70;
+    pos @kc87_first_48 @kc87_second_50 -280;
+    pos @kc87_first_48 @kc87_second_51 -350;
+    pos @kc87_first_48 @kc87_second_53 -35;
+    pos @kc87_first_48 @kc87_second_54 -70;
+    pos @kc87_first_48 @kc87_second_60 -245;
+    pos @kc87_first_48 @kc87_second_62 -245;
+    pos @kc87_first_48 @kc87_second_63 -280;
     pos @kc87_first_48 @kc87_second_64 -210;
-    pos @kc87_first_49 @kc87_second_5 -70;
-    pos @kc87_first_49 @kc87_second_11 -35;
-    pos @kc87_first_49 @kc87_second_12 -240;
-    pos @kc87_first_49 @kc87_second_13 -70;
-    pos @kc87_first_49 @kc87_second_14 -140;
-    pos @kc87_first_49 @kc87_second_15 -105;
-    pos @kc87_first_49 @kc87_second_16 -70;
-    pos @kc87_first_49 @kc87_second_26 -70;
-    pos @kc87_first_49 @kc87_second_27 -70;
-    pos @kc87_first_49 @kc87_second_35 -35;
-    pos @kc87_first_49 @kc87_second_39 -70;
-    pos @kc87_first_49 @kc87_second_42 -35;
+    pos @kc87_first_48 @kc87_second_65 -70;
+    pos @kc87_first_48 @kc87_second_66 -70;
+    pos @kc87_first_49 @kc87_second_3 -70;
+    pos @kc87_first_49 @kc87_second_4 -105;
+    pos @kc87_first_49 @kc87_second_6 -210;
+    pos @kc87_first_49 @kc87_second_7 -70;
+    pos @kc87_first_49 @kc87_second_8 -175;
+    pos @kc87_first_49 @kc87_second_17 -210;
+    pos @kc87_first_49 @kc87_second_20 -140;
+    pos @kc87_first_49 @kc87_second_21 -210;
+    pos @kc87_first_49 @kc87_second_22 -210;
+    pos @kc87_first_49 @kc87_second_23 -210;
+    pos @kc87_first_49 @kc87_second_24 -140;
+    pos @kc87_first_49 @kc87_second_25 -140;
+    pos @kc87_first_49 @kc87_second_27 -140;
+    pos @kc87_first_49 @kc87_second_29 -210;
+    pos @kc87_first_49 @kc87_second_30 -210;
+    pos @kc87_first_49 @kc87_second_31 -140;
+    pos @kc87_first_49 @kc87_second_32 -140;
+    pos @kc87_first_49 @kc87_second_35 -210;
+    pos @kc87_first_49 @kc87_second_36 -70;
+    pos @kc87_first_49 @kc87_second_37 -175;
+    pos @kc87_first_49 @kc87_second_38 -210;
+    pos @kc87_first_49 @kc87_second_39 -175;
+    pos @kc87_first_49 @kc87_second_40 -210;
+    pos @kc87_first_49 @kc87_second_41 -105;
     pos @kc87_first_49 @kc87_second_43 -70;
-    pos @kc87_first_49 @kc87_second_45 1;
-    pos @kc87_first_49 @kc87_second_47 -35;
-    pos @kc87_first_49 @kc87_second_48 -140;
-    pos @kc87_first_49 @kc87_second_51 1;
-    pos @kc87_first_49 @kc87_second_56 -35;
-    pos @kc87_first_49 @kc87_second_60 -35;
-    pos @kc87_first_49 @kc87_second_61 -105;
-    pos @kc87_first_49 @kc87_second_62 -70;
-    pos @kc87_first_50 @kc87_second_65 -210;
-    pos @kc87_first_51 @kc87_second_32 -315;
-    pos @kc87_first_51 @kc87_second_66 -210;
-    pos @kc87_first_52 @kc87_second_1 -105;
-    pos @kc87_first_52 @kc87_second_2 -210;
-    pos @kc87_first_52 @kc87_second_6 -140;
-    pos @kc87_first_52 @kc87_second_11 -70;
-    pos @kc87_first_52 @kc87_second_12 -210;
-    pos @kc87_first_52 @kc87_second_13 -210;
-    pos @kc87_first_52 @kc87_second_14 -105;
-    pos @kc87_first_52 @kc87_second_15 -70;
-    pos @kc87_first_52 @kc87_second_16 -140;
-    pos @kc87_first_52 @kc87_second_17 -35;
-    pos @kc87_first_52 @kc87_second_22 -35;
-    pos @kc87_first_52 @kc87_second_24 -210;
-    pos @kc87_first_52 @kc87_second_26 -70;
-    pos @kc87_first_52 @kc87_second_27 -70;
-    pos @kc87_first_52 @kc87_second_29 -35;
-    pos @kc87_first_52 @kc87_second_34 -210;
-    pos @kc87_first_52 @kc87_second_35 -140;
-    pos @kc87_first_52 @kc87_second_42 -35;
-    pos @kc87_first_52 @kc87_second_43 -70;
-    pos @kc87_first_52 @kc87_second_45 1;
-    pos @kc87_first_52 @kc87_second_47 -35;
-    pos @kc87_first_52 @kc87_second_48 -105;
-    pos @kc87_first_52 @kc87_second_53 -210;
-    pos @kc87_first_52 @kc87_second_55 -140;
-    pos @kc87_first_52 @kc87_second_57 -175;
-    pos @kc87_first_52 @kc87_second_61 -35;
-    pos @kc87_first_52 @kc87_second_62 -35;
-    pos @kc87_first_52 @kc87_second_63 -35;
-    pos @kc87_first_52 @kc87_second_64 -70;
-    pos @kc87_first_53 @kc87_second_1 -35;
-    pos @kc87_first_53 @kc87_second_2 -70;
-    pos @kc87_first_53 @kc87_second_5 -105;
-    pos @kc87_first_53 @kc87_second_6 -35;
-    pos @kc87_first_53 @kc87_second_9 -70;
-    pos @kc87_first_53 @kc87_second_11 -70;
-    pos @kc87_first_53 @kc87_second_12 -240;
-    pos @kc87_first_53 @kc87_second_13 -245;
-    pos @kc87_first_53 @kc87_second_14 -140;
-    pos @kc87_first_53 @kc87_second_15 -105;
-    pos @kc87_first_53 @kc87_second_16 -105;
-    pos @kc87_first_53 @kc87_second_18 -70;
-    pos @kc87_first_53 @kc87_second_19 -70;
-    pos @kc87_first_53 @kc87_second_24 -35;
-    pos @kc87_first_53 @kc87_second_25 -70;
-    pos @kc87_first_53 @kc87_second_26 -140;
-    pos @kc87_first_53 @kc87_second_27 -105;
-    pos @kc87_first_53 @kc87_second_34 -35;
-    pos @kc87_first_53 @kc87_second_35 -140;
-    pos @kc87_first_53 @kc87_second_39 -105;
-    pos @kc87_first_53 @kc87_second_40 -70;
-    pos @kc87_first_53 @kc87_second_42 -105;
-    pos @kc87_first_53 @kc87_second_43 -175;
-    pos @kc87_first_53 @kc87_second_45 1;
-    pos @kc87_first_53 @kc87_second_47 -70;
-    pos @kc87_first_53 @kc87_second_48 -140;
-    pos @kc87_first_53 @kc87_second_49 -70;
-    pos @kc87_first_53 @kc87_second_53 -210;
-    pos @kc87_first_53 @kc87_second_54 -70;
-    pos @kc87_first_53 @kc87_second_55 -175;
-    pos @kc87_first_53 @kc87_second_56 -105;
-    pos @kc87_first_53 @kc87_second_57 -175;
-    pos @kc87_first_53 @kc87_second_60 -50;
-    pos @kc87_first_53 @kc87_second_61 -105;
-    pos @kc87_first_53 @kc87_second_62 -70;
-    pos @kc87_first_53 @kc87_second_64 -35;
+    pos @kc87_first_49 @kc87_second_46 -105;
+    pos @kc87_first_49 @kc87_second_48 1;
+    pos @kc87_first_49 @kc87_second_49 -35;
+    pos @kc87_first_49 @kc87_second_50 -210;
+    pos @kc87_first_49 @kc87_second_52 -210;
+    pos @kc87_first_49 @kc87_second_53 -210;
+    pos @kc87_first_49 @kc87_second_54 -175;
+    pos @kc87_first_49 @kc87_second_55 -175;
+    pos @kc87_first_49 @kc87_second_57 -210;
+    pos @kc87_first_49 @kc87_second_58 -140;
+    pos @kc87_first_49 @kc87_second_59 -210;
+    pos @kc87_first_49 @kc87_second_60 -210;
+    pos @kc87_first_49 @kc87_second_61 -175;
+    pos @kc87_first_49 @kc87_second_62 -175;
+    pos @kc87_first_49 @kc87_second_65 -210;
+    pos @kc87_first_49 @kc87_second_66 -210;
+    pos @kc87_first_50 @kc87_second_1 -35;
+    pos @kc87_first_50 @kc87_second_2 -70;
+    pos @kc87_first_50 @kc87_second_5 -70;
+    pos @kc87_first_50 @kc87_second_11 -35;
+    pos @kc87_first_50 @kc87_second_12 -140;
+    pos @kc87_first_50 @kc87_second_13 -140;
+    pos @kc87_first_50 @kc87_second_14 -70;
+    pos @kc87_first_50 @kc87_second_15 -35;
+    pos @kc87_first_50 @kc87_second_16 -105;
+    pos @kc87_first_50 @kc87_second_26 -35;
+    pos @kc87_first_50 @kc87_second_27 -70;
+    pos @kc87_first_50 @kc87_second_36 -70;
+    pos @kc87_first_50 @kc87_second_43 -70;
+    pos @kc87_first_50 @kc87_second_48 1;
+    pos @kc87_first_50 @kc87_second_55 -175;
+    pos @kc87_first_50 @kc87_second_57 -140;
+    pos @kc87_first_50 @kc87_second_59 -140;
+    pos @kc87_first_50 @kc87_second_63 -35;
+    pos @kc87_first_51 @kc87_second_5 -70;
+    pos @kc87_first_51 @kc87_second_11 -35;
+    pos @kc87_first_51 @kc87_second_12 -240;
+    pos @kc87_first_51 @kc87_second_13 -70;
+    pos @kc87_first_51 @kc87_second_14 -140;
+    pos @kc87_first_51 @kc87_second_15 -105;
+    pos @kc87_first_51 @kc87_second_16 -70;
+    pos @kc87_first_51 @kc87_second_26 -70;
+    pos @kc87_first_51 @kc87_second_27 -70;
+    pos @kc87_first_51 @kc87_second_36 -35;
+    pos @kc87_first_51 @kc87_second_40 -70;
+    pos @kc87_first_51 @kc87_second_43 -70;
+    pos @kc87_first_51 @kc87_second_45 -35;
+    pos @kc87_first_51 @kc87_second_48 1;
+    pos @kc87_first_51 @kc87_second_50 -35;
+    pos @kc87_first_51 @kc87_second_51 -140;
+    pos @kc87_first_51 @kc87_second_53 1;
+    pos @kc87_first_51 @kc87_second_58 -35;
+    pos @kc87_first_51 @kc87_second_62 -35;
+    pos @kc87_first_51 @kc87_second_63 -105;
+    pos @kc87_first_51 @kc87_second_64 -70;
+    pos @kc87_first_52 @kc87_second_67 -210;
+    pos @kc87_first_53 @kc87_second_33 -315;
+    pos @kc87_first_53 @kc87_second_68 -210;
     pos @kc87_first_54 @kc87_second_1 -105;
     pos @kc87_first_54 @kc87_second_2 -210;
-    pos @kc87_first_54 @kc87_second_5 -70;
-    pos @kc87_first_54 @kc87_second_6 -105;
-    pos @kc87_first_54 @kc87_second_13 -70;
-    pos @kc87_first_54 @kc87_second_14 -35;
+    pos @kc87_first_54 @kc87_second_6 -140;
+    pos @kc87_first_54 @kc87_second_11 -70;
+    pos @kc87_first_54 @kc87_second_12 -210;
+    pos @kc87_first_54 @kc87_second_13 -210;
+    pos @kc87_first_54 @kc87_second_14 -105;
+    pos @kc87_first_54 @kc87_second_15 -70;
     pos @kc87_first_54 @kc87_second_16 -140;
-    pos @kc87_first_54 @kc87_second_17 -70;
-    pos @kc87_first_54 @kc87_second_19 -210;
+    pos @kc87_first_54 @kc87_second_17 -35;
     pos @kc87_first_54 @kc87_second_22 -35;
     pos @kc87_first_54 @kc87_second_24 -210;
+    pos @kc87_first_54 @kc87_second_26 -70;
+    pos @kc87_first_54 @kc87_second_27 -70;
     pos @kc87_first_54 @kc87_second_29 -35;
-    pos @kc87_first_54 @kc87_second_32 -105;
-    pos @kc87_first_54 @kc87_second_34 -105;
-    pos @kc87_first_54 @kc87_second_35 -140;
-    pos @kc87_first_54 @kc87_second_38 -70;
-    pos @kc87_first_54 @kc87_second_45 1;
-    pos @kc87_first_54 @kc87_second_51 -35;
-    pos @kc87_first_54 @kc87_second_53 -245;
+    pos @kc87_first_54 @kc87_second_35 -210;
+    pos @kc87_first_54 @kc87_second_36 -140;
+    pos @kc87_first_54 @kc87_second_43 -70;
+    pos @kc87_first_54 @kc87_second_45 -35;
+    pos @kc87_first_54 @kc87_second_48 1;
+    pos @kc87_first_54 @kc87_second_50 -35;
+    pos @kc87_first_54 @kc87_second_51 -105;
     pos @kc87_first_54 @kc87_second_55 -210;
-    pos @kc87_first_54 @kc87_second_57 -210;
-    pos @kc87_first_54 @kc87_second_63 -70;
-    pos @kc87_first_54 @kc87_second_64 -105;
-    pos @kc87_first_55 @kc87_second_12 -240;
-    pos @kc87_first_55 @kc87_second_13 -140;
-    pos @kc87_first_55 @kc87_second_14 -105;
-    pos @kc87_first_55 @kc87_second_15 -35;
-    pos @kc87_first_55 @kc87_second_33 100;
-    pos @kc87_first_55 @kc87_second_45 1;
-    pos @kc87_first_55 @kc87_second_50 100;
-    pos @kc87_first_56 @kc87_second_1 -140;
-    pos @kc87_first_56 @kc87_second_2 -210;
-    pos @kc87_first_56 @kc87_second_6 -140;
-    pos @kc87_first_56 @kc87_second_12 -175;
+    pos @kc87_first_54 @kc87_second_57 -140;
+    pos @kc87_first_54 @kc87_second_59 -175;
+    pos @kc87_first_54 @kc87_second_63 -35;
+    pos @kc87_first_54 @kc87_second_64 -35;
+    pos @kc87_first_54 @kc87_second_65 -35;
+    pos @kc87_first_54 @kc87_second_66 -70;
+    pos @kc87_first_55 @kc87_second_1 -105;
+    pos @kc87_first_55 @kc87_second_2 -210;
+    pos @kc87_first_55 @kc87_second_5 -70;
+    pos @kc87_first_55 @kc87_second_6 -105;
+    pos @kc87_first_55 @kc87_second_13 -70;
+    pos @kc87_first_55 @kc87_second_14 -35;
+    pos @kc87_first_55 @kc87_second_16 -140;
+    pos @kc87_first_55 @kc87_second_17 -70;
+    pos @kc87_first_55 @kc87_second_19 -210;
+    pos @kc87_first_55 @kc87_second_22 -35;
+    pos @kc87_first_55 @kc87_second_24 -210;
+    pos @kc87_first_55 @kc87_second_29 -35;
+    pos @kc87_first_55 @kc87_second_32 -70;
+    pos @kc87_first_55 @kc87_second_33 -105;
+    pos @kc87_first_55 @kc87_second_35 -105;
+    pos @kc87_first_55 @kc87_second_36 -140;
+    pos @kc87_first_55 @kc87_second_39 -70;
+    pos @kc87_first_55 @kc87_second_48 1;
+    pos @kc87_first_55 @kc87_second_53 -35;
+    pos @kc87_first_55 @kc87_second_55 -245;
+    pos @kc87_first_55 @kc87_second_57 -210;
+    pos @kc87_first_55 @kc87_second_59 -210;
+    pos @kc87_first_55 @kc87_second_65 -70;
+    pos @kc87_first_55 @kc87_second_66 -105;
+    pos @kc87_first_56 @kc87_second_12 -240;
     pos @kc87_first_56 @kc87_second_13 -140;
-    pos @kc87_first_56 @kc87_second_16 -140;
-    pos @kc87_first_56 @kc87_second_19 -210;
-    pos @kc87_first_56 @kc87_second_24 -210;
-    pos @kc87_first_56 @kc87_second_32 -140;
-    pos @kc87_first_56 @kc87_second_34 -140;
-    pos @kc87_first_56 @kc87_second_35 -210;
-    pos @kc87_first_56 @kc87_second_36 -35;
-    pos @kc87_first_56 @kc87_second_45 1;
-    pos @kc87_first_56 @kc87_second_53 -210;
-    pos @kc87_first_56 @kc87_second_55 -175;
-    pos @kc87_first_56 @kc87_second_57 -175;
-    pos @kc87_first_56 @kc87_second_63 -105;
-    pos @kc87_first_56 @kc87_second_64 -210;
-    pos @kc87_first_57 @kc87_second_12 -240;
-    pos @kc87_first_57 @kc87_second_13 -175;
-    pos @kc87_first_57 @kc87_second_14 -70;
-    pos @kc87_first_57 @kc87_second_15 -35;
-    pos @kc87_first_57 @kc87_second_19 -35;
-    pos @kc87_first_57 @kc87_second_26 -35;
-    pos @kc87_first_57 @kc87_second_39 -35;
-    pos @kc87_first_57 @kc87_second_40 -35;
-    pos @kc87_first_57 @kc87_second_43 -70;
-    pos @kc87_first_57 @kc87_second_45 1;
-    pos @kc87_first_57 @kc87_second_47 -35;
-    pos @kc87_first_57 @kc87_second_48 -70;
-    pos @kc87_first_57 @kc87_second_58 -35;
-    pos @kc87_first_57 @kc87_second_60 -35;
-    pos @kc87_first_57 @kc87_second_61 -70;
-    pos @kc87_first_57 @kc87_second_62 -35;
-    pos @kc87_first_58 @kc87_second_13 -35;
-    pos @kc87_first_58 @kc87_second_58 -35;
+    pos @kc87_first_56 @kc87_second_14 -105;
+    pos @kc87_first_56 @kc87_second_15 -35;
+    pos @kc87_first_56 @kc87_second_34 100;
+    pos @kc87_first_56 @kc87_second_48 1;
+    pos @kc87_first_56 @kc87_second_52 100;
+    pos @kc87_first_57 @kc87_second_1 -140;
+    pos @kc87_first_57 @kc87_second_2 -210;
+    pos @kc87_first_57 @kc87_second_6 -140;
+    pos @kc87_first_57 @kc87_second_12 -175;
+    pos @kc87_first_57 @kc87_second_13 -140;
+    pos @kc87_first_57 @kc87_second_16 -140;
+    pos @kc87_first_57 @kc87_second_19 -210;
+    pos @kc87_first_57 @kc87_second_24 -210;
+    pos @kc87_first_57 @kc87_second_32 -35;
+    pos @kc87_first_57 @kc87_second_33 -140;
+    pos @kc87_first_57 @kc87_second_35 -140;
+    pos @kc87_first_57 @kc87_second_36 -210;
+    pos @kc87_first_57 @kc87_second_37 -35;
+    pos @kc87_first_57 @kc87_second_48 1;
+    pos @kc87_first_57 @kc87_second_55 -210;
+    pos @kc87_first_57 @kc87_second_57 -175;
+    pos @kc87_first_57 @kc87_second_59 -175;
+    pos @kc87_first_57 @kc87_second_65 -105;
+    pos @kc87_first_57 @kc87_second_66 -210;
+    pos @kc87_first_58 @kc87_second_12 -240;
+    pos @kc87_first_58 @kc87_second_13 -175;
+    pos @kc87_first_58 @kc87_second_14 -70;
+    pos @kc87_first_58 @kc87_second_15 -35;
+    pos @kc87_first_58 @kc87_second_19 -35;
+    pos @kc87_first_58 @kc87_second_26 -35;
+    pos @kc87_first_58 @kc87_second_40 -35;
+    pos @kc87_first_58 @kc87_second_41 -35;
+    pos @kc87_first_58 @kc87_second_43 -70;
+    pos @kc87_first_58 @kc87_second_48 1;
+    pos @kc87_first_58 @kc87_second_50 -35;
+    pos @kc87_first_58 @kc87_second_51 -70;
+    pos @kc87_first_58 @kc87_second_60 -35;
+    pos @kc87_first_58 @kc87_second_62 -35;
+    pos @kc87_first_58 @kc87_second_63 -70;
     pos @kc87_first_58 @kc87_second_64 -35;
-    pos @kc87_first_59 @kc87_second_12 -175;
-    pos @kc87_first_59 @kc87_second_13 -140;
-    pos @kc87_first_59 @kc87_second_14 -35;
-    pos @kc87_first_59 @kc87_second_45 1;
-    pos @kc87_first_60 @kc87_second_1 -140;
-    pos @kc87_first_60 @kc87_second_2 -280;
-    pos @kc87_first_60 @kc87_second_5 -140;
-    pos @kc87_first_60 @kc87_second_6 -280;
-    pos @kc87_first_60 @kc87_second_8 -70;
-    pos @kc87_first_60 @kc87_second_10 -70;
-    pos @kc87_first_60 @kc87_second_11 -175;
-    pos @kc87_first_60 @kc87_second_12 -240;
-    pos @kc87_first_60 @kc87_second_13 -140;
-    pos @kc87_first_60 @kc87_second_14 -105;
-    pos @kc87_first_60 @kc87_second_15 -70;
-    pos @kc87_first_60 @kc87_second_16 -175;
-    pos @kc87_first_60 @kc87_second_17 -70;
-    pos @kc87_first_60 @kc87_second_19 -280;
-    pos @kc87_first_60 @kc87_second_22 -70;
-    pos @kc87_first_60 @kc87_second_23 -70;
-    pos @kc87_first_60 @kc87_second_24 -210;
-    pos @kc87_first_60 @kc87_second_26 -70;
-    pos @kc87_first_60 @kc87_second_27 -70;
-    pos @kc87_first_60 @kc87_second_29 -70;
+    pos @kc87_first_59 @kc87_second_1 -210;
+    pos @kc87_first_59 @kc87_second_2 -210;
+    pos @kc87_first_59 @kc87_second_3 -70;
+    pos @kc87_first_59 @kc87_second_4 -35;
+    pos @kc87_first_59 @kc87_second_6 -210;
+    pos @kc87_first_59 @kc87_second_7 -70;
+    pos @kc87_first_59 @kc87_second_8 -70;
+    pos @kc87_first_59 @kc87_second_16 -70;
+    pos @kc87_first_59 @kc87_second_17 -140;
+    pos @kc87_first_59 @kc87_second_19 -210;
+    pos @kc87_first_59 @kc87_second_20 -140;
+    pos @kc87_first_59 @kc87_second_21 -35;
+    pos @kc87_first_59 @kc87_second_22 -175;
+    pos @kc87_first_59 @kc87_second_23 -140;
+    pos @kc87_first_59 @kc87_second_24 -280;
+    pos @kc87_first_59 @kc87_second_29 -35;
+    pos @kc87_first_59 @kc87_second_30 -35;
+    pos @kc87_first_59 @kc87_second_32 -140;
+    pos @kc87_first_59 @kc87_second_33 -210;
+    pos @kc87_first_59 @kc87_second_35 -245;
+    pos @kc87_first_59 @kc87_second_36 -140;
+    pos @kc87_first_59 @kc87_second_37 -140;
+    pos @kc87_first_59 @kc87_second_38 -140;
+    pos @kc87_first_59 @kc87_second_39 -140;
+    pos @kc87_first_59 @kc87_second_40 -35;
+    pos @kc87_first_59 @kc87_second_46 -35;
+    pos @kc87_first_59 @kc87_second_47 -35;
+    pos @kc87_first_59 @kc87_second_48 1;
+    pos @kc87_first_59 @kc87_second_53 -140;
+    pos @kc87_first_59 @kc87_second_54 -70;
+    pos @kc87_first_59 @kc87_second_55 -210;
+    pos @kc87_first_59 @kc87_second_57 -210;
+    pos @kc87_first_59 @kc87_second_59 -210;
+    pos @kc87_first_59 @kc87_second_60 -35;
+    pos @kc87_first_59 @kc87_second_65 -175;
+    pos @kc87_first_59 @kc87_second_66 -245;
+    pos @kc87_first_60 @kc87_second_13 -35;
     pos @kc87_first_60 @kc87_second_32 -70;
-    pos @kc87_first_60 @kc87_second_34 -315;
-    pos @kc87_first_60 @kc87_second_35 -140;
-    pos @kc87_first_60 @kc87_second_36 -70;
-    pos @kc87_first_60 @kc87_second_38 -105;
-    pos @kc87_first_60 @kc87_second_45 1;
-    pos @kc87_first_60 @kc87_second_48 -35;
-    pos @kc87_first_60 @kc87_second_51 -50;
-    pos @kc87_first_60 @kc87_second_53 -210;
-    pos @kc87_first_60 @kc87_second_55 -175;
-    pos @kc87_first_60 @kc87_second_57 -210;
-    pos @kc87_first_60 @kc87_second_59 -35;
-    pos @kc87_first_60 @kc87_second_61 -70;
-    pos @kc87_first_60 @kc87_second_62 -35;
-    pos @kc87_first_60 @kc87_second_63 -140;
-    pos @kc87_first_60 @kc87_second_64 -210;
-    pos @kc87_first_61 @kc87_second_1 -35;
-    pos @kc87_first_61 @kc87_second_2 -70;
-    pos @kc87_first_61 @kc87_second_5 -70;
-    pos @kc87_first_61 @kc87_second_11 -35;
-    pos @kc87_first_61 @kc87_second_12 -140;
+    pos @kc87_first_60 @kc87_second_60 -35;
+    pos @kc87_first_60 @kc87_second_66 -35;
+    pos @kc87_first_61 @kc87_second_12 -175;
     pos @kc87_first_61 @kc87_second_13 -140;
-    pos @kc87_first_61 @kc87_second_14 -70;
-    pos @kc87_first_61 @kc87_second_15 -35;
-    pos @kc87_first_61 @kc87_second_16 -105;
-    pos @kc87_first_61 @kc87_second_26 -35;
-    pos @kc87_first_61 @kc87_second_27 -70;
-    pos @kc87_first_61 @kc87_second_35 -70;
-    pos @kc87_first_61 @kc87_second_43 -70;
-    pos @kc87_first_61 @kc87_second_45 1;
-    pos @kc87_first_61 @kc87_second_53 -175;
-    pos @kc87_first_61 @kc87_second_55 -140;
-    pos @kc87_first_61 @kc87_second_57 -140;
-    pos @kc87_first_61 @kc87_second_61 -35;
-    pos @kc87_first_62 @kc87_second_5 -70;
-    pos @kc87_first_62 @kc87_second_9 -70;
-    pos @kc87_first_62 @kc87_second_11 -35;
-    pos @kc87_first_62 @kc87_second_12 -350;
-    pos @kc87_first_62 @kc87_second_13 -315;
-    pos @kc87_first_62 @kc87_second_14 -175;
-    pos @kc87_first_62 @kc87_second_15 -140;
-    pos @kc87_first_62 @kc87_second_16 -70;
-    pos @kc87_first_62 @kc87_second_18 -70;
+    pos @kc87_first_61 @kc87_second_14 -35;
+    pos @kc87_first_61 @kc87_second_48 1;
+    pos @kc87_first_62 @kc87_second_1 -140;
+    pos @kc87_first_62 @kc87_second_2 -280;
+    pos @kc87_first_62 @kc87_second_5 -140;
+    pos @kc87_first_62 @kc87_second_6 -280;
+    pos @kc87_first_62 @kc87_second_8 -70;
+    pos @kc87_first_62 @kc87_second_10 -70;
+    pos @kc87_first_62 @kc87_second_11 -175;
+    pos @kc87_first_62 @kc87_second_12 -240;
+    pos @kc87_first_62 @kc87_second_13 -140;
+    pos @kc87_first_62 @kc87_second_14 -105;
+    pos @kc87_first_62 @kc87_second_15 -70;
+    pos @kc87_first_62 @kc87_second_16 -175;
+    pos @kc87_first_62 @kc87_second_17 -70;
+    pos @kc87_first_62 @kc87_second_19 -280;
+    pos @kc87_first_62 @kc87_second_22 -70;
+    pos @kc87_first_62 @kc87_second_23 -70;
+    pos @kc87_first_62 @kc87_second_24 -210;
+    pos @kc87_first_62 @kc87_second_26 -70;
     pos @kc87_first_62 @kc87_second_27 -70;
-    pos @kc87_first_62 @kc87_second_31 -50;
-    pos @kc87_first_62 @kc87_second_39 -140;
-    pos @kc87_first_62 @kc87_second_40 -50;
-    pos @kc87_first_62 @kc87_second_42 -35;
-    pos @kc87_first_62 @kc87_second_43 -175;
-    pos @kc87_first_62 @kc87_second_45 1;
-    pos @kc87_first_62 @kc87_second_47 -70;
-    pos @kc87_first_62 @kc87_second_48 -175;
-    pos @kc87_first_62 @kc87_second_54 -70;
-    pos @kc87_first_62 @kc87_second_58 -70;
-    pos @kc87_first_62 @kc87_second_60 -50;
-    pos @kc87_first_62 @kc87_second_61 -140;
-    pos @kc87_first_62 @kc87_second_62 -105;
-    pos @kc87_first_63 @kc87_second_4 -105;
+    pos @kc87_first_62 @kc87_second_29 -70;
+    pos @kc87_first_62 @kc87_second_32 -70;
+    pos @kc87_first_62 @kc87_second_33 -70;
+    pos @kc87_first_62 @kc87_second_35 -315;
+    pos @kc87_first_62 @kc87_second_36 -140;
+    pos @kc87_first_62 @kc87_second_37 -70;
+    pos @kc87_first_62 @kc87_second_39 -105;
+    pos @kc87_first_62 @kc87_second_48 1;
+    pos @kc87_first_62 @kc87_second_51 -35;
+    pos @kc87_first_62 @kc87_second_53 -50;
+    pos @kc87_first_62 @kc87_second_55 -210;
+    pos @kc87_first_62 @kc87_second_57 -175;
+    pos @kc87_first_62 @kc87_second_59 -210;
+    pos @kc87_first_62 @kc87_second_61 -35;
+    pos @kc87_first_62 @kc87_second_63 -70;
+    pos @kc87_first_62 @kc87_second_64 -35;
+    pos @kc87_first_62 @kc87_second_65 -140;
+    pos @kc87_first_62 @kc87_second_66 -210;
     pos @kc87_first_63 @kc87_second_6 -35;
-    pos @kc87_first_63 @kc87_second_8 1;
-    pos @kc87_first_63 @kc87_second_9 -245;
-    pos @kc87_first_63 @kc87_second_12 -210;
-    pos @kc87_first_63 @kc87_second_13 -210;
-    pos @kc87_first_63 @kc87_second_14 -210;
-    pos @kc87_first_63 @kc87_second_15 -175;
-    pos @kc87_first_63 @kc87_second_17 -70;
-    pos @kc87_first_63 @kc87_second_18 -180;
-    pos @kc87_first_63 @kc87_second_20 -140;
-    pos @kc87_first_63 @kc87_second_22 -105;
-    pos @kc87_first_63 @kc87_second_25 -140;
-    pos @kc87_first_63 @kc87_second_29 -105;
-    pos @kc87_first_63 @kc87_second_31 -140;
-    pos @kc87_first_63 @kc87_second_34 -35;
-    pos @kc87_first_63 @kc87_second_36 -35;
-    pos @kc87_first_63 @kc87_second_38 -175;
-    pos @kc87_first_63 @kc87_second_39 -142;
-    pos @kc87_first_63 @kc87_second_40 -245;
-    pos @kc87_first_63 @kc87_second_43 -210;
-    pos @kc87_first_63 @kc87_second_44 -105;
-    pos @kc87_first_63 @kc87_second_45 1;
-    pos @kc87_first_63 @kc87_second_46 -35;
-    pos @kc87_first_63 @kc87_second_47 -210;
-    pos @kc87_first_63 @kc87_second_48 -210;
+    pos @kc87_first_63 @kc87_second_12 -240;
+    pos @kc87_first_63 @kc87_second_13 -140;
+    pos @kc87_first_63 @kc87_second_14 -70;
+    pos @kc87_first_63 @kc87_second_15 -35;
+    pos @kc87_first_63 @kc87_second_20 -35;
+    pos @kc87_first_63 @kc87_second_22 -35;
+    pos @kc87_first_63 @kc87_second_35 -70;
+    pos @kc87_first_63 @kc87_second_39 -70;
+    pos @kc87_first_63 @kc87_second_40 -50;
+    pos @kc87_first_63 @kc87_second_48 1;
     pos @kc87_first_63 @kc87_second_51 -35;
-    pos @kc87_first_63 @kc87_second_58 -280;
-    pos @kc87_first_63 @kc87_second_60 -175;
-    pos @kc87_first_63 @kc87_second_61 -140;
-    pos @kc87_first_63 @kc87_second_62 -140;
-    pos @kc87_first_63 @kc87_second_63 -70;
-    pos @kc87_first_63 @kc87_second_64 -70;
-    pos @kc87_first_64 @kc87_second_1 -175;
-    pos @kc87_first_64 @kc87_second_2 -175;
+    pos @kc87_first_63 @kc87_second_65 -35;
+    pos @kc87_first_63 @kc87_second_66 -35;
     pos @kc87_first_64 @kc87_second_5 -70;
-    pos @kc87_first_64 @kc87_second_6 -105;
-    pos @kc87_first_64 @kc87_second_11 -105;
-    pos @kc87_first_64 @kc87_second_12 -175;
-    pos @kc87_first_64 @kc87_second_13 -140;
-    pos @kc87_first_64 @kc87_second_14 -70;
-    pos @kc87_first_64 @kc87_second_15 -35;
-    pos @kc87_first_64 @kc87_second_16 -140;
-    pos @kc87_first_64 @kc87_second_17 -70;
-    pos @kc87_first_64 @kc87_second_19 -175;
-    pos @kc87_first_64 @kc87_second_22 -70;
-    pos @kc87_first_64 @kc87_second_29 -35;
-    pos @kc87_first_64 @kc87_second_34 -105;
-    pos @kc87_first_64 @kc87_second_35 -175;
-    pos @kc87_first_64 @kc87_second_36 -35;
-    pos @kc87_first_64 @kc87_second_38 -70;
-    pos @kc87_first_64 @kc87_second_45 1;
-    pos @kc87_first_64 @kc87_second_51 -35;
-    pos @kc87_first_64 @kc87_second_53 -140;
-    pos @kc87_first_64 @kc87_second_55 -140;
-    pos @kc87_first_64 @kc87_second_57 -140;
-    pos @kc87_first_64 @kc87_second_63 -70;
+    pos @kc87_first_64 @kc87_second_9 -70;
+    pos @kc87_first_64 @kc87_second_11 -35;
+    pos @kc87_first_64 @kc87_second_12 -350;
+    pos @kc87_first_64 @kc87_second_13 -315;
+    pos @kc87_first_64 @kc87_second_14 -175;
+    pos @kc87_first_64 @kc87_second_15 -140;
+    pos @kc87_first_64 @kc87_second_16 -70;
+    pos @kc87_first_64 @kc87_second_18 -70;
+    pos @kc87_first_64 @kc87_second_27 -70;
+    pos @kc87_first_64 @kc87_second_31 -50;
+    pos @kc87_first_64 @kc87_second_40 -140;
+    pos @kc87_first_64 @kc87_second_41 -50;
+    pos @kc87_first_64 @kc87_second_43 -175;
+    pos @kc87_first_64 @kc87_second_45 -35;
+    pos @kc87_first_64 @kc87_second_48 1;
+    pos @kc87_first_64 @kc87_second_50 -70;
+    pos @kc87_first_64 @kc87_second_51 -175;
+    pos @kc87_first_64 @kc87_second_56 -70;
+    pos @kc87_first_64 @kc87_second_60 -70;
+    pos @kc87_first_64 @kc87_second_62 -50;
+    pos @kc87_first_64 @kc87_second_63 -140;
     pos @kc87_first_64 @kc87_second_64 -105;
-    pos @kc87_first_65 @kc87_second_1 -210;
-    pos @kc87_first_65 @kc87_second_2 -210;
-    pos @kc87_first_65 @kc87_second_3 -70;
-    pos @kc87_first_65 @kc87_second_4 -35;
-    pos @kc87_first_65 @kc87_second_6 -210;
-    pos @kc87_first_65 @kc87_second_7 -70;
-    pos @kc87_first_65 @kc87_second_8 -70;
-    pos @kc87_first_65 @kc87_second_16 -70;
-    pos @kc87_first_65 @kc87_second_17 -140;
-    pos @kc87_first_65 @kc87_second_19 -210;
+    pos @kc87_first_65 @kc87_second_4 -105;
+    pos @kc87_first_65 @kc87_second_6 -35;
+    pos @kc87_first_65 @kc87_second_8 1;
+    pos @kc87_first_65 @kc87_second_9 -245;
+    pos @kc87_first_65 @kc87_second_12 -210;
+    pos @kc87_first_65 @kc87_second_13 -210;
+    pos @kc87_first_65 @kc87_second_14 -210;
+    pos @kc87_first_65 @kc87_second_15 -175;
+    pos @kc87_first_65 @kc87_second_17 -70;
+    pos @kc87_first_65 @kc87_second_18 -180;
     pos @kc87_first_65 @kc87_second_20 -140;
-    pos @kc87_first_65 @kc87_second_21 -35;
-    pos @kc87_first_65 @kc87_second_22 -175;
-    pos @kc87_first_65 @kc87_second_23 -140;
-    pos @kc87_first_65 @kc87_second_24 -280;
-    pos @kc87_first_65 @kc87_second_29 -35;
-    pos @kc87_first_65 @kc87_second_30 -35;
-    pos @kc87_first_65 @kc87_second_32 -210;
-    pos @kc87_first_65 @kc87_second_34 -245;
-    pos @kc87_first_65 @kc87_second_35 -140;
-    pos @kc87_first_65 @kc87_second_36 -140;
-    pos @kc87_first_65 @kc87_second_37 -140;
-    pos @kc87_first_65 @kc87_second_38 -140;
-    pos @kc87_first_65 @kc87_second_39 -35;
-    pos @kc87_first_65 @kc87_second_44 -35;
-    pos @kc87_first_65 @kc87_second_45 1;
+    pos @kc87_first_65 @kc87_second_22 -105;
+    pos @kc87_first_65 @kc87_second_25 -140;
+    pos @kc87_first_65 @kc87_second_29 -105;
+    pos @kc87_first_65 @kc87_second_31 -140;
+    pos @kc87_first_65 @kc87_second_32 -105;
+    pos @kc87_first_65 @kc87_second_35 -35;
+    pos @kc87_first_65 @kc87_second_37 -35;
+    pos @kc87_first_65 @kc87_second_39 -175;
+    pos @kc87_first_65 @kc87_second_40 -142;
+    pos @kc87_first_65 @kc87_second_41 -245;
+    pos @kc87_first_65 @kc87_second_43 -210;
+    pos @kc87_first_65 @kc87_second_44 -175;
+    pos @kc87_first_65 @kc87_second_46 -105;
+    pos @kc87_first_65 @kc87_second_48 1;
     pos @kc87_first_65 @kc87_second_49 -35;
-    pos @kc87_first_65 @kc87_second_51 -140;
-    pos @kc87_first_65 @kc87_second_52 -70;
-    pos @kc87_first_65 @kc87_second_53 -210;
-    pos @kc87_first_65 @kc87_second_55 -210;
-    pos @kc87_first_65 @kc87_second_57 -210;
-    pos @kc87_first_65 @kc87_second_58 -35;
-    pos @kc87_first_65 @kc87_second_63 -175;
-    pos @kc87_first_65 @kc87_second_64 -245;
-    pos @kc87_first_66 @kc87_second_6 -35;
-    pos @kc87_first_66 @kc87_second_12 -240;
+    pos @kc87_first_65 @kc87_second_50 -210;
+    pos @kc87_first_65 @kc87_second_51 -210;
+    pos @kc87_first_65 @kc87_second_53 -35;
+    pos @kc87_first_65 @kc87_second_60 -280;
+    pos @kc87_first_65 @kc87_second_62 -175;
+    pos @kc87_first_65 @kc87_second_63 -140;
+    pos @kc87_first_65 @kc87_second_64 -140;
+    pos @kc87_first_65 @kc87_second_65 -70;
+    pos @kc87_first_65 @kc87_second_66 -70;
+    pos @kc87_first_66 @kc87_second_1 -175;
+    pos @kc87_first_66 @kc87_second_2 -175;
+    pos @kc87_first_66 @kc87_second_5 -70;
+    pos @kc87_first_66 @kc87_second_6 -105;
+    pos @kc87_first_66 @kc87_second_11 -105;
+    pos @kc87_first_66 @kc87_second_12 -175;
     pos @kc87_first_66 @kc87_second_13 -140;
     pos @kc87_first_66 @kc87_second_14 -70;
     pos @kc87_first_66 @kc87_second_15 -35;
-    pos @kc87_first_66 @kc87_second_20 -35;
-    pos @kc87_first_66 @kc87_second_22 -35;
-    pos @kc87_first_66 @kc87_second_34 -70;
-    pos @kc87_first_66 @kc87_second_38 -70;
-    pos @kc87_first_66 @kc87_second_39 -50;
-    pos @kc87_first_66 @kc87_second_45 1;
-    pos @kc87_first_66 @kc87_second_48 -35;
-    pos @kc87_first_66 @kc87_second_63 -35;
-    pos @kc87_first_66 @kc87_second_64 -35;
+    pos @kc87_first_66 @kc87_second_16 -140;
+    pos @kc87_first_66 @kc87_second_17 -70;
+    pos @kc87_first_66 @kc87_second_19 -175;
+    pos @kc87_first_66 @kc87_second_22 -70;
+    pos @kc87_first_66 @kc87_second_29 -35;
+    pos @kc87_first_66 @kc87_second_32 -70;
+    pos @kc87_first_66 @kc87_second_35 -105;
+    pos @kc87_first_66 @kc87_second_36 -175;
+    pos @kc87_first_66 @kc87_second_37 -35;
+    pos @kc87_first_66 @kc87_second_39 -70;
+    pos @kc87_first_66 @kc87_second_48 1;
+    pos @kc87_first_66 @kc87_second_53 -35;
+    pos @kc87_first_66 @kc87_second_55 -140;
+    pos @kc87_first_66 @kc87_second_57 -140;
+    pos @kc87_first_66 @kc87_second_59 -140;
+    pos @kc87_first_66 @kc87_second_65 -70;
+    pos @kc87_first_66 @kc87_second_66 -105;
     pos @kc87_first_67 @kc87_second_3 -100;
     pos @kc87_first_67 @kc87_second_4 -50;
     pos @kc87_first_67 @kc87_second_6 -50;
@@ -10063,23 +10133,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_67 @kc87_second_23 -70;
     pos @kc87_first_67 @kc87_second_29 -35;
     pos @kc87_first_67 @kc87_second_31 -70;
-    pos @kc87_first_67 @kc87_second_33 105;
-    pos @kc87_first_67 @kc87_second_34 -35;
-    pos @kc87_first_67 @kc87_second_38 -70;
-    pos @kc87_first_67 @kc87_second_39 -140;
+    pos @kc87_first_67 @kc87_second_32 -50;
+    pos @kc87_first_67 @kc87_second_34 105;
+    pos @kc87_first_67 @kc87_second_35 -35;
+    pos @kc87_first_67 @kc87_second_39 -70;
     pos @kc87_first_67 @kc87_second_40 -140;
+    pos @kc87_first_67 @kc87_second_41 -140;
     pos @kc87_first_67 @kc87_second_43 -140;
-    pos @kc87_first_67 @kc87_second_44 -35;
-    pos @kc87_first_67 @kc87_second_45 1;
-    pos @kc87_first_67 @kc87_second_47 -70;
-    pos @kc87_first_67 @kc87_second_48 -100;
-    pos @kc87_first_67 @kc87_second_50 105;
-    pos @kc87_first_67 @kc87_second_58 -140;
-    pos @kc87_first_67 @kc87_second_60 -70;
-    pos @kc87_first_67 @kc87_second_61 -70;
-    pos @kc87_first_67 @kc87_second_62 -50;
-    pos @kc87_first_67 @kc87_second_63 -35;
-    pos @kc87_first_67 @kc87_second_64 -35;
+    pos @kc87_first_67 @kc87_second_44 -50;
+    pos @kc87_first_67 @kc87_second_46 -35;
+    pos @kc87_first_67 @kc87_second_48 1;
+    pos @kc87_first_67 @kc87_second_50 -70;
+    pos @kc87_first_67 @kc87_second_51 -100;
+    pos @kc87_first_67 @kc87_second_52 105;
+    pos @kc87_first_67 @kc87_second_60 -140;
+    pos @kc87_first_67 @kc87_second_62 -70;
+    pos @kc87_first_67 @kc87_second_63 -70;
+    pos @kc87_first_67 @kc87_second_64 -50;
+    pos @kc87_first_67 @kc87_second_65 -35;
+    pos @kc87_first_67 @kc87_second_66 -35;
     pos @kc87_first_68 @kc87_second_3 -70;
     pos @kc87_first_68 @kc87_second_4 -50;
     pos @kc87_first_68 @kc87_second_6 -50;
@@ -10096,21 +10168,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_68 @kc87_second_23 -70;
     pos @kc87_first_68 @kc87_second_29 -35;
     pos @kc87_first_68 @kc87_second_31 -70;
-    pos @kc87_first_68 @kc87_second_34 -35;
-    pos @kc87_first_68 @kc87_second_38 -70;
-    pos @kc87_first_68 @kc87_second_39 -140;
+    pos @kc87_first_68 @kc87_second_35 -35;
+    pos @kc87_first_68 @kc87_second_39 -70;
     pos @kc87_first_68 @kc87_second_40 -140;
+    pos @kc87_first_68 @kc87_second_41 -140;
     pos @kc87_first_68 @kc87_second_43 -140;
-    pos @kc87_first_68 @kc87_second_44 -35;
-    pos @kc87_first_68 @kc87_second_45 1;
-    pos @kc87_first_68 @kc87_second_47 -70;
-    pos @kc87_first_68 @kc87_second_48 -140;
-    pos @kc87_first_68 @kc87_second_58 -140;
-    pos @kc87_first_68 @kc87_second_60 -70;
-    pos @kc87_first_68 @kc87_second_61 -105;
+    pos @kc87_first_68 @kc87_second_46 -35;
+    pos @kc87_first_68 @kc87_second_48 1;
+    pos @kc87_first_68 @kc87_second_50 -70;
+    pos @kc87_first_68 @kc87_second_51 -140;
+    pos @kc87_first_68 @kc87_second_60 -140;
     pos @kc87_first_68 @kc87_second_62 -70;
-    pos @kc87_first_68 @kc87_second_63 -35;
-    pos @kc87_first_68 @kc87_second_64 -35;
+    pos @kc87_first_68 @kc87_second_63 -105;
+    pos @kc87_first_68 @kc87_second_64 -70;
+    pos @kc87_first_68 @kc87_second_65 -35;
+    pos @kc87_first_68 @kc87_second_66 -35;
     pos @kc87_first_69 @kc87_second_3 -70;
     pos @kc87_first_69 @kc87_second_4 -50;
     pos @kc87_first_69 @kc87_second_6 -50;
@@ -10127,23 +10199,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_69 @kc87_second_23 -100;
     pos @kc87_first_69 @kc87_second_29 -35;
     pos @kc87_first_69 @kc87_second_31 -70;
-    pos @kc87_first_69 @kc87_second_33 105;
-    pos @kc87_first_69 @kc87_second_34 -35;
-    pos @kc87_first_69 @kc87_second_38 -70;
-    pos @kc87_first_69 @kc87_second_39 -140;
+    pos @kc87_first_69 @kc87_second_32 -50;
+    pos @kc87_first_69 @kc87_second_34 105;
+    pos @kc87_first_69 @kc87_second_35 -35;
+    pos @kc87_first_69 @kc87_second_39 -70;
     pos @kc87_first_69 @kc87_second_40 -140;
+    pos @kc87_first_69 @kc87_second_41 -140;
     pos @kc87_first_69 @kc87_second_43 -140;
-    pos @kc87_first_69 @kc87_second_44 -35;
-    pos @kc87_first_69 @kc87_second_45 1;
-    pos @kc87_first_69 @kc87_second_47 -70;
-    pos @kc87_first_69 @kc87_second_48 -140;
-    pos @kc87_first_69 @kc87_second_50 105;
-    pos @kc87_first_69 @kc87_second_58 -140;
-    pos @kc87_first_69 @kc87_second_60 -70;
-    pos @kc87_first_69 @kc87_second_61 -70;
-    pos @kc87_first_69 @kc87_second_62 -50;
-    pos @kc87_first_69 @kc87_second_63 -35;
-    pos @kc87_first_69 @kc87_second_64 -35;
+    pos @kc87_first_69 @kc87_second_44 -50;
+    pos @kc87_first_69 @kc87_second_46 -35;
+    pos @kc87_first_69 @kc87_second_48 1;
+    pos @kc87_first_69 @kc87_second_50 -70;
+    pos @kc87_first_69 @kc87_second_51 -140;
+    pos @kc87_first_69 @kc87_second_52 105;
+    pos @kc87_first_69 @kc87_second_60 -140;
+    pos @kc87_first_69 @kc87_second_62 -70;
+    pos @kc87_first_69 @kc87_second_63 -70;
+    pos @kc87_first_69 @kc87_second_64 -50;
+    pos @kc87_first_69 @kc87_second_65 -35;
+    pos @kc87_first_69 @kc87_second_66 -35;
     pos @kc87_first_70 @kc87_second_1 -210;
     pos @kc87_first_70 @kc87_second_2 -210;
     pos @kc87_first_70 @kc87_second_3 -35;
@@ -10157,24 +10231,25 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_70 @kc87_second_23 -105;
     pos @kc87_first_70 @kc87_second_24 -175;
     pos @kc87_first_70 @kc87_second_29 -105;
-    pos @kc87_first_70 @kc87_second_34 -175;
-    pos @kc87_first_70 @kc87_second_35 -140;
-    pos @kc87_first_70 @kc87_second_36 -70;
-    pos @kc87_first_70 @kc87_second_37 -105;
+    pos @kc87_first_70 @kc87_second_32 -140;
+    pos @kc87_first_70 @kc87_second_35 -175;
+    pos @kc87_first_70 @kc87_second_36 -140;
+    pos @kc87_first_70 @kc87_second_37 -70;
     pos @kc87_first_70 @kc87_second_38 -105;
-    pos @kc87_first_70 @kc87_second_39 -70;
-    pos @kc87_first_70 @kc87_second_44 -35;
-    pos @kc87_first_70 @kc87_second_45 1;
-    pos @kc87_first_70 @kc87_second_50 -35;
-    pos @kc87_first_70 @kc87_second_51 -70;
-    pos @kc87_first_70 @kc87_second_52 -70;
-    pos @kc87_first_70 @kc87_second_53 -175;
+    pos @kc87_first_70 @kc87_second_39 -105;
+    pos @kc87_first_70 @kc87_second_40 -70;
+    pos @kc87_first_70 @kc87_second_46 -35;
+    pos @kc87_first_70 @kc87_second_48 1;
+    pos @kc87_first_70 @kc87_second_52 -35;
+    pos @kc87_first_70 @kc87_second_53 -70;
+    pos @kc87_first_70 @kc87_second_54 -70;
     pos @kc87_first_70 @kc87_second_55 -175;
     pos @kc87_first_70 @kc87_second_57 -175;
-    pos @kc87_first_70 @kc87_second_58 -35;
-    pos @kc87_first_70 @kc87_second_59 -35;
-    pos @kc87_first_70 @kc87_second_63 -140;
-    pos @kc87_first_70 @kc87_second_64 -175;
+    pos @kc87_first_70 @kc87_second_59 -175;
+    pos @kc87_first_70 @kc87_second_60 -35;
+    pos @kc87_first_70 @kc87_second_61 -35;
+    pos @kc87_first_70 @kc87_second_65 -140;
+    pos @kc87_first_70 @kc87_second_66 -175;
     pos @kc87_first_71 @kc87_second_5 -70;
     pos @kc87_first_71 @kc87_second_8 -70;
     pos @kc87_first_71 @kc87_second_9 -105;
@@ -10189,22 +10264,23 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_71 @kc87_second_26 -35;
     pos @kc87_first_71 @kc87_second_27 -70;
     pos @kc87_first_71 @kc87_second_31 -70;
-    pos @kc87_first_71 @kc87_second_38 -35;
-    pos @kc87_first_71 @kc87_second_39 -245;
-    pos @kc87_first_71 @kc87_second_40 -70;
-    pos @kc87_first_71 @kc87_second_42 -35;
+    pos @kc87_first_71 @kc87_second_39 -35;
+    pos @kc87_first_71 @kc87_second_40 -245;
+    pos @kc87_first_71 @kc87_second_41 -70;
     pos @kc87_first_71 @kc87_second_43 -240;
-    pos @kc87_first_71 @kc87_second_45 1;
-    pos @kc87_first_71 @kc87_second_47 -105;
-    pos @kc87_first_71 @kc87_second_48 -280;
-    pos @kc87_first_71 @kc87_second_49 -35;
-    pos @kc87_first_71 @kc87_second_54 -35;
-    pos @kc87_first_71 @kc87_second_56 -70;
-    pos @kc87_first_71 @kc87_second_58 -105;
-    pos @kc87_first_71 @kc87_second_59 -35;
-    pos @kc87_first_71 @kc87_second_60 -70;
-    pos @kc87_first_71 @kc87_second_61 -175;
-    pos @kc87_first_71 @kc87_second_62 -140;
+    pos @kc87_first_71 @kc87_second_44 -210;
+    pos @kc87_first_71 @kc87_second_45 -35;
+    pos @kc87_first_71 @kc87_second_47 -35;
+    pos @kc87_first_71 @kc87_second_48 1;
+    pos @kc87_first_71 @kc87_second_50 -105;
+    pos @kc87_first_71 @kc87_second_51 -280;
+    pos @kc87_first_71 @kc87_second_56 -35;
+    pos @kc87_first_71 @kc87_second_58 -70;
+    pos @kc87_first_71 @kc87_second_60 -105;
+    pos @kc87_first_71 @kc87_second_61 -35;
+    pos @kc87_first_71 @kc87_second_62 -70;
+    pos @kc87_first_71 @kc87_second_63 -175;
+    pos @kc87_first_71 @kc87_second_64 -140;
     pos @kc87_first_72 @kc87_second_1 -140;
     pos @kc87_first_72 @kc87_second_2 -140;
     pos @kc87_first_72 @kc87_second_6 -140;
@@ -10217,20 +10293,21 @@ lookup kern_Horizontal_kerning {
     pos @kc87_first_72 @kc87_second_23 -70;
     pos @kc87_first_72 @kc87_second_24 -140;
     pos @kc87_first_72 @kc87_second_29 -70;
-    pos @kc87_first_72 @kc87_second_34 -175;
-    pos @kc87_first_72 @kc87_second_35 -105;
-    pos @kc87_first_72 @kc87_second_36 -70;
+    pos @kc87_first_72 @kc87_second_32 -35;
+    pos @kc87_first_72 @kc87_second_35 -175;
+    pos @kc87_first_72 @kc87_second_36 -105;
     pos @kc87_first_72 @kc87_second_37 -70;
     pos @kc87_first_72 @kc87_second_38 -70;
-    pos @kc87_first_72 @kc87_second_39 -35;
-    pos @kc87_first_72 @kc87_second_45 1;
-    pos @kc87_first_72 @kc87_second_50 -35;
-    pos @kc87_first_72 @kc87_second_51 -35;
-    pos @kc87_first_72 @kc87_second_53 -140;
+    pos @kc87_first_72 @kc87_second_39 -70;
+    pos @kc87_first_72 @kc87_second_40 -35;
+    pos @kc87_first_72 @kc87_second_48 1;
+    pos @kc87_first_72 @kc87_second_52 -35;
+    pos @kc87_first_72 @kc87_second_53 -35;
     pos @kc87_first_72 @kc87_second_55 -140;
     pos @kc87_first_72 @kc87_second_57 -140;
-    pos @kc87_first_72 @kc87_second_63 -105;
-    pos @kc87_first_72 @kc87_second_64 -105;
+    pos @kc87_first_72 @kc87_second_59 -140;
+    pos @kc87_first_72 @kc87_second_65 -105;
+    pos @kc87_first_72 @kc87_second_66 -105;
 } kern_Horizontal_kerning;
 
 lookup mark_Mark_positioning {
@@ -12714,6 +12791,7 @@ feature mkmk {
       lookup mkmk_mark_to_mark_bottom_center;
       lookup mkmk_mark_to_mark_greek_top_center;
 } mkmk;
+#Mark attachment classes (defined in GDEF, used in lookupflags)
 
 @GDEF_Simple = [\o \n \u \d \b \p \q \h \m \e \c \f \r \t \v \w \x \y \l \k \s \a \g \z \space \A \V \H 
 	\O \E \F \P \N \L \I \D \B \T \R \C \G \Q \U \M \Z \X \Y \W \J \K \S \eight \six \nine \three \zero 

--- a/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Giphurs-ThinItalic.ufo/fontinfo.plist
@@ -32,7 +32,7 @@
     <string>2023-01-20: Finally found a name for the font lol
 2022-06-21: Created with FontForge (http://fontforge.org)</string>
     <key>openTypeHeadCreated</key>
-    <string>2026/07/30 16:15:21</string>
+    <string>2026/07/30 22:07:12</string>
     <key>openTypeHheaAscender</key>
     <integer>2048</integer>
     <key>openTypeHheaDescender</key>


### PR DESCRIPTION
Closes #114.

Looks good to me.

<img width="2306" height="381" alt="image" src="https://github.com/user-attachments/assets/45ccff57-21e6-458e-a9ce-d7d6b8250b74" />

Did not add `.superior.pnum` digits tho, would add too much complexity and not really much worth it (unless someone else is motivated lol).