### PR TITLE
Fix script to change version string inside UFOs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 # Name of the font
 FONT_NAME := Giphurs
+FONT_VERSION := 3.000
 
 # Paths (without '/' for directories!)
 UFO_DIR := ./sources
@@ -9,6 +10,7 @@ UFO_COMPOSED_GENERATOR_SCRIPT := "scripts/composed_glyphs_generator.py"
 UFO_COMPOSED_SCRIPT := "scripts/ufo_composed_glyphs.py"
 UFO_COMPOSED_CSV_1 := "scripts/composed_glyphs.csv"  # filled by hand
 UFO_COMPOSED_CSV_2 := "scripts/composed_glyphs_generated.csv"  # filled by UFO_COMPOSED_SCRIPT
+UFO_SET_VERSION := "scripts/ufo_set_version.py"
 UFO_USE_TYPO_METRICS_SCRIPT := "scripts/ufo_use_typo_metrics.py"
 
 # documentaton
@@ -21,7 +23,8 @@ help:
 	@echo "  * make proof        : Creates HTML specimens of the font (in output/ directory) and opens the HTML report in your web browser."
 	@echo "  * make tests        : Runs automated tests (in output/ directory) and opens the HTML report in your web browser."
 	@echo "UFO sources scripts"
-	@echo "  * make ufo_composed_glyphs  : Build all glyphs based on other glyphs across all UFOs (the UFO files must be opened and exported throught Fontforge after, and accented glyphs has to be already built)."
+	@echo "  * make ufo_composed_glyphs  : Build all glyphs based on other glyphs across all UFOs (the UFO files must be opened and exported with Fontforge after, and accented glyphs has to be already built)."
+	@echo "  * ufo_set_version           : Change version string inside sources/ UFOs (value defined in the Makefile as FONT_VERSION variable.)"
 	@echo "  * make ufo_use_typo_metrics : Enable bit 7 ("use typo metrics") of openTypeOS2Selection in fontinfo.plist"
 
 # make a zip archive of the font folder
@@ -50,6 +53,10 @@ ufo_composed_glyphs: scripts/ sources/
 	python3 $(UFO_COMPOSED_SCRIPT) $(UFO_DIR)/$(FONT_NAME)-Italic.ufo 400 2 $(UFO_COMPOSED_CSV_1) $(UFO_COMPOSED_CSV_2)
 	python3 $(UFO_COMPOSED_SCRIPT) $(UFO_DIR)/$(FONT_NAME)-ExtraBlack.ufo 1000 1 $(UFO_COMPOSED_CSV_1) $(UFO_COMPOSED_CSV_2)
 	python3 $(UFO_COMPOSED_SCRIPT) $(UFO_DIR)/$(FONT_NAME)-ExtraBlackItalic.ufo 1000 2 $(UFO_COMPOSED_CSV_1) $(UFO_COMPOSED_CSV_2)
+
+ufo_set_version:
+	UFO_FILES=$$(find $(UFO_DIR) -name "*.ufo" 2>/dev/null); \
+	for ufo in $$UFO_FILES; do python3 $(UFO_SET_VERSION) $(FONT_VERSION) $${ufo}; done
 
 # edit fontinfo.plist to set the bit 7 of openTypeOS2Selection ("use typo metrics")
 # Note: This is currently automatically run when building fonts

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,7 +20,6 @@ It is possible to configure some of the scripts using a `.env` file at the proje
 | `COMMON_LOOKUPS_LIST` | `Path` | `'./scripts/common_lookups_list.txt'` | Path to a text file listing the standard OpenType lookup blocks that must be systematically copied across all UFOs. |
 | `FEATURES_LOOKUPS_REF` | `Path` | `./{SOURCES_INST_DIR_PATH} / '{FONT_NAME}-Regular.ufo / features.fea'` | The master OpenType feature file utilized as the golden reference source when injecting lookups and features into other styles. |
 | `FONT_NAME` | `str` | `'Giphurs'` | The primary family name of the font. Used for identifying specific source files and naming output files. |
-| `FONT_VERSION` | `str` | `None` | The version string to apply to all fonts (e.g., `"2.0.1"`). If left blank/unset, the script preserves whatever version values already exist inside the UFO sources. |
 | `FONTS_DIR_BACKUP_PATH` | `Path` | `'./fonts-backup'` | The directory where existing font binaries are archived before a new build process is initiated. |
 | `FONTS_DIR_PATH` | `Path` | `'./fonts'` | The target output directory where all generated font binaries (`otf`, `ttf`, `woff2`) will be saved. |
 | `KEEP_UFO_INST` | `bool` | `False` | Determines whether the temporary working folder (`SOURCES_INST_DIR_PATH`) should be kept or deleted after the build finishes. Evaluates to `True` if set to `true` or `1`. |

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import shutil
 import time
 from ufo_copy_fea_blocks import copy_fea_blocks
-from ufo_set_version import set_version
 from ufo_use_typo_metrics import use_typo_metrics
 from verboselogs import VerboseLogger   # pyright: ignore[reportMissingTypeStubs]
 
@@ -450,10 +449,6 @@ for ufo in UFO_FILES_LIST:
     # lookup blocks
     if FEATURES_LOOKUPS_REF != ufo / 'features.fea':
         if copy_fea_blocks(FEATURES_LOOKUPS_REF, ufo / 'features.fea', 'lookup', lookup_list) != 0:
-            exit(1)
-    # version
-    if FONT_VERSION is not None:
-        if set_version(FONT_VERSION, ufo) != 0:
             exit(1)
 logger.success('Pre-processing done with success.')  # pyright: ignore[reportUnknownMemberType]
 

--- a/scripts/ufo_set_version.py
+++ b/scripts/ufo_set_version.py
@@ -17,7 +17,7 @@ def set_version(version_string: str, ufo_dir: Path) -> int:
     '''
     Set the version value of a UFO. Writes into the fontinfo.plist file of the UFO.
 
-    Version string must be a decimal numbe, for example "2", "2.010" or "2.0.1" (which is the same as "2.010").
+    Version string must be a decimal number, for example "2", "2.010" or "2.0.1" (which is the same as "2.010").
     The version string written inside the UFO will be in the form of a decimal number with at least 3 decimals.
 
     This function handles the logging.
@@ -30,20 +30,15 @@ def set_version(version_string: str, ufo_dir: Path) -> int:
     '''
 
     # Read version string
-    version_major: str = version_string.split('.', maxsplit=1)[0]
-    version_minor: str
+    version_major: int = int(version_string.split('.', maxsplit=1)[0])
+    version_minor: int
     if len(version_string.split('.', maxsplit=1)) < 2:
-        version_minor = '000'
+        version_minor = 0
     else:
-        version_minor = version_string.split('.', maxsplit=1)[1].replace('.', '')
-        while len(version_minor) < 3:
-            version_minor += '0'
-    if not version_major.isnumeric() or not version_minor.isnumeric():
-        logger.critical(f'Invalid version_string value: "{version_string}".')
-        return 1
+        version_minor = int(version_string.split('.', maxsplit=1)[1].replace('.', ''))
 
     # Read file
-    logger.info(f'Setting font version value of "{ufo_dir}" to {version_major}.{version_minor}')
+    logger.info(f'Setting font version value of "{ufo_dir}" to "{version_string}..."')
     plist_raw_content: Any
     try:
         with open(ufo_dir / 'fontinfo.plist', 'rb') as f:
@@ -59,7 +54,7 @@ def set_version(version_string: str, ufo_dir: Path) -> int:
     plist_dict: dict[str, Any] = plist_raw_content  # pyright: ignore[reportUnknownVariableType]
 
     # Set (add field if missing)
-    plist_dict['openTypeNameVersion'] = f'Version {version_major}.{version_minor}'
+    plist_dict['openTypeNameVersion'] = f'Version {version_string}'
     plist_dict['versionMajor'] = version_major
     plist_dict['versionMinor'] = version_minor
 
@@ -72,7 +67,7 @@ def set_version(version_string: str, ufo_dir: Path) -> int:
         logger.critical(f'Failed to write into "{ufo_dir / 'fontinfo.plist'}": {err}')
         return 1
 
-    logger.success(f'UFO "{ufo_dir}" font version has been set to {version_major}.{version_minor}')  # pyright: ignore[reportUnknownMemberType]
+    logger.success(f'UFO "{ufo_dir}" font version has been set to {version_string} (major={version_major} minor={version_minor})')  # pyright: ignore[reportUnknownMemberType]
     return 0
 
 


### PR DESCRIPTION
The `ufo_set_version.py` script, which is used to change the version string of the UFOs when building, was broken, it was making the UFOs impossible to compile caused by incorrect typing. Plus the way it was implemented wasn't practical, it was done at the building process, through a `.env` variable, otherwise, uses the sources UFOs.

This PR does the following: 
* Fixes the bugs inside this script
* Do not change font version string inside UFO when building them, and remove the `FONT_VERSION` variable in `.env`. From now the font version is only set inside `sources/` UFOs.
* Introduces the `make ufo_set_version` to change version string inside all UFOs in `sources/`. The value is defined inside the Makefile.